### PR TITLE
add try-catch blocks for compat with ie8

### DIFF
--- a/loader/framework-detection.js
+++ b/loader/framework-detection.js
@@ -22,32 +22,47 @@ function getFrameworks() {
     if (window.Meteor) frameworks.push(FRAMEWORKS.METEOR)
     if (window.Zepto) frameworks.push(FRAMEWORKS.ZEPTO)
     if (window.jQuery) frameworks.push(FRAMEWORKS.JQUERY)
-    return frameworks
   } catch (err) {
     // not supported?
   }
+  return frameworks
 }
 
 function detectReact() {
-  if (!!window.React || !!window.ReactDOM || !!window.ReactRedux) return true
-  if (document.querySelector('[data-reactroot], [data-reactid]')) return true
-  var divs = document.querySelectorAll('body > div')
-  for (var i = 0; i < divs.length; i++) {
-    if (Object.keys(divs[i]).indexOf('_reactRootContainer') >= 0) return true
+  try {
+    if (!!window.React || !!window.ReactDOM || !!window.ReactRedux) return true
+    if (document.querySelector('[data-reactroot], [data-reactid]')) return true
+    var divs = document.querySelectorAll('body > div')
+    for (var i = 0; i < divs.length; i++) {
+      if (Object.keys(divs[i]).indexOf('_reactRootContainer') >= 0) return true
+    }
+    return false
+  } catch (err) {
+    // not supported?
+    return false
   }
-  return false
 }
 
 function detectAngularJs() {
-  if (window.angular) return true
-  if (document.querySelector('.ng-binding, [ng-app], [data-ng-app], [ng-controller], [data-ng-controller], [ng-repeat], [data-ng-repeat]')) return true
-  if (document.querySelector('script[src*="angular.js"], script[src*="angular.min.js"]')) return true
-  return false
+  try {
+    if (window.angular) return true
+    if (document.querySelector('.ng-binding, [ng-app], [data-ng-app], [ng-controller], [data-ng-controller], [ng-repeat], [data-ng-repeat]')) return true
+    if (document.querySelector('script[src*="angular.js"], script[src*="angular.min.js"]')) return true
+    return false
+  } catch (err) {
+    // not supported?
+    return false
+  }
 }
 
 function detectAngular() {
-  if (window.hasOwnProperty('ng') && window.ng.hasOwnProperty('coreTokens') && window.ng.coreTokens.hasOwnProperty('NgZone')) return true
-  return !!document.querySelectorAll('[ng-version]').length
+  try {
+    if (window.hasOwnProperty('ng') && window.ng.hasOwnProperty('coreTokens') && window.ng.coreTokens.hasOwnProperty('NgZone')) return true
+    return !!document.querySelectorAll('[ng-version]').length
+  } catch (err) {
+    // not supported?
+    return false
+  }
 }
 
 module.exports = getFrameworks()


### PR DESCRIPTION
### Overview
This PR fixes an issue for a niche bug that popped up in IE8.  It adds try catch fallbacks for unsupported DOM query methods.

### Testing
Testing for this is difficult because IE8 is not officially supported by the browser agent, and the test suite is not ran against an instance of IE8.  IE8 emulation is also difficult to come by.  The problem changed can be found [here](https://caniuse.com/queryselector), and this should help alleviate the issue.