### PR TITLE
update CLS to to max in window of time

### DIFF
--- a/agent/timings.js
+++ b/agent/timings.js
@@ -72,7 +72,8 @@ function init(nr, options) {
 
 function recordLcp() {
   if (!lcpRecorded && lcp !== null) {
-    var lcpEntry = lcp
+    var lcpEntry = lcp[0]
+    var cls = lcp[1]
 
     var attrs = {
       'size': lcpEntry.size,
@@ -90,12 +91,12 @@ function recordLcp() {
 
 function updateLatestLcp(lcpEntry) {
   if (lcp) {
-    var previous = lcp
+    var previous = lcp[0]
     if (previous.size >= lcpEntry.size) {
       return
     }
   }
-  lcp = lcpEntry
+  lcp = [lcpEntry, cls]
 }
 
 function updateClsScore(clsEntry) {

--- a/agent/timings.js
+++ b/agent/timings.js
@@ -22,7 +22,7 @@ var lcpRecorded = false
 var lcp = null
 var clsSupported = false
 var cls = 0
-var nextCls = {value: 0, startedAt: now(), updatedAt: now()}
+var clsSession = {value: 0, firstEntryTime: 0, lastEntryTime: 0}
 var pageHideRecorded = false
 
 module.exports = {
@@ -101,18 +101,18 @@ function updateLatestLcp(lcpEntry) {
 
 function updateClsScore(clsEntry) {
   if (clsSupported) {
-    var n = now()
     // this used to be cumulative for the whole page, now we need to split it to a
     // new CLS measurement after 1s between shifts or 5s total
-    if ((n - nextCls.updatedAt) > 1000 || (n - nextCls.startedAt) > 5000) {
-      nextCls = {value: 0, startedAt: n}
+    if ((clsEntry.startTime - clsSession.lastEntryTime) > 1000 ||
+        (clsEntry.startTime - clsSession.firstEntryTime) > 5000) {
+      clsSession = {value: 0, firstEntryTime: clsEntry.startTime, lastEntryTime: clsEntry.startTime}
     }
 
-    nextCls.value += clsEntry.value
-    nextCls.updatedAt = n
+    clsSession.value += clsEntry.value
+    clsSession.lastEntryTime = Math.max(clsSession.lastEntryTime, clsEntry.startTime)
 
     // only keep the biggest CLS we've observed
-    if (cls < nextCls.value) cls = nextCls.value
+    if (cls < clsSession.value) cls = clsSession.value
   }
 }
 

--- a/tests/assets/cls-multiple-big-then-small.html
+++ b/tests/assets/cls-multiple-big-then-small.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {config}
+    {loader}
+  </head>
+  <body>
+    <div id="initial">THIS IS A CLS PAGE THAT INSERTS IN MULTIPLE CHUNKS</div>
+
+    <script>
+
+      window.cls = cls = 0
+      window.nextCls = nextCls = {value: 0, startedAt: performance.now(), updatedAt: performance.now()}
+      window.allCls = allCls = []
+      window.addEventListener('load', run)
+
+      function run() {
+        // when not delayed, the CLS entry is seen as having recent input
+        // not sure why that it, it only happens in Selenium
+        setTimeout(triggerCls, 6000)
+        setTimeout(triggerBigCls, 600)
+      }
+
+      function triggerCls() {
+        var newDiv = document.createElement("div")
+        newDiv.id = 'clsText'
+        newDiv.innerText = 'inserted text'
+        document.body.insertBefore(newDiv, document.body.firstChild)
+      }
+
+      function triggerBigCls(reps) {
+        reps = reps || 1
+        if (reps < 20){
+          var newDiv = document.createElement("div")
+          newDiv.id = 'bigClsText' + reps
+          newDiv.innerText = 'inserted text ' + reps
+          document.body.insertBefore(newDiv, document.body.firstChild)
+          setTimeout(function(){
+            triggerBigCls(reps+1)
+          }, 50, reps)
+        } else {
+          allCls.push(nextCls.value)
+          window.contentAdded = true
+        }
+      }
+
+      clsPerformanceObserver = new PerformanceObserver(clsObserver) // eslint-disable-line no-undef
+      try {
+        clsPerformanceObserver.observe({type: 'layout-shift', buffered: true})
+      } catch (e) {}
+
+      function clsObserver(list){
+          list.getEntries().forEach(function(clsEntry) {
+          if (!clsEntry.hadRecentInput) {
+            var n = performance.now()
+            // this used to be cumulative for the whole page, now we need to split it to a
+            // new CLS measurement after 1s between shifts or 5s total
+            if ((n - nextCls.updatedAt) > 1000 || (n - nextCls.startedAt) > 5000) {
+              allCls.push(cls)
+              nextCls = {value: 0, startedAt: n}
+            }
+            nextCls.value += clsEntry.value
+            nextCls.updatedAt = n
+            if (cls < nextCls.value) cls = nextCls.value
+          }
+        })
+      }
+    </script>
+  </body>
+</html>

--- a/tests/assets/cls-multiple-small-then-big.html
+++ b/tests/assets/cls-multiple-small-then-big.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {config}
+    {loader}
+  </head>
+  <body>
+    <div id="initial">THIS IS A CLS PAGE THAT INSERTS IN MULTIPLE CHUNKS</div>
+
+    <script>
+
+      window.cls = cls = 0
+      window.nextCls = nextCls = {value: 0, startedAt: performance.now(), updatedAt: performance.now()}
+      window.allCls = allCls = []
+      window.addEventListener('load', run)
+
+      function run() {
+        // when not delayed, the CLS entry is seen as having recent input
+        // not sure why that it, it only happens in Selenium
+        setTimeout(triggerCls, 600)
+        setTimeout(triggerBigCls, 6000)
+      }
+
+      function triggerCls() {
+        var newDiv = document.createElement("div")
+        newDiv.id = 'clsText'
+        newDiv.innerText = 'inserted text'
+        document.body.insertBefore(newDiv, document.body.firstChild)
+      }
+
+      function triggerBigCls(reps) {
+        reps = reps || 1
+        if (reps < 20){
+          var newDiv = document.createElement("div")
+          newDiv.id = 'bigClsText' + reps
+          newDiv.innerText = 'inserted text ' + reps
+          document.body.insertBefore(newDiv, document.body.firstChild)
+          setTimeout(function(){
+            triggerBigCls(reps+1)
+          }, 50, reps)
+        } else {
+          allCls.push(nextCls.value)
+          window.contentAdded = true
+        }
+      }
+
+      clsPerformanceObserver = new PerformanceObserver(clsObserver) // eslint-disable-line no-undef
+      try {
+        clsPerformanceObserver.observe({type: 'layout-shift', buffered: true})
+      } catch (e) {}
+
+      function clsObserver(list){
+          list.getEntries().forEach(function(clsEntry) {
+          if (!clsEntry.hadRecentInput) {
+            var n = performance.now()
+            // this used to be cumulative for the whole page, now we need to split it to a
+            // new CLS measurement after 1s between shifts or 5s total
+            if ((n - nextCls.updatedAt) > 1000 || (n - nextCls.startedAt) > 5000) {
+              allCls.push(cls)
+              nextCls = {value: 0, startedAt: n}
+            }
+            nextCls.value += clsEntry.value
+            nextCls.updatedAt = n
+            if (cls < nextCls.value) cls = nextCls.value
+          }
+        })
+      }
+    </script>
+  </body>
+</html>

--- a/tests/browser/timings-lcp-cls.test.js
+++ b/tests/browser/timings-lcp-cls.test.js
@@ -35,8 +35,24 @@ jil.browserTest('LCP event with CLS attribute', supported, function (t) {
   // invoke final harvest, which includes harvesting LCP
   timingModule.finalHarvest()
 
-  var timing = timingModule.timings.find(t => t.name === 'lcp')
+  var timing = find(timingModule.timings, function(t) {
+    return t.name === 'lcp'
+  })
+
   t.equal(timing.attrs.cls, 1, 'CLS value should be the one present at the time LCP happened')
 
   t.end()
 })
+
+function find(arr, fn) {
+  if (arr.find) {
+    return arr.find(fn)
+  }
+  var match = null
+  arr.forEach(function(t) {
+    if (fn(t)) {
+      match = t
+    }
+  })
+  return match
+}

--- a/tests/browser/timings-lcp-cls.test.js
+++ b/tests/browser/timings-lcp-cls.test.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const jil = require('jil')
+const matcher = require('../../tools/jil/util/browser-matcher')
+
+let supported = matcher.withFeature('wrappableAddEventListener')
+
+jil.browserTest('LCP event with CLS attribute', supported, function (t) {
+  var handle = require('handle')
+  var harvest = require('../../agent/harvest')
+  var timingModule = require('../../agent/timings')
+  var drain = require('../../agent/drain')
+
+  // override harvest calls, so that no network calls are made
+  harvest.send = function() {
+    return {}
+  }
+
+  var mockLoader = {
+    info: {}
+  }
+
+  timingModule.init(mockLoader, {})
+
+  // drain adds `timing` and `lcp` event listeners in the agent/timings module
+  drain('feature')
+
+  handle('cls', [{ value: 1 }])
+  handle('lcp', [{ size: 1, startTime: 1 }])
+  handle('cls', [{ value: 2 }])
+
+  // invoke final harvest, which includes harvesting LCP
+  timingModule.finalHarvest()
+
+  var timing = timingModule.timings.find(t => t.name === 'lcp')
+  t.equal(timing.attrs.cls, 1, 'CLS value should be the one present at the time LCP happened')
+
+  t.end()
+})

--- a/tests/browser/timings-lcp.test.js
+++ b/tests/browser/timings-lcp.test.js
@@ -8,12 +8,12 @@ const matcher = require('../../tools/jil/util/browser-matcher')
 
 let supported = matcher.withFeature('wrappableAddEventListener')
 
-var handle = require('handle')
-var harvest = require('../../agent/harvest')
-var timingModule = require('../../agent/timings')
-var drain = require('../../agent/drain')
-
 jil.browserTest('LCP is not collected on unload when the LCP value occurs after max timeout', supported, function (t) {
+  var handle = require('handle')
+  var harvest = require('../../agent/harvest')
+  var timingModule = require('../../agent/timings')
+  var drain = require('../../agent/drain')
+
   // override harvest calls, so that no network calls are made
   harvest.send = function() {
     return {}

--- a/tests/browser/timings.test.js
+++ b/tests/browser/timings.test.js
@@ -9,7 +9,6 @@ const matcher = require('../../tools/jil/util/browser-matcher')
 let supported = matcher.withFeature('wrappableAddEventListener')
 var qp = require('@newrelic/nr-querypack')
 
-
 if (process.browser) {
   let helpers = require('./spa/helpers')
   var loaded = false

--- a/tests/browser/timings.test.js
+++ b/tests/browser/timings.test.js
@@ -9,7 +9,6 @@ const matcher = require('../../tools/jil/util/browser-matcher')
 let supported = matcher.withFeature('wrappableAddEventListener')
 var qp = require('@newrelic/nr-querypack')
 
-var timing = require('../../agent/timings')
 
 if (process.browser) {
   let helpers = require('./spa/helpers')
@@ -244,6 +243,7 @@ function waitForWindowLoad (fn) {
 }
 
 jil.browserTest('spa interaction serializer attributes', supported, function (t) {
+  var timing = require('../../agent/timings')
   var schema = qp.schemas['bel.6']
 
   waitForWindowLoad(startTest)
@@ -262,6 +262,7 @@ jil.browserTest('spa interaction serializer attributes', supported, function (t)
 })
 
 jil.browserTest('spa interaction serializer attributes', supported, function (t) {
+  var timing = require('../../agent/timings')
   waitForWindowLoad(startTest)
 
   function startTest () {

--- a/tests/functional/timings.test.js
+++ b/tests/functional/timings.test.js
@@ -46,7 +46,6 @@ testDriver.test('Disabled timings feature', reliableFinalHarvest, function (t, b
       t.equal(router.seenRequests.events, 0, 'no events harvest yet')
 
       let domPromise = browser
-        .setAsyncScriptTimeout(10000) // the default is too low for IE
         .elementById('standardBtn')
         .click()
         .get(router.assetURL('/'))
@@ -537,7 +536,7 @@ function runClsTests(loader) {
         const domPromise = browser
           .elementById('btn1')
           .click()
-          .waitForConditionInBrowser('window.contentAdded === true')
+          .waitForConditionInBrowser('window.contentAdded === true', 10000)
           .get(router.assetURL('/'))
 
         const timingsPromise = router.expectTimings()
@@ -578,11 +577,9 @@ function runClsTests(loader) {
       .then(([timingsResult, domResult, loadResult]) => {
         const {body, query} = timingsResult
         const timings = querypack.decode(body && body.length ? body : query.e)
-        const timing = timings.find(t => t.name === 'lcp')
+
+        const timing = timings.find(t => t.name === 'unload')
         const cls = timing.attributes.find(a => a.key === 'cls')
-        console.log('CLS COULD BE ANY OF:', loadResult)
-        console.log('CLS SHOULD BE:', Math.max(...loadResult))
-        console.log('CLS ACTUALLY IS:', cls.value)
         t.ok(cls.value >= 0, 'cls is a non-negative value')
         t.ok(cls.value === Math.max(...loadResult), 'CLS is set to the largest CLS session')
         t.equal(cls.type, 'doubleAttribute', 'cls is doubleAttribute')
@@ -613,18 +610,17 @@ function runClsTests(loader) {
       .then(([timingsResult, domResult, loadResult]) => {
         const {body, query} = timingsResult
         const timings = querypack.decode(body && body.length ? body : query.e)
+
         const load = timings.find(t => t.name === 'load')
         const loadCls = load.attributes.find(a => a.key === 'cls')
         t.ok(loadCls.value === 0, 'initial CLS is 0')
         t.equal(loadCls.type, 'doubleAttribute', 'cls is doubleAttribute')
-        const lcp = timings.find(t => t.name === 'lcp')
-        const lcpCls = lcp.attributes.find(a => a.key === 'cls')
-        console.log('new CLS COULD BE ANY OF:', loadResult)
-        console.log('new CLS SHOULD BE:', Math.max(...loadResult))
-        console.log('new CLS ACTUALLY IS:', lcpCls.value)
-        t.ok(lcpCls.value >= 0, 'cls is a non-negative value')
-        t.ok(lcpCls.value === Math.max(...loadResult), 'CLS is set to the largest CLS session')
-        t.equal(lcpCls.type, 'doubleAttribute', 'cls is doubleAttribute')
+
+        const unload = timings.find(t => t.name === 'unload')
+        const unloadCls = unload.attributes.find(a => a.key === 'cls')
+        t.ok(unloadCls.value >= 0, 'cls is a non-negative value')
+        t.ok(unloadCls.value === Math.max(...loadResult), 'CLS is set to the largest CLS session')
+        t.equal(unloadCls.type, 'doubleAttribute', 'cls is doubleAttribute')
 
         t.end()
       })

--- a/tools/jil/runner/index.js
+++ b/tools/jil/runner/index.js
@@ -77,10 +77,10 @@ function loadDefaultFiles (cb) {
 function loadFiles (testFiles, cb) {
   for (let file of testFiles) {
     file = resolve(process.cwd(), file)
-    if (file.slice(-11) !== '.browser.js') {
-      require(file)
-    } else {
+    if (file.slice(-11) === '.browser.js') {
       loadBrowser(testDriver, file)
+    } else if (file.slice(-8) === '.test.js') {
+      require(file)
     }
   }
 


### PR DESCRIPTION
### Overview
This PR modifies the way CLS is calculated to include looking at windows of time, and taking the maximum. CLS used to be cumulative for the whole page, however now we need to split it to look at a new CLS measurement after 1s between shifts or 5s total, and only keep the biggest one.

### Related Github Issue
[Issue](https://github.com/newrelic/newrelic-browser-agent/issues/105)