### PR TITLE
Updating husky dependency

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,7 +10,6 @@ babel.config.js
 tools/test-builds/*
 tests/assets/test-builds/**/*.js
 tests/*
-packages/**/*
 
 cdn/
 tools/jil/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
-
 {
+  "ignorePatterns": ["packages/**/*"],
   "parserOptions": {
     "ecmaVersion": 5,
     "sourceType": "script",

--- a/.eslintrc.json.nx
+++ b/.eslintrc.json.nx
@@ -4,7 +4,7 @@
   "plugins": ["@nrwl/nx"],
   "overrides": [
     {
-      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "files": ["*.ts", "*.js"],
       "rules": {
         "@nrwl/nx/enforce-module-boundaries": [
           "error",
@@ -22,21 +22,28 @@
       }
     },
     {
-      "files": ["*.ts", "*.tsx"],
+      "files": ["*.ts"],
       "extends": ["plugin:@nrwl/nx/typescript"],
       "rules": {}
     },
     {
-      "files": ["*.js", "*.jsx"],
+      "files": ["*.js"],
       "extends": ["plugin:@nrwl/nx/javascript"],
       "rules": {}
     },
     {
-      "files": ["*.spec.ts", "*.spec.tsx", "*.spec.js", "*.spec.jsx"],
+      "files": ["*.spec.ts", "*.spec.js", "**/__mocks__/**/*", "**/__tests__/**/*"],
       "env": {
         "jest": true
       },
-      "rules": {}
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off",
+        "@nrwl/nx/enforce-module-boundaries": [
+          "error",
+          {
+            "enforceBuildableLibDependency": false
+          }
+        ]}
     },
     {
       "files": "*.json",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run sauce:get-browsers

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx nx affected --target=lint
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "gulp-file": "^0.4.0",
         "gulp-sourcemaps": "1.6.0",
         "gulp-uglify": "^1.5.4",
-        "husky": "^0.11.6",
+        "husky": "^8.0.0",
         "jest": "28.1.1",
         "jest-environment-jsdom": "28.1.1",
         "jquery": "1.11.3",
@@ -6222,12 +6222,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/ci-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-      "dev": true
-    },
     "node_modules/cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -11129,23 +11123,18 @@
       }
     },
     "node_modules/husky": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.11.9.tgz",
-      "integrity": "sha512-5iRwfa/2o8lhT2rxoW18MhPVzRwhwg1abpXvVNl0vvJPit5dmpohTjStDLIk8uo3/eUeaY/KZkBPiNFvb0V5Gg==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
       "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "is-ci": "^1.0.9",
-        "normalize-path": "^1.0.0"
-      }
-    },
-    "node_modules/husky/node_modules/normalize-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-      "integrity": "sha512-7WyT0w8jhpDStXRq5836AMmihQwq2nrUVQrgjvUo/p/NZf9uy/MeJ246lBJVmWuYXMlJuG9BNZHF0hWjfTbQUA==",
-      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -11426,18 +11415,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-      "dev": true,
-      "dependencies": {
-        "ci-info": "^1.5.0"
-      },
-      "bin": {
-        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -26997,12 +26974,6 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
       "dev": true
     },
-    "ci-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-      "dev": true
-    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -30952,22 +30923,10 @@
       "dev": true
     },
     "husky": {
-      "version": "0.11.9",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.11.9.tgz",
-      "integrity": "sha512-5iRwfa/2o8lhT2rxoW18MhPVzRwhwg1abpXvVNl0vvJPit5dmpohTjStDLIk8uo3/eUeaY/KZkBPiNFvb0V5Gg==",
-      "dev": true,
-      "requires": {
-        "is-ci": "^1.0.9",
-        "normalize-path": "^1.0.0"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-          "integrity": "sha512-7WyT0w8jhpDStXRq5836AMmihQwq2nrUVQrgjvUo/p/NZf9uy/MeJ246lBJVmWuYXMlJuG9BNZHF0hWjfTbQUA==",
-          "dev": true
-        }
-      }
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
+      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.6.3",
@@ -31177,15 +31136,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
-    },
-    "is-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^1.5.0"
-      }
     },
     "is-core-module": {
       "version": "2.11.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "legacy:build": "rm -rf build && mkdir build && gulp build",
     "build:all": "npx nx run-many --target=build && npm run packages:bundle && npm run cdn:build:local",
     "build-mac": "gulp && osascript -e 'display notification \"The agent has been built.\" with title \"Build Complete\"'",
-    "prepush": "npm run lint && node -e 'process.exit((process.argv[1] === \"master\") ? 1 : 0)' `git rev-parse --abbrev-ref HEAD`",
     "postinstall": "npm --prefix tools/jil ci && rm -f node_modules/jil && ln -s ../tools/jil node_modules/jil",
     "phantomjs": "phantomjs",
     "lint": "eslint --ext .js -c .eslintrc .",
@@ -36,12 +35,12 @@
     "test-server": "node ./tools/jil/bin/server",
     "sauce:connect": "node ./tools/jil/bin/sauce",
     "sauce:get-browsers": "node ./tools/jil/util/sauce-browsers",
-    "tools:test-builds": "npm --prefix ./tools/test-builds/build-time-mfe run build"
+    "tools:test-builds": "npm --prefix ./tools/test-builds/build-time-mfe run build",
+    "prepare": "husky install"
   },
   "config": {
     "unsafe-perm": true
   },
