### PR TITLE
Final harvest should try pageHide

### DIFF
--- a/agent/timings.js
+++ b/agent/timings.js
@@ -100,14 +100,15 @@ function updateClsScore(clsEntry) {
   cls += clsEntry.value
 }
 
-function updatePageHide(timestamp, state) {
-  if (!pageHideRecorded && state === 'hidden') {
+function updatePageHide(timestamp) {
+  if (!pageHideRecorded) {
     addTiming('pageHide', timestamp, null, true)
     pageHideRecorded = true
   }
 }
 
 function recordUnload() {
+  updatePageHide(now())
   addTiming('unload', now(), null, true)
 }
 

--- a/loader/timings.js
+++ b/loader/timings.js
@@ -101,5 +101,7 @@ function captureInteraction(evt) {
 subscribeToVisibilityChange(captureVisibilityChange)
 
 function captureVisibilityChange(state) {
-  handle('pageHide', [loader.now(), state])
+  if (state === 'hidden') {
+    handle('pageHide', [loader.now(), state])
+  }
 }

--- a/loader/timings.js
+++ b/loader/timings.js
@@ -102,6 +102,6 @@ subscribeToVisibilityChange(captureVisibilityChange)
 
 function captureVisibilityChange(state) {
   if (state === 'hidden') {
-    handle('pageHide', [loader.now(), state])
+    handle('pageHide', [loader.now()])
   }
 }

--- a/tests/browser/timings-lcp.browser.js
+++ b/tests/browser/timings-lcp.browser.js
@@ -37,7 +37,6 @@ jil.browserTest('LCP is not collected on unload when the LCP value occurs after 
     // invoke final harvest, which includes harvesting LCP
     timingModule.finalHarvest()
 
-    console.log('timingModule', timingModule)
     t.equals(timingModule.timings.length, 2, 'there should be only 2 timings (pageHide and unload)')
     t.ok(timingModule.timings[0].name === 'pageHide', 'should have pageHide timing')
     t.ok(timingModule.timings[1].name === 'unload', 'should have unload timing')

--- a/tests/browser/timings-lcp.browser.js
+++ b/tests/browser/timings-lcp.browser.js
@@ -37,7 +37,9 @@ jil.browserTest('LCP is not collected on unload when the LCP value occurs after 
     // invoke final harvest, which includes harvesting LCP
     timingModule.finalHarvest()
 
-    t.equals(timingModule.timings.length, 1, 'there should be only one timing')
+    t.equals(timingModule.timings.length, 2, 'there should be only pageHide and unload timings')
+    t.ok(!!timingModule.timings.find(x => x.name === 'pageHide'), 'should have pageHide timing')
+    t.ok(!!timingModule.timings.find(x => x.name === 'unload'), 'should have unload timing')
     t.notEquals(timingModule.timings[0].name, 'lcp')
 
     t.end()

--- a/tests/browser/timings-lcp.browser.js
+++ b/tests/browser/timings-lcp.browser.js
@@ -37,10 +37,10 @@ jil.browserTest('LCP is not collected on unload when the LCP value occurs after 
     // invoke final harvest, which includes harvesting LCP
     timingModule.finalHarvest()
 
-    t.equals(timingModule.timings.length, 2, 'there should be only pageHide and unload timings')
-    t.ok(!!timingModule.timings.find(x => x.name === 'pageHide'), 'should have pageHide timing')
-    t.ok(!!timingModule.timings.find(x => x.name === 'unload'), 'should have unload timing')
-    t.notEquals(timingModule.timings[0].name, 'lcp')
+    console.log('timingModule', timingModule)
+    t.equals(timingModule.timings.length, 2, 'there should be only 2 timings (pageHide and unload)')
+    t.ok(timingModule.timings[0].name === 'pageHide', 'should have pageHide timing')
+    t.ok(timingModule.timings[1].name === 'unload', 'should have unload timing')
 
     t.end()
   }, 1000)

--- a/tests/functional/final-harvest.test.js
+++ b/tests/functional/final-harvest.test.js
@@ -103,7 +103,7 @@ testDriver.test('final harvest sends pageHide if not already recorded', reliable
 })
 
 testDriver.test('final harvest doesnt append pageHide if already previously recorded', reliableFinalHarvest, function (t, browser, router) {
-  let url = router.assetURL('pageHide.html', { loader: 'rum' })
+  let url = router.assetURL('pagehide.html', { loader: 'rum' })
   let loadPromise = browser.safeGet(url).catch(fail)
   let start = Date.now()
 

--- a/tests/functional/final-harvest.test.js
+++ b/tests/functional/final-harvest.test.js
@@ -62,7 +62,6 @@ testDriver.test('final harvest sends page action', reliableFinalHarvest, functio
 })
 
 testDriver.test('final harvest sends pageHide if not already recorded', reliableFinalHarvest, function (t, browser, router) {
-  t.plan(6)
   let url = router.assetURL('final-harvest-timings.html', { loader: 'rum' })
   let loadPromise = browser.safeGet(url).catch(fail)
   let rumPromise = router.expectRum()
@@ -103,7 +102,7 @@ testDriver.test('final harvest sends pageHide if not already recorded', reliable
   }
 })
 
-testDriver.test('final harvest does append pageHide if already previously recorded', reliableFinalHarvest, function (t, browser, router) {
+testDriver.test('final harvest doesnt append pageHide if already previously recorded', reliableFinalHarvest, function (t, browser, router) {
   let url = router.assetURL('pageHide.html', { loader: 'rum' })
   let loadPromise = browser.safeGet(url).catch(fail)
   let start = Date.now()
@@ -116,8 +115,7 @@ testDriver.test('final harvest does append pageHide if already previously record
         const timingsPromise = router.expectTimings()
         return Promise.all([timingsPromise, clickPromise])
       })
-      .then(([timingsResult]) => {
-        const {body, query} = timingsResult
+      .then(([{body, query}]) => {
         const timings = querypack.decode(body && body.length ? body : query.e)
         let duration = Date.now() - start
         t.ok(timings.length > 0, 'there should be at least one timing metric')

--- a/tests/functional/final-harvest.test.js
+++ b/tests/functional/final-harvest.test.js
@@ -103,7 +103,7 @@ testDriver.test('final harvest sends pageHide if not already recorded', reliable
   }
 })
 
-testDriver.test('final harvest does not send pageHide if already recorded', reliableFinalHarvest, function (t, browser, router) {
+testDriver.test('final harvest does append pageHide if already previously recorded', reliableFinalHarvest, function (t, browser, router) {
   let url = router.assetURL('pageHide.html', { loader: 'rum' })
   let loadPromise = browser.safeGet(url).catch(fail)
   let start = Date.now()
@@ -117,21 +117,15 @@ testDriver.test('final harvest does not send pageHide if already recorded', reli
         return Promise.all([timingsPromise, clickPromise])
       })
       .then(([timingsResult]) => {
-        let domPromise = browser
-        .setAsyncScriptTimeout(10000) // the default is too low for IE
-        .get(router.assetURL('/'))
-
-        domPromise.then(() => {
-          const {body, query} = timingsResult
-          const timings = querypack.decode(body && body.length ? body : query.e)
-          let duration = Date.now() - start
-          t.ok(timings.length > 0, 'there should be at least one timing metric')
-          const pageHide = timings.filter(t => t.name === 'pageHide')
-          t.ok(timings && pageHide.length === 1, 'there should be ONLY ONE pageHide timing')
-          t.ok(pageHide[0].value > 0, 'value should be a positive number')
-          t.ok(pageHide[0].value <= duration, 'value should not be larger than time since start of the test')
-          t.end()
-        })
+        const {body, query} = timingsResult
+        const timings = querypack.decode(body && body.length ? body : query.e)
+        let duration = Date.now() - start
+        t.ok(timings.length > 0, 'there should be at least one timing metric')
+        const pageHide = timings.filter(t => t.name === 'pageHide')
+        t.ok(timings && pageHide.length === 1, 'there should be ONLY ONE pageHide timing')
+        t.ok(pageHide[0].value > 0, 'value should be a positive number')
+        t.ok(pageHide[0].value <= duration, 'value should not be larger than time since start of the test')
+        t.end()
       })
       .catch(fail)
 


### PR DESCRIPTION
### Overview
This PR adds a check in the final harvest on `recordUnload` to check for `pageHide`.  If `pageHide` has not already been handled, it adds it before unloading.  This will aid with future CLS queries.

### Related Github Issue
[Issue](https://github.com/newrelic/newrelic-browser-agent/issues/47)