### PR TITLE
Retry tests with failed child tests

### DIFF
--- a/tools/jil/driver/TapeTestObserver.js
+++ b/tools/jil/driver/TapeTestObserver.js
@@ -1,0 +1,42 @@
+
+function observe(t, finishedCallback, resultCallback) {
+  var allOk = true
+  observeTapeTest(t, false)
+
+  function observeTapeTest(t, isChild) {
+    t.on('end', function () {
+      onTestFinished(t, !!isChild)
+    })
+
+    t.on('result', function(result) {
+      if (resultCallback) {
+        resultCallback(result)
+      }
+    })
+
+    t.on('test', function(childTest) {
+      observeTapeTest(childTest, true)
+    })
+  }
+
+  function onTestFinished(t, isChild) {
+    let plannedOk = !t._plan || t._plan <= t.assertCount
+    let allAssertsOk = t._ok
+    allOk = allOk && allAssertsOk && plannedOk
+
+    if (!isChild) {
+      if (!plannedOk) {
+        t.once('result', function() {
+          if (t.error) {
+            allOk = false
+          }
+          finishedCallback(allOk, t)
+        })
+      } else {
+        finishedCallback(allOk, t)
+      }
+    }
+  }
+}
+
+module.exports = observe

--- a/tools/jil/runner/index.js
+++ b/tools/jil/runner/index.js
@@ -2,8 +2,7 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
-var newrelic = require('newrelic')
+const newrelic = require('newrelic')
 const config = require('./args')
 const path = require('path')
 const resolve = require('path').resolve
@@ -17,7 +16,7 @@ const loadBrowser = require('../loader/loadBrowser')
 const {getSauceLabsCreds, startExternalServices, stopExternalServices} = require('../util/external-services')
 
 const buildIdentifier = getBuildIdentifier()
-let output = new Output(config)
+const output = new Output(config)
 const testDriver = new Driver(config, output)
 
 module.exports = testDriver

--- a/tools/jil/test/tape-observer.test.js
+++ b/tools/jil/test/tape-observer.test.js
@@ -1,0 +1,97 @@
+const test = require('tape')
+const { Test } = require('tape')
+const observe = require('../driver/TapeTestObserver')
+
+test('simple pass', function(t) {
+  t.plan(1)
+
+  let tapeTest = new Test('parent', function(t) {
+    t.ok(true)
+    t.end()
+  })
+
+  observe(tapeTest, onFinished)
+
+  tapeTest.run()
+
+  function onFinished(passed) {
+    t.ok(passed, 'test passed')
+  }
+})
+
+test('simple fail', function(t) {
+  t.plan(2)
+
+  let tapeTest = new Test('parent', function(t) {
+    t.ok(false)
+    t.end()
+  })
+
+  observe(tapeTest, onFinished, onResult)
+
+  tapeTest.run()
+
+  function onFinished(passed) {
+    t.ok(!passed, 'test failed')
+  }
+
+  function onResult(result) {
+    t.ok(!result.ok, 'received failed result')
+  }
+})
+
+test('failing with passing child', function(t) {
+  t.plan(3)
+
+  let tapeTest = new Test('parent test', function(t) {
+    t.ok(false, 'assertion in parent')
+    t.test('child test', function(t) {
+      t.ok(true, 'assertion in child')
+      t.end()
+    })
+    t.end()
+  })
+
+  observe(tapeTest, onFinished, onResult)
+
+  tapeTest.run()
+
+  function onFinished(passed, test) {
+    t.equal(test.name, 'parent test')
+    t.ok(!passed, 'test failed')
+  }
+
+  function onResult(result) {
+    if (result.name === 'assertion in parent') {
+      t.ok(!result.ok, 'received failed result')
+    }
+  }
+})
+
+test('failing child', function(t) {
+  t.plan(3)
+
+  let tapeTest = new Test('parent test', function(t) {
+    t.ok(true, 'assertion in parent')
+    t.test('child test', function(t) {
+      t.ok(false, 'assertion in child')
+      t.end()
+    })
+    t.end()
+  })
+
+  observe(tapeTest, onFinished, onResult)
+
+  tapeTest.run()
+
+  function onFinished(passed, test) {
+    t.equal(test.name, 'parent test')
+    t.ok(!passed, 'test failed')
+  }
+
+  function onResult(result) {
+    if (result.name === 'assertion in child') {
+      t.ok(!result.ok, 'received failed result')
+    }
+  }
+})


### PR DESCRIPTION
### Overview
This is a fix for retrying tests with failed child tests. The logic for observing tape tests has been extracted into a separate modules (covered by tests). 

I have extracted the logic for observing tape tests, and the main fix is in the new TapeTestObserver.js file on line 17, where I am adding child tests to be observed as well.