### PR TITLE
Fix initial page load harvest with Nuxt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The Agent will now take into account the error object type and message when deci
 ### Detect Workflow Changes
 PRs will run an action to detect workflow changes for a warning layer against vulnerability.
 
+### Fix initial page load interaction reporting with Nuxt
+Fixed an issue where when using the SPA loader with Nuxt, the initial page load interaction was never being completed. This resulted in events like errors being retained in memory and never harvested because they were tied to an incomplete interaction.
+
 ## v1220
 
 * Internal NR Platform release date: 10/5/2022

--- a/packages/browser-agent-core/src/features/spa/aggregate/index.js
+++ b/packages/browser-agent-core/src/features/spa/aggregate/index.js
@@ -187,7 +187,11 @@ export class Aggregate extends FeatureBase {
         this.prevNode = state.currentNode = null
         if (state.initialPageLoad) {
           eventNode = state.initialPageLoad.root
-          state.initialPageLoad[REMAINING]--
+
+          // Even if initialPageLoad has remaining callbacks, force the initialPageLoad
+          // interaction to complete when the page load event occurs.
+          state.initialPageLoad[REMAINING] = 0
+
           originalSetTimeout(function () {
             INTERACTION_EVENTS.push('popstate')
           })

--- a/packages/browser-agent-core/src/features/spa/aggregate/interaction.js
+++ b/packages/browser-agent-core/src/features/spa/aggregate/interaction.js
@@ -45,8 +45,8 @@ var InteractionPrototype = Interaction.prototype
 
 InteractionPrototype.checkFinish = function checkFinish() {
   var interaction = this
- 
-  if (interaction.remaining) {
+
+  if (interaction.remaining > 0) {
     interaction._resetFinishCheck()
     return
   }
@@ -64,7 +64,7 @@ InteractionPrototype.checkFinish = function checkFinish() {
     interaction.checkingFinish = false
     interaction.finishTimer = originalSetTimeout(() => {
       interaction.finishTimer = null
-      if (!interaction.remaining) interaction.finish()
+      if (interaction.remaining <= 0) interaction.finish()
     }, 1)
   }, 0)
 }


### PR DESCRIPTION
### Overview

Primarily this changes how we treat the `initialPageLoad` interaction when the page `load` event happens. Currently, if that interaction still contains incomplete callbacks, the interaction's `finish` method will never be called. With the change, we no longer wait for any pending callbacks tied to the `initialPageLoad` interaction when the page `load` event happens.

### Related Github Issue

https://issues.newrelic.com/browse/NEWRELIC-3891

### Testing

To test locally, download the attached reproduction project.

1. Extract the project and open in your IDE
2. Create a new browser project in NR1-Staging
3. Use the copy/paste method and copy the generated script from NR1
4. In the reproduction project, open `config/newrelic.js` and paste in the copied script tag into the `innerHTML` field, making sure to remove the `<script>` and `</script>` parts
5. Run `npm i && npm run build && npm start`, a local web server should start at http://localhost:3000
6. Open the test page and review the network calls
7. You should see no errors being reported even though the reproduction app does generate an error
8. You should see no calls out for `bel.7`
9. In NR1 for your test browser app, you should have no errors reported but there should be a session trace that does contain an error when opened
    - If the session trace is not showing up, refresh the page and wait about 1 minute, it was consistently showing for me
10. In NR1, query the data using the below nrql and you should get no results
    - `SELECT * from BrowserInteraction where entityGuid = '<GUID>' since 30 minutes ago`
    - Replace `<GUID>` with the quid for your test app, found in the app metadata

To fix the issue using this branch:

1. Pull down this branch and run `npm i && npm run build:all`
2. Open the file `build/nr-loader-spa.js`
3. Search for `/build/` and replace it with `http://bam-test-1.nr-local.net:3333/build/`
4. Run `npm run test-server` to start the local agent server
5.  In the reproduction project, open `config/newrelic.js` and remove the loader from the `innerHTML` string leaving only the init, config, and info pieces
6. Create a new object in this file using the below snippet
```
{
    hid: 'newRelicAgent',
    type: "text/javascript",
    charset: "utf-8",
    src: "http://bam-test-1.nr-local.net:3333/build/nr-loader-spa.js"
  }
```
7. Stop the reproduction project's server and run `npm run build && npm start`
8. Open the test page and review the network calls
9. You should see no the error correctly reported to NR1
10. You should see the `bel.7` call for the `initialPageLoad`
11. In NR1 for your test browser app, you should now have errors reported and there should be a session trace that does contain an error when opened
    - If the session trace is not showing up, refresh the page and wait about 1 minute, it was consistently showing for me
12. In NR1, query the data using the below nrql and you should get a result for the initial page load
    - `SELECT * from BrowserInteraction where entityGuid = '<GUID>' since 30 minutes ago`
    - Replace `<GUID>` with the quid for your test app, found in the app metadata

**NOTE:** with Nuxt, you need to use node <= v16

[5lowdp.zip](https://github.com/newrelic/newrelic-browser-agent/files/10116050/5lowdp.zip)
