### PR TITLE
Trace IDs should be 32 bytes of random hex chars

### DIFF
--- a/loader/unique-id.js
+++ b/loader/unique-id.js
@@ -62,7 +62,7 @@ function generateRandomHexString(length) {
   var rvIndex = 0
   var crypto = window.crypto || window.msCrypto
   if (crypto && crypto.getRandomValues && Uint8Array) {
-    randomVals = crypto.getRandomValues(new Uint8Array(31))
+    randomVals = crypto.getRandomValues(new Uint8Array(32))
   }
 
   var chars = []


### PR DESCRIPTION


_Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

---

### Overview
The function as-is will always generate a trace ID that ends in 0. The reason is that the array passed to crypto.getRandomValues() only has 31 elements. That's fine when you're looking at the GUID function, which only has 31 random characters.

In the current code, the array is created with 31 elements, indexed 0-30. The last character is pulled using `randomVals[31]` which returns undefined, which gets translated to 0 (`undefined & 15 === 0`).

### Related Github Issue
none

### Testing
Just made a quick test in Firefox.

---   
_More details on running your tests locally can be found in the
[CONTRIBUTING](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [README](https://github.com/newrelic/newrelic-browser-agent/blob/main/README.md) docs._