-  "pre-commit": "sauce:get-browsers",
   "bin": {
     "jil": "./tools/jil/bin/cli.js",
     "jil-server": "./tools/jil/bin/server.js",
@@ -92,7 +91,7 @@
     "gulp-file": "^0.4.0",
     "gulp-sourcemaps": "1.6.0",
     "gulp-uglify": "^1.5.4",
-    "husky": "^0.11.6",
+    "husky": "^8.0.0",
     "jest": "28.1.1",
     "jest-environment-jsdom": "28.1.1",
     "jquery": "1.11.3",

--- a/packages/browser-agent-core/.eslintrc.json
+++ b/packages/browser-agent-core/.eslintrc.json
@@ -1,16 +1,16 @@
 {
-  "extends": ["../../.eslintrc.json"],
+  "extends": ["../../.eslintrc.json.nx"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
-      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "files": ["*.ts", "*.js"],
       "rules": {
         "no-var": "off",
         "prefer-const": "off"
       }
     },
     {
-      "files": ["*.ts", "*.tsx"],
+      "files": ["*.ts"],
       "rules": {
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-unused-vars": "off",
@@ -22,7 +22,7 @@
       }
     },
     {
-      "files": ["*.js", "*.jsx"],
+      "files": ["*.js"],
       "rules": {}
     }
   ]

--- a/packages/browser-agent/.eslintrc.json
+++ b/packages/browser-agent/.eslintrc.json
@@ -1,16 +1,16 @@
 {
-  "extends": ["../../.eslintrc.json"],
+  "extends": ["../../.eslintrc.json.nx"],
   "ignorePatterns": ["!**/*"],
   "overrides": [
     {
-      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "files": ["*.ts", "*.js"],
       "rules": {
         "no-var": "off",
         "prefer-const": "off"
       }
     },
     {
-      "files": ["*.ts", "*.tsx"],
+      "files": ["*.ts"],
       "rules": {
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-unused-vars": "off",
@@ -22,7 +22,7 @@
       }
     },
     {
-      "files": ["*.js", "*.jsx"],
+      "files": ["*.js"],
       "rules": {}
     }
   ]

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -41,36 +41,36 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "106",
-      "browserVersion": "106"
-    },
-    {
-      "browserName": "MicrosoftEdge",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "104",
-      "browserVersion": "104"
-    },
-    {
-      "browserName": "MicrosoftEdge",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "102",
-      "browserVersion": "102"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "100",
-      "browserVersion": "100"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "97",
-      "browserVersion": "97"
+      "version": "103",
+      "browserVersion": "103"
+    },
+    {
+      "browserName": "MicrosoftEdge",
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "101",
+      "browserVersion": "101"
+    },
+    {
+      "browserName": "MicrosoftEdge",
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "98",
+      "browserVersion": "98"
     }
   ],
   "safari": [
@@ -109,27 +109,27 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "106"
+      "version": "107"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "104"
+      "version": "105"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "102"
+      "version": "103"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "100"
+      "version": "101"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "97"
+      "version": "98"
     }
   ],
   "ios": [


### PR DESCRIPTION
### Overview

Updating the husky dependency to the latest version. This newer version has changed how we manage the hooks but functionally works the same as the previous version we were using.

### Related Github Issue

https://issues.newrelic.com/browse/NEWRELIC-5568

### Testing

Install the dependencies using `npm i` and then run `git commit --allow-empty -m "Empty test commit"` to test the pre-commit hook. Run `git push` to test the pre-push hook.