### PR TITLE
Test migration: finished browser wrap-function/ and xhr/

### DIFF
--- a/packages/browser-agent-core/common/config/config.js
+++ b/packages/browser-agent-core/common/config/config.js
@@ -4,4 +4,5 @@ import { getLoaderConfig, setLoaderConfig } from './state/loader-config'
 import { originals } from './state/originals'
 import { getRuntime, setRuntime } from './state/runtime'
 
+// This module acts as a hub that bundles the static and dynamic properties used by each agent instance into one single interface
 export { getInfo, setInfo, getConfiguration, getConfigurationValue, setConfiguration, getLoaderConfig, setLoaderConfig, originals, getRuntime, setRuntime }

--- a/packages/browser-agent-core/common/url/parse-url.js
+++ b/packages/browser-agent-core/common/url/parse-url.js
@@ -9,6 +9,12 @@ export function parseUrl (url) {
   if (url in stringsToParsedUrls) {
     return stringsToParsedUrls[url]
   }
+  // Return if URL is a data URL, parseUrl assumes urls are http/https
+  if ((url || '').indexOf('data:') === 0) {
+    return {
+      protocol: 'data'
+    }
+  }
 
   var urlEl = document.createElement('a')
   var location = window.location

--- a/packages/browser-agent-core/features/ajax/instrument/distributed-tracing.js
+++ b/packages/browser-agent-core/features/ajax/instrument/distributed-tracing.js
@@ -9,9 +9,13 @@ import { parseUrl } from '../../../common/url/parse-url'
 export class DT {
   constructor(agentIdentifier) {
     this.agentIdentifier = agentIdentifier
+    // Binds this class instance context to the following fn used in an external module (exported);
+    //  Alternatively, can make them class field arrow functions, but requires experimental features/plugin for eslint.
+    this.generateTracePayload = this.generateTracePayload.bind(this);
+    this.shouldGenerateTrace = this.shouldGenerateTrace.bind(this);
   }
 
-  generateTracePayload (parsedOrigin) {
+  generateTracePayload(parsedOrigin) {
     if (!this.shouldGenerateTrace(parsedOrigin)) {
       return null
     }
@@ -96,7 +100,7 @@ export class DT {
 
   // return true if DT is enabled and the origin is allowed, either by being
   // same-origin, or included in the allowed list
-  shouldGenerateTrace (parsedOrigin) {
+  shouldGenerateTrace(parsedOrigin) {
     return this.isDtEnabled() && this.isAllowedOrigin(parsedOrigin)
   }
 

--- a/tests/browser/wrap-function/no-events-for-recursive-wrapped-calls.browser.js
+++ b/tests/browser/wrap-function/no-events-for-recursive-wrapped-calls.browser.js
@@ -3,15 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var rootEE = require('ee')
-var wrapFn = require('../../../wrap-function')
-var test = require('../../../tools/jil/browser-test.js')
+import { setup } from '../utils/setup'
+import createWrapperWithEmitter from '../../../packages/browser-agent-core/common/wrap/wrap-function'
+import test from '../../../tools/jil/browser-test.js'
+
+const { baseEE } = setup();
 
 var eeId = 0
 
 test('recursive calls to wrapped functions from start/end event callbacks should not trigger more events', function (t) {
-  let ee = rootEE.get(eeId++)
-  let wrappedFoo = wrapFn(ee)(foo, 'fn-')
+  let ee = baseEE.get(eeId++)
+  let wrappedFoo = createWrapperWithEmitter(ee)(foo, 'fn-')
 
   let fooCallCount = 0
   let fnStartCount = 0
@@ -40,8 +42,8 @@ test('recursive calls to wrapped functions from start/end event callbacks should
 })
 
 test('calls to other wrapped functions from start/end event callbacks should not trigger more events', function (t) {
-  let ee = rootEE.get(eeId++)
-  let wrapper = wrapFn(ee)
+  let ee = baseEE.get(eeId++)
+  let wrapper = createWrapperWithEmitter(ee)
   let wrappedFoo = wrapper(foo, 'fn-')
   let wrappedBar = wrapper(bar, 'fn-')
 
@@ -78,8 +80,8 @@ test('calls to other wrapped functions from start/end event callbacks should not
 })
 
 test('calls to other wrapped functions from start/end event callbacks with different prefix should not trigger more events', function (t) {
-  let ee = rootEE.get(eeId++)
-  let wrapper = wrapFn(ee)
+  let ee = baseEE.get(eeId++)
+  let wrapper = createWrapperWithEmitter(ee)
   let wrappedFoo = wrapper(foo, 'foo-')
   let wrappedBar = wrapper(bar, 'bar-')
 
@@ -129,9 +131,9 @@ test('always flag allows nested calls', function (t) {
   let fooStartCount = 0
   let barStartCount = 0
 
-  let ee = rootEE.get(eeId++)
-  let alwaysWrappedFoo = wrapFn(ee, true)(foo, 'foo-')
-  let wrappedBar = wrapFn(ee)(bar, 'bar-')
+  let ee = baseEE.get(eeId++)
+  let alwaysWrappedFoo = createWrapperWithEmitter(ee, true)(foo, 'foo-')
+  let wrappedBar = createWrapperWithEmitter(ee)(bar, 'bar-')
 
   ee.on('foo-start', function () {
     fooStartCount += 1

--- a/tests/browser/xhr/deny-list.browser.js
+++ b/tests/browser/xhr/deny-list.browser.js
@@ -3,14 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var test = require('../../../tools/jil/browser-test.js')
-var parseUrl = require('../../../feature/xhr/instrument/parse-url')
+import test from '../../../tools/jil/browser-test'
+import { parseUrl } from '../../../packages/browser-agent-core/common/url/parse-url'
+import { setDenyList, shouldCollectEvent } from '../../../packages/browser-agent-core/common/deny-list/deny-list'
 
-const loader = require('loader')
-loader.features.xhr = true
-
-var shouldCollectEvent = require('../../../feature/xhr/aggregate/index').shouldCollectEvent
-var setDenyList = require('../../../feature/xhr/aggregate/index').setDenyList
+/* NOTE: This file contains pure unit tests that has no need for the agent at all.
+*/
 
 test('domain-only blocks all subdomains and all paths', function(t) {
   setDenyList([

--- a/tests/browser/xhr/onreadystatechange.browser.js
+++ b/tests/browser/xhr/onreadystatechange.browser.js
@@ -4,12 +4,16 @@
  */
 
 const jil = require('jil')
-let BrowserMatcher = require('jil/util/browser-matcher')
-let supported = BrowserMatcher.withFeature('xhr')
+const BrowserMatcher = require('jil/util/browser-matcher')
+import { setup } from '../utils/setup'
+const supported = BrowserMatcher.withFeature('xhr')
 
-jil.browserTest('xhr with onreadystatechange assigned after send', supported, function (t) {
-  var ffVersion = require('../../../loader/firefox-version')
-  require('../../../feature/xhr/instrument/index')
+const { agentIdentifier } = setup();
+
+jil.browserTest('xhr with onreadystatechange assigned after send', supported, async function (t) {
+  const ffVersion = await import('../../../packages/browser-agent-core/common/browser-version/firefox-version');
+  const { Instrument: AjaxInstrum } = await import('../../../packages/browser-agent-core/features/ajax/instrument/index');
+  const ajaxTestInstr = new AjaxInstrum(agentIdentifier);
 
   setTimeout(() => {
     let xhr = new XMLHttpRequest()
@@ -40,9 +44,10 @@ jil.browserTest('xhr with onreadystatechange assigned after send', supported, fu
   })
 })
 
-jil.browserTest('multiple XHRs with onreadystatechange assigned after send', supported, function (t) {
-  var ffVersion = require('../../../loader/firefox-version')
-  require('../../../feature/xhr/instrument/index')
+jil.browserTest('multiple XHRs with onreadystatechange assigned after send', supported, async function (t) {
+  const ffVersion = await import('../../../packages/browser-agent-core/common/browser-version/firefox-version');
+  const { Instrument: AjaxInstrum } = await import('../../../packages/browser-agent-core/features/ajax/instrument/index');
+  const ajaxTestInstr = new AjaxInstrum(agentIdentifier);
 
   setTimeout(() => {
     let xhr1 = new XMLHttpRequest()

--- a/tests/browser/xhr/parse-url.browser.js
+++ b/tests/browser/xhr/parse-url.browser.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-var test = require('../../../tools/jil/browser-test.js')
-var parseUrl = require('../../../feature/xhr/instrument/parse-url')
+import test from '../../../tools/jil/browser-test'
+import { parseUrl } from '../../../packages/browser-agent-core/common/url/parse-url'
 
 if (window.XMLHttpRequest && XMLHttpRequest.prototype && XMLHttpRequest.prototype.addEventListener) xhr_tests()
 else {

--- a/tests/browser/xhr/response-size.browser.js
+++ b/tests/browser/xhr/response-size.browser.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const test = require('../../../tools/jil/browser-test')
-var responseSizeFromXhr = require('../../../feature/xhr/instrument/response-size')
+import test from '../../../tools/jil/browser-test'
+import { responseSizeFromXhr } from '../../../packages/browser-agent-core/features/ajax/instrument/response-size'
 
 test('ms-stream has undefined size', function(t) {
   var xhrRequest = {

--- a/tests/browser/xhr/xhr-with-blob-body.browser.js
+++ b/tests/browser/xhr/xhr-with-blob-body.browser.js
@@ -4,15 +4,19 @@
  */
 
 const jil = require('jil')
-let BrowserMatcher = require('jil/util/browser-matcher')
-let xhrSupported = BrowserMatcher.withFeature('xhr')
-let blobSupported = BrowserMatcher.withFeature('blob')
-let supported = xhrSupported.intersect(blobSupported)
+const BrowserMatcher = require('jil/util/browser-matcher')
+import { setup } from '../utils/setup'
 
-jil.browserTest('xhr with blob request body', supported, function (t) {
-  require('../../../feature/xhr/instrument/index')
-  let drain = require('../../../agent/drain')
-  let register = require('../../../agent/register-handler')
+const { agentIdentifier, baseEE, aggregator } = setup();
+const xhrSupported = BrowserMatcher.withFeature('xhr')
+const blobSupported = BrowserMatcher.withFeature('blob')
+const supported = xhrSupported.intersect(blobSupported)
+
+jil.browserTest('xhr with blob request body', supported, async function (t) {
+  const { Instrument: AjaxInstrum } = await import('../../../packages/browser-agent-core/features/ajax/instrument/index');
+  const ajaxTestInstr = new AjaxInstrum(agentIdentifier);
+  const { drain } = await import('../../../packages/browser-agent-core/common/drain/drain')
+  const { registerHandler } = await import('../../../packages/browser-agent-core/common/event-emitter/register-handler')
 
   t.plan(3)
 
@@ -32,12 +36,14 @@ jil.browserTest('xhr with blob request body', supported, function (t) {
 
   xhr.send(new Blob(['hi!']))
 
-  register('xhr', function (params, metrics, start) {
-    require('../../../feature/xhr/aggregate')(params, metrics, start)
+  registerHandler('xhr', async function (params, metrics, start) {
+    const { Aggregate: AjaxAggreg } = await import('../../../packages/browser-agent-core/features/ajax/aggregate/index');
+    const ajaxTestAgg = new AjaxAggreg(agentIdentifier, aggregator);
+    ajaxTestAgg.storeXhr(params, metrics, start);
 
     t.equal(metrics.txSize, 3, 'correct size for sent blob objects')
     t.equal(metrics.rxSize, 3, 'correct size for received blob objects')
-  })
+  }, undefined, baseEE);
 
-  drain('feature')
+  drain(agentIdentifier, 'feature')
 })


### PR DESCRIPTION

### Overview

- `tests/browser/wrap-function/` folder migrated
- `tests/browser/xhr/` folder mgirated

### Related Github Issue
Part of the "Migrate CDN Browser Tests" roadmap task.
Part of the "Migrate to NPM agent" project (tests conversion phase).

### Testing
Tested both folders on local chrome@latest (macOS Monterey, .browser.js files) and,
Sauce's chrome@latest (windows 10, all files).

- 40 checks in wrap-function/
- 272 checks in xhr/
