### PR TITLE
Differentiate babel targets for polyfill and non-polyfill builds (NEWRELIC-5374)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@ node_modules
 **/local-install
 tests/assets/test-builds/**/*
 packages/browser-agent-core/cjs
-**/webpack-analysis.html
+**/webpack-analysis*.html
 /cdn/build

--- a/cdn/package.json
+++ b/cdn/package.json
@@ -36,11 +36,6 @@
     "core-js": "^3.23.3"
   },
   "browserslist": [
-    "chrome >= 60",
-    "safari >= 11",
-    "firefox >= 56",
-    "ios >= 10.3",
-    "ie >= 11",
-    "edge >= 60"
+    "ie >= 11"
   ]
 }

--- a/cdn/package.json
+++ b/cdn/package.json
@@ -34,8 +34,5 @@
     "@newrelic/browser-agent": "^0.0.9",
     "@newrelic/browser-agent-core/src": "^0.0.9",
     "core-js": "^3.23.3"
-  },
-  "browserslist": [
-    "ie >= 11"
-  ]
+  }
 }

--- a/cdn/webpack.config.js
+++ b/cdn/webpack.config.js
@@ -63,85 +63,113 @@ console.log("MAP_PATH", MAP_PATH)
 console.log("IS_LOCAL", IS_LOCAL)
 if (PR_NAME) console.log("PR_NAME", PR_NAME)
 
