### PR TITLE
Fix for interaction waiting on setTimeout without callback

### DIFF
--- a/feature/spa/aggregate/index.js
+++ b/feature/spa/aggregate/index.js
@@ -221,6 +221,7 @@ baseEE.on('feat-spa', function () {
   // callbacks that fire around the callback passed to setTimeout originally.
   register.on(timerEE, 'setTimeout-end', function saveId (args, obj, timerId) {
     if (!currentNode || (timerBudget - this.timerDuration) < 0) return
+    if (args && !(args[0] instanceof Function)) return
     currentNode[INTERACTION][REMAINING]++
     this.timerId = timerId
     timerMap[timerId] = currentNode

--- a/tests/assets/spa/incorrect-timer.html
+++ b/tests/assets/spa/incorrect-timer.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {loader}
+    {config}
+  </head>
+  <body>
+    This page has has a setTimeout call with no callback. Click anywhere to invoke it.
+    <script>
+    document.addEventListener('click', onclick)
+
+    function onclick () {
+      window.history.replaceState({}, '', window.location.pathname + window.location.search + '#' + Math.random())
+      
+      // call setTimeout with first arg that is not a function
+      // the agent should be able to handle this gracefully
+      setTimeout(true, 500) 
+    }
+    </script>
+  </body>
+</html>

--- a/tests/assets/spa/incorrect-timer.html
+++ b/tests/assets/spa/incorrect-timer.html
@@ -15,7 +15,7 @@
     document.addEventListener('click', onclick)
 
     function onclick () {
-      window.history.replaceState({}, '', window.location.pathname + window.location.search + '#' + Math.random())
+      window.location.hash = Math.random()
       
       // call setTimeout with first arg that is not a function
       // the agent should be able to handle this gracefully

--- a/tests/functional/spa/timers.test.es6
+++ b/tests/functional/spa/timers.test.es6
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import testDriver from '../../../tools/jil/index.es6'
+import querypack from '@newrelic/nr-querypack'
+
+testDriver.test('incorrect timer', function (t, browser, router) {
+  let rumPromise = router.expectRum()
+  let eventsPromise = router.expectEvents()
+  let loadPromise = browser.safeGet(router.assetURL('spa/incorrect-timer.html', { loader: 'spa' }))
+
+  Promise.all([eventsPromise, rumPromise, loadPromise])
+    .then(([eventsResult]) => {
+      let eventPromise = router.expectEvents()
+      let domPromise = browser.elementByCssSelector('body').click()
+
+      return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
+        return eventData
+      })
+    })
+    .then(({query, body}) => {
+      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+      t.equal(interactionTree.trigger, 'click')
+      t.end()
+    })
+    .catch(fail)
+
+  function fail(err) {
+    t.error(err)
+    t.end()
+  }
+})

--- a/tests/functional/spa/timers.test.es6
+++ b/tests/functional/spa/timers.test.es6
@@ -17,14 +17,13 @@ testDriver.test('incorrect timer', supported, function (t, browser, router) {
     .then(([eventsResult]) => {
       let eventPromise = router.expectEvents()
       let domPromise = browser.elementByCssSelector('body').click()
-
       return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
         return eventData
       })
     })
     .then(({query, body}) => {
       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
-      t.equal(interactionTree.trigger, 'click')
+      t.equal(interactionTree.category, 'Route change', 'gout route change harvest call')
       t.end()
     })
     .catch(fail)

--- a/tests/functional/spa/timers.test.es6
+++ b/tests/functional/spa/timers.test.es6
@@ -6,7 +6,9 @@
 import testDriver from '../../../tools/jil/index.es6'
 import querypack from '@newrelic/nr-querypack'
 
-testDriver.test('incorrect timer', function (t, browser, router) {
+const supported = testDriver.Matcher.withFeature('addEventListener')
+
+testDriver.test('incorrect timer', supported, function (t, browser, router) {
   let rumPromise = router.expectRum()
   let eventsPromise = router.expectEvents()
   let loadPromise = browser.safeGet(router.assetURL('spa/incorrect-timer.html', { loader: 'spa' }))

--- a/tests/functional/spa/timers.test.js
+++ b/tests/functional/spa/timers.test.js
@@ -2,9 +2,8 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-import testDriver from '../../../tools/jil/index.es6'
-import querypack from '@newrelic/nr-querypack'
+const testDriver = require('../../../tools/jil')
+const querypack = require('@newrelic/nr-querypack')
 
 const supported = testDriver.Matcher.withFeature('addEventListener')
 


### PR DESCRIPTION
### Overview
Browser interactions (route changes) would wait forever if a setTimeout was called in the code without a callback (or the first argument different type than a function).

### Testing
Test is included with the PR.