### PR TITLE
Fix: LCP metric no longer reported on initially hidden pages

### DIFF
--- a/loader/visibility.js
+++ b/loader/visibility.js
@@ -5,7 +5,10 @@
 
 var eventListenerOpts = require('event-listener-opts')
 
-module.exports = subscribeToVisibilityChange
+module.exports = {
+  subscribeToVisibilityChange: subscribeToVisibilityChange,
+  initializeHiddenTime: initHidTime,
+};
 
 var hidden, eventName, state
 
@@ -36,4 +39,8 @@ function subscribeToVisibilityChange(cb) {
       cb('visible')
     }
   }
+}
+
+function initHidTime() {
+    return document.visibilityState === 'hidden' ? -1 : Infinity;
 }

--- a/loader/visibility.js
+++ b/loader/visibility.js
@@ -7,7 +7,7 @@ var eventListenerOpts = require('event-listener-opts')
 
 module.exports = {
   subscribeToVisibilityChange: subscribeToVisibilityChange,
-  initializeHiddenTime: initHidTime,
+  initializeHiddenTime: initHidTime
 };
 
 var hidden, eventName, state

--- a/packages/browser-agent-core/common/window/visibility.js
+++ b/packages/browser-agent-core/common/window/visibility.js
@@ -35,3 +35,7 @@ export function subscribeToVisibilityChange(cb) {
     }
   }
 }
+
+export function initializeHiddenTime() {
+  return document.visibilityState === 'hidden' ? -1 : Infinity;
+}

--- a/packages/browser-agent-core/features/spa/aggregate/interaction-node.js
+++ b/packages/browser-agent-core/features/spa/aggregate/interaction-node.js
@@ -9,7 +9,7 @@ var lastId = 0
 
 export function InteractionNode (interaction, parent, type, timestamp) {
   Object.defineProperty(this, 'interaction', {
-    value: interaction, writable: true, // enumerable: false -- by default, which hides this prop from obj (iterations)
+    value: interaction, writable: true // enumerable: false -- by default, which hides this prop from obj (iterations)
   })
   this.parent = parent
   this.id = ++lastId

--- a/tests/assets/pagehide-beforeload.html
+++ b/tests/assets/pagehide-beforeload.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    <script>Object.defineProperty(document, 'visibilityState', {value: 'hidden', writable: true})</script>
+    {config}
+    {loader}
+  </head>
+  <body>
+    <div id="initial">initial content</div>
+  </body>
+</html>


### PR DESCRIPTION
_Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

---

### Overview
Previously, pages opened in the background and had a `visibilityState == 'hidden'` would continue to report the LCP metric, and an inflated one at that.

Now, in such cases the LCP will not be reported (or even buffered at all). 

### Related Github Issue
Fixes #170 

### Testing
- New html added to `tests/assets/`
- Test subcase appended to existing case in `tests/functional/timings.test.js`

In addition to manually pasting the Browser Agent, follow the test case in the related issue to add a basic performance observer and/or core-web-vitals' `getLCP` for comparison. Example:
<img width="1328" alt="image" src="https://user-images.githubusercontent.com/28714891/173165818-81845e9b-02da-40b8-9983-7f656a2c7865.png">
It may be helpful to programmatically include this in the `lcpObserver` code right before the `handle("lcp", payload)` line:
`console.log("NR LCP Observer - handling lcp payload", payload);`
\
\
Now on your test server, test the workflow of opening a new in-focus tab and background tab.

- For the foreground tab, the regression test should show the LCP output in console, with the data reported to NR1:
<img width="1701" alt="image" src="https://user-images.githubusercontent.com/28714891/173165920-e960ec41-4ca3-49c2-9cc9-132da0c5284c.png">

- While the background tab should show the output from NR agent (and CWV) missing, with just the `performance observer LCP` output.

---   
_More details on running your tests locally can be found in the
[CONTRIBUTING](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [README](https://github.com/newrelic/newrelic-browser-agent/blob/main/README.md) docs._