### PR TITLE
Reconfigure config methods to allow backwards compat for nr.info placement

### DIFF
--- a/cdn/agent-aggregator/aggregator.js
+++ b/cdn/agent-aggregator/aggregator.js
@@ -1,11 +1,19 @@
-import { getRuntime } from '@newrelic/browser-agent-core/common/config/config'
+import { getRuntime, setInfo, setConfiguration, setLoaderConfig } from '@newrelic/browser-agent-core/common/config/config'
 import { importFeatures } from './util/features'
 import { activateFeatures, activatedFeatures } from '@newrelic/browser-agent-core/common/util/feature-flags'
-import { addToNREUM, gosNREUMInitializedAgents } from '@newrelic/browser-agent-core/common/window/nreum'
+import { addToNREUM, gosCDN, gosNREUMInitializedAgents } from '@newrelic/browser-agent-core/common/window/nreum'
 import agentIdentifier from '../shared/agentIdentifier'
 import { initializeAPI } from './util/api'
 
 export function aggregator(build) {
+  // do this again in case they are using a custom build that has 
+  // nr.info below the main agent script in some way
+  const nr = gosCDN()
+  setInfo(agentIdentifier, nr.info)
+  setConfiguration(agentIdentifier, nr.init)
+  setLoaderConfig(agentIdentifier, nr.loader_config)
+  // don't set runtime again no matter what, it is always set in the loader stage.
+
   const autorun = typeof (getRuntime(agentIdentifier).autorun) !== 'undefined' ? getRuntime(agentIdentifier).autorun : true
 
   initializeAPI(agentIdentifier)

--- a/cdn/agent-loader/utils/configure.js
+++ b/cdn/agent-loader/utils/configure.js
@@ -15,10 +15,6 @@ export function configure() {
             return
         }
         const nr = gosCDN()
-        if (!requiredKeys.every(key => Object.keys(nr.info).includes(key))) {
-            reject(new Error(`Missing Configuration -- New Relic Browser Agent requires ${requiredKeys.join(", ")}`))
-            return
-        }
         
         try {
         setInfo(agentIdentifier, nr.info)

--- a/tests/assets/instrumented.html
+++ b/tests/assets/instrumented.html
@@ -7,8 +7,8 @@
   <head>
     <title>RUM Unit Test</title>
     {init}
-    {config}
     {loader}
+    {config}
   </head>
   <body>
     this is a generic page that is instrumented by the JS agent


### PR DESCRIPTION
### Overview
Formerly, version 1218+ of the agent required ALL configuration blocks (nr.info, nr.init, nr.loader_config) to be present before the agent script.  This PR allows the agent nr.info block to be present after the agent script, which matches the behavior of 1216 and below.  This should allow for backwards compatibility for pre-existing custom configurations to continue to work without needing to be changed.

### Testing
`instrumented.html` has been modified to include the nr.info block AFTER the agent code block.