### PR TITLE
Update jserror bucketing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 To address "mismatched anonymous define" errors thrown by RequireJS, the agent's webpack library output will no longer include UMD checks for CommonJS and AMD module environments, and will instead be exposed globally via `self`.
 
 ### Update JS error bucketing algorithm
-The Agent will now take into account the error object type and message when deciding on whether multiple JS errors should be bucketed together.
+The Agent will now take into account the error object type, message, and original stack trace when deciding on whether multiple JS errors should be bucketed together.
 
 ### Detect Workflow Changes
 PRs will run an action to detect workflow changes for a warning layer against vulnerability.

--- a/tests/assets/js-error-column-bucketing.html
+++ b/tests/assets/js-error-column-bucketing.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>RUM Unit Test</title>
+  {init}
+  {config}
+  {loader}
+</head>
+<body>
+this is a generic page that is instrumented by the JS agent
+
+<script>function myFunc(a) { console.log(a.click); }</script><script>(() => {var myVar; myFunc(myVar)})()</script><script>(() => {var myVar2; myFunc(myVar2)})();</script>
+</body>
+</html>

--- a/tests/functional/err/assertion-helpers.js
+++ b/tests/functional/err/assertion-helpers.js
@@ -69,7 +69,7 @@ function assertExpectedErrors (t, browser, actualErrors, expectedErrors, assetUR
     }
 
     var expectedCanonicalStack = computeExpectedCanonicalStack(expectedStack)
-    var expectedStackHash = stringHashCode(`${expectedError.name}_${expectedError.message}_${expectedCanonicalStack}`)
+    var expectedStackHash = stringHashCode(expectedCanonicalStack)
 
     t.equal(actualError.params.stackHash, expectedStackHash, 'Stack hash for error ' + expectedError.message)
 


### PR DESCRIPTION
### Overview

This PR reverts the changes to the canonical stack hash in #303 and instead updates the bucket hash to account for the error name/type, message, and original stack trace.

### Related Github Issue

https://issues.newrelic.com/browse/NR-40043
https://issues.newrelic.com/browse/NEWRELIC-3359

### Testing

To test locally, download the attached reproduction project.

1. Extract the project and open in your IDE
2. Create a new browser project in NR1-Staging
3. Use the copy/paste method and copy the generated script from NR1
4. In the reproduction project, open `index.html`
5. Paste in the code from NR1 into the head
6. Run `python3 -m http.server`, a local web server should start at http://localhost:8000
7. Open the test page and wait for the errors to report
8. In NR1 for your test browser app, open the js errors screen
9. You should see 1 error that was reported 8 times

To fix the issue using this branch:

1. Pull down this branch and run `npm i && npm run build:all`
2. Open the file `build/nr-loader-spa.js`
3. Search for `/build/` and replace it with `http://bam-test-1.nr-local.net:3333/build/`
4. Run `npm run test-server` to start the local agent server
5.  In the reproduction project, open `index.html` and remove the loader from the script tag copied from NR1 leaving only the init, config, and info pieces
6. Add a script tag with a src of `http://bam-test-1.nr-local.net:3333/build/nr-loader-spa.js`
7. Open the test page and wait for the errors to be reported
10. In NR1, you should now see the 8 different errors reported

[noticeError-bucketing.zip](https://github.com/newrelic/newrelic-browser-agent/files/10143771/noticeError-bucketing.zip)
