### PR TITLE
Remove dev deploy versions

### DIFF
--- a/lib/versionify.js
+++ b/lib/versionify.js
@@ -48,7 +48,7 @@ function versionify (min, payloadVariant) {
     }
     function end () {
       var payloadVariantPart = payloadVariant ? '-' + payloadVariant : '' // '' or '-<variant name>'
-      var versionPart = buildNumber ? '-' + buildNumber : '' // '' or '-<build number>'
+      var versionPart = process.env.SUBPATH ? '' : buildNumber ? '-' + buildNumber : '' // '' or '-<build number>'
       var minPart = min ? '.min' : ''
 
       // [-<variant name>][-<build number>][.min]

--- a/tools/scripts/upload-to-s3.js
+++ b/tools/scripts/upload-to-s3.js
@@ -126,7 +126,7 @@ function uploadAllToS3 (cb) {
   var allFiles = payloads.concat(loaders).concat(maps)
 
   asyncForEach(allFiles, function (file, next) {
-    var filename = getFilenameWithVersion(file, agentVersion)
+    var filename = argv['dev'] === true ? file : getFilenameWithVersion(file, agentVersion)
     console.log('uploading ' + filename + ' to S3')
     uploadToS3(argv['bucket'], filename, fileData[file], next)
   }, cb, uploadErrorCallback)


### PR DESCRIPTION
This changes the reference agent link in the loader to not include a version number