### PR TITLE
1217 Session Trace fix

### DIFF
--- a/packages/browser-agent-core/features/session-trace/aggregate/index.js
+++ b/packages/browser-agent-core/features/session-trace/aggregate/index.js
@@ -354,7 +354,7 @@ export class Aggregate extends FeatureBase {
     var maxLen = this.toAggregate[name][1]
     var lastO = {}
 
-    return function (byOrigin, evt) {
+    return (byOrigin, evt) => {
       var lastArr = byOrigin[evt.o]
 
       lastArr || (lastArr = byOrigin[evt.o] = [])


### PR DESCRIPTION
### Overview
A quick fix for an issue uncovered in testing the dev release. There was a case where certain session trace events would throw an error when being aggregated, caused by a nested anonymous function.