### PR TITLE
Webworkers final harvest NR-58010

### DIFF
--- a/tests/functional/worker/all-uncategorized.test.js
+++ b/tests/functional/worker/all-uncategorized.test.js
@@ -1,12 +1,10 @@
 const testDriver = require('../../../tools/jil/index')
 const {workerTypes, typeToMatcher} = require('./helpers')
-const {fail, failWithEndTimeout, asyncApiFns, extractWorkerSM, getMetricsFromResponse, checkPayload, url, cleanURL} = 
-	require('../uncat-internal-help.cjs')
+const {fail, checkPayload, url} = require('../uncat-internal-help.cjs')
 
 const reliableFinalHarvest = testDriver.Matcher.withFeature('reliableFinalHarvest')
 const withUnload = testDriver.Matcher.withFeature('reliableUnloadEvent')
 const fetchExt = testDriver.Matcher.withFeature('fetchExt')
-const nestedWorkerSupport = testDriver.Matcher.withFeature('nestedWorkers')
 
 const FAIL_MSG = 'unexpected error';
 
@@ -19,11 +17,6 @@ workerTypes.forEach(type => {  // runs all test for classic & module workers & u
 
 	harvestReferrerSent(type, browsersWithOrWithoutModuleSupport);
 	harvestSessionIsNullWhenEnabled(type, browsersWithOrWithoutModuleSupport);
-
-	metricsApiCreatesSM(type, browsersWithOrWithoutModuleSupport.and(withUnload));
-	metricsValidObfuscationCreatesSM(type, browsersWithOrWithoutModuleSupport.and(fetchExt));
-	metricsInvalidObfuscationCreatesSM(type, browsersWithOrWithoutModuleSupport.and(fetchExt));
-	metricsWorkersCreateSM(type, browsersWithOrWithoutModuleSupport.and(nestedWorkerSupport));
 
 	obfuscateAll(type, browsersWithOrWithoutModuleSupport.and(fetchExt));
 });
@@ -152,7 +145,7 @@ function apiAddReleaseNotUsed (type, browserVersionMatcher) {
 	);
 }
 
-// --- Final harvest tests --- ... looking for this? Go to ./final-harvest.test.js 
+// --- Final harvest tests --- ... looking for this? Go to ./eol-harvest.test.js 
 // --- Framework detection tests --- ... not available right now (in worker), leave a msg after the tone (don't wait)
 
 // --- Harvest tests ---
@@ -206,205 +199,7 @@ function harvestSessionIsNullWhenEnabled (type, browserVersionMatcher) {
 	);
 }
 
