### PR TITLE
Prevent duplicate Session Trace 'resource' node

### DIFF
--- a/feature/stn/aggregate/index.js
+++ b/feature/stn/aggregate/index.js
@@ -225,6 +225,8 @@ function storeHist (path, old, time) {
 var laststart = 0
 
 function storeResources (resources) {
+  if (!resources || resources.length === 0) return
+
   resources.forEach(function (currentResource) {
     var parsed = parseUrl(currentResource.name)
     var res = {
@@ -236,12 +238,12 @@ function storeResources (resources) {
     }
 
     // don't recollect old resources
-    if (res.s < laststart) return
-
-    laststart = res.s
+    if (res.s <= laststart) return
 
     storeSTN(res)
   })
+
+  laststart = resources[resources.length - 1].fetchStart | 0
 }
 
 function storeErrorAgg (type, name, params, metrics) {

--- a/tests/functional/stn/harvest.test.js
+++ b/tests/functional/stn/harvest.test.js
@@ -133,10 +133,10 @@ testDriver.test('session traces are retried when collector returns 429 during sc
 
     // this is really checking that no nodes have been resent
     var resentNodes = intersectPayloads(secondParsed, firstParsed)
-    t.ok(resentNodes.length === 1 && resentNodes[0].t === 'resource', 'nodes from first successful harvest are not resend')
+    t.ok(resentNodes.length === 0, 'nodes from first successful harvest are not resent in second harvest')
 
     resentNodes = intersectPayloads(thirdParsed, firstParsed)
-    t.ok(resentNodes.length === 1 && resentNodes[0].t === 'resource', 'nodes from first successful harvest are not resend')
+    t.ok(resentNodes.length === 0, 'nodes from first successful harvest are not resent in third harvest')
 
     t.equal(result.res.statusCode, 200, 'server responded with 200')
     t.equal(router.seenRequests.resources, 3, 'got three harvest requests')


### PR DESCRIPTION
### Overview
A behavior in Session Trace's aggregation of the resourceTiming API caused an overlap in the resources collected across harvests. This showed up in the UI as certain Session Trace nodes having a duplicate on the timeline.