### PR TITLE
Fix for matching domain in Ajax deny list

### DIFF
--- a/feature/xhr/aggregate/deny-list.js
+++ b/feature/xhr/aggregate/deny-list.js
@@ -16,7 +16,7 @@ function shouldCollectEvent(params) {
     if (parsed.hostname === '*') {
       return false
     }
-    if (compareDomain(parsed.hostname, params.hostname) &&
+    if (domainMatchesPattern(parsed.hostname, params.hostname) &&
         comparePath(parsed.pathname, params.pathname)) {
       return false
     }
@@ -51,7 +51,12 @@ function setDenyList(denyListConfig) {
   }
 }
 
-function compareDomain(pattern, domain) {
+// returns true if the right side of the domain matches the pattern
+function domainMatchesPattern(pattern, domain) {
+  if (pattern.length > domain.length) {
+    return false
+  }
+
   if (domain.indexOf(pattern) === (domain.length - pattern.length)) {
     return true
   }

--- a/tests/browser/xhr/deny-list.browser.js
+++ b/tests/browser/xhr/deny-list.browser.js
@@ -25,6 +25,8 @@ test('domain-only blocks all subdomains and all paths', function(t) {
   t.equals(shouldCollectEvent(parseUrl('http://a.b.foo.com')), false)
   t.equals(shouldCollectEvent(parseUrl('http://a.b.foo.com/c/d')), false)
 
+  t.equals(shouldCollectEvent(parseUrl('http://oo.com')), true, 'regression for length comparison')
+
   // other domains are allowed
   t.equals(shouldCollectEvent(parseUrl('http://bar.com')), true)
 


### PR DESCRIPTION
### Overview
The logic for comparing domains did not work for one edge case - when the domain did not match the pattern (indexOf returning -1) and domain length was one character smaller than the pattern, then the result was evaluated as a match.