-// --- Metrics tests ---
-function metricsApiCreatesSM (type, browserVersionMatcher) {
-	testDriver.test(`${type} - Calling a newrelic[api] fn creates a supportability metric`, browserVersionMatcher, 
-		function (t, browser, router) {
-			const EXPECTED_APIS_CALLED = asyncApiFns.length;
-			t.plan(EXPECTED_APIS_CALLED + 5);	// the magic number 5 comes from the "extra" assertions labeled below		~YW, *cli 10/22
-
-			let assetURL = router.assetURL(`worker/${type}-worker.html`, {
-				init: {
-					jserrors: { enabled: false }
-				},
-				workerCommands: [() => { 
-					newrelic.noticeError('too many free taco coupons')
-					newrelic.setPageViewName('test')
-					newrelic.setCustomAttribute('test')
-					newrelic.setErrorHandler()
-					newrelic.finished()
-					newrelic.addToTrace('test')
-					newrelic.addRelease('test')
-
-					newrelic.setPageViewName('test')
-					newrelic.setPageViewName('test')
-					newrelic.setPageViewName('test')
-					newrelic.setPageViewName('test')
-				}].map(x => x.toString())
-			});
-			const loadPromise = browser.get(assetURL);
-			const errPromise = router.expectErrors();
-			const observedAPImetrics = [];
-
-			Promise.all([errPromise, loadPromise])
-			.then(( [data] ) => {
-				const supportabilityMetrics = getMetricsFromResponse(data, true)
-				const customMetrics = getMetricsFromResponse(data, false)
-				t.ok(supportabilityMetrics && !!supportabilityMetrics.length, 'SupportabilityMetrics object(s) were generated')	// extra #1
-				t.ok(customMetrics && !!customMetrics.length, 'CustomMetrics object(s) were generated')	// extra #2
-
-				for (const sm of supportabilityMetrics) {
-					const matchIdx = asyncApiFns.findIndex(x => x === sm.params.name);
-					if (matchIdx != -1) observedAPImetrics.push(asyncApiFns[matchIdx]);
-
-					if (matchIdx == 1)	// this is the index of 'setPageViewName' in asyncApiFns
-						t.equal(sm.stats.c, 5, sm.params.name + ' count was incremented by 1 until reached 5');
-					else if (sm.params.name.startsWith('Workers/'))	// these metrics have a dynamic count & are tested separately anyways
-						continue;
-					else 
-						t.equal(sm.stats.c, 1, sm.params.name + ' count was incremented by 1');	// there should be 1 generic sm for agent version--extra #3
-				}
-				t.ok(observedAPImetrics.length === EXPECTED_APIS_CALLED, 'Saw all asyncApiFns')	// extra #4
-				t.ok(customMetrics[0].params.name === 'finished', 'a `Finished` Custom Metric (cm) was also generated')	// extra #5
-				t.end()
-			}).catch(failWithEndTimeout(t));
-		}
-	);
-}
-function metricsValidObfuscationCreatesSM (type, browserVersionMatcher) {
-	testDriver.test(`${type} - a valid obfuscationRule creates detected supportability metric`, browserVersionMatcher, 
-		function (t, browser, router) {
-			let assetURL = router.assetURL(`worker/${type}-worker.html`, {
-				init: {
-					obfuscate: [{
-						regex: /pii/g,
-						replacement: 'OBFUSCATED'
-					}],
-					ajax: { harvestTimeSeconds: 2 },
-					jserrors: { enabled: false },
-					ins: { harvestTimeSeconds: 2 }
-				},
-				workerCommands: [() => { 
-					setTimeout(function () {
-						fetch('/tests/assets/obfuscate-pii-valid.html')
-						throw new Error('pii')
-					}, 100);
-					newrelic.addPageAction('pageactionpii');
-    			newrelic.setCustomAttribute('piicustomAttribute', 'customAttribute');
-				}].map(x => x.toString())
-			});
-			const loadPromise = browser.get(assetURL);
-			const errPromise = router.expectErrors();
-
-			Promise.all([errPromise, loadPromise])
-			.then(( [data] ) => {
-				const supportabilityMetrics = getMetricsFromResponse(data, true)
-				t.ok(supportabilityMetrics && !!supportabilityMetrics.length, 'SupportabilityMetrics object(s) were generated')
-				supportabilityMetrics.forEach(sm => {
-					t.ok(!sm.params.name.includes('Generic/Obfuscate/Invalid'), sm.params.name + ' contains correct name')
-				})
-				t.end()
-			}).catch(failWithEndTimeout(t));
-		}
-	);
-}
-function metricsInvalidObfuscationCreatesSM (type, browserVersionMatcher) {
-	const badObfusRulesArr = [{
-		regex: 123,
-		replacement: 'invalid;type'		// #1 - invalid regex object
-	}, {
-		replacement: 'invalid,undefined'	// #2 - regex undefined
-	}, {
-		regex: /backslash/g,
-		replacement: 123			// #3 - invalid replacement type (string)
-	}];
-
-	for (badRuleNum in badObfusRulesArr)
-		testDriver.test(`${type} - invalid obfuscation rule #${parseInt(badRuleNum)+1} creates invalid supportability metric`, browserVersionMatcher, 
-			function (t, browser, router) {
-				let assetURL = router.assetURL(`worker/${type}-worker.html`, {
-					init: {
-						obfuscate: [badObfusRulesArr[badRuleNum]],
-						ajax: { harvestTimeSeconds: 2 },
-						jserrors: { enabled: false },
-						ins: { harvestTimeSeconds: 2 }
-					},
-					workerCommands: [() => { 
-						setTimeout(function () {
-							fetch('/tests/assets/obfuscate-pii-valid.html')
-							throw new Error('pii')
-						}, 100);
-						newrelic.addPageAction('pageactionpii');
-						newrelic.setCustomAttribute('piicustomAttribute', 'customAttribute');
-					}].map(x => x.toString())
-				});
-
-				const loadPromise = browser.get(assetURL);
-				const errPromise = router.expectErrors();
-
-				Promise.all([errPromise, loadPromise])
-				.then(( [data] ) => {
-					const supportabilityMetrics = getMetricsFromResponse(data, true)
-					t.ok(supportabilityMetrics && !!supportabilityMetrics.length, 'SupportabilityMetrics object(s) were generated')
-					let invalidDetected = false;
-					supportabilityMetrics.forEach(sm => {
-						if (sm.params.name.includes('Generic/Obfuscate/Invalid')) invalidDetected = true;
-					})
-					t.ok(invalidDetected, 'an invalid regex rule detected')
-					t.end()
-				}).catch(failWithEndTimeout(t));
-			}
-		);
-}
-function metricsWorkersCreateSM (type, browserVersionMatcher) {
-	testDriver.test(`${type} - workers creation generates sm`, browserVersionMatcher, 
-		function (t, browser, router) {
-			let assetURL = router.assetURL(`worker/${type}-worker.html`, {
-				init: {
-					jserrors: { enabled: false }
-				},
-				workerCommands: [() => { 
-					try {
-            let worker1 = new Worker('./worker-scripts/simple.js');
-            let worker2 = new Worker('./worker-scripts/simple.js', {type: 'module'});
-					} catch (e) {
-							console.warn(e);
-					}
-					try {
-            let worker1 = new SharedWorker('./worker-scripts/simple.js');
-            let worker2 = new SharedWorker('./worker-scripts/simple.js', {type: 'module'});
-					} catch (e) {
-							console.warn(e);
-					}
-					try {
-            let worker1 = self.navigator.serviceWorker.register('./worker-scripts/simple.js');  // This script will probably cause an error
-            let worker2 = self.navigator.serviceWorker.register('./worker-scripts/simple.js', {type: 'module'});
-					} catch (e) {
-							console.warn(e);
-					}
-				}].map(x => x.toString())
-			});
-			const loadPromise = browser.get(assetURL);
-			const errPromise = router.expectErrors();
-
-			Promise.all([errPromise, loadPromise])
-			.then(( [data] ) => {
-				const supportabilityMetrics = getMetricsFromResponse(data, true)
-				t.ok(supportabilityMetrics && !!supportabilityMetrics.length, `${supportabilityMetrics.length} SupportabilityMetrics object(s) were generated`);
-				
-				const wsm = extractWorkerSM(supportabilityMetrics);
-
-				// Since this test is supposed to run inside a worker, there's no need to check if we're in a worker compat browser & version...
-				if (!wsm.workerImplFail) {  // worker may be avail in Chrome v4, but our SM implementation may not be supported until v60, etc.
-					t.ok(wsm.classicWorker, 'classic worker is expected and used');
-					t.ok(wsm.moduleWorker, 'module worker is expected and used');	// see note on this from original metrics.test.js test
-				}
-
-				// NOTE: we're only testing (default|module) *dedicated* workers right now, not shared or service
-				// The sharedWorker class is actually n/a inside of workers...
-				t.notOk(wsm.classicShared, 'classic sharedworker is NOT expected but used');
-				t.notOk(wsm.moduleShared, 'module sharedworker is NOT expected but used');
-				t.notOk(wsm.sharedUnavail || wsm.sharedImplFail, 'sharedworker supportability should not be emitted by or within a worker');
-
-				// Don't think the serviceWorker class is or will be available inside of workers either...
-				t.notOk(wsm.classicService || wsm.moduleService, 'classic or module serviceworker is NOT expected or used');
-				t.notOk(wsm.serviceUnavail || wsm.serviceImplFail, 'serviceworker supportability should not be emitted by or within a worker');
-
-				t.end()
-			}).catch(failWithEndTimeout(t));
-		}
-	);
-}
+// --- Metrics tests --- ... looking for this? Go to ./metrics.test.js
 
 // --- Nav cookie tests --- ... how has this not been yanked out from the repo yet?
 

