### PR TITLE
Add element identifying attributes to LCP

### DIFF
--- a/agent/timings.js
+++ b/agent/timings.js
@@ -15,6 +15,7 @@ var harvest = require('./harvest')
 var HarvestScheduler = require('./harvest-scheduler')
 var register = require('./register-handler')
 var subscribeToUnload = require('./unload')
+var cleanURL = require('./clean-url')
 
 var timings = []
 var timingsSent = []
@@ -79,6 +80,11 @@ function recordLcp() {
       'size': lcpEntry.size,
       'eid': lcpEntry.id
     }
+
+    if (lcpEntry.url) {
+      attrs['url'] = cleanURL(lcpEntry.url)
+    }
+
     // collect 0 only when CLS is supported, since 0 is a valid score
     if (cls > 0 || clsSupported) {
       attrs['cls'] = cls

--- a/agent/timings.js
+++ b/agent/timings.js
@@ -85,6 +85,10 @@ function recordLcp() {
       attrs['url'] = cleanURL(lcpEntry.url)
     }
 
+    if (lcpEntry.element && lcpEntry.element.tagName) {
+      attrs['tag'] = lcpEntry.element.tagName
+    }
+
     // collect 0 only when CLS is supported, since 0 is a valid score
     if (cls > 0 || clsSupported) {
       attrs['cls'] = cls

--- a/tests/browser/timings-lcp-attributes.test.js
+++ b/tests/browser/timings-lcp-attributes.test.js
@@ -28,7 +28,7 @@ jil.browserTest('sends expected attributes when available', supported, function(
     maxLCPTimeSeconds: 0.5
   })
 
-  // timingModule.init(mockLoader)
+  timingModule.init(mockLoader)
 
   // drain adds `timing` and `lcp` event listeners in the agent/timings module
   drain('feature')
@@ -38,7 +38,10 @@ jil.browserTest('sends expected attributes when available', supported, function(
     size: 123,
     startTime: 1,
     id: 'some-element-id',
-    url: 'http://foo.com/a/b?c=1#2'
+    url: 'http://foo.com/a/b?c=1#2',
+    element: {
+      tagName: 'IMG'
+    }
   }])
 
   setTimeout(function() {
@@ -49,6 +52,7 @@ jil.browserTest('sends expected attributes when available', supported, function(
     t.equal(attributes.eid, 'some-element-id', 'eid should be present')
     t.equal(attributes.size, 123, 'size should be present')
     t.equal(attributes.url, 'http://foo.com/a/b', 'url should be present')
+    t.equal(attributes.tag, 'IMG', 'element.tagName should be present')
 
     t.end()
   }, 1000)

--- a/tests/browser/timings-lcp-attributes.test.js
+++ b/tests/browser/timings-lcp-attributes.test.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const jil = require('jil')
+const matcher = require('../../tools/jil/util/browser-matcher')
+
+let supported = matcher.withFeature('wrappableAddEventListener')
+
+jil.browserTest('sends expected attributes when available', supported, function(t) {
+  var handle = require('handle')
+  var harvest = require('../../agent/harvest')
+  var timingModule = require('../../agent/timings')
+  var drain = require('../../agent/drain')
+
+  // override harvest calls, so that no network calls are made
+  harvest.send = function() {
+    return {}
+  }
+
+  var mockLoader = {
+    info: {}
+  }
+
+  // timeout causes LCP to be added to the queue of timings for next harvest
+  timingModule.init(mockLoader, {
+    maxLCPTimeSeconds: 0.5
+  })
+
+  // timingModule.init(mockLoader)
+
+  // drain adds `timing` and `lcp` event listeners in the agent/timings module
+  drain('feature')
+
+  // simulate LCP observed
+  handle('lcp', [{
+    size: 123,
+    startTime: 1,
+    id: 'some-element-id',
+    url: 'http://foo.com/a/b?c=1#2'
+  }])
+
+  setTimeout(function() {
+    t.equals(timingModule.timings.length, 1, 'there should be only 2 timings (pageHide and unload)')
+    t.ok(timingModule.timings[0].name === 'lcp', 'lcp should be present')
+
+    const attributes = timingModule.timings[0].attrs
+    t.equal(attributes.eid, 'some-element-id', 'eid should be present')
+    t.equal(attributes.size, 123, 'size should be present')
+    t.equal(attributes.url, 'http://foo.com/a/b', 'url should be present')
+
+    t.end()
+  }, 1000)
+})

--- a/tests/functional/timings.test.js
+++ b/tests/functional/timings.test.js
@@ -167,7 +167,7 @@ function runFirstInteractionTests(loader) {
 
 function runLargestContentfulPaintFromInteractionTests(loader) {
   testDriver.test(`Largest Contentful Paint from first interaction event for ${loader} agent`, supportedLcp, function (t, browser, router) {
-    t.plan(7)
+    t.plan(9)
     const rumPromise = router.expectRum()
     const loadPromise = browser.safeGet(router.assetURL('basic-click-tracking.html', { loader: loader }))
 
@@ -193,7 +193,12 @@ function runLargestContentfulPaintFromInteractionTests(loader) {
         var size = timing.attributes.find(a => a.key === 'size')
         t.ok(size.value > 0, 'size is a non-negative value')
         t.equal(size.type, 'doubleAttribute', 'largestContentfulPaint attribute size is doubleAttribute')
-        t.equal(timing.attributes.length, 3, 'largestContentfulPaint has two attributes')
+
+        var tagName = timing.attributes.find(a => a.key === 'tag')
+        t.equal(tagName.value, 'BUTTON', 'element.tagName is present and correct')
+        t.equal(size.type, 'doubleAttribute', 'largestContentfulPaint attribute elementTagName is stringAttribute')
+
+        t.equal(timing.attributes.length, 4, 'largestContentfulPaint has two attributes')
 
         t.end()
       })


### PR DESCRIPTION
### Overview
This PR adds the [image URL](https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint/url) (for LCP triggered by images) and [element.tagName](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName) attributes to LCP PageViewTiming events.

### Related Github Issue
https://github.com/newrelic/newrelic-browser-agent/issues/145

### Testing
Unit test was added to validate the new attributes are sent.
