### PR TITLE
Fix publish current script

### DIFF
--- a/.github/workflows/publish-current.yml
+++ b/.github/workflows/publish-current.yml
@@ -15,7 +15,8 @@ jobs:
       - name: install
         run: npm ci
       - name: publish
-        run: node tools/scripts/publish-current.js \
-          --bucket ${{ secrets.AWS_BUCKET }} \
-          --role ${{ secrets.AWS_ROLE_ARN }} \
-          --build-number $(cat VERSION)
+        run: |
+          node tools/scripts/publish-current.js \
+            --bucket ${{ secrets.AWS_BUCKET }} \
+            --role ${{ secrets.AWS_ROLE_ARN }} \
+            --build-number $(cat VERSION)


### PR DESCRIPTION
### Overview
The command line args were not getting properly passed in to the script. I have already tested it by running the action with this update to publish the 1209 version as current.