### PR TITLE
Change usage of Buffer to address test-run warning.

### DIFF
--- a/tests/functional/xhr/xhr-dt-header.test.js
+++ b/tests/functional/xhr/xhr-dt-header.test.js
@@ -58,7 +58,7 @@ testDriver.test('XHR request on same origin has DT headers', supported, function
       t.ok(headers['newrelic'], 'newrelic header should be present')
 
       // newrelic header
-      let buffer = new Buffer(headers['newrelic'], 'base64')
+      let buffer = Buffer.from(headers['newrelic'], 'base64')
       let text = buffer.toString('ascii')
       let dtPayload = JSON.parse(text)
 

--- a/tests/functional/xhr/xhr-dt-header.test.js
+++ b/tests/functional/xhr/xhr-dt-header.test.js
@@ -58,7 +58,7 @@ testDriver.test('XHR request on same origin has DT headers', supported, function
       t.ok(headers['newrelic'], 'newrelic header should be present')
 
       // newrelic header
-      let buffer = Buffer.from(headers['newrelic'], 'base64')
+      let buffer = new Buffer(headers['newrelic'], 'base64')
       let text = buffer.toString('ascii')
       let dtPayload = JSON.parse(text)
 

--- a/tools/jil/server/asset-server.js
+++ b/tools/jil/server/asset-server.js
@@ -702,7 +702,7 @@ class AssetServer extends BaseServer {
     function unitTestTarget(file) {
       let script = `/${path.relative(server.assetsDir, file)}?browserify=true`
       return server.urlFor('/tests/assets/browser.html', {
-        config: new Buffer(JSON.stringify({
+        config: Buffer.from(JSON.stringify({
           assetServerPort: server.router.assetServer.port,
           assetServerSSLPort: server.router.assetServer.sslPort,
           corsServerPort: server.corsServer.port


### PR DESCRIPTION
### Overview
Modifies usage of Buffer to address warning during JIL test runs: `DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.` See [info on porting](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) in Node.js docs.

### Related Github Issue
N/A

### Testing
N/A