### PR TITLE
fix packages:watch command

### DIFF
--- a/cdn/package-lock.json
+++ b/cdn/package-lock.json
@@ -465,9 +465,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001334",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true,
       "funding": [
         {
@@ -755,9 +755,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.122",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.122.tgz",
-      "integrity": "sha512-VuLNxTIt8sBWIT2sd186xPd18Y8KcK8myLd9nMdSJOYZwFUxxbLVmX/T1VX+qqaytRlrYYQv39myxJdXtu7Ysw==",
+      "version": "1.4.124",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+      "integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
       "dev": true
     },
     "node_modules/enhanced-resolve": {
@@ -1625,9 +1625,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "dev": true
     },
     "node_modules/npm-run-path": {
@@ -2860,9 +2860,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001334",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true
     },
     "chalk": {
@@ -3069,9 +3069,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.122",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.122.tgz",
-      "integrity": "sha512-VuLNxTIt8sBWIT2sd186xPd18Y8KcK8myLd9nMdSJOYZwFUxxbLVmX/T1VX+qqaytRlrYYQv39myxJdXtu7Ysw==",
+      "version": "1.4.124",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+      "integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
       "dev": true
     },
     "enhanced-resolve": {
@@ -3725,9 +3725,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "dev": true
     },
     "npm-run-path": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "packages:build": "npm --prefix packages/scoped run build",
     "packages:pack": "npm --prefix packages/scoped run pack",
     "packages:test": "npm --prefix packages/scoped run test",
-    "packages:watch": "jung -D '\\.npm|.git|node_modules|build|tools|tests|coverage|dist' --run -- npm run packages:build",
+    "packages:watch": "jung -d './packages/scoped/src|./modules' --run -- npm run packages:build",
 
     "test-server": "node ./tools/jil/bin/server",
     "sauce:connect": "node ./tools/jil/bin/sauce"

--- a/packages/scoped/package-lock.json
+++ b/packages/scoped/package-lock.json
@@ -32,12 +32,13 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -2387,10 +2388,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
       "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -3330,9 +3353,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001334",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true,
       "funding": [
         {
@@ -3493,12 +3516,12 @@
       "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.2.tgz",
-      "integrity": "sha512-Fns9lU06ZJ07pdfmPMu7OnkIKGPKDzXKIiuGlSvHHapwqMUF2QnnsWwtueFZtSyZEilP0o6iUeHQwpn7LxtLUw==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+      "integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.20.2",
+        "browserslist": "^4.20.3",
         "semver": "7.0.0"
       },
       "funding": {
@@ -3730,9 +3753,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.122",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.122.tgz",
-      "integrity": "sha512-VuLNxTIt8sBWIT2sd186xPd18Y8KcK8myLd9nMdSJOYZwFUxxbLVmX/T1VX+qqaytRlrYYQv39myxJdXtu7Ysw==",
+      "version": "1.4.124",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+      "integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -6947,9 +6970,9 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -8658,12 +8681,13 @@
   },
   "dependencies": {
     "@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
+      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
       "dev": true,
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.0"
+        "@jridgewell/gen-mapping": "^0.1.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
     "@babel/code-frame": {
@@ -10341,10 +10365,26 @@
         }
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
+      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
       "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
+      "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
@@ -11145,9 +11185,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001334",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001334.tgz",
+      "integrity": "sha512-kbaCEBRRVSoeNs74sCuq92MJyGrMtjWVfhltoHUCW4t4pXFvGjUBrfo47weBRViHkiV3eBYyIsfl956NtHGazw==",
       "dev": true
     },
     "chalk": {
@@ -11277,12 +11317,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.2.tgz",
-      "integrity": "sha512-Fns9lU06ZJ07pdfmPMu7OnkIKGPKDzXKIiuGlSvHHapwqMUF2QnnsWwtueFZtSyZEilP0o6iUeHQwpn7LxtLUw==",
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
+      "integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.20.2",
+        "browserslist": "^4.20.3",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -11457,9 +11497,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.122",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.122.tgz",
-      "integrity": "sha512-VuLNxTIt8sBWIT2sd186xPd18Y8KcK8myLd9nMdSJOYZwFUxxbLVmX/T1VX+qqaytRlrYYQv39myxJdXtu7Ysw==",
+      "version": "1.4.124",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.124.tgz",
+      "integrity": "sha512-VhaE9VUYU6d2eIb+4xf83CATD+T+3bTzvxvlADkQE+c2hisiw3sZmvEDtsW704+Zky9WZGhBuQXijDVqSriQLA==",
       "dev": true
     },
     "emittery": {
@@ -13871,9 +13911,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
-      "integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
       "dev": true
     },
     "normalize-path": {

--- a/packages/scoped/webpack.config.js
+++ b/packages/scoped/webpack.config.js
@@ -13,7 +13,10 @@ module.exports = {
       type: 'umd'
     }
   },
-
+  watch: !!process.env.WATCH,
+  watchOptions: {
+    ignored: ['**/node_modules', '**/dist', '**/coverage']
+  },
   plugins: [
     new Dotenv({
       path: path.resolve(__dirname, './.env')


### PR DESCRIPTION
### Overview

This PR fixes the `packages:watch` command in the top level `package.json` file.  It will now automatically rebuild packages when changes occur in `modules/*` or in `packages/scoped`

### Testing

1 - Execute `npm run packages:watch` from the root.
2 - Change a file in `modules/*` or in `packages/scoped`
3 - See that webpack automatically rebuilds `packages/scoped`