--- a/tests/functional/worker/eol-harvest.test.js
+++ b/tests/functional/worker/eol-harvest.test.js
@@ -1,0 +1,65 @@
+const testDriver = require('../../../tools/jil/index')
+const {workerTypes, typeToMatcher} = require('./helpers')
+const {fail} = require('../uncat-internal-help.cjs')
+
+workerTypes.forEach(type => {  // runs all test for classic & module workers & use the 'workers' browser-matcher for classic and the 'workersFull' for module
+	const browsersWithOrWithoutModuleSupport = typeToMatcher(type);
+	finalHarvest(type, browsersWithOrWithoutModuleSupport);
+});
+
+// --- Tests ---
+function finalHarvest (type, browserVersionMatcher) {
+	testDriver.test(`${type} - buffered events are sent at end-of-life aka worker closing`, browserVersionMatcher, 
+		function (t, browser, router) {
+			// CAUTION: RegExp objs must be explicitly stringified to be transferred, and atm our code reads it as a RegExp rather than a string
+			let assetURL = router.assetURL(`worker/${type}-worker.html`, {
+				init: {
+					ajax: { harvestTimeSeconds: 81 },
+					jserrors: { harvestTimeSeconds: 81 },
+					ins: { harvestTimeSeconds: 81 }
+				},
+				workerCommands: [() => {
+					newrelic.noticeError("test");
+					newrelic.addPageAction("blahblahblah");
+					fetch('/json');
+					self.close();
+				}].map(x => x.toString())
+			});
+
+			const loadPromise = browser.get(assetURL);
+			const metrPromise = router.expectErrors();
+			const errPromise = router.expectErrors();		// CAUTION: the order of metrics (sm) and jserrors matters; metrics are always sent out FIRST
+			const ajaxPromise = router.expectAjaxEvents();
+			const insPromise = router.expectIns();
+
+			Promise.all([loadPromise, metrPromise, errPromise, ajaxPromise, insPromise])
+			.then(( [, metrResponse, errResponse, ajaxResponse, insResponse] ) => {
+				let body;
+
+				body = JSON.parse(metrResponse.body);
+				t.ok(body.sm, 'supportability metrics are sent on close');
+				t.ok(body.sm.length >= 2, 'metrics included api calls as expected');
+				t.equal(metrResponse.req.method, 'POST', 'metrics(-jserror) harvest is a POST');
+
+				body = JSON.parse(errResponse.body);
+				t.ok(body.err, 'jserrors are sent on close');
+				t.equal(body.err.length, 1, 'should have 1 error obj');
+				t.equal(body.err[0].params.message, 'test', 'should have correct message');
+				t.equal(errResponse.req.method, 'POST', 'jserrors harvest is a POST');
+
+				body = ajaxResponse.body;
+				t.ok(/^bel.*\/jserrors.*\/ins.*$/.test(body), 'ajax event is sent on close with right payload');
+				t.equal(errResponse.req.method, 'POST', 'events harvest is a POST');
+
+				body = JSON.parse(insResponse.body);
+				t.ok(body.ins, 'page actions are sent on close');
+				t.equal(body.ins.length, 1, 'should have 1 action obj');
+				t.equal(body.ins[0].actionName, 'blahblahblah', 'should have correct actionName');
+				t.equal(insResponse.req.method, 'POST', 'ins harvest is a POST');
+
+      	t.end()
+			})
+			.catch(fail(t));
+		}
+	);
+}

