### PR TITLE
Supportability metrics for excluded Ajax events

### DIFF
--- a/feature/xhr/aggregate/index.js
+++ b/feature/xhr/aggregate/index.js
@@ -19,6 +19,7 @@ var HarvestScheduler = require('../../../agent/harvest-scheduler')
 var setDenyList = require('./deny-list').setDenyList
 var shouldCollectEvent = require('./deny-list').shouldCollectEvent
 var subscribeToUnload = require('../../../agent/unload')
+var recordSupportability = require('metrics').recordSupportability
 
 var ajaxEvents = []
 var spaAjaxEvents = {}
@@ -77,7 +78,16 @@ function storeXhr(params, metrics, startTime, endTime, type) {
   // store as metric
   agg.store('xhr', hash, params, metrics)
 
-  if (!shouldCollectEvent(params) || !allAjaxIsEnabled()) {
+  if (!allAjaxIsEnabled()) {
+    return
+  }
+
+  if (!shouldCollectEvent(params)) {
+    if (params.hostname === loader.info.errorBeacon) {
+      recordSupportability('Ajax/Events/Excluded/Agent')
+    } else {
+      recordSupportability('Ajax/Events/Excluded/App')
+    }
     return
   }
 


### PR DESCRIPTION
### Overview
Adding two supportability metrics for tracking ajax events that were excluded because of the deny list -

* `Ajax/Events/Excluded/App` for events generated by the application (excludes agent calls)
* `Ajax/Events/Excluded/Agent` for events generated by the agent

The reason there are two metrics is because the deny list by default contains the domain that the agent sends data to. Having these two metrics allows to verify the correct default behavior as well as detect changes in the deny list.
