### PR TITLE
Add handling for data URLs

### DIFF
--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -19,6 +19,7 @@ var ffVersion = require('../../../loader/firefox-version')
 var dataSize = require('ds')
 var responseSizeFromXhr = require('./response-size')
 var eventListenerOpts = require('event-listener-opts')
+var recordSupportability = require('metrics').recordSupportability
 
 var origRequest = NREUM.o.REQ
 var origXHR = window.XMLHttpRequest
@@ -283,7 +284,10 @@ ee.on('fetch-done', function (err, res) {
   }
 
   // Do not generate telemetry for Data URL requests because they don't behave like other network requests
-  if (this.params.protocol === 'data') return
+  if (this.params.protocol === 'data') {
+    recordSupportability('Ajax/DataUrl/Excluded')
+    return
+  }
 
   this.params.status = res ? res.status : 0
 
@@ -315,7 +319,10 @@ function end (xhr) {
   }
 
   // Do not generate telemetry for Data URL requests because they don't behave like other network requests
-  if (params.protocol && params.protocol === 'data') return
+  if (params.protocol && params.protocol === 'data') {
+    recordSupportability('Ajax/DataUrl/Excluded')
+    return
+  }
 
   if (params.aborted) return
   metrics.duration = loader.now() - this.startTime

--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -264,6 +264,7 @@ ee.on('fetch-start', function (fetchArguments, dtPayload) {
   }
   addUrl(this, url)
 
+  // Do not generate telemetry for Data URL requests because they don't behave like other network requests
   if (this.params.protocol === 'data') return
 
   var method = ('' + ((target && target instanceof origRequest && target.method) ||
@@ -281,6 +282,7 @@ ee.on('fetch-done', function (err, res) {
     this.params = {}
   }
 
+  // Do not generate telemetry for Data URL requests because they don't behave like other network requests
   if (this.params.protocol === 'data') return
 
   this.params.status = res ? res.status : 0
@@ -311,6 +313,9 @@ function end (xhr) {
   for (var i = 0; i < handlersLen; i++) {
     xhr.removeEventListener(handlers[i], this.listener, false)
   }
+
+  // Do not generate telemetry for Data URL requests because they don't behave like other network requests
+  if (params.protocol && params.protocol === 'data') return
 
   if (params.aborted) return
   metrics.duration = loader.now() - this.startTime

--- a/feature/xhr/instrument/index.js
+++ b/feature/xhr/instrument/index.js
@@ -264,6 +264,8 @@ ee.on('fetch-start', function (fetchArguments, dtPayload) {
   }
   addUrl(this, url)
 
+  if (this.params.protocol === 'data') return
+
   var method = ('' + ((target && target instanceof origRequest && target.method) ||
     opts.method || 'GET')).toUpperCase()
   this.params.method = method
@@ -278,6 +280,9 @@ ee.on('fetch-done', function (err, res) {
   if (!this.params) {
     this.params = {}
   }
+
+  if (this.params.protocol === 'data') return
+
   this.params.status = res ? res.status : 0
 
   // convert rxSize to a number

--- a/feature/xhr/instrument/parse-url.js
+++ b/feature/xhr/instrument/parse-url.js
@@ -10,6 +10,7 @@ module.exports = function parseUrl (url) {
     return stringsToParsedUrls[url]
   }
 
+  // Return if URL is a data URL, parseUrl assumes urls are http/https
   if (url.indexOf('data:') === 0) {
     return {
       protocol: 'data'

--- a/feature/xhr/instrument/parse-url.js
+++ b/feature/xhr/instrument/parse-url.js
@@ -11,7 +11,7 @@ module.exports = function parseUrl (url) {
   }
 
   // Return if URL is a data URL, parseUrl assumes urls are http/https
-  if (url.indexOf('data:') === 0) {
+  if ((url || '').indexOf('data:') === 0) {
     return {
       protocol: 'data'
     }

--- a/feature/xhr/instrument/parse-url.js
+++ b/feature/xhr/instrument/parse-url.js
@@ -10,6 +10,12 @@ module.exports = function parseUrl (url) {
     return stringsToParsedUrls[url]
   }
 
+  if (url.indexOf('data:') === 0) {
+    return {
+      protocol: 'data'
+    }
+  }
+
   var urlEl = document.createElement('a')
   var location = window.location
   var ret = {}

--- a/tests/browser/xhr/data-url.browser.js
+++ b/tests/browser/xhr/data-url.browser.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const test = require('../../../tools/jil/browser-test')
+const ee = require('ee')
+const handleEE = ee.get('handle')
+
+const hasXhr = window.XMLHttpRequest && XMLHttpRequest.prototype && XMLHttpRequest.prototype.addEventListener
+
+require('../../../feature/xhr/instrument')
+
+test('XHR request for Data URL does not generate telemetry', function(t) {
+  if (!hasXhr) {
+    t.pass('xhr is not supported in this browser')
+    t.end()
+    return
+  }
+
+  handleEE.addEventListener('xhr', failCase)
+
+  ee.addEventListener('send-xhr-start', validate)
+
+  var xhr = new XMLHttpRequest()
+  xhr.open('GET', 'data:,data-uri')
+  xhr.send()
+
+  function validate (args, xhr) {
+    t.equals(this.params.protocol, 'data', 'XHR Data URL request recorded')
+    setTimeout(() => {
+      handleEE.removeEventListener('xhr', failCase)
+      ee.removeEventListener('send-xhr-start', validate)
+
+      t.pass('XHR Data URL request did not generate telemetry')
+      t.end()
+    }, 100)
+  }
+
+  function failCase (params, metrics, start) {
+    t.fail('XHR request for Data URL should not generate telemetry')
+    handleEE.removeEventListener('xhr', failCase)
+  }
+})
+
+test('Data URL Fetch requests do not generate telemetry', function(t) {
+  if (!window.fetch) {
+    t.pass('fetch is not supported in this browser')
+    t.end()
+    return
+  }
+
+  handleEE.addEventListener('xhr', failCase)
+
+  ee.addEventListener('fetch-done', validate)
+
+  fetch('data:,dataUrl')
+
+  function validate () {
+    t.equals(this.params.protocol, 'data', 'Fetch data URL request recorded')
+
+    setTimeout(() => {
+      handleEE.removeEventListener('xhr', failCase)
+      ee.removeEventListener('fetch-done', validate)
+
+      t.pass('Fetch data URL request did not generate telemetry')
+      t.end()
+    }, 100)
+  }
+
+  function failCase(params, metrics, start) {
+    t.fail('Data URL Fetch requests should not generate telemetry')
+    handleEE.removeEventListener('xhr', failCase)
+    ee.removeEventListener('fetch-done', validate)
+  }
+})

--- a/tests/browser/xhr/parse-url.browser.js
+++ b/tests/browser/xhr/parse-url.browser.js
@@ -79,6 +79,12 @@ function xhr_tests () {
           port: location.port,
           sameOrigin: true
         }
+      },
+      {
+        url: 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==',
+        results: {
+          protocol: 'data'
+        }
       }
     ]
 


### PR DESCRIPTION
### Overview
As described in issue https://github.com/newrelic/newrelic-browser-agent/issues/163, agent harvests can fail when a data URL is fetched. This PR includes changes to identify when a request with a Data URL is made using Fetch or XMLHttpRequest and prevent those requests from aggregating telemetry.

We can revisit this change and consider adding support for Data URLs if a use-case for them comes up but currently the information in a Data URL request/response doesn't contain the information needed to create our existing AjaxRequest events or Ajax metrics.

### Related Github Issue
https://github.com/newrelic/newrelic-browser-agent/issues/163

### Testing
New Browser tests were created to validate that when an XHR or Fetch request is made that they do not result in an event being aggregated: [/tests/browser/xhr/data-url.browser.js](https://github.com/newrelic/newrelic-browser-agent/blob/25ca4782d17335858c9b8cf562c2d350441d3c6c/tests/browser/xhr/data-url.browser.js)

The opposite behavior can be validated locally (that tests will fail if events are aggregated) by disabling the three new lines below:
https://github.com/newrelic/newrelic-browser-agent/blob/d720dccab07920cc10c1d75c3660190caca82898/feature/xhr/instrument/index.js#L268
https://github.com/newrelic/newrelic-browser-agent/blob/d720dccab07920cc10c1d75c3660190caca82898/feature/xhr/instrument/index.js#L286
https://github.com/newrelic/newrelic-browser-agent/blob/d720dccab07920cc10c1d75c3660190caca82898/feature/xhr/instrument/index.js#L318

A test was also added for the parseUrl behavior of returning a special object for URLs using the `data:` protocol.