### PR TITLE
add custom attribute for unhandled promise rejections

### DIFF
--- a/packages/browser-agent-core/features/jserrors/instrument/index.js
+++ b/packages/browser-agent-core/features/jserrors/instrument/index.js
@@ -61,7 +61,8 @@ export class Instrument extends FeatureBase {
 
     try {
       window.addEventListener('unhandledrejection', (e) => {
-        this.onerrorHandler(null, null, null, null, new Error(e.reason))
+        const err = new Error(`${e.reason}`)
+        handle('err', [err, now(), false, {unhandledPromiseRejection: 1}], undefined, undefined, this.ee)
       })
     } catch (err) {
       // do nothing -- addEventListener is not supported


### PR DESCRIPTION
### Overview 

This PR adds a custom attribute to unhandled promise rejection errors to add the ability to differentiate between promise rejections and window errors.