### PR TITLE
Handle max payloads

### DIFF
--- a/agent/harvest-scheduler.js
+++ b/agent/harvest-scheduler.js
@@ -55,7 +55,10 @@ HarvestScheduler.prototype.runHarvest = function runHarvest(opts) {
     var retry = submitMethod.method === submitData.xhr
     var payload = this.opts.getPayload({ retry: retry })
     if (payload) {
-      harvest.send(this.endpoint, this.loader, payload, opts, submitMethod, onHarvestFinished)
+      payload = Array.isArray(payload) ? payload : [payload]
+      for (var i = 0; i < payload.length; i++) {
+        harvest.send(this.endpoint, this.loader, payload[i], opts, submitMethod, onHarvestFinished)
+      }
     }
   } else {
     harvest.sendX(this.endpoint, this.loader, opts, onHarvestFinished)

--- a/feature/xhr/aggregate/index.js
+++ b/feature/xhr/aggregate/index.js
@@ -25,7 +25,7 @@ var sentAjaxEvents = []
 if (!loader.features.xhr) return
 
 var harvestTimeSeconds = config.getConfiguration('ajax.harvestTimeSeconds') || 10
-var MAX_PAYLOAD_SIZE = config.getConfiguration('ajax.maxPayloadSize') || 500
+var MAX_PAYLOAD_SIZE = config.getConfiguration('ajax.maxPayloadSize') || 1000000
 
 baseEE.on('feat-err', function() {
   register('xhr', storeXhr)

--- a/feature/xhr/aggregate/index.js
+++ b/feature/xhr/aggregate/index.js
@@ -24,7 +24,7 @@ var sentAjaxEvents = []
 // bail if not instrumented
 if (!loader.features.xhr) return
 
-var harvestTimeSeconds = config.getConfiguration('ajax.harvestTimeSeconds') || 10
+var harvestTimeSeconds = config.getConfiguration('ajax.harvestTimeSeconds') || 60
 var MAX_PAYLOAD_SIZE = config.getConfiguration('ajax.maxPayloadSize') || 1000000
 
 baseEE.on('feat-err', function() {
@@ -129,62 +129,26 @@ function prepareHarvest(options) {
 
 function getPayload (events, maxPayloadSize, chunks) {
   chunks = chunks || 1
-  var adders = []
-  var ver = 'bel.7;'
   var payload = []
   var chunkSize = events.length / chunks
-  var eventChunks = chunk(events, chunkSize)
-
+  var eventChunks = splitChunks(events, chunkSize)
+  var tooBig = false
   for (var i = 0; i < eventChunks.length; i++) {
-    adders.push(getAddStringContext())
-    payload.push(ver)
     var currentChunk = eventChunks[i]
-
-    for (var j = 0; j < currentChunk.length; j++) {
-      var addString = adders[i]
-      var event = currentChunk[j]
-
-      var fields = [
-        numeric(event.startTime),
-        numeric(event.endTime - event.startTime),
-        numeric(0), // callbackEnd
-        numeric(0), // no callbackDuration for non-SPA events
-        addString(event.method),
-        numeric(event.status),
-        addString(event.domain),
-        addString(event.path),
-        numeric(event.requestSize),
-        numeric(event.responseSize),
-        event.type === 'fetch' ? 1 : '',
-        addString(0), // nodeId
-        nullable(null, addString, true) + // guid
-        nullable(null, addString, true) + // traceId
-        nullable(null, numeric, false) // timestamp
-      ]
-
-      var insert = '2,'
-
-      // add custom attributes
-      var attrParts = addCustomAttributes(loader.info.jsAttributes || {}, addString)
-      fields.unshift(numeric(attrParts.length))
-
-      insert += fields.join(',')
-
-      if (attrParts && attrParts.length > 0) {
-        insert += ';' + attrParts.join(';')
+    if (currentChunk.tooBig(maxPayloadSize)) {
+      if (currentChunk.events.length !== 1) {
+        /* if it is too big BUT it isnt length 1, we can split it down again,
+         else we just want to NOT push it into payload
+         because if it's length 1 and still too big for the maxPayloadSize
+         it cant get any smaller and we dont want to recurse forever */
+        tooBig = true
+        break
       }
-
-      if ((j + 1) < currentChunk.length) insert += ';'
-
-      payload[i] += insert
+    } else {
+      payload.push(currentChunk.payload)
     }
   }
-
-  var tooBig = false
-  for (var x = 0; x < payload.length; x++) {
   // check if the current payload string is too big, if so then run getPayload again with more buckets
-    if (exceedsSizeLimit(payload[x], maxPayloadSize)) tooBig = true
-  }
   return tooBig ? getPayload(events, maxPayloadSize, ++chunks) : payload
 }
 
@@ -195,16 +159,64 @@ function onEventsHarvestFinished(result) {
   }
 }
 
-function exceedsSizeLimit(payload, maxPayloadSize) {
-  maxPayloadSize = maxPayloadSize || MAX_PAYLOAD_SIZE
-  return window.Blob ? new Blob([payload]).size > maxPayloadSize : false
-}
-
-function chunk(arr, chunkSize) {
-  if (chunkSize <= 0) throw new Error('Invalid chunk size')
+function splitChunks(arr, chunkSize) {
+  chunkSize = chunkSize || arr.length
   var chunks = []
   for (var i = 0, len = arr.length; i < len; i += chunkSize) {
-    chunks.push(arr.slice(i, i + chunkSize))
+    var chunk = new Chunk(arr.slice(i, i + chunkSize))
+    chunk.serialize()
+    chunks.push(chunk)
   }
   return chunks
+}
+
+function Chunk (events) {
+  this.addString = getAddStringContext()
+  this.payload = 'bel.7;'
+  this.events = events
+
+  this.serialize = function() {
+    for (var i = 0; i < this.events.length; i++) {
+      var event = this.events[i]
+
+      var fields = [
+        numeric(event.startTime),
+        numeric(event.endTime - event.startTime),
+        numeric(0), // callbackEnd
+        numeric(0), // no callbackDuration for non-SPA events
+        this.addString(event.method),
+        numeric(event.status),
+        this.addString(event.domain),
+        this.addString(event.path),
+        numeric(event.requestSize),
+        numeric(event.responseSize),
+        event.type === 'fetch' ? 1 : '',
+        this.addString(0), // nodeId
+        nullable(null, this.addString, true) + // guid
+        nullable(null, this.addString, true) + // traceId
+        nullable(null, numeric, false) // timestamp
+      ]
+
+      var insert = '2,'
+
+    // add custom attributes
+      var attrParts = addCustomAttributes(loader.info.jsAttributes || {}, this.addString)
+      fields.unshift(numeric(attrParts.length))
+
+      insert += fields.join(',')
+
+      if (attrParts && attrParts.length > 0) {
+        insert += ';' + attrParts.join(';')
+      }
+
+      if ((i + 1) < this.events.length) insert += ';'
+
+      this.payload += insert
+    }
+  }
+
+  this.tooBig = function(maxPayloadSize) {
+    maxPayloadSize = maxPayloadSize || MAX_PAYLOAD_SIZE
+    return this.payload.length * 2 > maxPayloadSize
+  }
 }

--- a/tests/assets/xhr-large-payload.html
+++ b/tests/assets/xhr-large-payload.html
@@ -14,7 +14,7 @@
         function sendHello() {
           console.log("send hello")
           var xhr = new XMLHttpRequest()
-              xhr.open('GET', `/json`)
+              xhr.open('GET', '/json')
               xhr.setRequestHeader('Content-Type', 'text/plain')
               xhr.onload = function (e) {
                   if (count < 50) {

--- a/tests/assets/xhr-large-payload.html
+++ b/tests/assets/xhr-large-payload.html
@@ -12,7 +12,6 @@
     <script type="text/javascript">
         var count = 0;
         function sendHello() {
-          console.log("send hello")
           var xhr = new XMLHttpRequest()
               xhr.open('GET', '/json')
               xhr.setRequestHeader('Content-Type', 'text/plain')
@@ -28,10 +27,6 @@
               sendHello()
         }, 2000)
     </script>
-    <script>
-      
-    
-  </script>
   </head>
   <body>
     This page sends 3000 XHRs after the window has loaded.

--- a/tests/assets/xhr-large-payload.html
+++ b/tests/assets/xhr-large-payload.html
@@ -10,15 +10,11 @@
     {loader}
     {config}
     <script type="text/javascript">
-        var loaded = [];
-        function getRandomNumber(){ Math.floor(Math.random() * 10000) }
         var count = 0;
         function sendHello() {
           console.log("send hello")
           var xhr = new XMLHttpRequest()
-              // const num = getRandomNumber();
               xhr.open('GET', `/json`)
-
               xhr.setRequestHeader('Content-Type', 'text/plain')
               xhr.onload = function (e) {
                   if (count < 50) {
@@ -26,12 +22,11 @@
                       sendHello();
                   }
               }
-
               xhr.send()
         }
         setTimeout(function() {
               sendHello()
-        }, 1000)
+        }, 2000)
     </script>
     <script>
       

--- a/tests/assets/xhr-large-payload.html
+++ b/tests/assets/xhr-large-payload.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>Basic XHR test</title>
+    {init}
+    {loader}
+    {config}
+    <script type="text/javascript">
+        var loaded = [];
+        function getRandomNumber(){ Math.floor(Math.random() * 10000) }
+        var count = 0;
+        function sendHello() {
+          console.log("send hello")
+          var xhr = new XMLHttpRequest()
+              // const num = getRandomNumber();
+              xhr.open('GET', `/json`)
+
+              xhr.setRequestHeader('Content-Type', 'text/plain')
+              xhr.onload = function (e) {
+                  if (count < 50) {
+                      count++
+                      sendHello();
+                  }
+              }
+
+              xhr.send()
+        }
+        setTimeout(function() {
+              sendHello()
+        }, 1000)
+    </script>
+    <script>
+      
+    
+  </script>
+  </head>
+  <body>
+    This page sends 3000 XHRs after the window has loaded.
+    
+  </body>
+</html>

--- a/tests/browser/xhr/ajax-events.browser.js
+++ b/tests/browser/xhr/ajax-events.browser.js
@@ -16,7 +16,7 @@ const getStoredEvents = require('../../../feature/xhr/aggregate/index').getStore
 const prepareHarvest = require('../../../feature/xhr/aggregate/index').prepareHarvest
 
 function exceedsSizeLimit(payload) {
-  return new Blob([payload]).size > loader.maxPayloadSize
+  return window.Blob ? new Blob([payload]).size > loader.maxPayloadSize : false
 }
 
 test('storeXhr for a SPA ajax request buffers in spaAjaxEvents', function (t) {

--- a/tests/browser/xhr/ajax-events.browser.js
+++ b/tests/browser/xhr/ajax-events.browser.js
@@ -15,8 +15,8 @@ const storeXhr = require('../../../feature/xhr/aggregate/index')
 const getStoredEvents = require('../../../feature/xhr/aggregate/index').getStoredEvents
 const prepareHarvest = require('../../../feature/xhr/aggregate/index').prepareHarvest
 
-function exceedsSizeLimit(payload) {
-  return window.Blob ? new Blob([payload]).size > loader.maxPayloadSize : false
+function exceedsSizeLimit(payload, maxPayloadSize) {
+  return payload.length * 2 > maxPayloadSize
 }
 
 test('storeXhr for a SPA ajax request buffers in spaAjaxEvents', function (t) {
@@ -286,7 +286,7 @@ test('prepareHarvest correctly serializes a very large AjaxRequest events payloa
   // we just want to check that the list of AJAX events to be sent contains multiple items because it exceeded the allowed byte limit,
   // and that each list item is smaller than the limit
   t.ok(decodedEvents.length > 1, 'Large Payload of AJAX Events are broken into multiple chunks (' + decodedEvents.length + ')')
-  t.ok(serializedPayload.every(sp => !exceedsSizeLimit(sp)), 'All AJAX chunks are less than the maxPayloadSize property (' + maxPayloadSize + ')')
+  t.ok(serializedPayload.every(sp => !exceedsSizeLimit(sp, maxPayloadSize)), 'All AJAX chunks are less than the maxPayloadSize property (' + maxPayloadSize + ')')
 
   decodedEvents.forEach((payload, idx) => {
     payload.forEach(event => {

--- a/tests/browser/xhr/ajax-events.browser.js
+++ b/tests/browser/xhr/ajax-events.browser.js
@@ -185,35 +185,37 @@ test('prepareHarvest correctly serializes an AjaxRequest events payload', functi
   const serializedPayload = prepareHarvest({retry: false})
   // serializedPayload from ajax comes back as an array of bodies now, so we just need to decode each one and flatten
   // this decoding does not happen elsewhere in the app so this only needs to happen here in this specific test
-  const decodedEvents = serializedPayload.map(sp => qp.decode(sp.body.e)).flat()
+  const decodedEvents = serializedPayload.map(sp => qp.decode(sp.body.e))
 
-  decodedEvents.forEach(event => {
-    t.equal(event.children.length, expectedCustomAttrCount, 'ajax event has expected number of custom attributes')
+  decodedEvents.forEach(payload => {
+    payload.forEach(event => {
+      t.equal(event.children.length, expectedCustomAttrCount, 'ajax event has expected number of custom attributes')
 
     // validate custom attribute values
-    event.children.forEach(attribute => {
-      switch (attribute.type) {
-        case 'stringAttribute':
-        case 'doubleAttribute':
-          t.ok(expectedCustomAttributes[attribute.key] === attribute.value, 'string & num custom attributes encoded')
-          break
-        case 'trueAttribute':
-          t.ok(expectedCustomAttributes[attribute.key] === true, 'true custom attribute encoded')
-          break
-        case 'falseAttribute':
-          t.ok(expectedCustomAttributes[attribute.key] === false, 'false custom attribute encoded')
-          break
-        case 'nullAttribute':
+      event.children.forEach(attribute => {
+        switch (attribute.type) {
+          case 'stringAttribute':
+          case 'doubleAttribute':
+            t.ok(expectedCustomAttributes[attribute.key] === attribute.value, 'string & num custom attributes encoded')
+            break
+          case 'trueAttribute':
+            t.ok(expectedCustomAttributes[attribute.key] === true, 'true custom attribute encoded')
+            break
+          case 'falseAttribute':
+            t.ok(expectedCustomAttributes[attribute.key] === false, 'false custom attribute encoded')
+            break
+          case 'nullAttribute':
           // undefined is treated as null in querypack
-          t.ok(expectedCustomAttributes[attribute.key] === undefined, 'undefined custom attributes encoded')
-          break
-        default:
-          t.fail('unexpected custom attribute type')
-      }
-    })
-    delete event.children
+            t.ok(expectedCustomAttributes[attribute.key] === undefined, 'undefined custom attributes encoded')
+            break
+          default:
+            t.fail('unexpected custom attribute type')
+        }
+      })
+      delete event.children
 
-    t.deepEqual(event, expected, 'event attributes serialized correctly')
+      t.deepEqual(event, expected, 'event attributes serialized correctly')
+    })
   })
 
   // clear ajaxEventsBuffer
@@ -283,7 +285,7 @@ test('prepareHarvest correctly serializes a very large AjaxRequest events payloa
 
   // we just want to check that the list of AJAX events to be sent contains multiple items because it exceeded the allowed byte limit,
   // and that each list item is smaller than the limit
-  t.ok(decodedEvents.length > 1, 'Large Payload of AJAX Events are broken into multiple chunks (' + decodedEvents.length + ') of (' + decodedEvents.flat().length + ') total events')
+  t.ok(decodedEvents.length > 1, 'Large Payload of AJAX Events are broken into multiple chunks (' + decodedEvents.length + ')')
   t.ok(serializedPayload.every(sp => !exceedsSizeLimit(sp)), 'All AJAX chunks are less than the maxPayloadSize property (' + maxPayloadSize + ')')
 
   decodedEvents.forEach((payload, idx) => {

--- a/tests/functional/final-harvest.test.js
+++ b/tests/functional/final-harvest.test.js
@@ -108,24 +108,24 @@ testDriver.test('final harvest doesnt append pageHide if already previously reco
   let start = Date.now()
 
   Promise.all([loadPromise, router.expectRum()])
-      .then(() => {
-        const clickPromise = browser
-          .elementById('btn1').click()
-          .get(router.assetURL('/'))
-        const timingsPromise = router.expectTimings()
-        return Promise.all([timingsPromise, clickPromise])
-      })
-      .then(([{body, query}]) => {
-        const timings = querypack.decode(body && body.length ? body : query.e)
-        let duration = Date.now() - start
-        t.ok(timings.length > 0, 'there should be at least one timing metric')
-        const pageHide = timings.filter(t => t.name === 'pageHide')
-        t.ok(timings && pageHide.length === 1, 'there should be ONLY ONE pageHide timing')
-        t.ok(pageHide[0].value > 0, 'value should be a positive number')
-        t.ok(pageHide[0].value <= duration, 'value should not be larger than time since start of the test')
-        t.end()
-      })
-      .catch(fail)
+    .then(() => {
+      const clickPromise = browser
+        .elementById('btn1').click()
+        .get(router.assetURL('/'))
+      const timingsPromise = router.expectTimings()
+      return Promise.all([timingsPromise, clickPromise])
+    })
+    .then(([{body, query}]) => {
+      const timings = querypack.decode(body && body.length ? body : query.e)
+      let duration = Date.now() - start
+      t.ok(timings.length > 0, 'there should be at least one timing metric')
+      const pageHide = timings.filter(t => t.name === 'pageHide')
+      t.ok(timings && pageHide.length === 1, 'there should be ONLY ONE pageHide timing')
+      t.ok(pageHide[0].value > 0, 'value should be a positive number')
+      t.ok(pageHide[0].value <= duration, 'value should not be larger than time since start of the test')
+      t.end()
+    })
+    .catch(fail)
 
   function fail (err) {
     t.error(err)

--- a/tests/functional/xhr/ajax-events.test.js
+++ b/tests/functional/xhr/ajax-events.test.js
@@ -33,6 +33,45 @@ testDriver.test('capturing XHR ajax events', xhrBrowsers, function (t, browser, 
   }
 })
 
+testDriver.test('capturing large payload of XHR ajax events', xhrBrowsers, function (t, browser, router) {
+  const ajaxPromise = router.expectAjaxEvents()
+  const rumPromise = router.expectRum()
+  const loadPromise = browser.safeGet(router.assetURL('xhr-large-payload.html', {
+    loader: 'spa',
+    init: {
+      ajax: {
+        harvestTimeSeconds: 5,
+        maxPayloadSize: 500
+      }
+    }
+  }))
+
+  let ajaxBundles = 0
+
+  function parseAjaxPromise(response) {
+    const {body, query} = response
+    const decoded = querypack.decode(body && body.length ? body : query.e)
+    const ajaxEvents = decoded.filter(e => e.type === 'ajax' && e.path === '/json')
+    if (ajaxEvents.length) ajaxBundles++
+    console.log('AJAX RESPONSE!', ajaxBundles)
+    if (ajaxBundles < 2) router.expectAjaxEvents().then(r => parseAjaxPromise(r))
+    else {
+      t.ok(ajaxBundles > 1, 'AJAX load is split into multiple payloads and sent')
+      t.end()
+    }
+  }
+
+  Promise.all([ajaxPromise, loadPromise, rumPromise])
+    .then(([response]) => {
+      parseAjaxPromise(response)
+    }).catch(fail)
+
+  function fail (err) {
+    t.error(err)
+    t.end()
+  }
+})
+
 testDriver.test('capturing Fetch ajax events', fetchBrowsers, function (t, browser, router) {
   const ajaxPromise = router.expectAjaxEvents()
   const rumPromise = router.expectRum()

--- a/tests/functional/xhr/ajax-events.test.js
+++ b/tests/functional/xhr/ajax-events.test.js
@@ -53,7 +53,6 @@ testDriver.test('capturing large payload of XHR ajax events', xhrBrowsers, funct
     const decoded = querypack.decode(body && body.length ? body : query.e)
     const ajaxEvents = decoded.filter(e => e.type === 'ajax' && e.path === '/json')
     if (ajaxEvents.length) ajaxBundles++
-    console.log('AJAX RESPONSE!', ajaxBundles)
     if (ajaxBundles < 2) router.expectAjaxEvents().then(r => parseAjaxPromise(r))
     else {
       t.ok(ajaxBundles > 1, 'AJAX load is split into multiple payloads and sent')


### PR DESCRIPTION
_Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

---

### Overview
##### The problem:
* If an app has thousands of AJAX requests in the harvest interval, the body could be too big and lots of data could be dropped.  There is a defined limit that can be placed on the agent.  We can check against that and break up the requests into multiple pieces if needed.

##### The approach:
* Payload is evaluated in the AJAX serialization for size
* Payload is split into array items if exceeds the size limit on the loader
* The harvester loops through all array items in the harvest and sends to NR1 for each.

### Related Github Issue
[GITHUB Card](https://github.com/newrelic/newrelic-browser-agent/projects/1#card-64211355)

### Testing
##### Automated testing is simply ensuring that:
if I add 2,000 requests to the harvest queue, that it breaks it into multiple items in the array, and that each is under the size limit

##### To test this manually, you can:
* Open the mock-bam-server
* paste in these file contents 
```<html>
<head>
  <script type="text/javascript">
    window.NREUM||(NREUM={});

    // agent loaded from a local directory
    // reporting to local fake consumer
    NREUM.info={
      agent:"localhost:8181/agent/dev/spa",
      beacon:"staging-bam.nr-data.net",
      errorBeacon: "staging-bam.nr-data.net",
      licenseKey:"2fec6ab188",
      applicationID:"34824659",
      sa: 1
    };

  </script>
  <script type="text/javascript" src="/loader/dev/spa"></script>
</head>
<body>
  hello
  <script>
      const loaded = [];
      const getRandomNumber = () => Math.floor(Math.random() * 10000)
      let count = 0;
      const sendHello = () => {
        let xhr = new XMLHttpRequest()
            // const num = getRandomNumber();
            xhr.open('GET', `/hello`)

            xhr.setRequestHeader('Content-Type', 'text/plain')
            xhr.onload = function (e) {
                if (count < 3000) {
                    count++
                    sendHello();
                }
            }

            xhr.send()
      }
      setTimeout(() => {
            sendHello()
        }, 250)
    
  </script>
</body>
</html>
```
* run against the file, which calls many ajax requests, and see that request is broken into multiple items and each is sent