### PR TITLE
Differentiate babel targets for polyfill and non-polyfill builds (NEWRELIC-5374)

### DIFF
--- a/cdn/package.json
+++ b/cdn/package.json
@@ -34,11 +34,6 @@
     "core-js": "^3.23.3"
   },
   "browserslist": [
-    "chrome >= 60",
-    "safari >= 11",
-    "firefox >= 56",
-    "ios >= 10.3",
-    "ie >= 11",
-    "edge >= 60"
+    "ie >= 11"
   ]
 }

--- a/tools/jil/server/asset-server.js
+++ b/tools/jil/server/asset-server.js
@@ -309,13 +309,13 @@ class BrowserifyTransform extends AssetTransform {
           ["@babel/preset-env", {
             loose: true,
             targets: {
-              browsers: [
-                "chrome >= 60",
-                "safari >= 11",
-                "firefox >= 56",
-                "ios >= 10.3",
-                "ie >= 11",
-                "edge >= 60"
+              browsers: runnerArgs.polyfills ? [
+                "ie >= 11"
+              ] : [
+                "last 10 Chrome versions",
+                "last 10 Safari versions",
+                "last 10 Firefox versions",
+                "last 10 Edge versions"
               ]
             }
           }]
@@ -323,6 +323,7 @@ class BrowserifyTransform extends AssetTransform {
         plugins: [
           "@babel/plugin-syntax-dynamic-import",
           '@babel/plugin-transform-modules-commonjs',
+          "@babel/plugin-proposal-optional-chaining",
           ["module-resolver", {
             "alias": {
               "@newrelic/browser-agent-core/src": './dist/packages/browser-agent-core/src'

--- a/tools/jil/server/asset-server.js
+++ b/tools/jil/server/asset-server.js
@@ -47,7 +47,7 @@ class AgentInjectorTransform extends AssetTransform {
     this.assetServer = assetServer
     this.router = router
 
-    this.polyfills = fs.readFileSync(`${this.buildDir}/nr-polyfills.min.js`)
+    this.polyfills = runnerArgs.polyfills ? fs.readFileSync(`${this.buildDir}/nr-polyfills.min.js`) : ''
   }
 
   parseConfigFromQueryString(params) {

--- a/tools/jil/util/browsers-polyfill.json
+++ b/tools/jil/util/browsers-polyfill.json
@@ -1,57 +1,9 @@
 {
-    "chrome": [
-      {
-        "browserName": "chrome",
-        "platform": "Windows 10",
-        "version": "60"
-      }
-    ],
-    "edge": [
-      {
-        "browserName": "MicrosoftEdge",
-        "platform": "Windows 10",
-        "version": "79"
-      }
-    ],
-    "ie": [
-      {
-        "browserName": "internet explorer",
-        "platform": "Windows 10",
-        "version": "11"
-      }
-    ],
-    "safari": [
-      {
-        "browserName": "safari",
-        "platform": "macOS 10.13",
-        "version": "11.1",
-        "comment": "macOS High Sierra - sendBeacon API with bug"
-      }
-    ],
-    "firefox": [
-      {
-        "browserName": "firefox",
-        "platform": "Windows 10",
-        "version": "56",
-        "comment": "last version before Quantum"
-      }
-    ],
-    "android": [
-      {
-          "browserName": "android",
-          "platform": "Linux",
-          "version": "8.1",
-          "device": "GalaxyS8PlusWQHDGoogleAPI",
-          "appium:deviceName": "Samsung Galaxy S8 Plus WQHD GoogleAPI Emulator",
-          "appium:platformVersion": "8.1"
-      }
-      ],
-      "ios": [
-        {
-          "deviceName": "iPhone Simulator",
-          "platformName": "iOS",
-          "platformVersion": "11.2",
-          "browserName": "Safari"
-        }
-      ]
+  "ie": [
+    {
+      "browserName": "internet explorer",
+      "platform": "Windows 10",
+      "version": "11"
     }
+  ]
+}


### PR DESCRIPTION
### Overview

#### `cdn/webpack.config.js`
- Replaced parameter-driven splitting of entries with distinct composable config objects.
- Ended up with three composed objects (`standardConfig`, `polyfillConfig`, `webworkerConfig`) based on `commonConfig`.
- Explicitly specified `target` config property for each build (was a parameter before).
- Changed webpack target to `web` for modern browsers.
- For standard build, targeted modern browsers with babel-loader: last ten versions of Chrome, Firefox, Edge, and Safari.
- For polyfill build, targeted only IE 11 with babel-loader (not older versions of modern browsers also as story proposes).
- Differentiated filenames of chunk outputs for polyfill build to prevent overwriting dependency modules shared with other builds.
- I have not made an entry in the change log. **Please advise in review**.

#### `cdn/package.json`
Modified `browserslist` to include only IE11, as only polyfills are using the `browserslist` target.

#### `tools/jil/server/asset-server.js`
The code was attempting to load `this.polyfills` in all cases, even when no `-P` flag was passed. This would be a problem only in cases where we are not building the polyfills (in which case they cannot be loaded). This would be a rare occurrance but came up in development as I was isolating test cases.

### Related Ticket
[NEWRELIC-5417](https://issues.newrelic.com/browse/NEWRELIC-5417)

### Testing
- Care should be taken to ensure that all tests run, as transpilation targets have changed for all builds.
- In addition, the output of the build directory should be reviewed to ensure minor changes in filename format do not impact downstream systems.