### PR TITLE
update to use forked repo for label changer

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: remove labels
-        uses: andymckay/labeler@master
+        uses: newrelic/labeler@master
         with:
           remove-labels: "safe to test"          

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This is a change to test if the labeler works.
-
 [![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 # New Relic Browser agent

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a change to test if the labeler works.
+
 [![Community Plus header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Plus.png)](https://opensource.newrelic.com/oss-category/#community-plus)
 
 # New Relic Browser agent


### PR DESCRIPTION

### Overview
This PR points to the forked repo for the labeler, which has a change to address the issue that prevented labels from changing automatically on PRs

### Testing
This should remove the `safe to test` label when a new commit is made.