-const config = (target) => {
-  const isWorker = target === 'webworker'
-  return {
+// The exported configs (standard, polyfill, webworker) compose from this common config.
+const commonConfig = {
+  devtool: false, // defer to SourceMapDevToolPlugin
+  mode: !IS_LOCAL ? 'production' : 'development',
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserPlugin({
+      include: [/\.min\.js$/, /^(?:[0-9])/],
+      terserOptions: {
+        mangle: true
+      }
+    })],
+    flagIncludedChunks: true,
+    mergeDuplicateChunks: true
+  },
+  output: {
+    filename: `[name].js`,
+    chunkFilename: SUBVERSION === 'PROD' ? `[name].[hash:8]${PATH_VERSION}.js` : `[name]${PATH_VERSION}.js`,
+    path: path.resolve(__dirname, '../build'),
+    publicPath: PUBLIC_PATH, // CDN route vs local route (for linking chunked assets)
+    library: {
+      name: 'NRBA',
+      type: 'self'
+    },
+    clean: false
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'WEBPACK_MINOR_VERSION': JSON.stringify(SUBVERSION || ''),
+      'WEBPACK_MAJOR_VERSION': JSON.stringify(VERSION || ''),
+      'WEBPACK_DEBUG': JSON.stringify(IS_LOCAL || false)
+    }),
+    new webpack.SourceMapDevToolPlugin({
+      append: MAP_PATH, // sourceMappingURL CDN route vs local route (for sourceMappingURL)
+      filename: SUBVERSION === 'PROD' ? `[name].[hash:8].map` : `[name].map`,
+      ...(JSON.parse(SOURCEMAPS) === false && { exclude: new RegExp(".*") }) // exclude all files if disabled
+    }),
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      openAnalyzer: false,
+      defaultSizes: 'stat',
+      reportFilename: path.resolve(__dirname, './webpack-analysis.html')
+    })
+  ],
+  resolve: {
+    alias: {
+      '@newrelic/browser-agent-core/src': path.resolve(__dirname, '../packages/browser-agent-core/src')
+    }
+  }
+}
+
+// Targets modern browsers (ES6).
+const standardConfig = {
+  ...commonConfig,
+  ...{
     entry: {
-      ...(!isWorker && {
         [`nr-loader-rum${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/lite.js'),
         [`nr-loader-rum${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/lite.js'),
         [`nr-loader-full${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/pro.js'),
         [`nr-loader-full${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/pro.js'),
         [`nr-loader-spa${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/spa.js'),
         [`nr-loader-spa${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/spa.js'),
-        [`nr-loader-rum-polyfills${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/polyfills/lite.js'),
-        [`nr-loader-rum-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/lite.js'),
-        [`nr-loader-full-polyfills${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/polyfills/pro.js'),
-        [`nr-loader-full-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/pro.js'),
-        [`nr-loader-spa-polyfills${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
-        [`nr-loader-spa-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
-        [`nr-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills.js')
-      }),
-      ...(isWorker && {
-        [`nr-loader-worker${PATH_VERSION}`]: {
-          import: path.resolve(__dirname, './agent-loader/worker.js'),
-          chunkLoading: false
-        },
-        [`nr-loader-worker${PATH_VERSION}.min`]: {
-          import: path.resolve(__dirname, './agent-loader/worker.js'),
-          chunkLoading: false
+    },
+    target: 'web',
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: /(node_modules)/,
+          use: {
+            loader: 'babel-loader',
+            options: {
+              presets: [
+                ['@babel/preset-env', {
+                  targets: {
+                    browsers: [
+                      "last 10 Chrome versions",
+                      "last 10 Safari versions",
+                      "last 10 Firefox versions",
+                      "last 10 Edge versions"
+                    ]
+                  }
+                }]
+              ]
+            }
+          }
         }
-      })
-    },
-    output: {
-      filename: `[name].js`,
-      chunkFilename: SUBVERSION === 'PROD' ? `[name].[hash:8]${PATH_VERSION}.js` : `[name]${PATH_VERSION}.js`,
-      path: path.resolve(__dirname, '../build'),
-      publicPath: PUBLIC_PATH, // CDN route vs local route (for linking chunked assets)
-      library: {
-        name: 'NRBA',
-        type: 'self'
-      },
-      clean: false
-    },
-    resolve: {
-      alias: {
-        '@newrelic/browser-agent-core/src': path.resolve(__dirname, '../packages/browser-agent-core/src')
-      }
-    },
+      ]
+    }
+  }
+}
 
-    optimization: {
-      minimize: true,
-      minimizer: [new TerserPlugin({
-        include: [/\.min\.js$/, /^(?:[0-9])/],
-        terserOptions: {
-          mangle: true
-        }
-      })],
-      flagIncludedChunks: true,
-      mergeDuplicateChunks: true
+// Targets Internet Explorer 11 (ES5).
+const polyfillConfig = {
+  ...commonConfig,
+  ...{
+    entry: {
+      [`nr-loader-rum-polyfills${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/polyfills/lite.js'),
+      [`nr-loader-rum-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/lite.js'),
+      [`nr-loader-full-polyfills${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/polyfills/pro.js'),
+      [`nr-loader-full-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/pro.js'),
+      [`nr-loader-spa-polyfills${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
+      [`nr-loader-spa-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
+      [`nr-loader-spa-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
+      [`nr-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills.js'),
     },
-    plugins: [
-      new webpack.DefinePlugin({
-        'WEBPACK_MINOR_VERSION': JSON.stringify(SUBVERSION || ''),
-        'WEBPACK_MAJOR_VERSION': JSON.stringify(VERSION || ''),
-        'WEBPACK_DEBUG': JSON.stringify(IS_LOCAL || false)
-      }),
-      new webpack.SourceMapDevToolPlugin({
-        append: MAP_PATH, // CDN route vs local route
-        filename: SUBVERSION === 'PROD' ? `[name].[hash:8].map` : `[name].map`,
-        ...(JSON.parse(SOURCEMAPS) === false && { exclude: new RegExp(".*") }) // exclude all files if disabled
-      }),
-      new BundleAnalyzerPlugin({
-        analyzerMode: 'static',
-        openAnalyzer: false,
-        defaultSizes: 'stat',
-        reportFilename: path.resolve(__dirname, './webpack-analysis.html')
-      })
-    ],
-    mode: !IS_LOCAL ? 'production' : 'development',
-    devtool: false,
-    target, // include this!!
+    target: 'browserslist',
     module: {
       rules: [
         {
@@ -157,12 +185,7 @@ const config = (target) => {
                   loose: true,
                   targets: {
                     browsers: [
-                      "chrome >= 60",
-                      "safari >= 11",
-                      "firefox >= 56",
-                      "ios >= 10.3",
-                      "ie >= 11",
-                      "edge >= 60"
+                      "ie >= 11"
                     ]
                   }
                 }]
@@ -171,8 +194,46 @@ const config = (target) => {
           }
         }
       ]
-    }
+    },
+    output: {
+      ...commonConfig.output,
+      ...{
+        // Because the ./agent-aggregator/aggregator.js dependency is async loaded, the output filename for that chunk will be the
+        // same across all bundles in non-production builds (where filenames aren't hashed) and will thus overwrite with either an
+        // ES5 or ES6 target. For differentiated transpilation of dynamically loaded dependencies in non-production builds, we can
+        // tag output filenames for chunks of the polyfills bundle with `-es5`.
+        chunkFilename: SUBVERSION === 'PROD' ? `[name].[hash:8]${PATH_VERSION}.js` : `[name]-es5${PATH_VERSION}.js`,
+      }
+    },
+    plugins: [
+      commonConfig.plugins[0],
+      new webpack.SourceMapDevToolPlugin({
+        append: MAP_PATH, // sourceMappingURL CDN route vs local route (for sourceMappingURL)
+        filename: SUBVERSION === 'PROD' ? `[name].[hash:8].map` : `[name]-es5.map`, // tag in non-production to prevent filename collisions
+        ...(JSON.parse(SOURCEMAPS) === false && { exclude: new RegExp(".*") }) // exclude all files if disabled
+      }),
+      commonConfig.plugins[2]
+    ]
   }
 }
 
-module.exports = [config('browserslist'), config('webworker')]
+// Targets same modern browsers as standard configuration.
+const webworkerConfig = {
+  ...commonConfig,
+  ...{
+    entry: {
+      [`nr-loader-worker${PATH_VERSION}`]: {
+        import: path.resolve(__dirname, './agent-loader/worker.js'),
+        chunkLoading: false
+      },
+      [`nr-loader-worker${PATH_VERSION}.min`]: {
+        import: path.resolve(__dirname, './agent-loader/worker.js'),
+        chunkLoading: false
+      }
+    },
+    target: 'webworker',
+    module: standardConfig.module
+  }
+}
+
+module.exports = [polyfillConfig, standardConfig, webworkerConfig]

--- a/cdn/webpack.config.js
+++ b/cdn/webpack.config.js
@@ -169,7 +169,6 @@ const polyfillConfig = {
       [`nr-loader-spa-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
       [`nr-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills.js'),
     },
-    target: 'browserslist',
     module: {
       rules: [
         {

--- a/tools/jil/server/asset-server.js
+++ b/tools/jil/server/asset-server.js
@@ -309,13 +309,13 @@ class BrowserifyTransform extends AssetTransform {
           ["@babel/preset-env", {
             loose: true,
             targets: {
-              browsers: [
-                "chrome >= 60",
-                "safari >= 11",
-                "firefox >= 56",
-                "ios >= 10.3",
-                "ie >= 11",
-                "edge >= 60"
+              browsers: runnerArgs.polyfills ? [
+                "ie >= 11"
+              ] : [
+                "last 10 Chrome versions",
+                "last 10 Safari versions",
+                "last 10 Firefox versions",
+                "last 10 Edge versions"
               ]
             }
           }]
@@ -323,6 +323,7 @@ class BrowserifyTransform extends AssetTransform {
         plugins: [
           "@babel/plugin-syntax-dynamic-import",
           '@babel/plugin-transform-modules-commonjs',
+          "@babel/plugin-proposal-optional-chaining",
           ["module-resolver", {
             "alias": {
               "@newrelic/browser-agent-core/src": './dist/packages/browser-agent-core/src'

--- a/tools/jil/server/asset-server.js
+++ b/tools/jil/server/asset-server.js
@@ -47,7 +47,7 @@ class AgentInjectorTransform extends AssetTransform {
     this.assetServer = assetServer
     this.router = router
 
-    this.polyfills = fs.readFileSync(`${this.buildDir}/nr-polyfills.min.js`)
+    this.polyfills = runnerArgs.polyfills ? fs.readFileSync(`${this.buildDir}/nr-polyfills.min.js`) : ''
   }
 
   parseConfigFromQueryString(params) {


### PR DESCRIPTION
### Overview

#### `cdn/webpack.config.js`
- Replaced parameter-driven splitting of entries with distinct composable config objects.
- Ended up with three composed objects (`standardConfig`, `polyfillConfig`, `webworkerConfig`) based on `commonConfig`.
- Explicitly specified `target` config property for each build (was a parameter before).
- Changed webpack target to `web` for modern browsers.
- For standard build, targeted modern browsers with babel-loader: last ten versions of Chrome, Firefox, Edge, and Safari.
- For polyfill build, targeted only IE 11 with babel-loader (not older versions of modern browsers also as story proposes).
- Differentiated filenames of chunk outputs for polyfill build to prevent overwriting dependency modules shared with other builds.
- Modified `asset-server.js` logic to split browserify babel targets on -P flag.
- Updated `browsers-polyfill.json` to only IE11.
- I have not made an entry in the change log. **Please advise in review**.

#### `cdn/package.json`
Modified `browserslist` to include only IE11, as only polyfills are using the `browserslist` target.

#### `tools/jil/server/asset-server.js`
The code was attempting to load `this.polyfills` in all cases, even when no `-P` flag was passed. This would be a problem only in cases where we are not building the polyfills (in which case they cannot be loaded). This would be a rare occurrance but came up in development as I was isolating test cases.

### Related Ticket
[NEWRELIC-5374](https://issues.newrelic.com/browse/NEWRELIC-5374)

### Testing
- Care should be taken to ensure that all tests run, as transpilation targets have changed for all builds.
- In addition, the output of the build directory should be reviewed to ensure minor changes in filename format do not impact downstream systems.