### PR TITLE
Add NetworkInformation attributes to LCP & FI

### DIFF
--- a/agent/timings.js
+++ b/agent/timings.js
@@ -25,6 +25,7 @@ var clsSupported = false
 var cls = 0
 var clsSession = {value: 0, firstEntryTime: 0, lastEntryTime: 0}
 var pageHideRecorded = false
+var networkInformation = null
 
 module.exports = {
   getPayload: getPayload,
@@ -55,6 +56,7 @@ function init(nr, options) {
   register('lcp', updateLatestLcp)
   register('cls', updateClsScore)
   register('pageHide', updatePageHide)
+  register('networkInformation', updateNetworkInformation)
 
   // final harvest is initiated from the main agent module, but since harvesting
   // here is not initiated by the harvester, we need to subscribe to the unload event
@@ -87,6 +89,13 @@ function recordLcp() {
 
     if (lcpEntry.element && lcpEntry.element.tagName) {
       attrs['tag'] = lcpEntry.element.tagName
+    }
+
+    if (networkInformation) {
+      if (networkInformation.type) attrs['net-type'] = networkInformation.type
+      if (networkInformation.effectiveType) attrs['net-etype'] = networkInformation.effectiveType
+      if (networkInformation.rtt) attrs['net-rtt'] = networkInformation.rtt
+      if (networkInformation.downlink) attrs['net-dlink'] = networkInformation.downlink
     }
 
     // collect 0 only when CLS is supported, since 0 is a valid score
@@ -134,6 +143,10 @@ function updatePageHide(timestamp) {
 function recordUnload() {
   updatePageHide(now())
   addTiming('unload', now(), null, true)
+}
+
+function updateNetworkInformation (latest) {
+  networkInformation = latest
 }
 
 function addTiming(name, value, attrs, addCls) {

--- a/loader/timings.js
+++ b/loader/timings.js
@@ -79,10 +79,8 @@ if ('addEventListener' in document) {
   })
 }
 
-if (window.navigator) {
-  var connection = getConnection()
-  if (!connection) return
-
+var connection = getConnection()
+if (connection) {
   handle('networkInformation', [connection])
 
   connection.addEventListener('change', function (evt) {
@@ -91,7 +89,7 @@ if (window.navigator) {
 }
 
 function getConnection () {
-  return window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection
+  return navigator.connection || navigator.mozConnection || navigator.webkitConnection
 }
 
 function captureInteraction(evt) {

--- a/loader/timings.js
+++ b/loader/timings.js
@@ -79,11 +79,34 @@ if ('addEventListener' in document) {
   })
 }
 
+if (window.navigator) {
+  var connection = getConnection()
+  if (!connection) return
+
+  handle('networkInformation', [connection])
+
+  connection.addEventListener('change', function (evt) {
+    handle('networkInformation', [evt.target])
+  })
+}
+
+function getConnection () {
+  return window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection
+}
+
 function captureInteraction(evt) {
   if (evt instanceof origEvent && !fiRecorded) {
     var fi = Math.round(evt.timeStamp)
     var attributes = {
       type: evt.type
+    }
+
+    var connection = getConnection()
+    if (connection) {
+      if (connection.type) attributes['net-type'] = connection.type
+      if (connection.effectiveType) attributes['net-etype'] = connection.effectiveType
+      if (connection.rtt) attributes['net-rtt'] = connection.rtt
+      if (connection.downlink) attributes['net-dlink'] = connection.downlink
     }
 
     // The value of Event.timeStamp is epoch time in some old browser, and relative

--- a/loader/timings.js
+++ b/loader/timings.js
@@ -37,7 +37,13 @@ function lcpObserver(list, observer) {
     var entry = entries[entries.length - 1]
 
     if (pageHiddenTime && pageHiddenTime < entry.startTime) return
-    handle('lcp', [entry])
+
+    var payload = [entry]
+
+    var attributes = addConnectionAttributes({})
+    if (attributes) payload.push(attributes)
+
+    handle('lcp', payload)
   }
 }
 
@@ -79,17 +85,17 @@ if ('addEventListener' in document) {
   })
 }
 
-var connection = getConnection()
-if (connection) {
-  handle('networkInformation', [connection])
+// takes an attributes object and appends connection attributes if available
+function addConnectionAttributes (attributes) {
+  var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection
+  if (!connection) return
 
-  connection.addEventListener('change', function (evt) {
-    handle('networkInformation', [evt.target])
-  })
-}
+  if (connection.type) attributes['net-type'] = connection.type
+  if (connection.effectiveType) attributes['net-etype'] = connection.effectiveType
+  if (connection.rtt) attributes['net-rtt'] = connection.rtt
+  if (connection.downlink) attributes['net-dlink'] = connection.downlink
 
-function getConnection () {
-  return navigator.connection || navigator.mozConnection || navigator.webkitConnection
+  return attributes
 }
 
 function captureInteraction(evt) {
@@ -99,13 +105,7 @@ function captureInteraction(evt) {
       type: evt.type
     }
 
-    var connection = getConnection()
-    if (connection) {
-      if (connection.type) attributes['net-type'] = connection.type
-      if (connection.effectiveType) attributes['net-etype'] = connection.effectiveType
-      if (connection.rtt) attributes['net-rtt'] = connection.rtt
-      if (connection.downlink) attributes['net-dlink'] = connection.downlink
-    }
+    addConnectionAttributes(attributes)
 
     // The value of Event.timeStamp is epoch time in some old browser, and relative
     // timestamp in newer browsers. We assume that large numbers represent epoch time.

--- a/tests/browser/timings-fi-attributes.test.js
+++ b/tests/browser/timings-fi-attributes.test.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const jil = require('jil')
+const matcher = require('../../tools/jil/util/browser-matcher')
+
+let supported = matcher.withFeature('wrappableAddEventListener')
+
+jil.browserTest('sends expected attributes when available', supported, function(t) {
+  var handle = require('handle')
+  var harvest = require('../../agent/harvest')
+  var timingModule = require('../../agent/timings')
+  var drain = require('../../agent/drain')
+
+  // override harvest calls, so that no network calls are made
+  harvest.send = function() {
+    return {}
+  }
+
+  var mockLoader = {
+    info: {}
+  }
+
+  timingModule.init(mockLoader)
+
+  // drain adds `timing` event listener in the agent/timings module
+  drain('feature')
+
+  var firstInteraction = 1234
+
+  var attributes = {
+    type: 'pointerdown',
+    fid: 5,
+    'net-type': 'cellular',
+    'net-etype': '3g',
+    'net-rtt': 270,
+    'net-dlink': 700
+  }
+
+  // simulate first interaction observed
+  handle('timing', ['fi', firstInteraction, attributes])
+
+  t.equals(timingModule.timings.length, 1, 'there should be only 1 timing (firstInteraction)')
+  t.ok(timingModule.timings[0].name === 'fi', 'fi should be present')
+
+  const payload = timingModule.timings[0].attrs
+  t.equal(payload.type, attributes.type, 'interactionType should be present')
+  t.equal(payload.fid, attributes.fid, 'fid should be present')
+  t.equal(payload['net-type'], attributes['net-type'], 'network type should be present')
+  t.equal(payload['net-etype'], attributes['net-etype'], 'network effectiveType should be present')
+  t.equal(payload['net-rtt'], attributes['net-rtt'], 'network rtt should be present')
+  t.equal(payload['net-dlink'], attributes['net-dlink'], 'network downlink should be present')
+
+  t.end()
+})

--- a/tests/browser/timings-lcp-attributes.test.js
+++ b/tests/browser/timings-lcp-attributes.test.js
@@ -28,13 +28,10 @@ jil.browserTest('sends expected attributes when available', supported, function(
     maxLCPTimeSeconds: 0.5
   })
 
-  timingModule.init(mockLoader)
-
   // drain adds `timing` and `lcp` event listeners in the agent/timings module
   drain('feature')
 
-  // simulate LCP observed
-  handle('lcp', [{
+  var lcpEntry = {
     size: 123,
     startTime: 1,
     id: 'some-element-id',
@@ -42,7 +39,17 @@ jil.browserTest('sends expected attributes when available', supported, function(
     element: {
       tagName: 'IMG'
     }
-  }])
+  }
+
+  var networkInfo = {
+    'net-type': 'cellular',
+    'net-etype': '3g',
+    'net-rtt': '270',
+    'net-dlink': '700'
+  }
+
+  // simulate LCP observed
+  handle('lcp', [lcpEntry, networkInfo])
 
   setTimeout(function() {
     t.equals(timingModule.timings.length, 1, 'there should be only 2 timings (pageHide and unload)')
@@ -53,6 +60,10 @@ jil.browserTest('sends expected attributes when available', supported, function(
     t.equal(attributes.size, 123, 'size should be present')
     t.equal(attributes.url, 'http://foo.com/a/b', 'url should be present')
     t.equal(attributes.tag, 'IMG', 'element.tagName should be present')
+    t.equal(attributes['net-type'], networkInfo['net-type'], 'network type should be present')
+    t.equal(attributes['net-etype'], networkInfo['net-etype'], 'network effectiveType should be present')
+    t.equal(attributes['net-rtt'], networkInfo['net-rtt'], 'network rtt should be present')
+    t.equal(attributes['net-dlink'], networkInfo['net-dlink'], 'network downlink should be present')
 
     t.end()
   }, 1000)

--- a/tests/functional/timings.test.js
+++ b/tests/functional/timings.test.js
@@ -198,7 +198,7 @@ function runLargestContentfulPaintFromInteractionTests(loader) {
         t.equal(tagName.value, 'BUTTON', 'element.tagName is present and correct')
         t.equal(size.type, 'doubleAttribute', 'largestContentfulPaint attribute elementTagName is stringAttribute')
 
-        t.equal(timing.attributes.length, 4, 'largestContentfulPaint has two attributes')
+        t.equal(timing.attributes.length, 7, 'largestContentfulPaint has seven attributes')
 
         t.end()
       })


### PR DESCRIPTION
### Overview
This PR adds attributes from the [NetworkInformation API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation) to certain PageViewTiming event types (currently LargestContentfulPaint & FirstInteraction)

### Related Github Issue
https://github.com/newrelic/newrelic-browser-agent/issues/144

### Testing
