### PR TITLE
Cleanup specs in .browser.js files

### DIFF
--- a/tests/browser/obfuscate.browser.js
+++ b/tests/browser/obfuscate.browser.js
@@ -5,8 +5,6 @@
 
 var jil = require('jil')
 
-const matcher = require('jil/util/browser-matcher')
-let supported = matcher.withFeature('obfuscate')
 
 var fileLocation = {
   hash: '',
@@ -69,7 +67,7 @@ var validationCases = [
   }
 ]
 
-jil.browserTest('Obfuscation validateRules input', supported, function (t) {
+jil.browserTest('Obfuscation validateRules input', function (t) {
   const obfuscate = require('../../agent/obfuscate')
 
   validationCases.forEach(function (testCase) {
@@ -81,7 +79,7 @@ jil.browserTest('Obfuscation validateRules input', supported, function (t) {
   })
 })
 
-jil.browserTest('Should Obfuscate', supported, function (t) {
+jil.browserTest('Should Obfuscate', function (t) {
   const win = require('../../agent/win')
   win.getWindow().NREUM = {
     init: {
@@ -97,7 +95,7 @@ jil.browserTest('Should Obfuscate', supported, function (t) {
   t.end()
 })
 
-jil.browserTest('Get Rules', supported, function (t) {
+jil.browserTest('Get Rules', function (t) {
   const win = require('../../agent/win')
   win.getWindow().NREUM = {
     init: {
@@ -118,7 +116,7 @@ jil.browserTest('Get Rules', supported, function (t) {
   t.end()
 })
 
-jil.browserTest('Obfuscate String Method', supported, function (t) {
+jil.browserTest('Obfuscate String Method', function (t) {
   const win = require('../../agent/win')
   win.getWindow().NREUM = {
     init: {

--- a/tests/browser/protocol.browser.js
+++ b/tests/browser/protocol.browser.js
@@ -5,8 +5,6 @@
 
 var jil = require('jil')
 
-const matcher = require('jil/util/browser-matcher')
-let supported = matcher.withFeature('obfuscate')
 
 var fileLocation = {
   hash: '',
@@ -19,7 +17,7 @@ var fileLocation = {
   protocol: 'file:'
 }
 
-jil.browserTest('isFileProtocol returns coorectly when detecting file protocol', supported, function (t) {
+jil.browserTest('isFileProtocol returns coorectly when detecting file protocol', function (t) {
   const win = require('../../agent/win')
   win.setWindow({ ...win.getWindow(), location: { ...fileLocation } })
 

--- a/tests/browser/spa/api.browser.js
+++ b/tests/browser/spa/api.browser.js
@@ -6,16 +6,14 @@
 let originalSetTimeout = global.setTimeout
 
 const jil = require('jil')
-const matcher = require('jil/util/browser-matcher')
 const {getInfo} = require('../../../packages/browser-agent-core/common/config/config')
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 
 let raf = global.reqiestAnimationFrame || function (fn) {
   return originalSetTimeout(fn, 16)
 }
 
-jil.browserTest('simple sync api test', supported, function (t) {
+jil.browserTest('simple sync api test', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -78,7 +76,7 @@ jil.browserTest('simple sync api test', supported, function (t) {
   }
 })
 
-jil.browserTest('simple async api test', supported, function (t) {
+jil.browserTest('simple async api test', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -122,7 +120,7 @@ jil.browserTest('simple async api test', supported, function (t) {
   }
 })
 
-jil.browserTest('async api no callback', supported, function (t) {
+jil.browserTest('async api no callback', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -165,7 +163,7 @@ jil.browserTest('async api no callback', supported, function (t) {
   }
 })
 
-jil.browserTest('async api outside interaction', supported, function (t) {
+jil.browserTest('async api outside interaction', function (t) {
   t.plan(4)
 
   var tracer = newrelic.interaction().createTracer('requestAnimationFrame', function (a, b, c) {
@@ -181,7 +179,7 @@ jil.browserTest('async api outside interaction', supported, function (t) {
   }, 5)
 })
 
-jil.browserTest('sync api outside interaction', supported, function (t) {
+jil.browserTest('sync api outside interaction', function (t) {
   t.plan(4)
 
   var returnVal = newrelic.interaction().createTracer('function 1', (a, b, c) => {
@@ -195,7 +193,7 @@ jil.browserTest('sync api outside interaction', supported, function (t) {
   t.end()
 })
 
-jil.browserTest('async api outside interaction with throw', supported, function (t) {
+jil.browserTest('async api outside interaction with throw', function (t) {
   var expected = new Error()
   var tracer = newrelic.interaction().createTracer('requestAnimationFrame', function (a, b, c) {
     t.equal(a, 1)
@@ -212,7 +210,7 @@ jil.browserTest('async api outside interaction with throw', supported, function 
   }
 })
 
-jil.browserTest('sync api outside interaction with throw', supported, function (t) {
+jil.browserTest('sync api outside interaction with throw', function (t) {
   var expected = new Error()
 
   try {
@@ -228,7 +226,7 @@ jil.browserTest('sync api outside interaction with throw', supported, function (
   }
 })
 
-jil.browserTest('simple sync api test with throw', supported, function (t) {
+jil.browserTest('simple sync api test with throw', function (t) {
   var expected = new Error()
   let helpers = require('./helpers')
 
@@ -277,7 +275,7 @@ jil.browserTest('simple sync api test with throw', supported, function (t) {
   }
 })
 
-jil.browserTest('simple async api test with throw', supported, function (t) {
+jil.browserTest('simple async api test with throw', function (t) {
   var expected = new Error()
   let helpers = require('./helpers')
 
@@ -329,7 +327,7 @@ jil.browserTest('simple async api test with throw', supported, function (t) {
   }
 })
 
-jil.browserTest('async api test with throw does not leave context', supported, function (t) {
+jil.browserTest('async api test with throw does not leave context', function (t) {
   var expected = new Error()
   let helpers = require('./helpers')
 
@@ -382,7 +380,7 @@ jil.browserTest('async api test with throw does not leave context', supported, f
   }
 })
 
-jil.browserTest('simple sync api test with throw and sibling', supported, function (t) {
+jil.browserTest('simple sync api test with throw and sibling', function (t) {
   var expected = new Error()
   let helpers = require('./helpers')
 
@@ -450,7 +448,7 @@ jil.browserTest('simple sync api test with throw and sibling', supported, functi
   }
 })
 
-jil.browserTest('end interaction', supported, function (t) {
+jil.browserTest('end interaction', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -481,7 +479,7 @@ jil.browserTest('end interaction', supported, function (t) {
   }
 })
 
-jil.browserTest('custom interaction name', supported, function (t) {
+jil.browserTest('custom interaction name', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -511,7 +509,7 @@ jil.browserTest('custom interaction name', supported, function (t) {
   }
 })
 
-jil.browserTest('custom actionText', supported, function (t) {
+jil.browserTest('custom actionText', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -543,7 +541,7 @@ jil.browserTest('custom actionText', supported, function (t) {
   }
 })
 
-jil.browserTest('ignore interaction', supported, function (t) {
+jil.browserTest('ignore interaction', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -572,7 +570,7 @@ jil.browserTest('ignore interaction', supported, function (t) {
   }
 })
 
-jil.browserTest('custom attributes', supported, function (t) {
+jil.browserTest('custom attributes', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -611,7 +609,7 @@ jil.browserTest('custom attributes', supported, function (t) {
   }
 })
 
-jil.browserTest('custom attributes and interaction attributes', supported, function (t) {
+jil.browserTest('custom attributes and interaction attributes', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -651,7 +649,7 @@ jil.browserTest('custom attributes and interaction attributes', supported, funct
   }
 })
 
-jil.browserTest('custom attributes and interaction attributes', supported, function (t) {
+jil.browserTest('custom attributes and interaction attributes', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -697,7 +695,7 @@ jil.browserTest('custom attributes and interaction attributes', supported, funct
   }
 })
 
-jil.browserTest('context store and onEnd', supported, function (t) {
+jil.browserTest('context store and onEnd', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -751,7 +749,7 @@ jil.browserTest('context store and onEnd', supported, function (t) {
   }
 })
 
-jil.browserTest('save', supported, function (t) {
+jil.browserTest('save', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -775,7 +773,7 @@ jil.browserTest('save', supported, function (t) {
   }
 })
 
-jil.browserTest('save with ignore', supported, function (t) {
+jil.browserTest('save with ignore', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -801,7 +799,7 @@ jil.browserTest('save with ignore', supported, function (t) {
   }
 })
 
-jil.browserTest('save with ignore after', supported, function (t) {
+jil.browserTest('save with ignore after', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -827,7 +825,7 @@ jil.browserTest('save with ignore after', supported, function (t) {
   }
 })
 
-jil.browserTest('interaction outside interaction', supported, function (t) {
+jil.browserTest('interaction outside interaction', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -880,7 +878,7 @@ jil.browserTest('interaction outside interaction', supported, function (t) {
   }
 })
 
-jil.browserTest('interaction outside wrapped function', supported, function (t) {
+jil.browserTest('interaction outside wrapped function', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -940,7 +938,7 @@ jil.browserTest('interaction outside wrapped function', supported, function (t) 
   }
 })
 
-jil.browserTest('set trigger', supported, function (t) {
+jil.browserTest('set trigger', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -983,7 +981,7 @@ jil.browserTest('set trigger', supported, function (t) {
   }
 })
 
-jil.browserTest('createTracer no name', supported, function (t) {
+jil.browserTest('createTracer no name', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -1024,7 +1022,7 @@ jil.browserTest('createTracer no name', supported, function (t) {
   }
 })
 
-jil.browserTest('createTracer no name, no callback', supported, function (t) {
+jil.browserTest('createTracer no name, no callback', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -1055,7 +1053,7 @@ jil.browserTest('createTracer no name, no callback', supported, function (t) {
   }
 })
 
-jil.browserTest('reuse handle from outside interaction', supported, function (t) {
+jil.browserTest('reuse handle from outside interaction', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/buffered-events.browser.js
+++ b/tests/browser/spa/buffered-events.browser.js
@@ -4,15 +4,13 @@
  */
 
 const jil = require('jil')
-const matcher = require('jil/util/browser-matcher')
 const { setup } = require('../utils/setup')
 
 const setupData = setup()
 const {baseEE, agentIdentifier, aggregator} = setupData
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa buffers all expected events', supported, function (t) {
+jil.browserTest('spa buffers all expected events', function (t) {
 
   var {registerHandler} = require('../../../packages/browser-agent-core/common/event-emitter/register-handler.js')
   var {drain} = require('../../../packages/browser-agent-core/common/drain/drain')

--- a/tests/browser/spa/callback-timing.browser.js
+++ b/tests/browser/spa/callback-timing.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('callback timing', supported, function (t) {
+jil.browserTest('callback timing', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',
@@ -43,7 +41,7 @@ jil.browserTest('callback timing', supported, function (t) {
   }
 })
 
-jil.browserTest('callback timing multiple callbacks', supported, function (t) {
+jil.browserTest('callback timing multiple callbacks', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',
@@ -85,7 +83,7 @@ jil.browserTest('callback timing multiple callbacks', supported, function (t) {
   }
 })
 
-jil.browserTest('callback timing microtasks', supported, function (t) {
+jil.browserTest('callback timing microtasks', function (t) {
   // can't use multiple matchers in same file
   if (!window.Promise) {
     t.end()

--- a/tests/browser/spa/cancelled-timer-in-callback.browser.js
+++ b/tests/browser/spa/cancelled-timer-in-callback.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa cancelled timer in callback', supported, function (t) {
+jil.browserTest('spa cancelled timer in callback', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/cancelled-timer-twice.browser.js
+++ b/tests/browser/spa/cancelled-timer-twice.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa cancelled timer in callback', supported, function (t) {
+jil.browserTest('spa cancelled timer in callback', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/cancelled-timer.browser.js
+++ b/tests/browser/spa/cancelled-timer.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa cancelled timer', supported, function (t) {
+jil.browserTest('spa cancelled timer', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/change.browser.js
+++ b/tests/browser/spa/change.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa change trigger', supported, function (t) {
+jil.browserTest('spa change trigger', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     attrs: { trigger: 'change' },

--- a/tests/browser/spa/ended-interaction.browser.js
+++ b/tests/browser/spa/ended-interaction.browser.js
@@ -4,8 +4,6 @@
  */
 
 const jil = require('jil')
-let matcher = require('jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
 if (process.browser) {
   var helpers = require('./helpers')
@@ -15,7 +13,7 @@ if (process.browser) {
   })
 }
 
-jil.browserTest('node is not restored for ended interaction', supported, function (t) {
+jil.browserTest('node is not restored for ended interaction', function (t) {
   t.plan(6)
 
   t.notok(helpers.currentNodeId(), 'interaction should be null at first')

--- a/tests/browser/spa/fetch-body-propagation-ext.browser.js
+++ b/tests/browser/spa/fetch-body-propagation-ext.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('fetchExt')
 
-jil.browserTest('spa single fetch with formData', supported, function (t) {
+jil.browserTest('spa single fetch with formData', function (t) {
   // check if Request.formData errors, see comment below
   var req = new Request('/formdata', {method: 'POST', body: new FormData()})
   if (req.formData) {

--- a/tests/browser/spa/fetch-body-propagation.browser.js
+++ b/tests/browser/spa/fetch-body-propagation.browser.js
@@ -4,8 +4,6 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('fetch')
 
 if (process.browser) {
   let helpers = require('./helpers')
@@ -18,7 +16,7 @@ if (process.browser) {
 var bodyMethods = ['arrayBuffer', 'blob', 'json', 'text']
 
 bodyMethods.forEach((bodyMethod) => {
-  jil.browserTest('Response.' + bodyMethod, supported, function (t) {
+  jil.browserTest('Response.' + bodyMethod, function (t) {
     let helpers = require('./helpers')
     let validator = new helpers.InteractionValidator({
       type: 'interaction',
@@ -70,7 +68,7 @@ bodyMethods.forEach((bodyMethod) => {
 })
 
 // Regression test that an interaction cannot have more than a set number of child nodes (MAX_NODES).
-jil.browserTest('Exceeding max SPA nodes', supported, function (t) {
+jil.browserTest('Exceeding max SPA nodes', function (t) {
   let helpers = require('./helpers')
   t.notok(helpers.currentNodeId(), 'interaction should be null at first')
 
@@ -114,7 +112,7 @@ jil.browserTest('Exceeding max SPA nodes', supported, function (t) {
   }
 })
 
-jil.browserTest('Response.formData', supported, function (t) {
+jil.browserTest('Response.formData', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     type: 'interaction',
@@ -166,7 +164,7 @@ jil.browserTest('Response.formData', supported, function (t) {
 })
 
 bodyMethods.forEach((bodyMethod) => {
-  jil.browserTest('Request.' + bodyMethod, supported, function (t) {
+  jil.browserTest('Request.' + bodyMethod, function (t) {
     let helpers = require('./helpers')
     let validator = new helpers.InteractionValidator({
       type: 'interaction',

--- a/tests/browser/spa/fetch-rejections.browser.js
+++ b/tests/browser/spa/fetch-rejections.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('fetch')
 
-jil.browserTest('fetch.reject', supported, function (t) {
+jil.browserTest('fetch.reject', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     type: 'interaction',
@@ -54,7 +52,7 @@ jil.browserTest('fetch.reject', supported, function (t) {
   }
 })
 
-jil.browserTest('fetch body.reject', supported, function (t) {
+jil.browserTest('fetch body.reject', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     type: 'interaction',

--- a/tests/browser/spa/hashchange-after-finish.browser.js
+++ b/tests/browser/spa/hashchange-after-finish.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa aggregator receives complete interaction when hashchange fires after finish', supported, function (t) {
+jil.browserTest('spa aggregator receives complete interaction when hashchange fires after finish', function (t) {
   let helpers = require('./helpers')
   let originalUrl = window.location.toString()
 

--- a/tests/browser/spa/hashchange-multiple-event-callbacks.browser.js
+++ b/tests/browser/spa/hashchange-multiple-event-callbacks.browser.js
@@ -4,14 +4,12 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
 if (process.browser) {
   var helpers = require('./helpers')
 }
 
-jil.browserTest('spa hashchange in second event callback', supported, function (t) {
+jil.browserTest('spa hashchange in second event callback', function (t) {
   var originalUrl = '' + window.location
   var expected = {
     name: 'interaction',

--- a/tests/browser/spa/hashchange-popstate.browser.js
+++ b/tests/browser/spa/hashchange-popstate.browser.js
@@ -5,8 +5,6 @@
 
 const jil = require('jil')
 let cleanUrl = require('../../../agent/clean-url')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
 if (process.browser) {
   var helpers = require('./helpers')
@@ -14,7 +12,7 @@ if (process.browser) {
   helpers.onWindowLoad(() => { loaded = true })
 }
 
-jil.browserTest('spa interaction triggered by hashchange + popstate', supported, function (t) {
+jil.browserTest('spa interaction triggered by hashchange + popstate', function (t) {
   if (!helpers.emitsPopstateEventOnHashChanges()) {
     t.skip('skipping popstate test in browser that does not emit popstate event on hash changes')
     t.end()

--- a/tests/browser/spa/initial-page-load.browser.js
+++ b/tests/browser/spa/initial-page-load.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('initial page load timing', supported, function (t) {
+jil.browserTest('initial page load timing', function (t) {
   var helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/keypress.browser.js
+++ b/tests/browser/spa/keypress.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa keypress trigger', supported, function (t) {
+jil.browserTest('spa keypress trigger', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     attrs: { trigger: 'keypress' },
@@ -49,7 +47,7 @@ jil.browserTest('spa keypress trigger', supported, function (t) {
   }
 })
 
-jil.browserTest('spa keyup trigger', supported, function (t) {
+jil.browserTest('spa keyup trigger', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     attrs: { trigger: 'keyup' },
@@ -91,7 +89,7 @@ jil.browserTest('spa keyup trigger', supported, function (t) {
   }
 })
 
-jil.browserTest('spa keydown trigger', supported, function (t) {
+jil.browserTest('spa keydown trigger', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     attrs: { trigger: 'keydown' },

--- a/tests/browser/spa/load-event-during-interaction.browser.js
+++ b/tests/browser/spa/load-event-during-interaction.browser.js
@@ -4,8 +4,6 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
 if (process.browser) {
   var helpers = require('./helpers')
@@ -15,7 +13,7 @@ if (process.browser) {
   })
 }
 
-jil.browserTest('load event during interaction', supported, function (t) {
+jil.browserTest('load event during interaction', function (t) {
   let validator = new helpers.InteractionValidator({
     name: 'interaction',
     children: []

--- a/tests/browser/spa/multiple-event-handlers.browser.js
+++ b/tests/browser/spa/multiple-event-handlers.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa multiple event handlers', supported, function (t) {
+jil.browserTest('spa multiple event handlers', function (t) {
   let helpers = require('./helpers')
 
   if (!window.performance) {

--- a/tests/browser/spa/mutation-observer-events.browser.js
+++ b/tests/browser/spa/mutation-observer-events.browser.js
@@ -4,15 +4,13 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('mutation')
 
 const { setup } = require('../utils/setup')
 
 const setupData = setup()
 const {baseEE} = setupData
 
-jil.browserTest('fn-start events for MutationObserver callbacks should have args', supported, function (t) {
+jil.browserTest('fn-start events for MutationObserver callbacks should have args', function (t) {
   t.plan(3)
 
   const {wrapMutation} = require('../../../packages/browser-agent-core/common/wrap/index')

--- a/tests/browser/spa/mutation-observer-instrumentation.browser.js
+++ b/tests/browser/spa/mutation-observer-instrumentation.browser.js
@@ -4,12 +4,9 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supportsMutationObserver = matcher.withFeature('mutation')
-let supportsEventListenerWrapping = matcher.withFeature('wrappableAddEventListener')
 let supported = supportsMutationObserver.intersect(supportsEventListenerWrapping)
 
-jil.browserTest('basic MutationObserver instrumentation', supported, function (t) {
+jil.browserTest('basic MutationObserver instrumentation', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/mutation-observer-instrumentation.browser.js
+++ b/tests/browser/spa/mutation-observer-instrumentation.browser.js
@@ -4,7 +4,6 @@
  */
 
 const jil = require('jil')
-let supported = supportsMutationObserver.intersect(supportsEventListenerWrapping)
 
 jil.browserTest('basic MutationObserver instrumentation', function (t) {
   let helpers = require('./helpers')

--- a/tests/browser/spa/mutation-observer.browser.js
+++ b/tests/browser/spa/mutation-observer.browser.js
@@ -4,15 +4,13 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('mutation')
 
 const { setup } = require('../utils/setup')
 
 const setupData = setup()
 const {agentIdentifier, nr} = setupData
 
-jil.browserTest('MutationObserver instanceof check', supported, function (t) {
+jil.browserTest('MutationObserver instanceof check', function (t) {
   var origMutationObserver = MutationObserver
   const {Instrument} = require('../../../packages/browser-agent-core/features/spa/instrument/index.js')
   new Instrument(agentIdentifier)
@@ -24,7 +22,7 @@ jil.browserTest('MutationObserver instanceof check', supported, function (t) {
   t.end()
 })
 
-jil.browserTest('MutationObserver double-instrumentation', supported, function (t) {
+jil.browserTest('MutationObserver double-instrumentation', function (t) {
   var OrigMutationObserver = MutationObserver
   const {Instrument} = require('../../../packages/browser-agent-core/features/spa/instrument/index.js')
   new Instrument(agentIdentifier)
@@ -41,7 +39,7 @@ jil.browserTest('MutationObserver double-instrumentation', supported, function (
   t.end()
 })
 
-jil.browserTest('MutationObserver functionality check', supported, function (t) {
+jil.browserTest('MutationObserver functionality check', function (t) {
   const {Instrument} = require('../../../packages/browser-agent-core/features/spa/instrument/index.js')
   new Instrument(agentIdentifier)
   let callbackInvocations = 0

--- a/tests/browser/spa/nested-timer.browser.js
+++ b/tests/browser/spa/nested-timer.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa nested timers', supported, function (t) {
+jil.browserTest('spa nested timers', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/nested-xhr.browser.js
+++ b/tests/browser/spa/nested-xhr.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa nested XHR', supported, function (t) {
+jil.browserTest('spa nested XHR', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/parallel-xhr-and-timers.browser.js
+++ b/tests/browser/spa/parallel-xhr-and-timers.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa parallel XHRs and timers', supported, function (t) {
+jil.browserTest('spa parallel XHRs and timers', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/promise-all.browser.js
+++ b/tests/browser/spa/promise-all.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
-jil.browserTest('Promise.all', supported, function (t) {
+jil.browserTest('Promise.all', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -49,7 +47,7 @@ jil.browserTest('Promise.all', supported, function (t) {
   }
 })
 
-jil.browserTest('Promise.all async resolve after rejected', supported, function (t) {
+jil.browserTest('Promise.all async resolve after rejected', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/promise-basic.browser.js
+++ b/tests/browser/spa/promise-basic.browser.js
@@ -6,18 +6,16 @@
 var unwrappedPromise = global.Promise
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
 // ff38 will throw if you copy the toString method from the native promise class
-jil.browserTest('stringifying promises still works', supported, function (t) {
+jil.browserTest('stringifying promises still works', function (t) {
   require('./helpers')
   t.ok(String(window.Promise).match(/function Promise\s*\(\)\s*{\s*\[native code\]\s*}/))
   t.ok(window.Promise.toString().match(/function Promise\s*\(\)\s*{\s*\[native code\]\s*}/))
   t.end()
 })
 
-jil.browserTest('basic promise chain', supported, function (t) {
+jil.browserTest('basic promise chain', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -80,7 +78,7 @@ jil.browserTest('basic promise chain', supported, function (t) {
   }
 })
 
-jil.browserTest('instanceof', supported, function diferTest (t) {
+jil.browserTest('instanceof', function diferTest (t) {
   var promise = Promise.resolve()
   var unwrapped = unwrappedPromise.resolve()
 
@@ -91,7 +89,7 @@ jil.browserTest('instanceof', supported, function diferTest (t) {
   t.end()
 })
 
-jil.browserTest('Promise throw in executor', supported, function (t) {
+jil.browserTest('Promise throw in executor', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/promise-catch.browser.js
+++ b/tests/browser/spa/promise-catch.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
-jil.browserTest('promise.catch', supported, function (t) {
+jil.browserTest('promise.catch', function (t) {
   let helpers = require('./helpers')
   var validator = new helpers.InteractionValidator({
     attrs: {
@@ -49,7 +47,7 @@ jil.browserTest('promise.catch', supported, function (t) {
   }
 })
 
-jil.browserTest('promise.catch chain with async', supported, function (t) {
+jil.browserTest('promise.catch chain with async', function (t) {
   let helpers = require('./helpers')
 
   if (!window.Promise) {
@@ -111,7 +109,7 @@ jil.browserTest('promise.catch chain with async', supported, function (t) {
   }
 })
 
-jil.browserTest('throw in promise.catch', supported, function (t) {
+jil.browserTest('throw in promise.catch', function (t) {
   let helpers = require('./helpers')
 
   var validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/promise-race.browser.js
+++ b/tests/browser/spa/promise-race.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
-jil.browserTest('Promise.race', supported, function (t) {
+jil.browserTest('Promise.race', function (t) {
   let helpers = require('./helpers')
   var validator = new helpers.InteractionValidator({
     attrs: {
@@ -49,7 +47,7 @@ jil.browserTest('Promise.race', supported, function (t) {
   }
 })
 
-jil.browserTest('Promise.race async accept', supported, function (t) {
+jil.browserTest('Promise.race async accept', function (t) {
   if (navigator.userAgent.match(/Edge\/\d/)) {
     t.skip('Promise.race is broken in edge 20, but fixed in latest release of edge which is not available in saucelabs')
     t.end()

--- a/tests/browser/spa/promise-reject.browser.js
+++ b/tests/browser/spa/promise-reject.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
-jil.browserTest('promise.reject', supported, function (t) {
+jil.browserTest('promise.reject', function (t) {
   let helpers = require('./helpers')
   var validator = new helpers.InteractionValidator({
     attrs: {

--- a/tests/browser/spa/promise-resolve.browser.js
+++ b/tests/browser/spa/promise-resolve.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
-jil.browserTest('Promise.resolve', supported, function (t) {
+jil.browserTest('Promise.resolve', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -48,7 +46,7 @@ jil.browserTest('Promise.resolve', supported, function (t) {
   }
 })
 
-jil.browserTest('promise.resolve with Promise argument', supported, function (t) {
+jil.browserTest('promise.resolve with Promise argument', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/promise-sync-chain.browser.js
+++ b/tests/browser/spa/promise-sync-chain.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
-jil.browserTest('promise.then sync chains', supported, function (t) {
+jil.browserTest('promise.then sync chains', function (t) {
   let helpers = require('./helpers')
   var validator = new helpers.InteractionValidator({
     attrs: {

--- a/tests/browser/spa/promise-then.browser.js
+++ b/tests/browser/spa/promise-then.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
-jil.browserTest('promise.then', supported, function (t) {
+jil.browserTest('promise.then', function (t) {
   let helpers = require('./helpers')
   var validator = new helpers.InteractionValidator({
     attrs: {
@@ -49,7 +47,7 @@ jil.browserTest('promise.then', supported, function (t) {
   }
 })
 
-jil.browserTest('promise.then chain with async', supported, function (t) {
+jil.browserTest('promise.then chain with async', function (t) {
   let helpers = require('./helpers')
 
   var validator = new helpers.InteractionValidator({
@@ -105,7 +103,7 @@ jil.browserTest('promise.then chain with async', supported, function (t) {
   }
 })
 
-jil.browserTest('promise.then chain with async with rejection', supported, function (t) {
+jil.browserTest('promise.then chain with async with rejection', function (t) {
   let helpers = require('./helpers')
 
   if (!window.Promise) {
@@ -167,7 +165,7 @@ jil.browserTest('promise.then chain with async with rejection', supported, funct
   }
 })
 
-jil.browserTest('throw in promise.then', supported, function (t) {
+jil.browserTest('throw in promise.then', function (t) {
   let helpers = require('./helpers')
 
   if (!window.Promise) {
@@ -220,7 +218,7 @@ jil.browserTest('throw in promise.then', supported, function (t) {
   }
 })
 
-jil.browserTest('throw in promise.then', supported, function (t) {
+jil.browserTest('throw in promise.then', function (t) {
   let helpers = require('./helpers')
 
   if (!window.Promise) {

--- a/tests/browser/spa/pushstate-popstate.browser.js
+++ b/tests/browser/spa/pushstate-popstate.browser.js
@@ -4,8 +4,6 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
 if (process.browser) {
   var helpers = require('./helpers')
@@ -13,7 +11,7 @@ if (process.browser) {
   helpers.onWindowLoad(() => { loaded = true })
 }
 
-jil.browserTest('spa interaction triggered by pushstate + popstate', supported, function (t) {
+jil.browserTest('spa interaction triggered by pushstate + popstate', function (t) {
   if (!window.history.pushState) {
     t.skip('skipping SPA test in browser that does not support pushState')
     t.end()

--- a/tests/browser/spa/route-change-detection.browser.js
+++ b/tests/browser/spa/route-change-detection.browser.js
@@ -4,11 +4,9 @@
  */
 
 const jil = require('jil')
-const matcher = require('../../../tools/jil/util/browser-matcher')
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('setCurrentRouteName', supported, function (t) {
+jil.browserTest('setCurrentRouteName', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -40,7 +38,7 @@ jil.browserTest('setCurrentRouteName', supported, function (t) {
   }
 })
 
-jil.browserTest('interaction is not a route change if it does not change the url while route name is null', supported, function (t) {
+jil.browserTest('interaction is not a route change if it does not change the url while route name is null', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -67,7 +65,7 @@ jil.browserTest('interaction is not a route change if it does not change the url
   }
 })
 
-jil.browserTest('interaction is not a route change if it does not change url or route', supported, function (t) {
+jil.browserTest('interaction is not a route change if it does not change url or route', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -94,7 +92,7 @@ jil.browserTest('interaction is not a route change if it does not change url or 
   }
 })
 
-jil.browserTest('url change is a route change when route name is set', supported, function (t) {
+jil.browserTest('url change is a route change when route name is set', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -122,7 +120,7 @@ jil.browserTest('url change is a route change when route name is set', supported
   }
 })
 
-jil.browserTest('replaceState is a route change when route name is set', supported, function (t) {
+jil.browserTest('replaceState is a route change when route name is set', function (t) {
   let helpers = require('./helpers')
 
   if (!window.history.replaceState) {
@@ -158,7 +156,7 @@ jil.browserTest('replaceState is a route change when route name is set', support
   }
 })
 
-jil.browserTest('setting route to null does not count as a route change', supported, function (t) {
+jil.browserTest('setting route to null does not count as a route change', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -186,7 +184,7 @@ jil.browserTest('setting route to null does not count as a route change', suppor
   }
 })
 
-jil.browserTest('changing the url when route name is null counts as a route change', supported, function (t) {
+jil.browserTest('changing the url when route name is null counts as a route change', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -216,7 +214,7 @@ jil.browserTest('changing the url when route name is null counts as a route chan
   }
 })
 
-jil.browserTest('resetting the route to the same routename does not count as a route change', supported, function (t) {
+jil.browserTest('resetting the route to the same routename does not count as a route change', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -245,7 +243,7 @@ jil.browserTest('resetting the route to the same routename does not count as a r
   }
 })
 
-jil.browserTest('changeing route, and changing back to original is not a route change', supported, function (t) {
+jil.browserTest('changeing route, and changing back to original is not a route change', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({
@@ -275,7 +273,7 @@ jil.browserTest('changeing route, and changing back to original is not a route c
   }
 })
 
-jil.browserTest('changeing url, and changing back to original is a route change', supported, function (t) {
+jil.browserTest('changeing url, and changing back to original is a route change', function (t) {
   let helpers = require('./helpers')
 
   let validator = new helpers.InteractionValidator({

--- a/tests/browser/spa/same-callback-multiple-xhrs.browser.js
+++ b/tests/browser/spa/same-callback-multiple-xhrs.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('multiple XHRs with the same callback function', supported, function (t) {
+jil.browserTest('multiple XHRs with the same callback function', function (t) {
   let helpers = require('./helpers')
 
   let i = 0

--- a/tests/browser/spa/serializer.browser.js
+++ b/tests/browser/spa/serializer.browser.js
@@ -4,13 +4,15 @@
  */
 
 const jil = require('jil')
+const matcher = require('../../../tools/jil/util/browser-matcher')
 const { setup } = require('../utils/setup')
 const { getInfo, setInfo } = require("../../../packages/browser-agent-core/common/config/config")
 
 const setupData = setup()
 const {baseEE, agentIdentifier, aggregator} = setupData
 
-
+// TO DO(?) - this file doesn't run correctly if it's cleaned up under pull #243, i.e. remove `matcher` and `supported`
+let supported = matcher.withFeature('wrappableAddEventListener')
 var qp = require('@newrelic/nr-querypack')
 let testCases = require('@newrelic/nr-querypack/examples/all.json').filter((testCase) => {
   return testCase.schema.name === 'bel' &&
@@ -37,12 +39,12 @@ var fieldPropMap = {
 }
 
 _forEach(testCases, function (testCase) {
-  jil.browserTest('spa interaction serializer ' + testCase.name, function (t) {
+  jil.browserTest('spa interaction serializer ' + testCase.name, supported, function (t) {
     runTest(testCase, t)
   })
 })
 
-jil.browserTest('spa interaction serializer attributes', function (t) {
+jil.browserTest('spa interaction serializer attributes', supported, function (t) {
   let interaction = new Interaction('click', 1459358524622, 'http://example.com/', undefined, undefined, agentIdentifier)
   interaction.root.attrs.custom['undefined'] = void 0
   interaction.root.attrs.custom['function'] = function foo (bar) {
@@ -73,7 +75,7 @@ jil.browserTest('spa interaction serializer attributes', function (t) {
   t.end()
 }, 'attributes should be correct')
 
-jil.browserTest('spa interaction serializer attributes', function (t) {
+jil.browserTest('spa interaction serializer attributes', supported, function (t) {
   let interaction = new Interaction('click', 1459358524622, 'http://example.com/', undefined, undefined, agentIdentifier)
 
   for (var i = 1; i < 100; ++i) {
@@ -90,14 +92,14 @@ jil.browserTest('spa interaction serializer attributes', function (t) {
   t.end()
 }, 'attributes should be limited')
 
-jil.browserTest('spa interaction serializer with undefined string values', function (t) {
+jil.browserTest('spa interaction serializer with undefined string values', supported, function (t) {
   var interaction = new Interaction('click', 1459358524622, 'http://domain/path', undefined, undefined, agentIdentifier)
   let decoded = qp.decode(serializer.serializeSingle(interaction.root))
   t.equal(decoded[0].customName, null, 'customName (which was undefined originally) should have default value')
   t.end()
 })
 
-jil.browserTest('serializing multiple interactions', function(t) {
+jil.browserTest('serializing multiple interactions', supported, function(t) {
   var ixn = new Interaction('initialPageLoad', 0, 'http://some-domain', undefined, undefined, agentIdentifier)
   addAjaxNode(ixn.root)
 

--- a/tests/browser/spa/serializer.browser.js
+++ b/tests/browser/spa/serializer.browser.js
@@ -4,7 +4,6 @@
  */
 
 const jil = require('jil')
-const matcher = require('../../../tools/jil/util/browser-matcher')
 const { setup } = require('../utils/setup')
 const { getInfo, setInfo } = require("../../../packages/browser-agent-core/common/config/config")
 
@@ -12,7 +11,6 @@ const setupData = setup()
 const {baseEE, agentIdentifier, aggregator} = setupData
 
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 var qp = require('@newrelic/nr-querypack')
 let testCases = require('@newrelic/nr-querypack/examples/all.json').filter((testCase) => {
   return testCase.schema.name === 'bel' &&
@@ -39,12 +37,12 @@ var fieldPropMap = {
 }
 
 _forEach(testCases, function (testCase) {
-  jil.browserTest('spa interaction serializer ' + testCase.name, supported, function (t) {
+  jil.browserTest('spa interaction serializer ' + testCase.name, function (t) {
     runTest(testCase, t)
   })
 })
 
-jil.browserTest('spa interaction serializer attributes', supported, function (t) {
+jil.browserTest('spa interaction serializer attributes', function (t) {
   let interaction = new Interaction('click', 1459358524622, 'http://example.com/', undefined, undefined, agentIdentifier)
   interaction.root.attrs.custom['undefined'] = void 0
   interaction.root.attrs.custom['function'] = function foo (bar) {
@@ -75,7 +73,7 @@ jil.browserTest('spa interaction serializer attributes', supported, function (t)
   t.end()
 }, 'attributes should be correct')
 
-jil.browserTest('spa interaction serializer attributes', supported, function (t) {
+jil.browserTest('spa interaction serializer attributes', function (t) {
   let interaction = new Interaction('click', 1459358524622, 'http://example.com/', undefined, undefined, agentIdentifier)
 
   for (var i = 1; i < 100; ++i) {
@@ -92,14 +90,14 @@ jil.browserTest('spa interaction serializer attributes', supported, function (t)
   t.end()
 }, 'attributes should be limited')
 
-jil.browserTest('spa interaction serializer with undefined string values', supported, function (t) {
+jil.browserTest('spa interaction serializer with undefined string values', function (t) {
   var interaction = new Interaction('click', 1459358524622, 'http://domain/path', undefined, undefined, agentIdentifier)
   let decoded = qp.decode(serializer.serializeSingle(interaction.root))
   t.equal(decoded[0].customName, null, 'customName (which was undefined originally) should have default value')
   t.end()
 })
 
-jil.browserTest('serializing multiple interactions', supported, function(t) {
+jil.browserTest('serializing multiple interactions', function(t) {
   var ixn = new Interaction('initialPageLoad', 0, 'http://some-domain', undefined, undefined, agentIdentifier)
   addAjaxNode(ixn.root)
 

--- a/tests/browser/spa/single-fetch.browser.js
+++ b/tests/browser/spa/single-fetch.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('fetch')
 
-jil.browserTest('spa single fetch', supported, function (t) {
+jil.browserTest('spa single fetch', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/single-timer.browser.js
+++ b/tests/browser/spa/single-timer.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa single timer', supported, function (t) {
+jil.browserTest('spa single timer', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/single-xhr.browser.js
+++ b/tests/browser/spa/single-xhr.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa single XHR', supported, function (t) {
+jil.browserTest('spa single XHR', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/sync-events.browser.js
+++ b/tests/browser/spa/sync-events.browser.js
@@ -4,8 +4,6 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
 let loaded = false
 let loadQueue = []
@@ -27,7 +25,7 @@ function onWindowLoad (cb) {
   }
 }
 
-jil.browserTest('sync event in timer', supported, function (t) {
+jil.browserTest('sync event in timer', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',
@@ -94,7 +92,7 @@ jil.browserTest('sync event in timer', supported, function (t) {
   }
 })
 
-jil.browserTest('sync event in click', supported, function (t) {
+jil.browserTest('sync event in click', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/timer-between-cb-and-microtasks.browser.js
+++ b/tests/browser/spa/timer-between-cb-and-microtasks.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('promise')
 
-jil.browserTest('timer between cb and microtasks', supported, function (t) {
+jil.browserTest('timer between cb and microtasks', function (t) {
   let helpers = require('./helpers')
   if (!window.performance) {
     t.skip('window.performance is required for this test')

--- a/tests/browser/spa/timer-cutoff.browser.js
+++ b/tests/browser/spa/timer-cutoff.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('timer cutoff', supported, function (t) {
+jil.browserTest('timer cutoff', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',
@@ -58,7 +56,7 @@ jil.browserTest('timer cutoff', supported, function (t) {
   }
 })
 
-jil.browserTest('string values for duration', supported, function (t) {
+jil.browserTest('string values for duration', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/traced-callback.browser.js
+++ b/tests/browser/spa/traced-callback.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa single timer', supported, function (t) {
+jil.browserTest('spa single timer', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/xhr-never-call-send.browser.js
+++ b/tests/browser/spa/xhr-never-call-send.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('interaction does not include xhrs that are not sent', supported, function (t) {
+jil.browserTest('interaction does not include xhrs that are not sent', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/spa/xhr-readystatechange.browser.js
+++ b/tests/browser/spa/xhr-readystatechange.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('spa XHR readystatechange callback', supported, function (t) {
+jil.browserTest('spa XHR readystatechange callback', function (t) {
   let helpers = require('./helpers')
   let validator = new helpers.InteractionValidator({
     name: 'interaction',

--- a/tests/browser/timings-fi-attributes.browser.js
+++ b/tests/browser/timings-fi-attributes.browser.js
@@ -4,11 +4,9 @@
  */
 
 const jil = require('jil')
-const matcher = require('../../tools/jil/util/browser-matcher')
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('sends expected attributes when available', supported, function(t) {
+jil.browserTest('sends expected attributes when available', function(t) {
   var handle = require('handle')
   var harvest = require('../../agent/harvest')
   var timingModule = require('../../agent/timings')

--- a/tests/browser/timings-lcp-attributes.browser.js
+++ b/tests/browser/timings-lcp-attributes.browser.js
@@ -4,11 +4,9 @@
  */
 
 const jil = require('jil')
-const matcher = require('../../tools/jil/util/browser-matcher')
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('sends expected attributes when available', supported, function(t) {
+jil.browserTest('sends expected attributes when available', function(t) {
   var handle = require('handle')
   var harvest = require('../../agent/harvest')
   var timingModule = require('../../agent/timings')

--- a/tests/browser/timings-lcp-cls.browser.js
+++ b/tests/browser/timings-lcp-cls.browser.js
@@ -4,11 +4,9 @@
  */
 
 const jil = require('jil')
-const matcher = require('../../tools/jil/util/browser-matcher')
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('LCP event with CLS attribute', supported, function (t) {
+jil.browserTest('LCP event with CLS attribute', function (t) {
   var handle = require('handle')
   var harvest = require('../../agent/harvest')
   var timingModule = require('../../agent/timings')

--- a/tests/browser/timings-lcp.browser.js
+++ b/tests/browser/timings-lcp.browser.js
@@ -4,11 +4,9 @@
  */
 
 const jil = require('jil')
-const matcher = require('../../tools/jil/util/browser-matcher')
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('LCP is not collected on unload when the LCP value occurs after max timeout', supported, function (t) {
+jil.browserTest('LCP is not collected on unload when the LCP value occurs after max timeout', function (t) {
   var handle = require('handle')
   var harvest = require('../../agent/harvest')
   var timingModule = require('../../agent/timings')

--- a/tests/browser/timings.browser.js
+++ b/tests/browser/timings.browser.js
@@ -4,9 +4,7 @@
  */
 
 const jil = require('jil')
-const matcher = require('../../tools/jil/util/browser-matcher')
 
-let supported = matcher.withFeature('wrappableAddEventListener')
 var qp = require('@newrelic/nr-querypack')
 
 if (process.browser) {
@@ -241,7 +239,7 @@ function waitForWindowLoad (fn) {
   }
 }
 
-jil.browserTest('spa interaction serializer attributes', supported, function (t) {
+jil.browserTest('spa interaction serializer attributes', function (t) {
   var timing = require('../../agent/timings')
   var schema = qp.schemas['bel.6']
 
@@ -260,7 +258,7 @@ jil.browserTest('spa interaction serializer attributes', supported, function (t)
   }
 })
 
-jil.browserTest('spa interaction serializer attributes', supported, function (t) {
+jil.browserTest('spa interaction serializer attributes', function (t) {
   var timing = require('../../agent/timings')
   waitForWindowLoad(startTest)
 

--- a/tests/browser/wrap-event-target.browser.js
+++ b/tests/browser/wrap-event-target.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
-jil.browserTest('AEL on window should call through to AEL on EventTarget', supported, function (t) {
+jil.browserTest('AEL on window should call through to AEL on EventTarget', function (t) {
   t.plan(3)
   var target = window
 

--- a/tests/browser/wrap-events-ie-iframe.browser.js
+++ b/tests/browser/wrap-events-ie-iframe.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('setImmediate')
 
-jil.browserTest('Does not throw an error when iframe with newrelic disappears', supported, function (t) {
+jil.browserTest('Does not throw an error when iframe with newrelic disappears', function (t) {
   var iframe = document.createElement('iframe')
   var followerDoc
   var attemptCount = 0

--- a/tests/browser/wrap-events.browser.js
+++ b/tests/browser/wrap-events.browser.js
@@ -4,8 +4,6 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('wrappableAddEventListener')
 
 function removeListener (type, fn) {
   const handlers = this.listeners(type)
@@ -13,7 +11,7 @@ function removeListener (type, fn) {
   handlers.splice(index, 1)
 }
 
-jil.browserTest('addEventListener should target only the given event', supported, function (t) {
+jil.browserTest('addEventListener should target only the given event', function (t) {
   var ee = require('ee')
   ee.removeListener = removeListener
   require('../../feature/wrap-events.js')
@@ -39,7 +37,7 @@ jil.browserTest('addEventListener should target only the given event', supported
   t.end()
 })
 
-jil.browserTest('addEventListener should not blow up with a null func', supported, function (t) {
+jil.browserTest('addEventListener should not blow up with a null func', function (t) {
   require('../../feature/wrap-events.js')
 
   let e = createAndAddDomElement()
@@ -53,7 +51,7 @@ jil.browserTest('addEventListener should not blow up with a null func', supporte
   t.end()
 })
 
-jil.browserTest('addEventListener allows multiple subscribers to same event on same element', supported, function (t) {
+jil.browserTest('addEventListener allows multiple subscribers to same event on same element', function (t) {
   require('../../feature/wrap-events.js')
 
   let handler1CallCount = 0
@@ -71,7 +69,7 @@ jil.browserTest('addEventListener allows multiple subscribers to same event on s
   t.end()
 })
 
-jil.browserTest('addEventListener allows object with handleEvent property', supported, function (t) {
+jil.browserTest('addEventListener allows object with handleEvent property', function (t) {
   var ee = require('ee')
   ee.removeListener = removeListener
   require('../../feature/wrap-events.js')
@@ -106,7 +104,7 @@ jil.browserTest('addEventListener allows object with handleEvent property', supp
   t.end()
 })
 
-jil.browserTest('addEventListener allows for multiple event listeners with an object', supported, function (t) {
+jil.browserTest('addEventListener allows for multiple event listeners with an object', function (t) {
   var ee = require('ee')
   ee.removeListener = removeListener
   require('../../feature/wrap-events.js')
@@ -151,7 +149,7 @@ jil.browserTest('addEventListener allows for multiple event listeners with an ob
   t.end()
 })
 
-jil.browserTest('addEventListener allows object with handleEvent property that is mutated', supported, function (t) {
+jil.browserTest('addEventListener allows object with handleEvent property that is mutated', function (t) {
   var ee = require('ee')
   ee.removeListener = removeListener
   require('../../feature/wrap-events.js')
@@ -189,7 +187,7 @@ jil.browserTest('addEventListener allows object with handleEvent property that i
   t.end()
 })
 
-jil.browserTest('addEventListener allows object with handleEvent property that is originally null', supported, function (t) {
+jil.browserTest('addEventListener allows object with handleEvent property that is originally null', function (t) {
   require('../../feature/wrap-events.js')
 
   let Clicker = function (el) {
@@ -213,7 +211,7 @@ jil.browserTest('addEventListener allows object with handleEvent property that i
   t.end()
 })
 
-jil.browserTest('removeEventListener works with handleEvent property', supported, function (t) {
+jil.browserTest('removeEventListener works with handleEvent property', function (t) {
   require('../../feature/wrap-events.js')
 
   let Clicker = function (el) {
@@ -240,7 +238,7 @@ jil.browserTest('removeEventListener works with handleEvent property', supported
   t.end()
 })
 
-jil.browserTest('removeEventListener works when same callback is passed for different events', supported, function (t) {
+jil.browserTest('removeEventListener works when same callback is passed for different events', function (t) {
   require('../../feature/wrap-events.js')
 
   let handlerCallCount = 0
@@ -270,7 +268,7 @@ jil.browserTest('removeEventListener works when same callback is passed for diff
   function handler () { handlerCallCount++ }
 })
 
-jil.browserTest('removeEventListener works when same callback is passed for different elements', supported, function (t) {
+jil.browserTest('removeEventListener works when same callback is passed for different elements', function (t) {
   require('../../feature/wrap-events.js')
 
   let handlerCallCount = 0

--- a/tests/browser/wrap-fetch.browser.js
+++ b/tests/browser/wrap-fetch.browser.js
@@ -4,10 +4,8 @@
  */
 
 const jil = require('jil')
-var matcher = require('../../tools/jil/util/browser-matcher')
-var supported = matcher.withFeature('fetch')
 
-jil.browserTest('response size', supported, function(t) {
+jil.browserTest('response size', function(t) {
   var fetchEE = require('../../feature/wrap-fetch.js')
 
   t.test('is captured when content-length is present', function(t) {
@@ -57,7 +55,7 @@ jil.browserTest('response size', supported, function(t) {
   })
 })
 
-jil.browserTest('Safari 11 fetch clone regression', supported, function (t) {
+jil.browserTest('Safari 11 fetch clone regression', function (t) {
   var responseSizes = [1, 10, 100, 1000, 10000, 100000]
   responseSizes.forEach(function(size) {
     t.test('agent should not cause clone to fail, response size: ' + size, function(t) {

--- a/tests/browser/wrap-jsonp.browser.js
+++ b/tests/browser/wrap-jsonp.browser.js
@@ -4,8 +4,6 @@
  */
 
 const jil = require('jil')
-let matcher = require('../../tools/jil/util/browser-matcher')
-let supported = matcher.withFeature('addEventListener')
 
 function removeListener (type, fn) {
   const handlers = this.listeners(type)
@@ -36,7 +34,7 @@ invalidUrls.forEach((url) => {
 })
 
 function shouldWork (url) {
-  jil.browserTest('jsonp works with ' + url, supported, function (t) {
+  jil.browserTest('jsonp works with ' + url, function (t) {
     t.plan(1)
 
     var ee = require('ee').get('jsonp')
@@ -61,7 +59,7 @@ function shouldWork (url) {
 }
 
 function shouldNotWork (url) {
-  jil.browserTest('jsonp does not work with ' + url, supported, function (t) {
+  jil.browserTest('jsonp does not work with ' + url, function (t) {
     t.plan(1)
 
     var ee = require('ee').get('jsonp')

--- a/tests/browser/xhr/onreadystatechange.browser.js
+++ b/tests/browser/xhr/onreadystatechange.browser.js
@@ -4,13 +4,11 @@
  */
 
 const jil = require('jil')
-const BrowserMatcher = require('jil/util/browser-matcher')
 import { setup } from '../utils/setup'
-const supported = BrowserMatcher.withFeature('xhr')
 
 const { agentIdentifier } = setup();
 
-jil.browserTest('xhr with onreadystatechange assigned after send', supported, async function (t) {
+jil.browserTest('xhr with onreadystatechange assigned after send', async function (t) {
   const ffVersion = await import('../../../packages/browser-agent-core/common/browser-version/firefox-version');
   const { Instrument: AjaxInstrum } = await import('../../../packages/browser-agent-core/features/ajax/instrument/index');
   const ajaxTestInstr = new AjaxInstrum(agentIdentifier);
@@ -44,7 +42,7 @@ jil.browserTest('xhr with onreadystatechange assigned after send', supported, as
   })
 })
 
-jil.browserTest('multiple XHRs with onreadystatechange assigned after send', supported, async function (t) {
+jil.browserTest('multiple XHRs with onreadystatechange assigned after send', async function (t) {
   const ffVersion = await import('../../../packages/browser-agent-core/common/browser-version/firefox-version');
   const { Instrument: AjaxInstrum } = await import('../../../packages/browser-agent-core/features/ajax/instrument/index');
   const ajaxTestInstr = new AjaxInstrum(agentIdentifier);

--- a/tests/browser/xhr/xhr-with-blob-body.browser.js
+++ b/tests/browser/xhr/xhr-with-blob-body.browser.js
@@ -4,15 +4,11 @@
  */
 
 const jil = require('jil')
-const BrowserMatcher = require('jil/util/browser-matcher')
 import { setup } from '../utils/setup'
 
 const { agentIdentifier, baseEE, aggregator } = setup();
-const xhrSupported = BrowserMatcher.withFeature('xhr')
-const blobSupported = BrowserMatcher.withFeature('blob')
-const supported = xhrSupported.intersect(blobSupported)
 
-jil.browserTest('xhr with blob request body', supported, async function (t) {
+jil.browserTest('xhr with blob request body', async function (t) {
   const { Instrument: AjaxInstrum } = await import('../../../packages/browser-agent-core/features/ajax/instrument/index');
   const ajaxTestInstr = new AjaxInstrum(agentIdentifier);
   const { drain } = await import('../../../packages/browser-agent-core/common/drain/drain')


### PR DESCRIPTION
### Overview
Post clean-up task of separating specs from `.browser.js` tests in previous PR.

### Related Github Issue
This is tied to #243 

### Testing
Re-tested against all of `tests/browser/` except for `stn/` and uncategorized tests, which are not yet migrated.