### PR TITLE
check if protocol is allowed before execution

### DIFF
--- a/feature/err/instrument/index.js
+++ b/feature/err/instrument/index.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var protocolAllowed = require('../../../loader/protocol-allowed')
-if (!protocolAllowed(window.location)) return
-
 var handle = require('handle')
 var slice = require('lodash._slice')
 var ee = require('ee')
@@ -14,6 +11,8 @@ var getOrSet = require('gos')
 var origOnerror = window.onerror
 var handleErrors = false
 var NR_ERR_PROP = 'nr@seenError'
+
+if (loader.disabled) return
 
 // skipNext counter to keep track of uncaught
 // errors that will be the same as caught errors.

--- a/feature/err/instrument/index.js
+++ b/feature/err/instrument/index.js
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+var protocolAllowed = require('../../../loader/protocol-allowed')
+if (!protocolAllowed(window.location)) return
+
 var handle = require('handle')
 var slice = require('lodash._slice')
 var ee = require('ee')

--- a/feature/ins/instrument/index.js
+++ b/feature/ins/instrument/index.js
@@ -3,5 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+var protocolAllowed = require('../../../loader/protocol-allowed')
+if (!protocolAllowed(window.location)) return
+
 // Turn on feature
 require('loader').features.ins = true

--- a/feature/ins/instrument/index.js
+++ b/feature/ins/instrument/index.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var protocolAllowed = require('../../../loader/protocol-allowed')
-if (!protocolAllowed(window.location)) return
-
 // Turn on feature
-require('loader').features.ins = true
+var loader = require('loader')
+
+if (loader.disabled) return
+loader.features.ins = true

--- a/feature/spa/instrument/index.js
+++ b/feature/spa/instrument/index.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var protocolAllowed = require('../../../loader/protocol-allowed')
-if (!protocolAllowed(window.location)) return
-
 var START = '-start'
 var END = '-end'
 var BODY = '-body'
@@ -24,7 +21,7 @@ var loader = require('loader')
 
 // loader.xhrWrappable will be false in chrome for ios, but addEventListener is still available.
 // sauce does not have a browser to test this case against, so be careful when modifying this check
-if (!win[ADD_EVENT_LISTENER] || !loader.xhrWrappable) return
+if (!win[ADD_EVENT_LISTENER] || !loader.xhrWrappable || loader.disabled) return
 
 var mutationEE = require('../../wrap-mutation')
 var promiseEE = require('../../wrap-promise')

--- a/feature/spa/instrument/index.js
+++ b/feature/spa/instrument/index.js
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+var protocolAllowed = require('../../../loader/protocol-allowed')
+if (!protocolAllowed(window.location)) return
+
 var START = '-start'
 var END = '-end'
 var BODY = '-body'

--- a/feature/stn/instrument/index.js
+++ b/feature/stn/instrument/index.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var protocolAllowed = require('../../../loader/protocol-allowed')
-if (!protocolAllowed(window.location)) return
-
 if (!(window.performance &&
   window.performance.timing &&
   window.performance.getEntriesByType
@@ -30,8 +27,8 @@ var PUSH_STATE = 'pushState'
 
 // Turn on feature harvesting
 var loader = require('loader')
-loader = Object.assign({}, loader, {features: Object.assign(loader.features || {}, {stn: true})})
-console.log('stn loader')
+if (loader.disabled) return
+
 loader.features.stn = true
 
 // wrap history ap

--- a/feature/stn/instrument/index.js
+++ b/feature/stn/instrument/index.js
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+var protocolAllowed = require('../../../loader/protocol-allowed')
+if (!protocolAllowed(window.location)) return
+
 if (!(window.performance &&
   window.performance.timing &&
   window.performance.getEntriesByType
@@ -27,6 +30,8 @@ var PUSH_STATE = 'pushState'
 
 // Turn on feature harvesting
 var loader = require('loader')
+loader = Object.assign({}, loader, {features: Object.assign(loader.features || {}, {stn: true})})
+console.log('stn loader')
 loader.features.stn = true
 
 // wrap history ap

--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+var protocolAllowed = require('../../../loader/protocol-allowed')
+if (!protocolAllowed(window.location)) return
+
 var loader = require('loader')
 
 // Don't instrument Chrome for iOS, it is buggy and acts like there are URL verification issues

--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -3,13 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var protocolAllowed = require('../../../loader/protocol-allowed')
-if (!protocolAllowed(window.location)) return
-
 var loader = require('loader')
 
 // Don't instrument Chrome for iOS, it is buggy and acts like there are URL verification issues
-if (!loader.xhrWrappable) return
+if (!loader.xhrWrappable || loader.disabled) return
 
 var handle = require('handle')
 var parseUrl = require('./parse-url.js')

--- a/loader/index.js
+++ b/loader/index.js
@@ -21,7 +21,7 @@ var ATTACH_EVENT = 'attachEvent'
 var XHR = win.XMLHttpRequest
 var XHR_PROTO = XHR && XHR.prototype
 
-if (!protocolAllowed(win.location)) return
+var disabled = !protocolAllowed(win.location)
 
 NREUM.o = {
   ST: setTimeout,
@@ -52,8 +52,11 @@ var exp = module.exports = {
   origin: origin,
   features: {},
   xhrWrappable: xhrWrappable,
-  userAgent: userAgent
+  userAgent: userAgent,
+  disabled: disabled
 }
+
+if (disabled) return
 
 // api loads registers several event listeners, but does not have any exports
 require('api')


### PR DESCRIPTION
_Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

---

### Overview
Please describe the changes present in the pull request and if applicable, describe why the changes are needed.

This PR addresses a bug where the loader object is empty when opening in a file:// protocol containing the agent code. This empty object causes nested property assignment down the chain to error out.  The solution proposed here is to prevent the instrument files from executing if the protocol is invalid (file://).

### Related Github Issue
Please include a link to the related GitHub issue, if applicable

[JIRA](https://newrelic.atlassian.net/browse/JS-7890)

### Testing
The browser agent includes a suite of tests which should be used to
verify that your changes don't break existing functionality. These tests will run through Github Actions when:

 1) A pull request is made _and_ 
 2) The pull request is marked as ready for testing by the internal team. 

##### Steps to test:
1. Directly open from your file directory (file://) an html file containing the newly built agent code.
2. Ensure no runtime errors display in the browser console.

---   
_More details on running your tests locally can be found in the
[CONTRIBUTING](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [README](https://github.com/newrelic/newrelic-browser-agent/blob/main/README.md) docs._