### PR TITLE
CYPRESS - Make sure that object is initialized with nested properties

### DIFF
--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -38,6 +38,8 @@ ee.on('new-xhr', function (xhr) {
   ctx.xhrGuids = {}
   ctx.lastSize = null
   ctx.loadCaptureCalled = false
+  ctx.params = this.params || {}
+  ctx.metrics = this.metrics || {}
 
   xhr.addEventListener('load', function (event) {
     captureXhrData(ctx, xhr)


### PR DESCRIPTION
### Overview
Cypress.io is a test framework that patches XMLHttpRequest, similarly to the NR agent. However, somehow it modifies the prototype chain, so that the `open` and `send` methods cannot be instrumented by us. This has a side-effect of the agent causing an error when tests are run in Cypress.  We have optional chaining errors happening in XHR initializer.  (They may also happen elsewhere but that has yet to have been observed).

### Related Github Issue
[JIRA](https://newrelic.atlassian.net/browse/JS-5793)

### Testing
Testing this requires running cypress.  I ran the tests agains the JIL asset server.  
* Here is a sample cypress app I made to do manual testing if you want to use --> [mock cypress app](https://github.com/metal-messiah/browser-agent-cypress)
* If you take the above approach, you need to spin up JIL Server before running the attached cypress test.
* Run the cypress test by installing (`npm install`) and running `npx cypress open` then clicking on the only test in the list.
* Make sure that the tests run (which wait for the page to fully load).  It should be running against both the known tests I found, and also tests labeled XHR.