--- a/tests/functional/worker/final-harvest.test.js
+++ b/tests/functional/worker/final-harvest.test.js
@@ -1,5 +1,0 @@
-// TO DO: "PageAction submission on final harvest" test from page-action-submission
-
-// TO DO: do we need to re-evaluate browser matcher reliablefinalharvest and unload?
-
-// TO DO: translate final-harvest.test.js from functional folder

--- a/tests/functional/worker/metrics.test.js
+++ b/tests/functional/worker/metrics.test.js
@@ -1,0 +1,215 @@
+const testDriver = require('../../../tools/jil/index')
+const {workerTypes, typeToMatcher} = require('./helpers')
+const {failWithEndTimeout, asyncApiFns, extractWorkerSM, getMetricsFromResponse} = require('../uncat-internal-help.cjs')
+
+const withUnload = testDriver.Matcher.withFeature('reliableUnloadEvent')
+const fetchExt = testDriver.Matcher.withFeature('fetchExt')
+const nestedWorkerSupport = testDriver.Matcher.withFeature('nestedWorkers')
+
+workerTypes.forEach(type => {  // runs all test for classic & module workers & use the 'workers' browser-matcher for classic and the 'workersFull' for module
+	const browsersWithOrWithoutModuleSupport = typeToMatcher(type);
+	metricsApiCreatesSM(type, browsersWithOrWithoutModuleSupport.and(withUnload));
+	metricsValidObfuscationCreatesSM(type, browsersWithOrWithoutModuleSupport.and(fetchExt));
+	metricsInvalidObfuscationCreatesSM(type, browsersWithOrWithoutModuleSupport.and(fetchExt));
+	metricsWorkersCreateSM(type, browsersWithOrWithoutModuleSupport.and(nestedWorkerSupport));
+});
+
+// --- Tests ---
+function metricsApiCreatesSM (type, browserVersionMatcher) {
+	testDriver.test(`${type} - Calling a newrelic[api] fn creates a supportability metric`, browserVersionMatcher, 
+		function (t, browser, router) {
+			const EXPECTED_APIS_CALLED = asyncApiFns.length;
+			t.plan(EXPECTED_APIS_CALLED + 5);	// the magic number 5 comes from the "extra" assertions labeled below		~YW, *cli 10/22
+
+			let assetURL = router.assetURL(`worker/${type}-worker.html`, {
+				init: {
+					jserrors: { enabled: false }
+				},
+				workerCommands: [() => { 
+					newrelic.noticeError('too many free taco coupons')
+					newrelic.setPageViewName('test')
+					newrelic.setCustomAttribute('test')
+					newrelic.setErrorHandler()
+					newrelic.finished()
+					newrelic.addToTrace('test')
+					newrelic.addRelease('test')
+
+					newrelic.setPageViewName('test')
+					newrelic.setPageViewName('test')
+					newrelic.setPageViewName('test')
+					newrelic.setPageViewName('test')
+				}].map(x => x.toString())
+			});
+			const loadPromise = browser.get(assetURL);
+			const errPromise = router.expectErrors();
+			const observedAPImetrics = [];
+
+			Promise.all([errPromise, loadPromise])
+			.then(( [data] ) => {
+				const supportabilityMetrics = getMetricsFromResponse(data, true)
+				const customMetrics = getMetricsFromResponse(data, false)
+				t.ok(supportabilityMetrics && !!supportabilityMetrics.length, 'SupportabilityMetrics object(s) were generated')	// extra #1
+				t.ok(customMetrics && !!customMetrics.length, 'CustomMetrics object(s) were generated')	// extra #2
+
+				for (const sm of supportabilityMetrics) {
+					const matchIdx = asyncApiFns.findIndex(x => x === sm.params.name);
+					if (matchIdx != -1) observedAPImetrics.push(asyncApiFns[matchIdx]);
+
+					if (matchIdx == 1)	// this is the index of 'setPageViewName' in asyncApiFns
+						t.equal(sm.stats.c, 5, sm.params.name + ' count was incremented by 1 until reached 5');
+					else if (sm.params.name.startsWith('Workers/'))	// these metrics have a dynamic count & are tested separately anyways
+						continue;
+					else 
+						t.equal(sm.stats.c, 1, sm.params.name + ' count was incremented by 1');	// there should be 1 generic sm for agent version--extra #3
+				}
+				t.ok(observedAPImetrics.length === EXPECTED_APIS_CALLED, 'Saw all asyncApiFns')	// extra #4
+				t.ok(customMetrics[0].params.name === 'finished', 'a `Finished` Custom Metric (cm) was also generated')	// extra #5
+				t.end()
+			}).catch(failWithEndTimeout(t));
+		}
+	);
+}
+function metricsValidObfuscationCreatesSM (type, browserVersionMatcher) {
+	testDriver.test(`${type} - a valid obfuscationRule creates detected supportability metric`, browserVersionMatcher, 
+		function (t, browser, router) {
+			let assetURL = router.assetURL(`worker/${type}-worker.html`, {
+				init: {
+					obfuscate: [{
+						regex: /pii/g,
+						replacement: 'OBFUSCATED'
+					}],
+					ajax: { harvestTimeSeconds: 2 },
+					jserrors: { enabled: false },
+					ins: { harvestTimeSeconds: 2 }
+				},
+				workerCommands: [() => { 
+					setTimeout(function () {
+						fetch('/tests/assets/obfuscate-pii-valid.html')
+						throw new Error('pii')
+					}, 100);
+					newrelic.addPageAction('pageactionpii');
+    			newrelic.setCustomAttribute('piicustomAttribute', 'customAttribute');
+				}].map(x => x.toString())
+			});
+			const loadPromise = browser.get(assetURL);
+			const errPromise = router.expectErrors();
+
+			Promise.all([errPromise, loadPromise])
+			.then(( [data] ) => {
+				const supportabilityMetrics = getMetricsFromResponse(data, true)
+				t.ok(supportabilityMetrics && !!supportabilityMetrics.length, 'SupportabilityMetrics object(s) were generated')
+				supportabilityMetrics.forEach(sm => {
+					t.ok(!sm.params.name.includes('Generic/Obfuscate/Invalid'), sm.params.name + ' contains correct name')
+				})
+				t.end()
+			}).catch(failWithEndTimeout(t));
+		}
+	);
+}
+function metricsInvalidObfuscationCreatesSM (type, browserVersionMatcher) {
+	const badObfusRulesArr = [{
+		regex: 123,
+		replacement: 'invalid;type'		// #1 - invalid regex object
+	}, {
+		replacement: 'invalid,undefined'	// #2 - regex undefined
+	}, {
+		regex: /backslash/g,
+		replacement: 123			// #3 - invalid replacement type (string)
+	}];
+
+	for (badRuleNum in badObfusRulesArr)
+		testDriver.test(`${type} - invalid obfuscation rule #${parseInt(badRuleNum)+1} creates invalid supportability metric`, browserVersionMatcher, 
+			function (t, browser, router) {
+				let assetURL = router.assetURL(`worker/${type}-worker.html`, {
+					init: {
+						obfuscate: [badObfusRulesArr[badRuleNum]],
+						ajax: { harvestTimeSeconds: 2 },
+						jserrors: { enabled: false },
+						ins: { harvestTimeSeconds: 2 }
+					},
+					workerCommands: [() => { 
+						setTimeout(function () {
+							fetch('/tests/assets/obfuscate-pii-valid.html')
+							throw new Error('pii')
+						}, 100);
+						newrelic.addPageAction('pageactionpii');
+						newrelic.setCustomAttribute('piicustomAttribute', 'customAttribute');
+					}].map(x => x.toString())
+				});
+
+				const loadPromise = browser.get(assetURL);
+				const errPromise = router.expectErrors();
+
+				Promise.all([errPromise, loadPromise])
+				.then(( [data] ) => {
+					const supportabilityMetrics = getMetricsFromResponse(data, true)
+					t.ok(supportabilityMetrics && !!supportabilityMetrics.length, 'SupportabilityMetrics object(s) were generated')
+					let invalidDetected = false;
+					supportabilityMetrics.forEach(sm => {
+						if (sm.params.name.includes('Generic/Obfuscate/Invalid')) invalidDetected = true;
+					})
+					t.ok(invalidDetected, 'an invalid regex rule detected')
+					t.end()
+				}).catch(failWithEndTimeout(t));
+			}
+		);
+}
+function metricsWorkersCreateSM (type, browserVersionMatcher) {
+	testDriver.test(`${type} - workers creation generates sm`, browserVersionMatcher, 
+		function (t, browser, router) {
+			let assetURL = router.assetURL(`worker/${type}-worker.html`, {
+				init: {
+					jserrors: { enabled: false }
+				},
+				workerCommands: [() => { 
+					try {
+            let worker1 = new Worker('./worker-scripts/simple.js');
+            let worker2 = new Worker('./worker-scripts/simple.js', {type: 'module'});
+					} catch (e) {
+							console.warn(e);
+					}
+					try {
+            let worker1 = new SharedWorker('./worker-scripts/simple.js');
+            let worker2 = new SharedWorker('./worker-scripts/simple.js', {type: 'module'});
+					} catch (e) {
+							console.warn(e);
+					}
+					try {
+            let worker1 = self.navigator.serviceWorker.register('./worker-scripts/simple.js');  // This script will probably cause an error
+            let worker2 = self.navigator.serviceWorker.register('./worker-scripts/simple.js', {type: 'module'});
+					} catch (e) {
+							console.warn(e);
+					}
+				}].map(x => x.toString())
+			});
+			const loadPromise = browser.get(assetURL);
+			const errPromise = router.expectErrors();
+
+			Promise.all([errPromise, loadPromise])
+			.then(( [data] ) => {
+				const supportabilityMetrics = getMetricsFromResponse(data, true)
+				t.ok(supportabilityMetrics && !!supportabilityMetrics.length, `${supportabilityMetrics.length} SupportabilityMetrics object(s) were generated`);
+				
+				const wsm = extractWorkerSM(supportabilityMetrics);
+
+				// Since this test is supposed to run inside a worker, there's no need to check if we're in a worker compat browser & version...
+				if (!wsm.workerImplFail) {  // worker may be avail in Chrome v4, but our SM implementation may not be supported until v60, etc.
+					t.ok(wsm.classicWorker, 'classic worker is expected and used');
+					t.ok(wsm.moduleWorker, 'module worker is expected and used');	// see note on this from original metrics.test.js test
+				}
+
+				// NOTE: we're only testing (default|module) *dedicated* workers right now, not shared or service
+				// The sharedWorker class is actually n/a inside of workers...
+				t.notOk(wsm.classicShared, 'classic sharedworker is NOT expected but used');
+				t.notOk(wsm.moduleShared, 'module sharedworker is NOT expected but used');
+				t.notOk(wsm.sharedUnavail || wsm.sharedImplFail, 'sharedworker supportability should not be emitted by or within a worker');
+
+				// Don't think the serviceWorker class is or will be available inside of workers either...
+				t.notOk(wsm.classicService || wsm.moduleService, 'classic or module serviceworker is NOT expected or used');
+				t.notOk(wsm.serviceUnavail || wsm.serviceImplFail, 'serviceworker supportability should not be emitted by or within a worker');
+
+				t.end()
+			}).catch(failWithEndTimeout(t));
+		}
+	);
+}


### PR DESCRIPTION
### Overview
Agent when running within workers will wrap the close method to simulate a web worker's equivalent of a window's unload event. Buffered data will be sent in a final harvest before thread closes. 

### Related Issue
Part of NEWRELIC-2433 epic

### Testing
New test ran on classic & module dedicated workers.

#### Other side effects
None