### PR TITLE
cb function cannot be null or wrapper throws internal error

### DIFF
--- a/loader/event-listener-opts.js
+++ b/loader/event-listener-opts.js
@@ -1,4 +1,3 @@
-
 var supportsPassive = false
 try {
   var opts = Object.defineProperty({}, 'passive', {
@@ -6,8 +5,8 @@ try {
       supportsPassive = true
     }
   })
-  window.addEventListener('testPassive', null, opts)
-  window.removeEventListener('testPassive', null, opts)
+  window.addEventListener('testPassive', function() {}, opts)
+  window.removeEventListener('testPassive', function() {}, opts)
 } catch (e) {}
 
 module.exports = function(useCapture) {


### PR DESCRIPTION
This PR addresses an internal bug that was generating ierr objects.  It was expecting `addEventListener` to provide a callback `function`, while it was supplying `null`.  This just changes the compatibility test to provide a callback `function` and should cease the ierr generation.