### PR TITLE
Updated LCP identifying attributes to have less generic names

### DIFF
--- a/agent/timings.js
+++ b/agent/timings.js
@@ -92,11 +92,11 @@ function recordLcp() {
     }
 
     if (lcpEntry.url) {
-      attrs['url'] = cleanURL(lcpEntry.url)
+      attrs['elUrl'] = cleanURL(lcpEntry.url)
     }
 
     if (lcpEntry.element && lcpEntry.element.tagName) {
-      attrs['tag'] = lcpEntry.element.tagName
+      attrs['elTag'] = lcpEntry.element.tagName
     }
 
     // collect 0 only when CLS is supported, since 0 is a valid score

--- a/agent/timings.js
+++ b/agent/timings.js
@@ -193,8 +193,10 @@ function appendGlobalCustomAttributes(timing) {
   var timingAttributes = timing.attrs || {}
   var customAttributes = loader.info.jsAttributes || {}
 
+  var reservedAttributes = ['size', 'eid', 'cls', 'type', 'fid', 'elTag', 'elUrl', 'net-type',
+    'net-etype', 'net-rtt', 'net-dlink']
   mapOwn(customAttributes, function (key, val) {
-    if (key !== 'size' && key !== 'eid' && key !== 'cls' && key !== 'type' && key !== 'fid') {
+    if (reservedAttributes.indexOf(key) < 0) {
       timingAttributes[key] = val
     }
   })

--- a/tests/assets/instrumented-with-custom-attributes.html
+++ b/tests/assets/instrumented-with-custom-attributes.html
@@ -17,6 +17,12 @@
       newrelic.setCustomAttribute('cls', 'invalid')
       newrelic.setCustomAttribute('type', 'invalid')
       newrelic.setCustomAttribute('fid', 'invalid')
+      newrelic.setCustomAttribute('elTag', 'invalid')
+      newrelic.setCustomAttribute('elUrl', 'invalid')
+      newrelic.setCustomAttribute('net-type', 'invalid')
+      newrelic.setCustomAttribute('net-etype', 'invalid')
+      newrelic.setCustomAttribute('net-rtt', 'invalid')
+      newrelic.setCustomAttribute('net-dlink', 'invalid')
 </script>
   </head>
   <body>

--- a/tests/browser/timings-lcp-attributes.test.js
+++ b/tests/browser/timings-lcp-attributes.test.js
@@ -58,8 +58,8 @@ jil.browserTest('sends expected attributes when available', supported, function(
     const attributes = timingModule.timings[0].attrs
     t.equal(attributes.eid, 'some-element-id', 'eid should be present')
     t.equal(attributes.size, 123, 'size should be present')
-    t.equal(attributes.url, 'http://foo.com/a/b', 'url should be present')
-    t.equal(attributes.tag, 'IMG', 'element.tagName should be present')
+    t.equal(attributes.elUrl, 'http://foo.com/a/b', 'url should be present')
+    t.equal(attributes.elTag, 'IMG', 'element.tagName should be present')
     t.equal(attributes['net-type'], networkInfo['net-type'], 'network type should be present')
     t.equal(attributes['net-etype'], networkInfo['net-etype'], 'network effectiveType should be present')
     t.equal(attributes['net-rtt'], networkInfo['net-rtt'], 'network rtt should be present')

--- a/tests/functional/timings.test.js
+++ b/tests/functional/timings.test.js
@@ -195,7 +195,7 @@ function runLargestContentfulPaintFromInteractionTests(loader) {
         t.ok(size.value > 0, 'size is a non-negative value')
         t.equal(size.type, 'doubleAttribute', 'largestContentfulPaint attribute size is doubleAttribute')
 
-        var tagName = timing.attributes.find(a => a.key === 'tag')
+        var tagName = timing.attributes.find(a => a.key === 'elTag')
         t.equal(tagName.value, 'BUTTON', 'element.tagName is present and correct')
         t.equal(size.type, 'doubleAttribute', 'largestContentfulPaint attribute elementTagName is stringAttribute')
 

--- a/tests/functional/timings.test.js
+++ b/tests/functional/timings.test.js
@@ -678,13 +678,8 @@ function runCustomAttributeTests(loader) {
 
     let url = router.assetURL('instrumented-with-custom-attributes.html', { loader: loader })
     let loadPromise = browser.safeGet(url).catch(fail)
-    var reservedTimingAttributes = {
-      'size': true,
-      'eid': true,
-      'cls': true,
-      'type': true,
-      'fid': true
-    }
+    var reservedTimingAttributes = ['size', 'eid', 'cls', 'type', 'fid', 'elUrl', 'elTag',
+      'net-type', 'net-etype', 'net-rtt', 'net-dlink']
 
     Promise.all([loadPromise, router.expectRum()])
       .then(() => {
@@ -702,7 +697,7 @@ function runCustomAttributeTests(loader) {
         t.ok(timings, 'there should be load timing')
 
         // attributes are invalid if they have the 'invalid' value set via setCustomAttribute
-        const containsReservedAttributes = timing.attributes.some(a => reservedTimingAttributes[a.key] && a.value === 'invalid')
+        const containsReservedAttributes = timing.attributes.some(a => reservedTimingAttributes.includes(a.key) && a.value === 'invalid')
         t.notok(containsReservedAttributes, 'PageViewTiming custom attributes should not contain default attribute keys')
 
         const expectedAttribute = timing.attributes.find(a => a.key === 'test')


### PR DESCRIPTION
Fixes https://github.com/newrelic/newrelic-browser-agent/issues/161

Related to https://github.com/newrelic/newrelic-browser-agent/pull/149

Renamed LCP PageViewTiming attribute from `url` to `elUrl` and `tag` to `elTag`. This makes the names less generic and as a result less likely to collide with custom attributes.