### PR TITLE
remove all references to pingErrors

### DIFF
--- a/agent/harvest.js
+++ b/agent/harvest.js
@@ -33,7 +33,6 @@ var addPaintMetric = require('./paint-metrics').addMetric
 module.exports = {
   sendRUM: single(sendRUM), // wrapping this in single makes it so that it can only be called once from outside
   sendFinal: sendAllFromUnload,
-  pingErrors: pingErrors,
   sendX: sendX,
   send: send,
   on: on,
@@ -281,14 +280,6 @@ function getSubmitMethod(endpoint, opts) {
     method: method,
     useBody: useBody
   }
-}
-
-function pingErrors (nr) {
-  if (scheme === 'http' || !(nr && nr.info && nr.info.errorBeacon && nr.ieVersion)) return
-
-  var url = 'https://' + nr.info.errorBeacon + '/jserrors/ping/' + nr.info.licenseKey + baseQueryString(nr)
-
-  submitData.img(url)
 }
 
 // Constructs the transaction name param for the beacon URL.

--- a/feature/err/aggregate/index.js
+++ b/feature/err/aggregate/index.js
@@ -64,11 +64,6 @@ function onHarvestStarted(options) {
 }
 
 function onHarvestFinished(result) {
-  if (!result.sent) {
-    // keep connection open
-    harvest.pingErrors(loader)
-  }
-
   if (result.retry && currentBody) {
     mapOwn(currentBody, function(key, value) {
       for (var i = 0; i < value.length; i++) {
@@ -80,9 +75,6 @@ function onHarvestFinished(result) {
     currentBody = null
   }
 }
-
-// open HTTPS connection, which is needed for sending data during page unload on older browsers
-harvest.pingErrors(loader)
 
 function nameHash (params) {
   return stringHashCode(params.exceptionClass) ^ params.stackHash


### PR DESCRIPTION
_Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

---

### Overview
Please describe the changes present in the pull request and if applicable, describe why the changes are needed.

The agent currently sends a call to `/jserrors/ping` every minute when there is no other harvest call made. The reason was to keep the HTTPS connection to our consumer open for old IE browsers (IE 9 and older).

The ingest team is removing the endpoint when browser ingest switches to Vortex. We need to align, and this creates a minimal impact as it only affects IE 9 and older.

Impact:
The call is only made on old IE browsers, so the impact is fairly small. It is also made by inserting an image to the page, which should not affect the web page in any way when the call fails.

### Related Github Issue
Please include a link to the related GitHub issue, if applicable
[JIRA](https://newrelic.atlassian.net/browse/JS-7858)

### Testing
The browser agent includes a suite of tests which should be used to
verify that your changes don't break existing functionality. These tests will run through Github Actions when:

 1) A pull request is made _and_ 
 2) The pull request is marked as ready for testing by the internal team. 

If applicable, please include details on how to test your changes.

The application should behave the same, it just wont send a ping out to jserror

---   
_More details on running your tests locally can be found in the
[CONTRIBUTING](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [README](https://github.com/newrelic/newrelic-browser-agent/blob/main/README.md) docs._