### PR TITLE
Adding logic for route changes outside a current interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ A new release of the Browser Agent will automatically raise a PR to the docs-sit
 ### Preserve unhandledPromiseRejection reasons as human-readable strings in error payloads
 The agent will attempt to preserve unhandledPromiseRejection reasons as human-readable messages on the Error payload that gets harvested. The previous strategy did not always work, because Promise.reject can pass any value, not just strings.
 
+### Fix missing interactions for dynamic routes in Next/React
+Fixed an issue where when using the SPA loader with Next/React, route changes that lazy loaded components would not be captured. While the issue specifically called out Next/React, this should apply to Nuxt/Vue and Angular.
 
 ## v1223
 

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -115,6 +115,7 @@ export class Aggregate extends AggregateBase {
 
     state.initialPageLoad = new Interaction('initialPageLoad', 0, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentIdentifier)
     state.initialPageLoad.save = true
+    state.prevInteraction = state.initialPageLoad
     state.currentNode = state.initialPageLoad.root // hint
     // ensure that checkFinish calls are safe during initialPageLoad
     state.initialPageLoad[REMAINING]++
@@ -206,6 +207,7 @@ export class Aggregate extends AggregateBase {
         // so that it has a chance to possibly start an interaction.
         if (INTERACTION_EVENTS.indexOf(evName) !== -1) {
           var ixn = new Interaction(evName, this[FN_START], state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentIdentifier)
+          state.prevInteraction = ixn
           setCurrentNode(ixn.root)
 
           if (evName === 'click') {
@@ -412,25 +414,26 @@ export class Aggregate extends AggregateBase {
     register('newURL', function (url, hashChangedDuringCb) {
       if (state.currentNode) {
         state.currentNode[INTERACTION].setNewURL(url)
-      } else if (state.prevInteraction && !state.prevInteraction.ignored && state.prevInteraction.eventName !== 'api') {
+      } else if (state.prevInteraction && !state.prevInteraction.ignored) {
         /*
          * The previous interaction was discarded before the route was changed. This can happen in SPA
          * frameworks when using lazy loading. We have also seen this in version 11+ of Nextjs where
          * some route changes re-use cached resolved promises.
          */
         const interaction = state.prevInteraction
-        state.prevInteraction = null
         interaction.setNewURL(url)
         interaction.root.end = null
 
         setCurrentNode(interaction.root)
       }
 
-      if (state.lastSeenUrl !== url) {
-        state.currentNode[INTERACTION].routeChange = true
-      }
-      if (hashChangedDuringCb) {
-        state.nodeOnLastHashUpdate = state.currentNode
+      if (state.currentNode) {
+        if (state.lastSeenUrl !== url) {
+          state.currentNode[INTERACTION].routeChange = true
+        }
+        if (hashChangedDuringCb) {
+          state.nodeOnLastHashUpdate = state.currentNode
+        }
       }
 
       state.lastSeenUrl = url
@@ -613,7 +616,6 @@ export class Aggregate extends AggregateBase {
     function setCurrentNode(newNode) {
       if (!state.pageLoaded && !newNode && state.initialPageLoad) newNode = state.initialPageLoad.root
       if (state.currentNode) {
-        state.prevInteraction = state.currentNode[INTERACTION]
         state.currentNode[INTERACTION].checkFinish()
       }
 
@@ -684,6 +686,12 @@ export class Aggregate extends AggregateBase {
         return
       }
 
+      if (state.prevInteraction === interaction) {
+        // If the interaction is being saved, remove it from prevInteraction variable
+        // to prevent the interaction from possibly being sent twice or causing an internal
+        // recursive loop issue.
+        state.prevInteraction = null;
+      }
       // assign unique id, this is serialized and used to link interactions with errors
       interaction.root.attrs.id = generateUuid()
 


### PR DESCRIPTION
### Overview

In some SPA applications, our code creates an interaction for the click of a link but that interaction is prematurely closed before the url change occurs. This results in missing data in NR1 since no interaction for the route change is reported.

The change stores the current interaction in memory as `state.prevInteraction` any time the code attempts to set a new node (null or otherwise). If a route change then happens, and there is no current interaction (`state.currentNode === null`), we will check for the previous interaction. If it meets requirements of not being set to be ignored and not created via the interactions API, it will be re-used and updated with the url change.

The restored interaction is re-processed and transmitted to NR1.

### Related Github Issue

https://issues.newrelic.com/browse/NEWRELIC-3359

### Testing

To test locally, download the attached reproduction project.

1. Extract the project and open in your IDE
2. Create a new browser project in NR1-Staging
3. Use the copy/paste method and copy the generated script from NR1
4. In the reproduction project, open `pages/_document.tsx`
5. Paste in the below code into the `<Head>` tag, replacing `<COPY/PASTE CODE HERE>` with the copied code from NR1, making sure to remove the extra script tags from NR1
```
          <script
            type="text/javascript"
            dangerouslySetInnerHTML={{ __html: `
              <COPY/PASTE CODE HERE>
            `}}
          />
```
6. Remove the other script tag that is already present
7. Run `npm i && npm run dev`, a local web server should start at http://localhost:3000
8. Open the test page and click through links
9. In NR1 for your test browser app, open the meta data and copy the GUID
10. In NR1, query the data using the below nrql and you should get no results
    - `SELECT timestamp, actionText, previousUrl, targetUrl from BrowserInteraction where entityGuid = '<GUID>' since 5 minute ago`
    - Replace `<GUID>` with the quid for your test app, found in the app metadata
11. You should see some interactions reported, mainly the initial page load and interactions for pages that have already been lazy loaded, but you will most likely be missing interactions

To fix the issue using this branch:

1. Pull down this branch and run `npm i && npm run build:all`
2. Open the file `build/nr-loader-spa.js`
3. Search for `/build/` and replace it with `http://bam-test-1.nr-local.net:3333/build/`
4. Run `npm run test-server` to start the local agent server
5.  In the reproduction project, open `pages/_document.tsx` and remove the loader from the `dangerouslySetInnerHTML` string leaving only the init, config, and info pieces
6. Add the below script to `Head` below the existing script
```
          <script
            type="text/javascript"
            src="http://bam-test-1.nr-local.net:3333/build/nr-loader-spa.js"
          />
```
7. Stop the reproduction project's server and run `npm run dev`
8. Open the test page and click through links
9. Rerun the query in NR1 and you should now see interactions reported for every link clicked

The ticket specifically calls out Next v12 but we were also seeing missing data with Next v11. If your would like to also test out Next v12 for the ticket, stop the reproduction server and run `npm uninstall next && npm i next@12.2.6 && rm -rf .next && npm run dev`

**NOTE:** with Next, you need to use node <= v16

[newrelic-nextjs-integration-main.zip](https://github.com/newrelic/newrelic-browser-agent/files/10127023/newrelic-nextjs-integration-main.zip)
