### PR TITLE
Prevent recording LCP after pageHide

### DIFF
--- a/loader/timings.js
+++ b/loader/timings.js
@@ -15,6 +15,7 @@ var loader = require('loader')
 var subscribeToVisibilityChange = require('visibility')
 
 var origEvent = NREUM.o.EV
+var pageHiddenTime
 
 // paint metrics
 function perfObserver(list, observer) {
@@ -32,7 +33,10 @@ function perfObserver(list, observer) {
 function lcpObserver(list, observer) {
   var entries = list.getEntries()
   if (entries.length > 0) {
-    handle('lcp', [entries[entries.length - 1]])
+    var entry = entries[entries.length - 1]
+
+    if (pageHiddenTime && pageHiddenTime < entry.startTime) return
+    handle('lcp', [entry])
   }
 }
 
@@ -102,6 +106,7 @@ subscribeToVisibilityChange(captureVisibilityChange)
 
 function captureVisibilityChange(state) {
   if (state === 'hidden') {
-    handle('pageHide', [loader.now()])
+    pageHiddenTime = loader.now()
+    handle('pageHide', [pageHiddenTime])
   }
 }

--- a/tests/assets/lcp-pagehide.html
+++ b/tests/assets/lcp-pagehide.html
@@ -7,15 +7,7 @@
   <head>
     <title>RUM Unit Test</title>
     {config}
-    <script>
-      NREUM.init = {
-        page_view_timing: {
-          enabled: true,
-          harvestTimeSeconds: 15,
-          maxLCPTimeSeconds: 2
-        }
-      }
-    </script>
+    {init}
     {loader}
   </head>
   <body>

--- a/tests/assets/lcp-pagehide.html
+++ b/tests/assets/lcp-pagehide.html
@@ -7,6 +7,15 @@
   <head>
     <title>RUM Unit Test</title>
     {config}
+    <script>
+      NREUM.init = {
+        page_view_timing: {
+          enabled: true,
+          harvestTimeSeconds: 15,
+          maxLCPTimeSeconds: 2
+        }
+      }
+    </script>
     {loader}
   </head>
   <body>
@@ -16,7 +25,6 @@
       setTimeout(function () {
         simulatePageHide()
         addLargerElement()
-        window.contentAdded = true
       }, 1000)
 
       function addLargerElement() {

--- a/tests/assets/lcp-pagehide.html
+++ b/tests/assets/lcp-pagehide.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {config}
+    {loader}
+  </head>
+  <body>
+    <div id="initial-content">initial content</div>    
+
+    <script>
+      setTimeout(function () {
+        simulatePageHide()
+        addLargerElement()
+        window.contentAdded = true
+      }, 1000)
+
+      function addLargerElement() {
+        var div = document.createElement("div")
+        div.innerText = 'larger element!!!!!!!!!!'
+        div.id = 'post-load-element'
+        document.body.insertBefore(div, document.body.firstChild)
+      }
+
+      // simulate page hide by dispatching the event manually
+      function simulatePageHide() {
+        Object.defineProperty(document, 'visibilityState', {value: 'visible', writable: true})
+        document.visibilityState = 'hidden'
+        document.dispatchEvent(new Event("visibilitychange"))
+      }
+    </script>
+  </body>
+</html>

--- a/tests/functional/timings.test.js
+++ b/tests/functional/timings.test.js
@@ -35,6 +35,8 @@ runClsTests('spa')
 runClsTests('rum')
 runCustomAttributeTests('spa')
 runCustomAttributeTests('rum')
+runLcpTests('rum')
+runLcpTests('spa')
 
 testDriver.test('Disabled timings feature', reliableFinalHarvest, function (t, browser, router) {
   let url = router.assetURL('final-harvest-page-view-timings-disabled.html', { loader: 'rum' })
@@ -676,6 +678,48 @@ function runCustomAttributeTests(loader) {
 
     function fail (err) {
       t.error(err)
+      t.end()
+    }
+  })
+}
+
+function runLcpTests (loader) {
+  testDriver.test('LCP is not collected after pageHide', testPageHide.and(supportedLcp), function (t, browser, router) {
+    const assetURL = router.assetURL('lcp-pagehide.html', {
+      loader: loader,
+      init: {
+        page_view_timing: {
+          enabled: true,
+          harvestTimeSeconds: 2,
+          maxLCPTimeSeconds: 20
+        }
+      }
+    })
+
+    const rumPromise = router.expectRum()
+    const loadPromise = browser.safeGet(assetURL)
+
+    Promise.all([rumPromise, loadPromise])
+      .then(() => {
+        const domPromise = browser.waitForConditionInBrowser('window.contentAdded === true', 10000)
+        const timingsPromise = router.expectTimings()
+
+        return Promise.all([timingsPromise, domPromise])
+      })
+      .then(([timingsResult]) => {
+        const {body, query} = timingsResult
+        const timings = querypack.decode(body && body.length ? body : query.e)
+        const timing = timings.find(t => t.name === 'lcp')
+        const elementId = timing.attributes.find(a => a.key === 'eid')
+
+        t.equals(elementId.value, 'initial-content', 'LCP captured the pre-pageHide attribute')
+
+        t.end()
+      })
+      .catch(fail)
+
+    function fail (e) {
+      t.error(e)
       t.end()
     }
   })

--- a/tests/functional/timings.test.js
+++ b/tests/functional/timings.test.js
@@ -692,7 +692,7 @@ function runLcpTests (loader) {
         page_view_timing: {
           enabled: true,
           harvestTimeSeconds: 15,
-          // maxLCPTimeSeconds: 2
+          maxLCPTimeSeconds: 2
         }
       }
     })
@@ -707,6 +707,7 @@ function runLcpTests (loader) {
       .then((timingsResult) => {
         const {body, query} = timingsResult
         const timings = querypack.decode(body && body.length ? body : query.e)
+
         const timing = timings.find(t => t.name === 'lcp')
         t.ok(timing, 'found an LCP timing')
         t.ok(timing.attributes, 'LCP has attributes')


### PR DESCRIPTION
### Overview
Google's WebVital library does not record LCP values after the page has been hidden. This PR updates the way we capture LCP to align with that behavior.

### Related Github Issue
https://github.com/newrelic/newrelic-browser-agent/issues/66

### Testing
A functional has been added to validate that LCP events emitted after a pageHide are not captured.