### PR TITLE
Add Session Trace ID to other harvests

### DIFF
--- a/agent/harvest.js
+++ b/agent/harvest.js
@@ -316,8 +316,8 @@ function baseQueryString (nr) {
     encode.param('ct', nr.customTransaction),
     '&rst=' + nr.now(),
     '&ck=' + (areCookiesEnabled ? '1' : '0'),
-    encode.param('ptid', nr.info.ptid),
-    encode.param('ref', cleanURL(locationUtil.getLocation()))
+    encode.param('ref', cleanURL(locationUtil.getLocation())),
+    encode.param('ptid', (nr.ptid ? '' + nr.ptid : ''))
   ].join(''))
 }
 

--- a/agent/harvest.js
+++ b/agent/harvest.js
@@ -316,6 +316,7 @@ function baseQueryString (nr) {
     encode.param('ct', nr.customTransaction),
     '&rst=' + nr.now(),
     '&ck=' + (areCookiesEnabled ? '1' : '0'),
+    encode.param('ptid', nr.info.ptid),
     encode.param('ref', cleanURL(locationUtil.getLocation()))
   ].join(''))
 }

--- a/feature/stn/aggregate/index.js
+++ b/feature/stn/aggregate/index.js
@@ -83,6 +83,7 @@ ee.on('feat-stn', function () {
     // start timer only if ptid was returned by server
     if (result.sent && result.responseText && !ptid) {
       ptid = result.responseText
+      loader.info.ptid = ptid
       scheduler.startTimer(harvestTimeSeconds)
     }
 
@@ -314,7 +315,7 @@ function takeSTNs (retry) {
   nodeCount = 0
 
   var stnInfo = {
-    qs: {st: '' + loader.offset, ptid: ptid},
+    qs: {st: '' + loader.offset},
     body: {res: stns}
   }
 

--- a/feature/stn/aggregate/index.js
+++ b/feature/stn/aggregate/index.js
@@ -83,7 +83,7 @@ ee.on('feat-stn', function () {
     // start timer only if ptid was returned by server
     if (result.sent && result.responseText && !ptid) {
       ptid = result.responseText
-      loader.info.ptid = ptid
+      loader.ptid = ptid
       scheduler.startTimer(harvestTimeSeconds)
     }
 

--- a/tests/browser/harvest.browser.js
+++ b/tests/browser/harvest.browser.js
@@ -354,6 +354,32 @@ test('adds ptid to harvest when ptid is present', function (t) {
   delete fakeNr.ptid
 })
 
+test('does not add ptid to harvest when ptid is not present', function (t) {
+  if (xhrUsable) {
+    t.plan(2)
+  } else {
+    t.plan(2)
+  }
+
+  resetSpies(null, { xhrWithLoadEvent: true })
+  harvest.on('jserrors', once(dummyPayload('jserrors')))
+
+  // simulate session trace not started on page
+  fakeNr.ptid = null
+
+  let result = harvest.sendX('jserrors', fakeNr, null, function () {})
+
+  if (xhrUsable) {
+    t.ok(result, 'result truthy when jserrors submitted via xhr')
+    let call = submitData.xhr.getCall(0)
+    t.ok(call.args[0].indexOf('ptid') === -1, 'ptid not included in querystring')
+  } else {
+    t.ok(result, 'result truthy when jserrors submitted via img')
+    let call = submitData.img.getCall(0)
+    t.ok(call.args[0].indexOf('ptid') === -1, 'ptid not included in querystring')
+  }
+})
+
 test('does not send jserrors when there is nothing to send', function (t) {
   resetSpies()
   harvest.on('jserrors', once(testPayload))

--- a/tests/browser/stn/stn.browser.js
+++ b/tests/browser/stn/stn.browser.js
@@ -64,7 +64,6 @@ function runTests () {
     let qs = payload.qs
 
     t.ok(+qs.st > 1404952055986 && Date.now() > +qs.st, 'Start time is between recent time and now ' + qs.st)
-    t.equal(qs.ptid, '', 'no ptid generated ' + qs.ptid)
 
     t.test('stn DOMContentLoaded', function (t) {
       let node = res.filter(function (node) { return node.n === 'DOMContentLoaded' })[0]


### PR DESCRIPTION
### Overview
This PR adds the session trace ID (`ptid`), if present, to the base querystring of harvest calls so events in that harvest can be associated with a session trace if one was active on the page.

Previously, `ptid` was added as a querystring argument to subsequent session trace (`/resources`) harvest calls, now any harvest calls after the initial session trace harvest call should include this parameter if a session trace is active.

### Related Github Issue
https://github.com/newrelic/newrelic-browser-agent/issues/153

### Testing
A test has been added to validate that the new querystring parameter is added.