### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+_Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._
+
+---
+
+### Overview
+Please describe the changes present in the pull request and if applicable, describe why the changes are needed.
+
+### Related Github Issue
+Please include a link to the related GitHub issue, if applicable
+
+### Testing
+The browser agent includes a suite of tests which should be used to
+verify that your changes don't break existing functionality. These tests will run through Github Actions when:
+
+ 1) A pull request is made _and_ 
+ 2) The pull request is marked as ready for testing by the internal team. 
+
+If applicable, please include details on how to test your changes.
+
+---   
+_More details on running your tests locally can be found in the
+[CONTRIBUTING](https://github.com/newrelic/newrelic-java-agent/blob/main/CONTRIBUTING.md) and [README](https://github.com/newrelic/newrelic-browser-agent/blob/main/README.md) docs._


### PR DESCRIPTION
### Overview
Now that the Browser Agent is open source, it needs a pull request template to ensure the sanity of our contributors and validators.  This PR adds a template which will get applied to future pull requests.

### Related Github Issue
N/A