### PR TITLE
Prevent buffering events if agent has been aborted

### DIFF
--- a/contextual-ee/index.js
+++ b/contextual-ee/index.js
@@ -106,6 +106,8 @@ function ee (old) {
   }
 
   function bufferEventsByGroup (types, group) {
+    // do not buffer events if agent has been aborted
+    if (baseEE.aborted) return
     mapOwn(types, function (i, type) {
       group = group || 'feature'
       bufferGroupMap[type] = group

--- a/tests/browser/contextual-ee.browser.js
+++ b/tests/browser/contextual-ee.browser.js
@@ -65,3 +65,42 @@ test('ee.abort condition not met', function (t) {
 
   t.end()
 })
+
+test('EE clears eventBuffer (ee.backlog) after abort', function (t) {
+  ee.aborted = false
+  if (ee.backlog) {
+    delete ee.backlog.feature
+  }
+
+  ee.buffer(['eventType'], 'feature')
+
+  t.equal(ee.backlog.feature instanceof Array, true, 'feature backlog is an array')
+  t.equal(ee.backlog.feature.length, 0, 'feature backlog is an empty array')
+
+  ee.emit('eventType', [], {})
+
+  t.equal(ee.backlog.feature.length, 1, 'emitted event was buffered')
+
+  ee.abort()
+
+  t.equal(Object.keys(ee.backlog).length, 0, 'EE backlog was cleared after abort')
+
+  t.end()
+})
+
+test('Forced EE does not buffer events after it has been aborted', function (t) {
+  ee.aborted = false
+  if (ee.backlog) {
+    delete ee.backlog.feature
+  }
+
+  ee.buffer(['eventType'], 'feature')
+  ee.abort()
+
+  ee.buffer(['eventType'], 'feature')
+  ee.emit('eventType', [], {}, true)
+
+  t.equal(Object.keys(ee.backlog).length, 0, 'emitted event was not buffered after ee.abort')
+
+  t.end()
+})


### PR DESCRIPTION
### Overview

This PR addresses a memory-leak issue in the agent where an event emitter continues to buffer events even after the base event emitter has been aborted.

When the agent loads normally, the event emitter's buffer should be emptied after the aggregator has loaded and harvest cycles have begun. However, in some cases the aggregator can be blocked from loading by tools like ad blockers. If this happens, there is a timeout to ensure that after a period, the emitter is aborted and no unexpected events are emitted or buffered.

There is, however, for legacy reasons, a mechanism to override the abort behavior and force an emitter to continue to emit events after the base emitter has been aborted. The bug this PR fixes is that this forcing behavior also causes those events to be buffered. I'm adding work to our backlog to investigate this legacy forcing behavior to determine whether it's still necessary to include at all.

While removing the forcing behavior requires more investigation- preventing events from being buffered does not- if the aggregator has not loaded, there is no code to process and harvest buffered events and they should not be stored.

### Testing

I've added two new Browser tests to validate that:
 1.  Aborting the event emitter clears the buffer
 2. Events emitted after aborting are not buffered