### PR TITLE
Migrate session-trace tests for CDN agent

### DIFF
--- a/cdn/agent-aggregator/util/featureDependencies.js
+++ b/cdn/agent-aggregator/util/featureDependencies.js
@@ -2,6 +2,8 @@ export function getFeatureDependencyNames(feature) {
     switch(feature){
         case 'ajax':
             return ['jserrors']
+        case 'session-trace':
+            return ['ajax']
         default:
             return []
     }

--- a/cdn/agent-loader/pro.js
+++ b/cdn/agent-loader/pro.js
@@ -24,8 +24,8 @@ const enabledFeatures = getEnabledFeatures(agentIdentifier)
 // instantiate auto-instrumentation specific to this loader...
 if (enabledFeatures.jserrors) new InstrumentErrors(agentIdentifier) // errors
 if (enabledFeatures.ajax) new InstrumentXhr(agentIdentifier) // ajax
-if (enabledFeatures['session-trace']) new InstrumentSessionTrace(agentIdentifier) // session traces
-if (enabledFeatures['page-action']) new InstrumentPageAction(agentIdentifier) // ins (apis)
+if (enabledFeatures['session_trace']) new InstrumentSessionTrace(agentIdentifier) // session traces
+if (enabledFeatures['page_action']) new InstrumentPageAction(agentIdentifier) // ins (apis)
 
 // imports the aggregator for 'lite' if no other aggregator takes precedence
 stageAggregator('pro')

--- a/feature/stn/instrument/index.js
+++ b/feature/stn/instrument/index.js
@@ -37,7 +37,7 @@ loader.features.stn = true
 // wrap history ap
 require('../../wrap-history')
 
-// wrap events
+// wrap events from [window, document, XHR].addEventListener
 if ('addEventListener' in window) {
   require('../../wrap-events')
 }
@@ -48,6 +48,7 @@ var origEvent = NREUM.o.EV
 
 ee.on(FN_START, function (args, target) {
   var evt = args[0]
+  // events from [window, document, XHR].addEventListener
   if (evt instanceof origEvent) {
     this.bstStart = loader.now()
   }
@@ -55,6 +56,7 @@ ee.on(FN_START, function (args, target) {
 
 ee.on(FN_END, function (args, target) {
   var evt = args[0]
+  // events from [window, document, XHR].addEventListener
   if (evt instanceof origEvent) {
     handle('bst', [evt, target, this.bstStart, loader.now()])
   }
@@ -128,6 +130,7 @@ if (supportsPerformanceObserver()) {
   }
 }
 
+// these trigger instrumentation above to create click, scroll and keypress events
 document[ADD_EVENT_LISTENER]('scroll', noOp, eventListenerOpts(false))
 document[ADD_EVENT_LISTENER]('keypress', noOp, eventListenerOpts(false))
 document[ADD_EVENT_LISTENER]('click', noOp, eventListenerOpts(false))

--- a/packages/browser-agent-core/features/session-trace/aggregate/index.js
+++ b/packages/browser-agent-core/features/session-trace/aggregate/index.js
@@ -246,7 +246,7 @@ export class Aggregate extends FeatureBase {
   storeResources(resources) {
     if (!resources || resources.length === 0) return
 
-    resources.forEach(function (currentResource) {
+    resources.forEach((currentResource) => {
       var parsed = parseUrl(currentResource.name)
       var res = {
         n: currentResource.initiatorType,

--- a/packages/browser-agent-core/features/session-trace/instrument/index.js
+++ b/packages/browser-agent-core/features/session-trace/instrument/index.js
@@ -29,6 +29,7 @@ export class Instrument extends FeatureBase {
     super(agentIdentifier)
     getRuntime(this.agentIdentifier).features.stn = true
 
+    const ee = this.ee
 
     console.log("initialize session-trace instrument!", agentIdentifier)
 
@@ -51,8 +52,10 @@ export class Instrument extends FeatureBase {
 
     this.ee.on(FN_END, function (args, target) {
       var evt = args[0]
-      if (evt instanceof origEvent) {
-        handle('bst', [evt, target, this.bstStart, now()])
+      if (evt instanceof origEvent) {        
+        // ISSUE: when target is XMLHttpRequest, nr@context should have params so we can calculate event origin
+        // When ajax is disabled, this may fail without making ajax a dependency of session-trace
+        handle('bst', [evt, target, this.bstStart, now()], undefined, undefined, ee)
       }
     })
 
@@ -62,7 +65,7 @@ export class Instrument extends FeatureBase {
     })
 
     this.timerEE.on(FN_END, function (args, target) {
-      handle(BST_TIMER, [target, this.bstStart, now(), this.bstType])
+      handle(BST_TIMER, [target, this.bstStart, now(), this.bstType], undefined, undefined, ee)
     })
 
     this.rafEE.on(FN_START, function () {
@@ -70,7 +73,7 @@ export class Instrument extends FeatureBase {
     })
 
     this.rafEE.on(FN_END, function (args, target) {
-      handle(BST_TIMER, [target, this.bstStart, now(), 'requestAnimationFrame'])
+      handle(BST_TIMER, [target, this.bstStart, now(), 'requestAnimationFrame'], undefined, undefined, ee)
     })
 
     this.ee.on(PUSH_STATE + START, function (args) {
@@ -78,7 +81,7 @@ export class Instrument extends FeatureBase {
       this.startPath = location.pathname + location.hash
     })
     this.ee.on(PUSH_STATE + END, function (args) {
-      handle('bstHist', [location.pathname + location.hash, this.startPath, this.time])
+      handle('bstHist', [location.pathname + location.hash, this.startPath, this.time], undefined, undefined, ee)
     })
 
     if (supportsPerformanceObserver()) {

--- a/tests/assets/click.html
+++ b/tests/assets/click.html
@@ -6,8 +6,9 @@
 <html>
   <head>
     <title>RUM Unit Test</title>
-    {loader}
+    
     {config}
+    {loader}
 
     <script type="text/javascript">
     // simulate application code overwriting window.Event

--- a/tests/assets/lotsatimers.html
+++ b/tests/assets/lotsatimers.html
@@ -7,8 +7,8 @@
   <head>
     <title>RUM Unit Test</title>
     {init}
-    {loader}
     {config}
+    {loader}
   </head>
   <body>
     This page creates a timer loop that will call setTimeout 100 times

--- a/tests/assets/sessiontraceerror.html
+++ b/tests/assets/sessiontraceerror.html
@@ -7,7 +7,8 @@
 
 <head>
   <title>RUM Unit Test</title>
-  {loader} {config}
+  {config}
+  {loader}
 </head>
 
 <body>

--- a/tests/assets/stn/ajax-disabled.html
+++ b/tests/assets/stn/ajax-disabled.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init}
+    {config}
+    {loader}
+  </head>
+  <body>
+    <button id="trigger">trigger</button>
+
+    <script type="text/javascript">
+      document.addEventListener('click', trigger)
+
+      function trigger() {
+        var xhr = new XMLHttpRequest()
+        xhr.open('GET', '/json')
+        xhr.addEventListener('load', function () {
+          generateNodes()
+        })
+        xhr.send()
+      }
+
+      // we need to have >30 nodes in the session trace to ensure it actually gets
+      // sent, so make some nodes
+      function generateNodes() {
+        for (var i = 0; i < 31; i++) {
+          setTimeout(function () {}, 0)
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/tests/assets/stn/ensure-passive.html
+++ b/tests/assets/stn/ensure-passive.html
@@ -19,8 +19,8 @@
         originalAddE.apply(this, arguments)
       }
     </script>
-    {loader}
     {config}
+    {loader}
   </head>
   <body>
   </body>

--- a/tests/assets/xhr-monkey-patched.html
+++ b/tests/assets/xhr-monkey-patched.html
@@ -6,8 +6,8 @@
 <html>
   <head>
     <title>XHR Monkey-patching test</title>
-    {loader}
     {config}
+    {loader}
     <script type="text/javascript">
       var orig = window.XMLHttpRequest.prototype.open
       window.XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {

--- a/tests/functional/stn/ajax-disabled.test.js
+++ b/tests/functional/stn/ajax-disabled.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const testDriver = require('../../../tools/jil/index')
+
+let supported = testDriver.Matcher.withFeature('stn')
+
+testDriver.test('session trace resources', supported, function (t, browser, router) {
+  let assetURL = router.assetURL('stn/ajax-disabled.html', {
+    loader: 'full',
+    init: {
+      stn: {
+        harvestTimeSeconds: 5
+      },
+      ajax: {
+        enabled: false
+      },
+      page_view_timing: {
+        enabled: false
+      }
+    }
+  })
+
+  let loadPromise = browser.safeGet(assetURL)
+  let rumPromise = router.expectRum()
+  let resourcePromise = router.expectResources()
+
+  Promise.all([resourcePromise, loadPromise, rumPromise]).then(([result]) => {
+    t.equal(result.res.statusCode, 200, 'server responded with 200')
+
+    const body = result.body
+    const harvestBody = JSON.parse(body).res
+
+    // trigger an XHR call after
+    var clickPromise = browser
+      .elementByCssSelector('body')
+      .click()
+
+    resourcePromise = router.expectResources()
+
+    return Promise.all([resourcePromise, clickPromise])
+  })
+  .then(([result]) => {
+    t.equal(router.seenRequests.resources, 2, 'got two harvest requests')
+    t.equal(result.res.statusCode, 200, 'server responded with 200')
+
+    const body = result.body
+    const harvestBody = JSON.parse(body).res
+    const loadNodes = harvestBody.filter(function (node) { return node.t === 'event' && node.n === 'load' || node.n === 'readystatechange' })
+    t.notOk(loadNodes.length > 0, 'XMLHttpRequest nodes not captured when ajax instrumentation is disabled')
+
+    t.end()
+  }).catch(fail)
+
+  function fail (err) {
+    t.error(err)
+    t.end()
+  }
+})

--- a/tests/functional/stn/resource-harvest.test.js
+++ b/tests/functional/stn/resource-harvest.test.js
@@ -14,9 +14,6 @@ testDriver.test('session trace resources', supported, function (t, browser, rout
       stn: {
         harvestTimeSeconds: 5
       },
-      ajax: {
-        enabled: false
-      },
       page_view_timing: {
         enabled: false
       }

--- a/tools/jil/driver/index.js
+++ b/tools/jil/driver/index.js
@@ -31,7 +31,9 @@ wd.addAsyncMethod('safeGet', function (url, cb) {
 
 wd.addAsyncMethod('waitForFeature', function (feat, cb) {
   this.waitFor(
+    // condition for gulp built agent
     // asserters.jsCondition('window.NREUM && window.NREUM.setToken && window.NREUM.setToken.active && window.NREUM.setToken.active.err'),
+    // condition for webpack built agent
     asserters.jsCondition(`window.NREUM && window.NREUM.activatedFeatures && window.NREUM.activatedFeatures['${feat}'] || window.NREUM.activatedFeatures.err`),
     this._testDriver.timeout,
     cb


### PR DESCRIPTION
### Overview
This migration was mostly adjusting code to account for the new scope of the class-based modules.

In session-trace aggregation, the functions passed to the HarvestScheduler needed access to class state, which I've implemented by binding the state to the function:
https://github.com/newrelic/newrelic-browser-agent/blob/81db9c2942b24a81a7bfaa166c0cb3ca6a49a0bc/packages/browser-agent-core/features/session-trace/aggregate/index.js#L84-L88
I'm very open to taking other approaches if they came up during other module migrations.

Commit 7c93c6e065d7e6f87d8097147b8556151aec9c7c handles the fact that in previous agent releases, the Ajax feature was always bundled with the Session Traces feature. The Session Trace feature currently depends on the Ajax feature's XHR decoration to generate XHR nodes so for now Ajax is marked as a dependency of Session Traces (this could be decoupled later). The agent will emit a warning if Session Traces is enabled and Ajax is disabled, and XHR nodes will not be generated.
