### PR TITLE
Increase the limit of page action events per harvest

### DIFF
--- a/feature/ins/aggregate/index.js
+++ b/feature/ins/aggregate/index.js
@@ -13,7 +13,7 @@ var HarvestScheduler = require('../../../agent/harvest-scheduler')
 var cleanURL = require('../../../agent/clean-url')
 var config = require('config')
 
-var eventsPerMinute = 120
+var eventsPerMinute = 240
 var harvestTimeSeconds = config.getConfiguration('ins.harvestTimeSeconds') || 30
 var eventsPerHarvest = eventsPerMinute * harvestTimeSeconds / 60
 var referrerUrl


### PR DESCRIPTION
### Overview
Doubling the max number of page action events that can be sent per harvest.

### Related Github Issue
https://github.com/newrelic/newrelic-browser-agent/issues/50