### PR TITLE
Add Span information to non-SPA AjaxRequest events

### DIFF
--- a/feature/xhr/aggregate/index.js
+++ b/feature/xhr/aggregate/index.js
@@ -95,10 +95,9 @@ function storeXhr(params, metrics, startTime, endTime, type) {
   }
 
   if (xhrContext.dt) {
-    event.dt = {}
-    event.dt.spanId = xhrContext.dt.spanId
-    event.dt.traceId = xhrContext.dt.traceId
-    event.dt.timestamp = xhrContext.dt.timestamp
+    event.spanId = xhrContext.dt.spanId
+    event.traceId = xhrContext.dt.traceId
+    event.spanTimestamp = xhrContext.dt.timestamp
   }
 
   // if the ajax happened inside an interaction, hold it until the interaction finishes
@@ -215,9 +214,9 @@ function Chunk (events) {
       numeric(event.responseSize),
       event.type === 'fetch' ? 1 : '',
       this.addString(0), // nodeId
-      nullable(event.dt && event.dt.spanId, this.addString, true) + // guid
-      nullable(event.dt && event.dt.traceId, this.addString, true) + // traceId
-      nullable(event.dt && event.dt.timestamp, numeric, false) // timestamp
+      nullable(event.spanId, this.addString, true) + // guid
+      nullable(event.traceId, this.addString, true) + // traceId
+      nullable(event.spanTimestamp, numeric, false) // timestamp
     ]
 
     var insert = '2,'

--- a/feature/xhr/aggregate/index.js
+++ b/feature/xhr/aggregate/index.js
@@ -79,6 +79,8 @@ function storeXhr(params, metrics, startTime, endTime, type) {
     return
   }
 
+  var xhrContext = this
+
   var event = {
     method: params.method,
     status: params.status,
@@ -90,6 +92,13 @@ function storeXhr(params, metrics, startTime, endTime, type) {
     startTime: startTime,
     endTime: endTime,
     callbackDuration: metrics.cbTime
+  }
+
+  if (xhrContext.dt) {
+    event.dt = {}
+    event.dt.spanId = xhrContext.dt.spanId
+    event.dt.traceId = xhrContext.dt.traceId
+    event.dt.timestamp = xhrContext.dt.timestamp
   }
 
   // if the ajax happened inside an interaction, hold it until the interaction finishes
@@ -206,9 +215,9 @@ function Chunk (events) {
       numeric(event.responseSize),
       event.type === 'fetch' ? 1 : '',
       this.addString(0), // nodeId
-      nullable(null, this.addString, true) + // guid
-        nullable(null, this.addString, true) + // traceId
-        nullable(null, numeric, false) // timestamp
+      nullable(event.dt && event.dt.spanId, this.addString, true) + // guid
+      nullable(event.dt && event.dt.traceId, this.addString, true) + // traceId
+      nullable(event.dt && event.dt.timestamp, numeric, false) // timestamp
     ]
 
     var insert = '2,'

--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -248,6 +248,7 @@ ee.on('fetch-start', function (fetchArguments, dtPayload) {
   this.params = {}
   this.metrics = {}
   this.startTime = loader.now()
+  this.dt = dtPayload
 
   if (fetchArguments.length >= 1) this.target = fetchArguments[0]
   if (fetchArguments.length >= 2) this.opts = fetchArguments[1]

--- a/tests/functional/xhr/ajax-events.test.js
+++ b/tests/functional/xhr/ajax-events.test.js
@@ -99,3 +99,89 @@ testDriver.test('capturing Fetch ajax events', fetchBrowsers, function (t, brows
     t.end()
   }
 })
+
+testDriver.test('Distributed Tracing info is added to XHR ajax events', xhrBrowsers, function (t, browser, router) {
+  const config = {
+    accountID: '1234',
+    agentID: '1',
+    trustKey: '1'
+  }
+
+  const ajaxPromise = router.expectAjaxEvents()
+  const rumPromise = router.expectRum()
+  const loadPromise = browser.safeGet(router.assetURL('xhr-outside-interaction.html', {
+    loader: 'spa',
+    injectUpdatedLoaderConfig: true,
+    config,
+    init: {
+      distributed_tracing: {
+        enabled: true
+      },
+      ajax: {
+        harvestTimeSeconds: 2
+      }
+    }
+  }))
+
+  Promise.all([ajaxPromise, loadPromise, rumPromise])
+    .then(([response]) => {
+      const {body, query} = response
+      const ajaxEvents = querypack.decode(body && body.length ? body : query.e)
+
+      const ajaxEvent = ajaxEvents.find(e => e.type === 'ajax' && e.path === '/json')
+      t.ok(ajaxEvent, 'XMLHttpRequest ajax event was harvested')
+      t.ok(ajaxEvent.guid && ajaxEvent.guid.length > 0, 'should be a non-empty guid string')
+      t.ok(ajaxEvent.traceId && ajaxEvent.traceId.length > 0, 'should be a non-empty traceId string')
+      t.ok(ajaxEvent.timestamp != null && ajaxEvent.timestamp > 0, 'should be a non-zero timestamp')
+
+      t.end()
+    }).catch(fail)
+
+  function fail (err) {
+    t.error(err)
+    t.end()
+  }
+})
+
+testDriver.test('Distributed Tracing info is added to Fetch ajax events', fetchBrowsers, function (t, browser, router) {
+  const config = {
+    accountID: '1234',
+    agentID: '1',
+    trustKey: '1'
+  }
+
+  const ajaxPromise = router.expectAjaxEvents()
+  const rumPromise = router.expectRum()
+  const loadPromise = browser.safeGet(router.assetURL('fetch-outside-interaction.html', {
+    loader: 'spa',
+    injectUpdatedLoaderConfig: true,
+    config,
+    init: {
+      distributed_tracing: {
+        enabled: true
+      },
+      ajax: {
+        harvestTimeSeconds: 2
+      }
+    }
+  }))
+
+  Promise.all([ajaxPromise, loadPromise, rumPromise])
+    .then(([response]) => {
+      const {body} = response
+      const ajaxEvents = querypack.decode(body)
+      const ajaxEvent = ajaxEvents.find(e => e.type === 'ajax' && e.path === '/json')
+
+      t.ok(ajaxEvent, 'Fetch ajax event was harvested')
+      t.ok(ajaxEvent.guid && ajaxEvent.guid.length > 0, 'should be a non-empty guid string')
+      t.ok(ajaxEvent.traceId && ajaxEvent.traceId.length > 0, 'should be a non-empty traceId string')
+      t.ok(ajaxEvent.timestamp != null && ajaxEvent.timestamp > 0, 'should be a non-zero timestamp')
+
+      t.end()
+    }).catch(fail)
+
+  function fail (err) {
+    t.error(err)
+    t.end()
+  }
+})


### PR DESCRIPTION
### Overview
This PR adds the attributes required to generate a Span event from an AjaxRequest event to the payloads of non-SPA AjaxRequest events.

### Testing
Functional tests added to validate span attributes were created correctly 
https://github.com/newrelic/newrelic-browser-agent/blob/7ba7567e79691697f53e8d110f5269b00e0b0571/tests/functional/xhr/ajax-events.test.js