### PR TITLE
handle endTime better

### DIFF
--- a/feature/xhr/aggregate/index.js
+++ b/feature/xhr/aggregate/index.js
@@ -75,6 +75,8 @@ function storeXhr(params, metrics, startTime, endTime, type) {
     return
   }
 
+  var useMetrics = startTime === undefined || startTime === null || startTime < 0 || !endTime || endTime < startTime
+
   var event = {
     method: params.method,
     status: params.status,
@@ -83,8 +85,8 @@ function storeXhr(params, metrics, startTime, endTime, type) {
     requestSize: metrics.txSize,
     responseSize: metrics.rxSize,
     type: type,
-    startTime: startTime && endTime ? startTime : metrics.time,
-    endTime: startTime && endTime ? endTime : metrics.time + metrics.duration,
+    startTime: !useMetrics ? startTime : metrics.time,
+    endTime: !useMetrics ? endTime : metrics.time + metrics.duration,
     callbackDuration: metrics.cbTime
   }
 

--- a/feature/xhr/aggregate/index.js
+++ b/feature/xhr/aggregate/index.js
@@ -83,8 +83,8 @@ function storeXhr(params, metrics, startTime, endTime, type) {
     requestSize: metrics.txSize,
     responseSize: metrics.rxSize,
     type: type,
-    startTime: startTime,
-    endTime: endTime,
+    startTime: startTime && endTime ? startTime : metrics.time,
+    endTime: startTime && endTime ? endTime : metrics.time + metrics.duration,
     callbackDuration: metrics.cbTime
   }
 

--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -298,6 +298,7 @@ ee.on('fetch-done', function (err, res) {
 
 // Create report for XHR request that has finished
 function end (xhr) {
+  this.endTime = this.endTime || loader.now()
   var params = this.params
   var metrics = this.metrics
 


### PR DESCRIPTION
### Overview
This PR attempts to address the issue that was observed on Nike.com.  EndTime is sometimes undefined. This made `timeToLoad Event Start` invalid on NR1, and also broke `qp.decode()` on the extension because that prop had NaN instead of a number.

This solution adds a check in the `end` emission, and also adds a check where the event object is made, using timings from the metrics object.  It was a little unclear still where the property was lost, but in all cases the timings still remained on the metric obj, so it should be safe to use as a check condition. Let me know if there's a better way to handle this.

### Testing
You can manually test using the [extension](https://github.com/newrelic-experimental/nr-ba-injector-extension) and the dev build on S3 [here](https://js-agent.newrelic.com/dev/nr-loader-spa.min.js) and going to nike.com, then checking that events decode properly in the console and that AjaxRequest event objects in NR1 have timeToLoad values.