### PR TITLE
Web workers - change global object scope and references NEWRELIC-4382

### DIFF
--- a/.github/workflows/tests-polyfill.yml
+++ b/.github/workflows/tests-polyfill.yml
@@ -5,6 +5,9 @@ on:
     types: [labeled]
   workflow_dispatch:
 
+env:
+  BUILD_NUMBER: PR${{ github.event.number }}-job-${{ github.run_number }}-attempt-${{ github.run_attempt }}
+
 jobs:
   chrome-functional:
     if: contains(fromJson('["workflow_dispatch"]'), github.event_name) || contains(github.event.pull_request.labels.*.name, 'safe to test')
@@ -18,7 +21,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -44,7 +47,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -70,7 +73,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -96,7 +99,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -122,7 +125,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -148,7 +151,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -174,7 +177,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -200,7 +203,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -226,7 +229,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -252,7 +255,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -278,7 +281,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -305,7 +308,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -332,7 +335,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -358,7 +361,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -377,7 +380,7 @@ jobs:
     container: node:14
     needs: [chrome-functional, chrome-unit, firefox-functional, firefox-unit, safari-functional, safari-unit, edge-functional, edge-unit, ios-functional, ios-unit, android-functional, android-unit, ie-functional, ie-unit]
     env:
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
       NRQL_API_KEY: ${{ secrets.NRQL_API_KEY }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests-polyfill.yml
+++ b/.github/workflows/tests-polyfill.yml
@@ -378,6 +378,7 @@ jobs:
   check-failures:
     runs-on: ubuntu-latest
     container: node:14
+    if: ${{ !failure() }}  # final check if each needed test either pass or cancelled (special circumstance) and didn't outright fail
     needs: [chrome-functional, chrome-unit, firefox-functional, firefox-unit, safari-functional, safari-unit, edge-functional, edge-unit, ios-functional, ios-unit, android-functional, android-unit, ie-functional, ie-unit]
     env:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -364,6 +364,7 @@ jobs:
   check-failures:
     runs-on: ubuntu-latest
     container: node:14
+    if: ${{ !failure() }}  # final check if each needed test either pass or cancelled (special circumstance) and didn't outright fail
     needs: [chrome-functional, chrome-unit, firefox-functional, firefox-unit, safari-functional, safari-unit, edge-functional, edge-unit, ios-functional, ios-unit]
     env:
       NRQL_API_KEY: ${{ secrets.NRQL_API_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     types: [labeled]
   workflow_dispatch:
 
+env:
+  BUILD_NUMBER: PR${{ github.event.number }}-job-${{ github.run_number }}-attempt-${{ github.run_attempt }}
+
 jobs:
   lint:
     if: contains(fromJson('["workflow_dispatch"]'), github.event_name) || contains(github.event.pull_request.labels.*.name, 'safe to test')
@@ -56,7 +59,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -82,7 +85,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -108,7 +111,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -134,7 +137,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -160,7 +163,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -186,7 +189,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -212,7 +215,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -238,7 +241,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -264,7 +267,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -290,7 +293,7 @@ jobs:
       JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
       JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -316,7 +319,7 @@ jobs:
   #     JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
   #     JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
   #     NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-  #     BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
   #   steps:
   #     - uses: actions/checkout@v2
   #       with:
@@ -343,7 +346,7 @@ jobs:
   #     JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
   #     JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
   #     NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-  #     BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
+
   #   steps:
   #     - uses: actions/checkout@v2
   #       with:
@@ -363,7 +366,6 @@ jobs:
     container: node:14
     needs: [chrome-functional, chrome-unit, firefox-functional, firefox-unit, safari-functional, safari-unit, edge-functional, edge-unit, ios-functional, ios-unit]
     env:
-      BUILD_NUMBER: PR${{ github.event.number }}-unit-${{ github.run_number }}
       NRQL_API_KEY: ${{ secrets.NRQL_API_KEY }}
     steps:
       - uses: actions/checkout@v2

--- a/cdn/agent-aggregator/util/api.js
+++ b/cdn/agent-aggregator/util/api.js
@@ -64,7 +64,7 @@ export function initializeAPI(agentIdentifier) {
     // dom_time - the time spent processing the result of the service call (or user defined)
     // fe_time - the time spent rendering the result of the service call (or user defined)
     function inlineHit(t, request_name, queue_time, app_time, total_be_time, dom_time, fe_time) {
-        request_name = window.encodeURIComponent(request_name)
+        request_name = self.encodeURIComponent(request_name)
         cycle += 1
 
 

--- a/cdn/agent-loader/utils/importAggregator.js
+++ b/cdn/agent-loader/utils/importAggregator.js
@@ -1,11 +1,13 @@
 
-import {onWindowLoad} from '@newrelic/browser-agent-core/common/window/load'
-import {ee} from '@newrelic/browser-agent-core/common/event-emitter/contextual-ee'
+import { onWindowLoad } from '@newrelic/browser-agent-core/common/window/load'
+import { isBrowserWindow } from '@newrelic/browser-agent-core/common/window/win'
+import { ee } from '@newrelic/browser-agent-core/common/event-emitter/contextual-ee'
 
 let loadFired = 0
 
-export function stageAggregator(loaderType, useTimeout, ms) {
-    if (useTimeout) setTimeout(() => importAggregator(loaderType), ms || 1000) // used just for local testing injecting the script after window load...
+export function stageAggregator(loaderType, useTimeout, ms = 1000) {
+    if (useTimeout) setTimeout(() => importAggregator(loaderType), ms) // used just for local testing injecting the script after window load...
+    else if (!isBrowserWindow) importAggregator(loaderType);    // run now if there's no window (to load)
     else onWindowLoad(() => importAggregator(loaderType)) // inject the aggregator when window load event fires
 }
 

--- a/packages/browser-agent-core/common/browser-version/ie-version.js
+++ b/packages/browser-agent-core/common/browser-version/ie-version.js
@@ -2,15 +2,21 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import { isBrowserWindow } from "../window/win"
 
-var div = document.createElement('div')
+// TO DO: this entire file & ieVersion descendents are severely outdated and can be scraped
 
-div.innerHTML = '<!--[if lte IE 6]><div></div><![endif]-->' +
-  '<!--[if lte IE 7]><div></div><![endif]-->' +
-  '<!--[if lte IE 8]><div></div><![endif]-->' +
-  '<!--[if lte IE 9]><div></div><![endif]-->'
+let len;
+if (isBrowserWindow) {
+  const div = document.createElement('div')
 
-var len = div.getElementsByTagName('div').length
+  div.innerHTML = '<!--[if lte IE 6]><div></div><![endif]-->' +
+    '<!--[if lte IE 7]><div></div><![endif]-->' +
+    '<!--[if lte IE 8]><div></div><![endif]-->' +
+    '<!--[if lte IE 9]><div></div><![endif]-->'
+  
+  len = div.getElementsByTagName('div').length
+}
 
 export var ieVersion
 if (len === 4) ieVersion = 6

--- a/packages/browser-agent-core/common/config/state/runtime.js
+++ b/packages/browser-agent-core/common/config/state/runtime.js
@@ -6,7 +6,7 @@ import { gosNREUMInitializedAgents } from '../../window/nreum'
 import { getCurrentSessionIdOrMakeNew } from '../../window/session-storage'
 import { getConfigurationValue } from '../config'
 
-var XHR = window.XMLHttpRequest
+var XHR = self.XMLHttpRequest
 var XHR_PROTO = XHR && XHR.prototype
 
 const model = agentId => { return {
@@ -16,10 +16,11 @@ const model = agentId => { return {
   maxBytes: ieVersion === 6 ? 2000 : 30000,
   offset: getLastTimestamp(),
   onerror: undefined,
-  origin: '' + window.location,
+  origin: '' + self.location,
   ptid: undefined,
   releaseIds: {},
-  sessionId: getConfigurationValue(agentId, 'privacy.cookies_enabled') === true ? getCurrentSessionIdOrMakeNew() : '0',
+  sessionId: getConfigurationValue(agentId, 'privacy.cookies_enabled') == true ?
+    getCurrentSessionIdOrMakeNew() : null,  // if cookies (now session tracking) is turned off or can't get session ID, this is null
   xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'] && !/CriOS/.test(navigator.userAgent),
   userAgent
 }}

--- a/packages/browser-agent-core/common/cookie/nav-cookie.js
+++ b/packages/browser-agent-core/common/cookie/nav-cookie.js
@@ -6,11 +6,14 @@
 import { sHash } from '../util/s-hash'
 import { navCookie } from '../timing/start-time'
 import { getConfigurationValue } from '../config/config'
+import { isBrowserWindow } from '../window/win'
+
+// TO DO: this entire file & document.cookie & conditionallySet in harvester are severely outdated and can be scraped
 
 export function conditionallySet(agentIdentifier) {
   var areCookiesEnabled = getConfigurationValue(agentIdentifier, 'privacy.cookies_enabled')
 
-  if (navCookie && areCookiesEnabled) {
+  if (navCookie && areCookiesEnabled && isBrowserWindow) {
     exports.setCookie(); // allow importing modules (e.g., browser tests) to change setCookie() below
   }
 }

--- a/packages/browser-agent-core/common/event-listener/add-e.js
+++ b/packages/browser-agent-core/common/event-listener/add-e.js
@@ -5,11 +5,11 @@
 
 import { eventListenerOpts } from './event-listener-opts'
 
-// Safely add an event listener to window in any browser
+// Safely add an event listener to WindowOrWorkerGlobalScope in any browser
 export function addE (sType, callback) {
-  if ('addEventListener' in window) {
-    return window.addEventListener(sType, callback, eventListenerOpts(false))
-  } else if ('attachEvent' in window) {
-    return window.attachEvent('on' + sType, callback)
+  if ('addEventListener' in self) {
+    return self.addEventListener(sType, callback, eventListenerOpts(false))
+  } else if ('attachEvent' in self) {
+    return self.attachEvent('on' + sType, callback)
   }
 }

--- a/packages/browser-agent-core/common/event-listener/event-listener-opts.js
+++ b/packages/browser-agent-core/common/event-listener/event-listener-opts.js
@@ -6,8 +6,8 @@ try {
       supportsPassive = true
     }
   })
-  window.addEventListener('testPassive', null, opts)
-  window.removeEventListener('testPassive', null, opts)
+  self.addEventListener('testPassive', null, opts)
+  self.removeEventListener('testPassive', null, opts)
 } catch (e) {
   // do nothing
 }

--- a/packages/browser-agent-core/common/harvest/harvest.js
+++ b/packages/browser-agent-core/common/harvest/harvest.js
@@ -172,7 +172,7 @@ export class Harvest extends SharedContext {
       encodeParam('ct', runtime.customTransaction),
       '&rst=' + now(),
       '&ck=0',  // ck param DEPRECATED - still expected by backend
-      '&s=' + runtime.sessionId || '0', // the 0 id encaps all untrackable and default traffic
+      '&s=' + (runtime.sessionId || '0'), // the 0 id encaps all untrackable and default traffic
       encodeParam('ref', ref),
       encodeParam('ptid', (runtime.ptid ? '' + runtime.ptid : ''))
     ].join(''))

--- a/packages/browser-agent-core/common/harvest/harvest.js
+++ b/packages/browser-agent-core/common/harvest/harvest.js
@@ -172,7 +172,7 @@ export class Harvest extends SharedContext {
       encodeParam('ct', runtime.customTransaction),
       '&rst=' + now(),
       '&ck=0',  // ck param DEPRECATED - still expected by backend
-      '&s=' + runtime.sessionId,
+      '&s=' + runtime.sessionId || '0', // the 0 id encaps all untrackable and default traffic
       encodeParam('ref', ref),
       encodeParam('ptid', (runtime.ptid ? '' + runtime.ptid : ''))
     ].join(''))

--- a/packages/browser-agent-core/common/ids/id.js
+++ b/packages/browser-agent-core/common/ids/id.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Start assigning ids at 1 so 0 can always be used for window, without
+// Start assigning ids at 1 so 0 can always be used for WindowOrWorkerGlobalScope, without
 // actually setting it (which would create a global variable).
 import { getOrSet } from '../util/get-or-set'
 var index = 1
@@ -15,7 +15,7 @@ export function id (obj) {
   // We can only tag objects, functions, and arrays with ids.
   // For all primitive values we instead return -1.
   if (!obj || !(type === 'object' || type === 'function')) return -1
-  if (obj === window) return 0
+  if (obj === self) return 0
 
   return getOrSet(obj, prop, function () { return index++ })
 }

--- a/packages/browser-agent-core/common/ids/unique-id.js
+++ b/packages/browser-agent-core/common/ids/unique-id.js
@@ -6,7 +6,7 @@
 export function generateUuid () {
   var randomVals = null
   var rvIndex = 0
-  var crypto = window.crypto || window.msCrypto
+  var crypto = self.crypto || self.msCrypto
   if (crypto && crypto.getRandomValues) {
     // eslint-disable-next-line
     randomVals = crypto.getRandomValues(new Uint8Array(31))
@@ -55,7 +55,7 @@ export function generateTraceId() {
 export function generateRandomHexString(length) {
   var randomVals = null
   var rvIndex = 0
-  var crypto = window.crypto || window.msCrypto
+  var crypto = self.crypto || self.msCrypto
   // eslint-disable-next-line
   if (crypto && crypto.getRandomValues && Uint8Array) {
     // eslint-disable-next-line

--- a/packages/browser-agent-core/common/metrics/framework-detection.js
+++ b/packages/browser-agent-core/common/metrics/framework-detection.js
@@ -1,3 +1,5 @@
+import { isBrowserWindow } from '../window/win';
+
 var FRAMEWORKS = {
   REACT: 'React',
   ANGULAR: 'Angular',
@@ -11,6 +13,8 @@ var FRAMEWORKS = {
 }
 
 export function getFrameworks() {
+  if (!isBrowserWindow) return [];  // don't bother detecting frameworks if not in the main window context
+
   var frameworks = []
   try {
     if (detectReact()) frameworks.push(FRAMEWORKS.REACT)

--- a/packages/browser-agent-core/common/timing/performance-check.js
+++ b/packages/browser-agent-core/common/timing/performance-check.js
@@ -2,4 +2,4 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export const exists = typeof (window.performance) !== 'undefined' && window.performance.timing && typeof (window.performance.timing.navigationStart) !== 'undefined'
+export const exists = typeof (self.performance?.timing?.navigationStart) !== 'undefined';

--- a/packages/browser-agent-core/common/timing/start-time.js
+++ b/packages/browser-agent-core/common/timing/start-time.js
@@ -17,7 +17,7 @@ export let navCookie = true
 
 export function findStartTime (agentId) {
   // findStartCookie is used for FF7/8 & browsers which do not support window.performance.timing.navigationStart
-  var starttime = findStartWebTiming() || findStartCookie()
+  var starttime = findStartWebTiming(); // || findStartCookie() -- now redundant *cli oct'22, TO DO: slated for removal
   if (!starttime) return
 
   mark(agentId, 'starttime', starttime)
@@ -34,10 +34,10 @@ function findStartWebTiming () {
   if (performanceCheckExists) {
     // note that we don't need to use a cookie to record navigation start time
     navCookie = false
-    return window.performance.timing.navigationStart
+    return self.performance.timing.navigationStart
   }
 }
-
+/*
 // Find the start time based on a cookie set by Episodes in the unload handler.
 function findStartCookie () {
   var aCookies = document.cookie.split(' ')
@@ -87,3 +87,4 @@ function findStartCookie () {
     }
   }
 }
+*/

--- a/packages/browser-agent-core/common/url/protocol.js
+++ b/packages/browser-agent-core/common/url/protocol.js
@@ -2,7 +2,7 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { getWindow } from '../window/win'
+import { getWindowOrWorkerGlobScope } from '../window/win'
 
 export const protocol = {
   isFileProtocol: isFileProtocol,
@@ -10,8 +10,8 @@ export const protocol = {
 }
 
 function isFileProtocol () {
-  let win = getWindow()
-  let isFile = !!(win.location && win.location.protocol && win.location.protocol === 'file:')
+  let globalScope = getWindowOrWorkerGlobScope()
+  let isFile = Boolean(globalScope.location?.protocol === 'file:');
   if (isFile) {
     //metrics.recordSupportability('Generic/FileProtocol/Detected') -- may be implemented later? Probably make sure it's once per window
     protocol.supportabilityMetricSent = true

--- a/packages/browser-agent-core/common/util/stringify.js
+++ b/packages/browser-agent-core/common/util/stringify.js
@@ -53,7 +53,7 @@ function str (key, holder) {
 
       // The value is an array. Stringify every element. Use null as a placeholder
       // for non-JSON values.
-      if (value instanceof window.Array || Object.prototype.toString.apply(value) === '[object Array]') {
+      if (value instanceof self.Array || Object.prototype.toString.apply(value) === '[object Array]') {
         var length = value.length
         for (var i = 0; i < length; i += 1) {
           partial[i] = str(i, value) || 'null'

--- a/packages/browser-agent-core/common/util/submit-data.js
+++ b/packages/browser-agent-core/common/util/submit-data.js
@@ -5,6 +5,9 @@
 
 export const submitData = {}
 
+/**
+ * Do NOT use this function outside of a guaranteed web window environment.
+ */
 submitData.jsonp = function jsonp (url, jsonp) {
   var element = document.createElement('script')
   element.type = 'text/javascript'

--- a/packages/browser-agent-core/common/window/load.js
+++ b/packages/browser-agent-core/common/window/load.js
@@ -3,7 +3,6 @@ import { eventListenerOpts } from '../event-listener/event-listener-opts'
 const win = window
 const doc = win.document
 const ADD_EVENT_LISTENER = 'addEventListener'
-const ATTACH_EVENT = 'attachEvent'
 
 function checkState (cb) {
   if (doc.readyState === 'complete') cb()
@@ -11,13 +10,11 @@ function checkState (cb) {
 
 export function onWindowLoad(cb) {
   checkState(cb)
-  if (doc[ADD_EVENT_LISTENER]) win[ADD_EVENT_LISTENER]('load', cb, eventListenerOpts(false))
-  else win[ATTACH_EVENT]('onload', cb)
+  win[ADD_EVENT_LISTENER]('load', cb, eventListenerOpts(false));
 }
 
 export function onDOMContentLoaded(cb) {
   checkState(cb)
-  if (doc[ADD_EVENT_LISTENER]) doc[ADD_EVENT_LISTENER]('DOMContentLoaded', cb, eventListenerOpts(false))
-  else doc[ATTACH_EVENT]('onreadystatechange', checkState)
+  doc[ADD_EVENT_LISTENER]('DOMContentLoaded', cb, eventListenerOpts(false));
 }
 

--- a/packages/browser-agent-core/common/window/nreum.js
+++ b/packages/browser-agent-core/common/window/nreum.js
@@ -7,11 +7,11 @@ export const defaults = {
 }
 
 export function gosNREUM() {
-  if (!window.NREUM) {
-    window.NREUM = {}
+  if (!self.NREUM) {
+    self.NREUM = {}
   }
-  if (typeof (window.newrelic) === 'undefined') window.newrelic = window.NREUM
-  return window.NREUM
+  if (typeof (self.newrelic) === 'undefined') self.newrelic = self.NREUM
+  return self.NREUM
 }
 
 export function gosNREUMInfo() {
@@ -52,7 +52,7 @@ export function gosNREUMInit() {
 export function gosNREUMOriginals() {
   let nr = gosNREUM()
   if (!nr.o) {
-    var win = window
+    var win = self
     // var doc = win.document
     var XHR = win.XMLHttpRequest
 
@@ -64,7 +64,7 @@ export function gosNREUMOriginals() {
       REQ: win.Request,
       EV: win.Event,
       PR: win.Promise,
-      MO: win.MutationObserver,
+      MO: win.MutationObserver, // this'll be undefined if not in a web window
       FETCH: win.fetch
     }
   }

--- a/packages/browser-agent-core/common/window/session-storage.js
+++ b/packages/browser-agent-core/common/window/session-storage.js
@@ -2,20 +2,23 @@
  * Interface for Agents' usage of the Window.sessionStorage as a replacement to third-party cookies.
  *  (All agents on a tab|window will share the same sessionStorage.)
  * 
- * @documentation https://newrelic.atlassian.net/wiki/spaces/INST/pages/2522513791/JSESSIONID+Cookie+Change+Design+Document
+ * @design https://newrelic.atlassian.net/wiki/spaces/INST/pages/2522513791/JSESSIONID+Cookie+Change+Design+Document
  * @environment Browser script
  */
 import { generateRandomHexString } from '../ids/unique-id'
+import { isBrowserWindow } from '../window/win'
 
 export { getCurrentSessionIdOrMakeNew };
 
-const ss = window.sessionStorage;
+const ss = isBrowserWindow ? window.sessionStorage : undefined;
 const SESS_ID = "NRBA_SESSION_ID"; // prevents potential key collisions in session storage
 
 /**
  * @returns {string} This tab|window's session identifier, or a new ID if not found in storage
  */
 function getCurrentSessionIdOrMakeNew() {
+  if (!ss) return null; // indicates sessionStoage API not avail
+
   let sessionId;
   if ((sessionId = ss.getItem(SESS_ID)) === null) {
     // Generate a new one if storage is empty (no previous ID was created or currently exists)

--- a/packages/browser-agent-core/common/window/supports-performance-observer.js
+++ b/packages/browser-agent-core/common/window/supports-performance-observer.js
@@ -4,5 +4,5 @@
  */
 
 export function supportsPerformanceObserver () {
-  return 'PerformanceObserver' in window && typeof window.PerformanceObserver === 'function'
+  return (typeof self.PerformanceObserver === 'function');
 }

--- a/packages/browser-agent-core/common/window/visibility.js
+++ b/packages/browser-agent-core/common/window/visibility.js
@@ -4,20 +4,23 @@
  */
 
 import {eventListenerOpts} from '../event-listener/event-listener-opts'
+import { isBrowserWindow } from './win'
 
 var hidden, eventName, state
 
-if (typeof document.hidden !== 'undefined') {
-  hidden = 'hidden'
-  eventName = 'visibilitychange'
-  state = 'visibilityState'
-} else if (typeof document.msHidden !== 'undefined') {
-  hidden = 'msHidden'
-  eventName = 'msvisibilitychange'
-} else if (typeof document.webkitHidden !== 'undefined') {
-  hidden = 'webkitHidden'
-  eventName = 'webkitvisibilitychange'
-  state = 'webkitVisibilityState'
+if (isBrowserWindow) {
+  if (typeof document.hidden !== 'undefined') {
+    hidden = 'hidden'
+    eventName = 'visibilitychange'
+    state = 'visibilityState'
+  } else if (typeof document.msHidden !== 'undefined') {
+    hidden = 'msHidden'
+    eventName = 'msvisibilitychange'
+  } else if (typeof document.webkitHidden !== 'undefined') {
+    hidden = 'webkitHidden'
+    eventName = 'webkitvisibilitychange'
+    state = 'webkitVisibilityState'
+  }
 }
 
 export function subscribeToVisibilityChange(cb) {

--- a/packages/browser-agent-core/common/window/win.js
+++ b/packages/browser-agent-core/common/window/win.js
@@ -1,15 +1,18 @@
 
-var origWindow = window
-var win = origWindow
+const origWindowOrWorkerGlobScope = self
+let curGlobScope = origWindowOrWorkerGlobScope
 
-export function getWindow() {
-  return win
+export function getWindowOrWorkerGlobScope() {
+  return curGlobScope
 }
 
-export function setWindow(x) {
-  win = x
+export function setWindowOrWorkerGlobScope(x) {
+  curGlobScope = x
 }
 
-export function resetWindow() {
-  win = origWindow
+export function resetWindowOrWorkerGlobScope() {
+  curGlobScope = origWindowOrWorkerGlobScope
 }
+
+export const isBrowserWindow = Boolean(typeof window === 'object' && self.document);
+export const isWebWorker = Boolean(typeof WorkerGlobalScope !== 'undefined' && typeof importScripts === 'function');

--- a/packages/browser-agent-core/common/wrap/wrap-events.js
+++ b/packages/browser-agent-core/common/wrap/wrap-events.js
@@ -6,6 +6,7 @@
 import {ee as baseEE} from '../event-emitter/contextual-ee'
 import { createWrapperWithEmitter as wfn } from './wrap-function'
 import { getOrSet } from '../util/get-or-set'
+import { isBrowserWindow } from '../window/win'
 
 const wrapped = {}
 
@@ -21,12 +22,13 @@ export function wrapEvents(sharedEE) {
 
   // Guard against instrumenting environments w/o necessary features
   if ('getPrototypeOf' in Object) {
-    findAndWrapNode(document)
-    findAndWrapNode(window)
+    if (isBrowserWindow)
+      findAndWrapNode(document);
+    findAndWrapNode(self);
     findAndWrapNode(XHR.prototype)
     // eslint-disable-next-line
   } else if (XHR.prototype.hasOwnProperty(ADD_EVENT_LISTENER)) {
-    wrapNode(window)
+    wrapNode(self)
     wrapNode(XHR.prototype)
   }
 

--- a/packages/browser-agent-core/common/wrap/wrap-fetch.js
+++ b/packages/browser-agent-core/common/wrap/wrap-fetch.js
@@ -8,7 +8,7 @@ import slice from 'lodash._slice'
 import { mapOwn } from '../util/map-own'
 
 
-var win = window
+var win = self
 var prefix = 'fetch-'
 var bodyPrefix = prefix + 'body-'
 var bodyMethods = ['arrayBuffer', 'blob', 'json', 'text', 'formData']
@@ -21,7 +21,7 @@ const wrapped = {}
 
 export function wrapFetch(sharedEE){
   const ee = scopedEE(sharedEE)
-  if (!(Req && Res && window.fetch)) {
+  if (!(Req && Res && win.fetch)) {
     return ee
   }
 

--- a/packages/browser-agent-core/common/wrap/wrap-history.js
+++ b/packages/browser-agent-core/common/wrap/wrap-history.js
@@ -6,12 +6,13 @@
 // History pushState wrapper
 import {ee as baseEE} from '../event-emitter/contextual-ee'
 import {createWrapperWithEmitter as wfn} from './wrap-function'
+import { isBrowserWindow } from '../window/win'
 
 const wrapped = {}
 
 export function wrapHistory(sharedEE){
   const ee = scopedEE(sharedEE)
-  if (wrapped[ee.debugId]) return ee
+  if (wrapped[ee.debugId] || !isBrowserWindow) return ee; // History API is only relevant within web env
   wrapped[ee.debugId] = true
   var wrapFn = wfn(ee)
   

--- a/packages/browser-agent-core/common/wrap/wrap-jsonp.js
+++ b/packages/browser-agent-core/common/wrap/wrap-jsonp.js
@@ -6,12 +6,13 @@
 import { eventListenerOpts } from '../event-listener/event-listener-opts'
 import { ee as baseEE } from '../event-emitter/contextual-ee'
 import { createWrapperWithEmitter as wfn } from './wrap-function'
+import { isBrowserWindow } from '../window/win'
 
 const wrapped = {}
 
 export function wrapJsonP(sharedEE){
   const ee = scopedEE(sharedEE)
-  if (wrapped[ee.debugId]) return ee
+  if (wrapped[ee.debugId] || !isBrowserWindow) return ee; // JSONP deals with DOM tags
   wrapped[ee.debugId] = true
   var wrapFn = wfn(ee)
   

--- a/packages/browser-agent-core/common/wrap/wrap-mutation.js
+++ b/packages/browser-agent-core/common/wrap/wrap-mutation.js
@@ -5,12 +5,13 @@
 import {ee as baseEE} from '../event-emitter/contextual-ee'
 import {createWrapperWithEmitter as wfn} from './wrap-function'
 import {originals} from '../config/config'
+import { isBrowserWindow } from '../window/win'
 
 const wrapped = {}
 
 export function wrapMutation (sharedEE){
   const ee = scopedEE(sharedEE)
-  if (wrapped[ee.debugId]) return ee
+  if (wrapped[ee.debugId] || !isBrowserWindow) return ee; // relates to the DOM tree (web env only)
   wrapped[ee.debugId] = true
   var wrapFn = wfn(ee)
   var OriginalObserver = originals.MO

--- a/packages/browser-agent-core/common/wrap/wrap-promise.js
+++ b/packages/browser-agent-core/common/wrap/wrap-promise.js
@@ -22,7 +22,7 @@ export function wrapPromise(sharedEE){
   }
   
   function wrap() {
-    window.Promise = WrappedPromise
+    self.Promise = WrappedPromise
   
     ;['all', 'race'].forEach(function (method) {
       var original = OriginalPromise[method]

--- a/packages/browser-agent-core/common/wrap/wrap-raf.js
+++ b/packages/browser-agent-core/common/wrap/wrap-raf.js
@@ -6,12 +6,13 @@
 // Request Animation Frame wrapper
 import { ee as baseEE } from '../event-emitter/contextual-ee'
 import { createWrapperWithEmitter as wfn } from './wrap-function'
+import { isBrowserWindow } from '../window/win'
 
 const wrapped = {}
 
 export function wrapRaf(sharedEE) {
   const ee = scopedEE(sharedEE)
-  if (wrapped[ee.debugId]) return ee
+  if (wrapped[ee.debugId] || !isBrowserWindow) return ee; // animation frames inherently tied to window
   wrapped[ee.debugId] = true
   var wrapFn = wfn(ee)
 

--- a/packages/browser-agent-core/common/wrap/wrap-timer.js
+++ b/packages/browser-agent-core/common/wrap/wrap-timer.js
@@ -20,9 +20,9 @@ export function wrapTimer(sharedEE) {
   var START = '-start'
   var DASH = '-'
 
-  wrapFn.inPlace(window, [SET_TIMEOUT, 'setImmediate'], SET_TIMEOUT + DASH)
-  wrapFn.inPlace(window, [SET_INTERVAL], SET_INTERVAL + DASH)
-  wrapFn.inPlace(window, [CLEAR_TIMEOUT, 'clearImmediate'], CLEAR_TIMEOUT + DASH)
+  wrapFn.inPlace(self, [SET_TIMEOUT, 'setImmediate'], SET_TIMEOUT + DASH)
+  wrapFn.inPlace(self, [SET_INTERVAL], SET_INTERVAL + DASH)
+  wrapFn.inPlace(self, [CLEAR_TIMEOUT, 'clearImmediate'], CLEAR_TIMEOUT + DASH)
 
   ee.on(SET_INTERVAL + START, interval)
   ee.on(SET_TIMEOUT + START, timer)

--- a/packages/browser-agent-core/common/wrap/wrap-xhr.js
+++ b/packages/browser-agent-core/common/wrap/wrap-xhr.js
@@ -31,9 +31,9 @@ export function wrapXhr (sharedEE) {
   var handlers = ['onload', 'onerror', 'onabort', 'onloadstart', 'onloadend', 'onprogress', 'ontimeout']
   var pendingXhrs = []
 
-  var activeListeners = window.XMLHttpRequest.listeners
+  var activeListeners = self.XMLHttpRequest.listeners
   
-  var XHR = window.XMLHttpRequest = newXHR
+  var XHR = self.XMLHttpRequest = newXHR
   
   function newXHR (opts) {
     var xhr = new OrigXHR(opts)
@@ -140,7 +140,7 @@ export function wrapXhr (sharedEE) {
       var dummyNode = document.createTextNode(toggle)
       new MutationObserver(drainPendingXhrs).observe(dummyNode, { characterData: true })
     }
-  } else {
+  } else {  // this below case applies to web workers too
     baseEE.on('fn-end', function (args) {
       // We don't want to try to wrap onreadystatechange from within a
       // readystatechange callback.

--- a/packages/browser-agent-core/features/ajax/instrument/distributed-tracing.js
+++ b/packages/browser-agent-core/features/ajax/instrument/distributed-tracing.js
@@ -75,7 +75,7 @@ export class DT {
   }
 
   generateTraceHeader (spanId, traceId, timestamp, accountId, appId, trustKey) {
-    var hasBtoa = ('btoa' in window && typeof window.btoa === 'function')
+    var hasBtoa = (typeof self.btoa === 'function')
     if (!hasBtoa) {
       return null
     }

--- a/packages/browser-agent-core/features/ajax/instrument/index.js
+++ b/packages/browser-agent-core/features/ajax/instrument/index.js
@@ -19,7 +19,7 @@ var handlers = ['load', 'error', 'abort', 'timeout']
 var handlersLen = handlers.length
 
 var origRequest = originals.REQ
-var origXHR = window.XMLHttpRequest
+var origXHR = self.XMLHttpRequest
 
 export class Instrument extends FeatureBase {
   constructor(agentIdentifier) {
@@ -226,7 +226,7 @@ function subscribeToEvents(agentIdentifier, ee, handler, dt) {
     } else if (args[0] && args[0].url) {
       url = args[0].url
       // argument is URL object
-    } else if (window.URL && args[0] && args[0] instanceof URL) {
+    } else if (self.URL && args[0] && args[0] instanceof URL) {
       url = args[0].href
     }
 
@@ -240,7 +240,7 @@ function subscribeToEvents(agentIdentifier, ee, handler, dt) {
       return
     }
 
-    if (typeof args[0] === 'string' || (window.URL && args[0] && args[0] instanceof URL)) {
+    if (typeof args[0] === 'string' || (self.URL && args[0] && args[0] instanceof URL)) {
       var clone = {}
 
       for (var key in opts) {
@@ -297,7 +297,7 @@ function subscribeToEvents(agentIdentifier, ee, handler, dt) {
       url = target
     } else if (typeof target === 'object' && target instanceof origRequest) {
       url = target.url
-    } else if (window.URL && typeof target === 'object' && target instanceof URL) {
+    } else if (self.URL && typeof target === 'object' && target instanceof URL) {
       url = target.href
     }
     addUrl(this, url)

--- a/packages/browser-agent-core/features/jserrors/aggregate/index.js
+++ b/packages/browser-agent-core/features/jserrors/aggregate/index.js
@@ -156,7 +156,7 @@ export class Aggregate extends FeatureBase {
     var params = {
       stackHash: stringHashCode(canonicalStack),
       exceptionClass: stackInfo.name,
-      request_uri: window.location.pathname
+      request_uri: self.location.pathname
     }
     if (stackInfo.message) {
       params.message = '' + stackInfo.message

--- a/packages/browser-agent-core/features/jserrors/instrument/index.js
+++ b/packages/browser-agent-core/features/jserrors/instrument/index.js
@@ -21,7 +21,7 @@ export class Instrument extends FeatureBase {
     // errors that will be the same as caught errors.
     this.skipNext = 0
     this.handleErrors = false
-    this.origOnerror = window.onerror
+    this.origOnerror = self.onerror
     
     const state = this
 
@@ -52,15 +52,15 @@ export class Instrument extends FeatureBase {
       handle('ierr', [e, now(), true], undefined, undefined, state.ee)
     })
 
-    const prevOnError = window.onerror
-    window.onerror = (...args) => {
+    const prevOnError = self.onerror
+    self.onerror = (...args) => {
       if (prevOnError) prevOnError(...args)
       this.onerrorHandler(...args)
       return false
     }
 
     try {
-      window.addEventListener('unhandledrejection', (e) => {
+      self.addEventListener('unhandledrejection', (e) => {
         const err = new Error(`${e.reason}`)
         handle('err', [err, now(), false, {unhandledPromiseRejection: 1}], undefined, undefined, this.ee)
       })
@@ -76,7 +76,7 @@ export class Instrument extends FeatureBase {
         wrapTimer(this.ee)
         wrapRaf(this.ee)
 
-        if ('addEventListener' in window) {
+        if ('addEventListener' in self) {
           wrapEvents(this.ee)
         }
 

--- a/packages/browser-agent-core/features/metrics/instrument/index.js
+++ b/packages/browser-agent-core/features/metrics/instrument/index.js
@@ -6,6 +6,7 @@ import { protocol } from '../../../common/url/protocol'
 import { getRules, validateRules } from '../../../common/util/obfuscate'
 import { VERSION } from '../../../common/constants/environment-variables'
 import { onDOMContentLoaded } from '../../../common/window/load'
+import { isBrowserWindow } from '../../../common/window/win'
 import * as WorkersHelper from './workers-helper'
 
 var SUPPORTABILITY_METRIC = 'sm'
@@ -61,11 +62,11 @@ export class Instrument extends FeatureBase {
         this.recordSupportability(`Generic/Version/${VERSION}/Detected`)
 
         // frameworks on page
-        onDOMContentLoaded(() => {
+        if(isBrowserWindow) onDOMContentLoaded(() => {
             getFrameworks().forEach(framework => {
                 this.recordSupportability('Framework/' + framework + '/Detected')
             })
-        })
+        });
 
         // file protocol detection
         if (protocol.isFileProtocol()) {

--- a/packages/browser-agent-core/features/page-action/aggregate/index.js
+++ b/packages/browser-agent-core/features/page-action/aggregate/index.js
@@ -10,6 +10,7 @@ import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { cleanURL } from '../../../common/url/clean-url'
 import { getConfigurationValue, getInfo, getRuntime } from '../../../common/config/config'
 import { FeatureBase } from '../../../common/util/feature-base'
+import { isBrowserWindow } from '../../../common/window/win'
 
 export class Aggregate extends FeatureBase {
   constructor(agentIdentifier, aggregator) {
@@ -24,7 +25,7 @@ export class Aggregate extends FeatureBase {
 
     this.att = getInfo(this.agentIdentifier).jsAttributes;  // per-agent, aggregators-shared info context
 
-    if (document.referrer) this.referrerUrl = cleanURL(document.referrer)
+    if (isBrowserWindow && document.referrer) this.referrerUrl = cleanURL(document.referrer)
 
     this.ee.on('feat-ins', () => {
       register('api-addPageAction', (...args) => this.addPageAction(...args), undefined, this.ee)
@@ -69,7 +70,7 @@ export class Aggregate extends FeatureBase {
     var height
     var eventAttributes = {}
 
-    if (typeof window !== 'undefined' && window.document && window.document.documentElement) {
+    if (isBrowserWindow && window.document.documentElement) {
       // Doesn't include the nav bar when it disappears in mobile safari
       // https://github.com/jquery/jquery/blob/10399ddcf8a239acc27bdec9231b996b178224d3/src/dimensions.js#L23
       width = window.document.documentElement.clientWidth

--- a/packages/browser-agent-core/features/page-view-event/aggregate/index.js
+++ b/packages/browser-agent-core/features/page-view-event/aggregate/index.js
@@ -8,13 +8,14 @@ import { submitData } from '../../../common/util/submit-data'
 import { getConfigurationValue, getInfo, getRuntime } from '../../../common/config/config'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { FeatureBase } from '../../../common/util/feature-base'
+import { isBrowserWindow } from '../../../common/window/win'
 
 const jsonp = 'NREUM.setToken'
 
 export class Aggregate extends FeatureBase {
   constructor(agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator)
-    this.sendRum()
+    if (isBrowserWindow) this.sendRum();  // initial RUM payload is only sent in web env, TO DO: can remove once aggregate is chained to instrument
   }
 
   getScheme() { 

--- a/packages/browser-agent-core/features/page-view-event/instrument/index.js
+++ b/packages/browser-agent-core/features/page-view-event/instrument/index.js
@@ -5,10 +5,12 @@ import { mark } from '../../../common/timing/stopwatch'
 import { findStartTime } from '../../../common/timing/start-time'
 import { FeatureBase } from '../../../common/util/feature-base'
 import { onDOMContentLoaded, onWindowLoad } from '../../../common/window/load'
+import { isBrowserWindow } from '../../../common/window/win'
 
 export class Instrument extends FeatureBase {
   constructor(agentIdentifier) {
     super(agentIdentifier)
+    if (!isBrowserWindow) return; // initial page view times non applicable outside web env
 
     findStartTime(agentIdentifier)
     mark(agentIdentifier, 'firstbyte', getLastTimestamp())

--- a/packages/browser-agent-core/features/page-view-timing/aggregate/index.js
+++ b/packages/browser-agent-core/features/page-view-timing/aggregate/index.js
@@ -12,9 +12,12 @@ import { cleanURL } from '../../../common/url/clean-url'
 import { handle } from '../../../common/event-emitter/handle'
 import { getInfo, getConfigurationValue } from '../../../common/config/config'
 import { FeatureBase } from '../../../common/util/feature-base'
+import { isBrowserWindow } from '../../../common/window/win'
+
 export class Aggregate extends FeatureBase {
   constructor(agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator)
+    if (!isBrowserWindow) return; // TO DO: can remove once aggregate is chained to instrument
 
     this.timings = []
     this.timingsSent = []

--- a/packages/browser-agent-core/features/page-view-timing/instrument/index.js
+++ b/packages/browser-agent-core/features/page-view-timing/instrument/index.js
@@ -8,17 +8,18 @@ import { eventListenerOpts } from '../../../common/event-listener/event-listener
 import { getOffset, now } from '../../../common/timing/now'
 import { getConfigurationValue, originals } from '../../../common/config/config'
 import { FeatureBase } from '../../../common/util/feature-base'
+import { isBrowserWindow } from '../../../common/window/win'
 
 export class Instrument extends FeatureBase {
   constructor(agentIdentifier) {
     super(agentIdentifier)
+    if (!this.isEnabled() || !isBrowserWindow) return;  // CWV is irrelevant outside web context
+
     this.pageHiddenTime = initializeHiddenTime()  // synonymous with initial visibilityState
     this.performanceObserver
     this.lcpPerformanceObserver
     this.clsPerformanceObserver
     this.fiRecorded = false
-
-    if (!this.isEnabled()) return
 
     if ('PerformanceObserver' in window && typeof window.PerformanceObserver === 'function') {
       // passing in an unknown entry type to observer could throw an exception

--- a/packages/browser-agent-core/features/session-trace/aggregate/index.js
+++ b/packages/browser-agent-core/features/session-trace/aggregate/index.js
@@ -24,7 +24,7 @@ export class Aggregate extends FeatureBase {
 
     if (!xhrUsable) return
     // bail if not instrumented
-    if (!agentRuntime.features.stn || !agentRuntime.xhrWrappable) return
+    if (!agentRuntime.features.stn || !agentRuntime.xhrWrappable) return  // TO DO: can remove once aggregate is chained to instrument
 
     this.ptid = ''
     this.ignoredEvents = {

--- a/packages/browser-agent-core/features/session-trace/instrument/index.js
+++ b/packages/browser-agent-core/features/session-trace/instrument/index.js
@@ -9,6 +9,7 @@ import { eventListenerOpts } from '../../../common/event-listener/event-listener
 import { originals, getRuntime } from '../../../common/config/config'
 import { now } from '../../../common/timing/now'
 import { FeatureBase } from '../../../common/util/feature-base'
+import { isBrowserWindow } from '../../../common/window/win'
 
 var learResourceTimings = 'learResourceTimings'
 var ADD_EVENT_LISTENER = 'addEventListener'
@@ -27,6 +28,7 @@ var origEvent = originals.EV
 export class Instrument extends FeatureBase {
   constructor(agentIdentifier) {
     super(agentIdentifier)
+    if (!isBrowserWindow) return; // session traces not supported outside web env
 
     if (!(window.performance &&
       window.performance.timing &&

--- a/packages/browser-agent-core/features/spa/aggregate/index.js
+++ b/packages/browser-agent-core/features/spa/aggregate/index.js
@@ -17,6 +17,7 @@ import { FeatureBase } from '../../../common/util/feature-base'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { Serializer } from './serializer'
 import { ee } from '../../../common/event-emitter/contextual-ee'
+import { isBrowserWindow } from '../../../common/window/win'
 
 var INTERACTION_EVENTS = [
   'click',
@@ -46,6 +47,7 @@ var originalSetTimeout = originals.ST
 export class Aggregate extends FeatureBase {
   constructor(agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator)
+    if (!isBrowserWindow) return; // TO DO: can remove once aggregate is chained to instrument
 
     this.state = {
       initialPageURL: getRuntime(agentIdentifier).origin,

--- a/packages/browser-agent-core/features/spa/instrument/index.js
+++ b/packages/browser-agent-core/features/spa/instrument/index.js
@@ -7,6 +7,7 @@ import { eventListenerOpts } from '../../../common/event-listener/event-listener
 import { FeatureBase } from '../../../common/util/feature-base'
 import { getRuntime } from '../../../common/config/config'
 import { now } from '../../../common/timing/now'
+import { isBrowserWindow } from '../../../common/window/win'
 
 var START = '-start'
 var END = '-end'
@@ -19,12 +20,14 @@ var JS_TIME = 'jsTime'
 var FETCH = 'fetch'
 var ADD_EVENT_LISTENER = 'addEventListener'
 
-var win = window
+var win = self
 var location = win.location
 
 export class Instrument extends FeatureBase {
     constructor(agentIdentifier) {
         super(agentIdentifier)
+        if (!isBrowserWindow) return; // SPA not supported outside web env
+
         const agentRuntime = getRuntime(this.agentIdentifier);
         // loader.xhrWrappable will be false in chrome for ios, but addEventListener is still available.
         // sauce does not have a browser to test this case against, so be careful when modifying this check

--- a/tests/browser/obfuscate.browser.js
+++ b/tests/browser/obfuscate.browser.js
@@ -94,7 +94,7 @@ jil.browserTest('Should Obfuscate', function (t) {
 
   t.ok(obfuscatorInst.shouldObfuscate(), 'When init.obfuscate is defined, shouldObfuscate is true')
 
-  //delete win.getWindow().NREUM.init.obfuscate
+  //delete win.getWindowOrWorkerGlobScope().NREUM.init.obfuscate
   setConfiguration(agentIdentifier, {});  // note this'll reset the *whole* config to the default values
   t.ok(!obfuscatorInst.shouldObfuscate(), 'When init.obfuscate is NOT defined, shouldObfuscate is false')
   t.end()
@@ -107,14 +107,14 @@ jil.browserTest('Get Rules', function (t) {
 
   t.ok(!!obfuscate.getRules(agentIdentifier).length, 'getRules should generate a list of rules from init.obfuscate')
 
-  //delete win.getWindow().NREUM.init.obfuscate
+  //delete win.getWindowOrWorkerGlobScope().NREUM.init.obfuscate
   setConfiguration(agentIdentifier, {});  // note this'll reset the *whole* config to the default values
   t.ok(!obfuscate.getRules(agentIdentifier).length, 'getRules should generate an empty list if init.obfuscate is undefined')
 
-  win.setWindow({ ...win.getWindow(), location: { ...fileLocation } })
+  win.setWindowOrWorkerGlobScope({ ...win.getWindowOrWorkerGlobScope(), location: { ...fileLocation } })
   t.ok(!!obfuscate.getRules(agentIdentifier).filter(x => x.regex.source.includes('file')).length, 'getRules should generate a rule for file obfuscation if file protocol is detected')
 
-  win.resetWindow()
+  win.resetWindowOrWorkerGlobScope()
   t.end()
 })
 
@@ -127,11 +127,11 @@ jil.browserTest('Obfuscate String Method', function (t) {
   t.ok(!obfuscatorInst.obfuscateString('http://example.com/pii/123').includes('pii'), 'Successfully obfuscates string')
   t.ok(!obfuscatorInst.obfuscateString('http://example.com/abcdefghijklmnopqrstuvwxyz/123').includes('i'), 'Successfully obfuscates regex')
 
-  win.setWindow({ ...win.getWindow(), location: { ...fileLocation } })
-  //delete win.getWindow().NREUM.init.obfuscate
+  win.setWindowOrWorkerGlobScope({ ...win.getWindowOrWorkerGlobScope(), location: { ...fileLocation } })
+  //delete win.getWindowOrWorkerGlobScope().NREUM.init.obfuscate
   setConfiguration(agentIdentifier, {});  // note this'll reset the *whole* config to the default values
   t.ok(obfuscatorInst.obfuscateString('file:///Users/jporter/Documents/Code/scratch/noticeErrorTest.html') === 'file://OBFUSCATED', 'Successfully obfuscates file protocol')
 
-  win.resetWindow()
+  win.resetWindowOrWorkerGlobScope()
   t.end()
 })

--- a/tests/browser/protocol.browser.js
+++ b/tests/browser/protocol.browser.js
@@ -19,11 +19,11 @@ var fileLocation = {
 }
 
 jil.browserTest('isFileProtocol returns coorectly when detecting file protocol', function (t) {
-  win.setWindow({ ...win.getWindow(), location: { ...fileLocation } })
+  win.setWindowOrWorkerGlobScope({ ...win.getWindowOrWorkerGlobScope(), location: { ...fileLocation } })
 
   t.ok(protocol.isFileProtocol(), 'Returned false when protocol is not file protocol')
   t.ok(protocol.supportabilityMetricSent, 'isFileProtocol should send supportability metric if file protocol is detected')
-  win.resetWindow()
+  win.resetWindowOrWorkerGlobScope()
 
   t.ok(!protocol.isFileProtocol(), 'Returned false when protocol is not file protocol')
   t.end()


### PR DESCRIPTION
### Overview
Many parts of the code references `window` and `document` which do not exists in workers. This change expands the allowed and considered global scopes so that the agent runs in:
a. browser window (web) context w/o any behavior difference
b. WorkerGlobalScope on a best-effort basis, pending future tuning

### Related Issue
Part of NRELIC-2433 Epic

### Testing
Regression test via running the automated suite.

#### Other side effects
- Tests workflows now distinguishes attempts on a wf run when reporting to NRDB. This addresses an issue with the check-failures job.