### PR TITLE
Record fetch calls as metrics

### DIFF
--- a/feature/spa/aggregate/index.js
+++ b/feature/spa/aggregate/index.js
@@ -361,9 +361,6 @@ baseEE.on('feat-spa', function () {
   register.on(fetchEE, FETCH_START, function (fetchArguments, dtPayload) {
     if (currentNode && fetchArguments) {
       this[SPA_NODE] = currentNode.child('ajax', this[FETCH_START])
-      if (fetchArguments.length >= 1) this.target = fetchArguments[0]
-      if (fetchArguments.length >= 2) this.opts = fetchArguments[1]
-
       if (dtPayload && this[SPA_NODE]) this[SPA_NODE].dt = dtPayload
     }
   })
@@ -393,30 +390,12 @@ baseEE.on('feat-spa', function () {
         return
       }
 
-      var url, method
-      if (typeof target === 'string') {
-        url = target
-      } else if (typeof target === 'object' && target instanceof origRequest) {
-        url = target.url
-      } else if (window.URL && typeof target === 'object' && target instanceof URL) {
-        url = target.href
-      }
-
-      method = ('' + ((target && target instanceof origRequest && target.method) || opts.method || 'GET')).toUpperCase()
       var attrs = node.attrs
-      var params = attrs.params = {}
-
-      var parsed = parseUrl(url)
-      params.method = method
-      params.pathname = parsed.pathname
-      params.host = parsed.hostname + ':' + parsed.port
-      params.status = res.status
-
+      attrs.params = this.params
       attrs.metrics = {
-        txSize: dataSize(opts.body) || 0,
+        txSize: this.txSize,
         rxSize: this.rxSize
       }
-
       attrs.isFetch = true
 
       node.finish(this[FETCH_DONE])

--- a/feature/xhr/aggregate/index.js
+++ b/feature/xhr/aggregate/index.js
@@ -22,8 +22,8 @@ ee.on('feat-err', function () { register('xhr', storeXhr) })
 
 module.exports = storeXhr
 
-function storeXhr (params, metrics, start) {
-  metrics.time = start
+function storeXhr (params, metrics, startTime) {
+  metrics.time = startTime
 
   var type = 'xhr'
   var hash

--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -239,6 +239,12 @@ ee.on('fetch-before-start', function (args) {
   }
 })
 
+ee.on('fetch-start', function (fetchArguments, dtPayload) {
+  this.startTime = loader.now()
+  if (fetchArguments.length >= 1) this.target = fetchArguments[0]
+  if (fetchArguments.length >= 2) this.opts = fetchArguments[1]
+})
+
 ee.on('fetch-done', function (err, res) {
   var target = this.target
   var opts = this.opts || {}
@@ -262,10 +268,15 @@ ee.on('fetch-done', function (err, res) {
   params.host = parsed.hostname + ':' + parsed.port
   params.status = res.status
 
+  var responseSize
+  if (typeof this.rxSize === 'string' && this.rxSize.length > 0) {
+    responseSize = +this.rxSize
+  }
+
   var metrics = {
     txSize: dataSize(opts.body) || 0,
-    rxSize: this.rxSize,
-    duration: loader.now() - this['fetch-start']
+    rxSize: responseSize,
+    duration: loader.now() - this.startTime
   }
 
   handle('xhr', [params, metrics, this.startTime])

--- a/tests/browser/xhr/fetch.browser.js
+++ b/tests/browser/xhr/fetch.browser.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const test = require('../../../tools/jil/browser-test')
+const register = require('../../../agent/register-handler')
+const drain = require('../../../agent/drain')
+const ee = require('ee')
+const ffVersion = require('../../../loader/firefox-version')
+const jil = require('jil')
+
+require('../../../feature/xhr/instrument')
+require('../../../feature/err/instrument')
+require('../../../feature/err/aggregate')
+
+let proto = location.protocol
+let assetServerHTTPPort = NREUM.info.assetServerPort
+let assetServerSSLPort = NREUM.info.assetServerSSLPort
+let assetServerPort = proto === 'http:' ? assetServerHTTPPort : assetServerSSLPort
+let corsServerPort = NREUM.info.corsServerPort
+let assetServerHostname = window.location.host.split(':')[0]
+
+test('basic fetch call', function(t) {
+  ee.emit('feat-err', [])
+
+  if (!window.NREUM) NREUM = {}
+  if (!NREUM.loader_config) NREUM.loader_config = {}
+
+  fetch('/json')
+
+  register('xhr', function(params, metrics, start) {
+    require('../../../feature/xhr/aggregate')(params, metrics, start)
+
+    t.equals(params.method, 'GET', 'method')
+    t.equals(params.status, 200, 'status')
+    t.equals(params.host, assetServerHostname + ':' + assetServerPort, 'host')
+    t.equals(params.pathname, '/json', 'pathname')
+
+    t.equals(metrics.txSize, 0, 'request size')
+    t.equals(metrics.rxSize, 14, 'response size')
+    t.ok(metrics.duration > 1, 'duration is a positive number')
+
+    t.ok(start > 0, 'start is a positive number')
+
+    t.end()
+  })
+
+  drain('feature')
+})


### PR DESCRIPTION
### Overview
Fetch calls are currently recorded only as AjaxRequest events with SPA browser interactions. This change records fetch calls as AJAX metrics, which will make them visible in the AJAX UI charts.

### Related Github Issue
https://github.com/newrelic/newrelic-browser-agent/issues/38