### PR TITLE
Added sessionId and deprecated 'ck' param in query string

### DIFF
--- a/packages/browser-agent-core/common/config/state/runtime.js
+++ b/packages/browser-agent-core/common/config/state/runtime.js
@@ -3,7 +3,7 @@ import { getLastTimestamp } from '../../timing/now'
 import * as userAgent from '../../util/user-agent'
 import { Configurable } from './configurable'
 import { gosNREUMInitializedAgents } from '../../window/nreum'
-import { getCurrentSessionId } from '../../window/session-storage'
+import { getCurrentSessionIdOrMakeNew } from '../../window/session-storage'
 import { getConfigurationValue } from '../config'
 
 var XHR = window.XMLHttpRequest
@@ -19,7 +19,7 @@ const model = agentId => { return {
   origin: '' + window.location,
   ptid: undefined,
   releaseIds: {},
-  sessionId: getConfigurationValue(agentId, 'privacy.cookies_enabled') === true ? getCurrentSessionId() : '0',
+  sessionId: getConfigurationValue(agentId, 'privacy.cookies_enabled') === true ? getCurrentSessionIdOrMakeNew() : '0',
   xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'] && !/CriOS/.test(navigator.userAgent),
   userAgent
 }}

--- a/packages/browser-agent-core/common/config/state/runtime.js
+++ b/packages/browser-agent-core/common/config/state/runtime.js
@@ -3,23 +3,26 @@ import { getLastTimestamp } from '../../timing/now'
 import * as userAgent from '../../util/user-agent'
 import { Configurable } from './configurable'
 import { gosNREUMInitializedAgents } from '../../window/nreum'
+import { getCurrentSessionId } from '../../window/session-storage'
+import { getConfigurationValue } from '../config'
 
 var XHR = window.XMLHttpRequest
 var XHR_PROTO = XHR && XHR.prototype
 
-const model = {
-  origin: '' + window.location,
+const model = agentId => { return {
+  customTransaction: undefined,
+  disabled: false,
+  features: {},
   maxBytes: ieVersion === 6 ? 2000 : 30000,
   offset: getLastTimestamp(),
-  features: {},
-  customTransaction: undefined,
   onerror: undefined,
-  releaseIds: {},
-  xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'] && !/CriOS/.test(navigator.userAgent),
-  disabled: false,
+  origin: '' + window.location,
   ptid: undefined,
+  releaseIds: {},
+  sessionId: getConfigurationValue(agentId, 'privacy.cookies_enabled') === true ? getCurrentSessionId() : '0',
+  xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'] && !/CriOS/.test(navigator.userAgent),
   userAgent
-}
+}}
 
 const _cache = {}
 
