### PR TITLE
Handle addEventListener with null function argument

### DIFF
--- a/feature/wrap-events.js
+++ b/feature/wrap-events.js
@@ -25,6 +25,9 @@ if ('getPrototypeOf' in Object) {
 
 ee.on(ADD_EVENT_LISTENER + '-start', function (args, target) {
   var originalListener = args[1]
+  if (typeof originalListener !== 'function') {
+    return
+  }
 
   var wrapped = getOrSet(originalListener, 'nr@wrapped', function () {
     var listener = {

--- a/feature/wrap-events.js
+++ b/feature/wrap-events.js
@@ -25,7 +25,9 @@ if ('getPrototypeOf' in Object) {
 
 ee.on(ADD_EVENT_LISTENER + '-start', function (args, target) {
   var originalListener = args[1]
-  if (typeof originalListener !== 'function') {
+  if (originalListener === null ||
+    (typeof originalListener !== 'function' && typeof originalListener !== 'object')
+  ) {
     return
   }
 

--- a/loader/event-listener-opts.js
+++ b/loader/event-listener-opts.js
@@ -5,8 +5,8 @@ try {
       supportsPassive = true
     }
   })
-  window.addEventListener('testPassive', function() {}, opts)
-  window.removeEventListener('testPassive', function() {}, opts)
+  window.addEventListener('testPassive', null, opts)
+  window.removeEventListener('testPassive', null, opts)
 } catch (e) {}
 
 module.exports = function(useCapture) {


### PR DESCRIPTION
### Overview
External code can pass in null as the second argument to the addEventListener method. When this happens, the agent throws an internal error. This change adds a check to protect against that.

This was discovered by testing with Vue, which uses the following to check if the browser supports passive listener.
https://github.com/vuejs/vue/blob/0603ff695d2f41286239298210113cbe2b209e28/src/core/util/env.js#L33

The agent also has a similar check, which was passing in a noop function. I changed this to null, since it is now being handled.