### PR TITLE
Build cdn to main build folder

### DIFF
--- a/cdn/webpack.config.js
+++ b/cdn/webpack.config.js
@@ -16,9 +16,9 @@ module.exports = {
   },
   output: {
     filename: '[name].js',
-    path: path.resolve(__dirname, './build'),
+    path: path.resolve(__dirname, '../build'),
     // publicPath: 'https://js-agent.newrelic.com/', // <- we need this to be set when we publish to the CDN
-    publicPath: '/cdn/build/', // <-- we need one property to be set when testing locally
+    publicPath: '/build/', // <-- we need one property to be set when testing locally
     library: {
       name: 'NRBA',
       type: 'umd'

--- a/packages/browser-agent-core/features/metrics/instrument/index.js
+++ b/packages/browser-agent-core/features/metrics/instrument/index.js
@@ -55,7 +55,7 @@ export class Instrument extends FeatureBase {
 
     singleChecks() {
         // note the browser agent version
-        this.recordSupportability(`Generic/Version/${VERSION}`)
+        this.recordSupportability(`Generic/Version/${VERSION}/Detected`)
 
         // frameworks on page
         getFrameworks().forEach(framework => {


### PR DESCRIPTION
### Overview 

This PR points the CDN build output to `/build` folder for JIL tests