@@ -31,6 +34,6 @@ export function getRuntime(id) {
 
 export function setRuntime(id, obj) {
   if (!id) throw new Error('All runtime objects require an agent identifier!')
-  _cache[id] = new Configurable(obj, model)
+  _cache[id] = new Configurable(obj, model(id))
   gosNREUMInitializedAgents(id, _cache[id], 'runtime')
 }

--- a/packages/browser-agent-core/common/harvest/harvest.js
+++ b/packages/browser-agent-core/common/harvest/harvest.js
@@ -146,15 +146,8 @@ export class Harvest extends SharedContext {
 
   // The stuff that gets sent every time.
   baseQueryString() {
-    var areCookiesEnabled = true
-    const init = getConfiguration(this.sharedContext.agentIdentifier)
     var runtime = getRuntime(this.sharedContext.agentIdentifier)
     var info = getInfo(this.sharedContext.agentIdentifier)
-
-    if ('privacy' in init) {
-      const ce = getConfigurationValue(this.sharedContext.agentIdentifier, 'privacy.cookies_enabled')
-      areCookiesEnabled = ce !== undefined ? ce : true
-    }
 
     var location = cleanURL(getLocation())
     var ref = this.obfuscator.shouldObfuscate() ? this.obfuscator.obfuscateString(location) : location
@@ -166,7 +159,8 @@ export class Harvest extends SharedContext {
       transactionNameParam(info),
       encodeParam('ct', runtime.customTransaction),
       '&rst=' + now(),
-      '&ck=' + (areCookiesEnabled ? '1' : '0'),
+      '&ck=0',  // ck param DEPRECATED - still expected by backend
+      '&s=' + runtime.sessionId,
       encodeParam('ref', ref),
       encodeParam('ptid', (runtime.ptid ? '' + runtime.ptid : ''))
     ].join(''))

--- a/packages/browser-agent-core/common/window/session-storage.js
+++ b/packages/browser-agent-core/common/window/session-storage.js
@@ -7,7 +7,7 @@
  */
 import { generateRandomHexString } from '../ids/unique-id'
 
-export { getCurrentSessionId };
+export { getCurrentSessionIdOrMakeNew };
 
 const ss = window.sessionStorage;
 const SESS_ID = Symbol("session id").toString(); // prevents potential key collisions in session storage
@@ -15,9 +15,10 @@ const SESS_ID = Symbol("session id").toString(); // prevents potential key colli
 /**
  * @returns {string} This tab|window's session identifier, or a new ID if not found in storage
  */
-function getCurrentSessionId() {
+function getCurrentSessionIdOrMakeNew() {
   let sessionId;
-  if ((sessionId = ss.getItem(SESS_ID)) === null) {  // it's possible that the ID is (was previously set to) 0
+  if ((sessionId = ss.getItem(SESS_ID)) === null) {
+    // Generate a new one if storage is empty (no previous ID was created or currently exists)
     sessionId = generateRandomHexString(16);
     ss.setItem(SESS_ID, sessionId);
   }

--- a/packages/browser-agent-core/common/window/session-storage.js
+++ b/packages/browser-agent-core/common/window/session-storage.js
@@ -10,7 +10,7 @@ import { generateRandomHexString } from '../ids/unique-id'
 export { getCurrentSessionIdOrMakeNew };
 
 const ss = window.sessionStorage;
-const SESS_ID = Symbol("session id").toString(); // prevents potential key collisions in session storage
+const SESS_ID = "NRBA_SESSION_ID"; // prevents potential key collisions in session storage
 
 /**
  * @returns {string} This tab|window's session identifier, or a new ID if not found in storage

--- a/packages/browser-agent-core/common/window/session-storage.js
+++ b/packages/browser-agent-core/common/window/session-storage.js
@@ -1,0 +1,27 @@
+/**
+ * Interface for Agents' usage of the Window.sessionStorage as a replacement to third-party cookies.
+ *  (All agents on a tab|window will share the same sessionStorage.)
+ * 
+ * @documentation https://newrelic.atlassian.net/wiki/spaces/INST/pages/2522513791/JSESSIONID+Cookie+Change+Design+Document
+ * @environment Browser script
+ */
+import { generateRandomHexString } from '../ids/unique-id'
+
+export { getCurrentSessionId };
+
+const ss = window.sessionStorage;
+const SESS_ID = Symbol("session id").toString(); // prevents potential key collisions in session storage
+
+/**
+ * @returns {string} This tab|window's session identifier, or a new ID if not found in storage
+ */
+function getCurrentSessionId() {
+  let sessionId;
+  if ((sessionId = ss.getItem(SESS_ID)) === null) {  // it's possible that the ID is (was previously set to) 0
+    sessionId = generateRandomHexString(16);
+    ss.setItem(SESS_ID, sessionId);
+  }
+  return sessionId;
+}
+
+// In the future, we may expand sessionStorage to, say, auto-save some other agent data between page refreshes.

--- a/tests/browser/harvest.browser.js
+++ b/tests/browser/harvest.browser.js
@@ -95,7 +95,7 @@ function validateUrl (t, actualUrl, expectedUrlTemplate, message) {
   // Also get the ck parameter value from the actual URL
   let queryString = actualUrl.split('?')[1]
   let pairs = queryString.split('&')
-  let submissionTimestamp
+  let submissionTimestamp, sessionId;
   let ckValue = '1'
   for (var i = 0; i < pairs.length; i++) {
     let pair = pairs[i].split('=')
@@ -103,12 +103,14 @@ function validateUrl (t, actualUrl, expectedUrlTemplate, message) {
       submissionTimestamp = pair[1]
     } else if (pair[0] === 'ck') {
       ckValue = pair[1]
+    } else if (pair[0] === 's') {
+      sessionId = pair[1];
     }
   }
 
   // In addition to replacing timestamp, add in the ck parameter which goes after timestamp
-  let expectedUrl = expectedUrlTemplate.replace('{TIMESTAMP}', submissionTimestamp + '&ck=' + ckValue)
-
+  let expectedUrl = expectedUrlTemplate.replace('{TIMESTAMP}', `${submissionTimestamp}&ck=${ckValue}&s=${sessionId}`)
+  
   t.equal(actualUrl, expectedUrl, message)
 }
 

--- a/tests/functional/harvest.test.js
+++ b/tests/functional/harvest.test.js
@@ -193,13 +193,14 @@ testDriver.test('browsers that decode the url when accessing window.location sub
   }
 })
 
-testDriver.test('cookie attribute in the query string is false when disabled', withTls, function (t, browser, router) {
-  t.plan(1)
+testDriver.test('cookie disabled: query string attributes', withTls, function (t, browser, router) {
+  t.plan(2)
   let loadPromise = browser.safeGet(router.assetURL('instrumented-disable-cookies.html'))
   let rumPromise = router.expectRum()
 
   Promise.all([rumPromise, loadPromise]).then(([{ query }]) => {
-    t.equal(query.ck, '0', 'The query string attribute ck should equal 0.')
+    t.equal(query.ck, '0', "The cookie flag ('ck') should equal 0.");
+    t.equal(query.s, '0', "The session id attr 's' should be 0.");
   }).catch(fail)
 
   function fail(err) {
@@ -208,13 +209,14 @@ testDriver.test('cookie attribute in the query string is false when disabled', w
   }
 })
 
-testDriver.test('cookie attribute in the query string is true by default', withTls, function (t, browser, router) {
-  t.plan(1)
+testDriver.test('cookie enabled by default: query string attributes', withTls, function (t, browser, router) {
+  t.plan(2)
   let loadPromise = browser.safeGet(router.assetURL('instrumented.html'))
   let rumPromise = router.expectRum()
 
   Promise.all([rumPromise, loadPromise]).then(([{ query }]) => {
-    t.equal(query.ck, '1', 'The query string attribute ck should equal 1.')
+    t.equal(query.ck, '0', "The cookie flag ('ck') should equal 0.");
+    t.notEqual(query.s, '0', "The session id ('s') should NOT be 0.");
   }).catch(fail)
 
   function fail (err) {


### PR DESCRIPTION
### Overview
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
Details of the change can be found in [this CDD](https://newrelic.atlassian.net/wiki/spaces/INST/pages/2522513791/JSESSIONID+Cookie+Change+Design+Document).
This commit:
- sunsets the `ck` param in harvest request URL to beacon
- creates and implement the new end-user generated `sessionId` in sessionStorage 

### Related Github Issue
N/A

### Testing
- `browser/harvest.browser.js` was updated to reflect this change
- `functional/harvest.test.js` was updated as well
 
**Other considerations:**
- (New) Unit testing deemed unnecessary at this time.
- Functionality of changes is closely tied to the functionality of sessionStorage itself. Hence, new automated functional tests are not added either.
-- Manually tested via navigation, e.g., duplicating tab, refreshing page, going back and forth.
-- Particularly, the case where navigating from "has-cookie.html" (`sessionId = 123`) to "no-cookie.html" (`sessionId = 0`) back to "has-cookie.html" will make `sessionId = 123` again.