### PR TITLE
Update cdn build to support typescript

### DIFF
--- a/cdn/webpack.config.js
+++ b/cdn/webpack.config.js
@@ -64,6 +64,28 @@ console.log("MAP_PATH", MAP_PATH)
 console.log("IS_LOCAL", IS_LOCAL)
 if (PR_NAME) console.log("PR_NAME", PR_NAME)
 
+
+const standardBabelPreset = ['@babel/preset-env', {
+  targets: {
+    browsers: [
+      "last 10 Chrome versions",
+      "last 10 Safari versions",
+      "last 10 Firefox versions",
+      "last 10 Edge versions"
+    ]
+  }
+}];
+const polyfillBabelPreset = ['@babel/preset-env', {
+  useBuiltIns: 'entry',
+  corejs: { version: 3.23, proposals: true },
+  loose: true,
+  targets: {
+    browsers: [
+      "ie >= 11" // Does not affect webpack's own runtime output; see `target` webpack config property.
+    ]
+  }
+}];
+
 /**
  * Helper for configuring a source map plugin instance with some common properties.
  * @param {string} [filename] - Overrides the standard filename configuration.
@@ -122,9 +144,10 @@ const commonConfig = {
       'WEBPACK_MINOR_VERSION': JSON.stringify(SUBVERSION || ''),
       'WEBPACK_MAJOR_VERSION': JSON.stringify(VERSION || ''),
       'WEBPACK_DEBUG': JSON.stringify(IS_LOCAL || false)
-    })    
+    })
   ],
   resolve: {
+    extensions: [".js", ".json", ".ts"],
     alias: {
       '@newrelic/browser-agent-core/src': path.resolve(__dirname, '../packages/browser-agent-core/src')
     }
@@ -149,18 +172,17 @@ const standardConfig = merge(commonConfig, {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: [
-              ['@babel/preset-env', {
-                targets: {
-                  browsers: [
-                    "last 10 Chrome versions",
-                    "last 10 Safari versions",
-                    "last 10 Firefox versions",
-                    "last 10 Edge versions"
-                  ]
-                }
-              }]
-            ]
+            presets: [standardBabelPreset]
+          }
+        }
+      },
+      {
+        test: /\.ts$/,
+        exclude: /(node_modules)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-typescript', standardBabelPreset]
           }
         }
       }
@@ -193,18 +215,17 @@ const polyfillsConfig = merge(commonConfig, {
         use: {
           loader: 'babel-loader',
           options: {
-            presets: [
-              ['@babel/preset-env', {
-                useBuiltIns: 'entry',
-                corejs: { version: 3.23, proposals: true },
-                loose: true,
-                targets: {
-                  browsers: [
-                    "ie >= 11" // Does not affect webpack's own runtime output; see `target` webpack config property.
-                  ]
-                }
-              }]
-            ]
+            presets: [polyfillBabelPreset]
+          }
+        }
+      },
+      {
+        test: /\.ts$/,
+        exclude: /(node_modules)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-typescript', polyfillBabelPreset]
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-modules-commonjs": "^7.18.2",
         "@babel/preset-env": "^7.18.2",
+        "@babel/preset-typescript": "^7.18.6",
         "@newrelic/nr-querypack": "https://git@github.com/newrelic/nr-querypack",
         "@nrwl/cli": "^15.0.9",
         "@nrwl/devkit": "^15.0.13",
@@ -1581,6 +1582,23 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.2.tgz",
+      "integrity": "sha512-jvS+ngBfrnTUBfOQq8NfGnSbF9BrqlR6hjJ2yVxMkmO5nL/cdifNbI30EfjRlN4g5wYWNnMPyj5Sa6R1pbLeag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-typescript": "^7.20.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
@@ -1712,6 +1730,23 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
+      "integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-transform-typescript": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -22834,6 +22869,17 @@
         "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.2.tgz",
+      "integrity": "sha512-jvS+ngBfrnTUBfOQq8NfGnSbF9BrqlR6hjJ2yVxMkmO5nL/cdifNbI30EfjRlN4g5wYWNnMPyj5Sa6R1pbLeag==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-typescript": "^7.20.0"
+      }
+    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.18.10",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
@@ -22947,6 +22993,17 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
+      "integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-transform-typescript": "^7.18.6"
       }
     },
     "@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.18.2",
     "@babel/preset-env": "^7.18.2",
+    "@babel/preset-typescript": "^7.18.6",
     "@newrelic/nr-querypack": "https://git@github.com/newrelic/nr-querypack",
     "@nrwl/cli": "^15.0.9",
     "@nrwl/devkit": "^15.0.13",


### PR DESCRIPTION
### Overview

Updating the cdn webpack config to support typescript files. With this change, JS files in the packages directory can be renamed with the `.ts` extension and the build will continue functioning as-is.

### Related Github Issue

https://issues.newrelic.com/browse/NEWRELIC-5562

### Testing

Update one of the files in the `browser-agent-core` package to have the `.ts` file extension and run `npm run cdn:build:prod` or any of the other build tasks. The build should complete with no changes to the output files.