### PR TITLE
handle setInfo more gracefully to account for existing jsAttributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Expose webpack library as output type "self" vs. "umd"
 To address "mismatched anonymous define" errors thrown by RequireJS, the agent's webpack library output will no longer include UMD checks for CommonJS and AMD module environments, and will instead be exposed globally via `self`.
 
+### Fix custom attribute handling in cases where the info block is loaded after initialization
+Fixed an issue where custom attributes could be cleared and reset if the info block was included on the page below the loader script. Our guidance still remains that **all configurations should be included on the page above the loader code**, however this is an attempt to do no harm when feasible for backwards compatibility.
+
 ### Update JS error bucketing algorithm
 The Agent will now take into account the error object type, message, and original stack trace when deciding on whether multiple JS errors should be bucketed together.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## v1221
 
+### Add infrastructure to run on web workers
+The agent's infrastructure will now allow for the agent to be built to run on web workers for future projects.
+
 ### Expose webpack library as output type "self" vs. "umd"
 To address "mismatched anonymous define" errors thrown by RequireJS, the agent's webpack library output will no longer include UMD checks for CommonJS and AMD module environments, and will instead be exposed globally via `self`.
 

--- a/tests/assets/custom-attribute-race-condition.html
+++ b/tests/assets/custom-attribute-race-condition.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+
+<head>
+  <title>RUM Unit Test</title>
+  {init}
+  {loader}
+  <script>
+    newrelic.setCustomAttribute('customParamKey', 0)
+  </script>
+</head>
+
+<body>
+  {config}
+  this is a generic page that is instrumented by the JS agent
+  <script>
+    try {
+      throw new Error("My error")
+    } catch (e) {
+      NREUM.noticeError(e)
+    }
+  </script>
+</body>
+
+</html>

--- a/tests/assets/pre-existing-custom-attribute-race-condition-precedence.html
+++ b/tests/assets/pre-existing-custom-attribute-race-condition-precedence.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+
+<head>
+  <title>RUM Unit Test</title>
+  {init}
+  {loader}
+  <script>
+    newrelic.setCustomAttribute('customParamKey', 0)
+  </script>
+</head>
+
+<body>
+  {config}
+  <script>
+    newrelic.info.jsAttributes = {'customParamKey': 1} // setCustomAttribute should take precedence over this, even though this is technically implemented later in the lifecycle
+  </script>
+  this is a generic page that is instrumented by the JS agent
+  <script>
+    try {
+      throw new Error("My error")
+    } catch (e) {
+      NREUM.noticeError(e)
+    }
+  </script>
+</body>
+
+</html>

--- a/tests/assets/pre-existing-custom-attribute-race-condition.html
+++ b/tests/assets/pre-existing-custom-attribute-race-condition.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+
+<head>
+  <title>RUM Unit Test</title>
+  {init}
+  {loader}
+  <script>
+    newrelic.setCustomAttribute('customParamKey', 0)
+  </script>
+</head>
+
+<body>
+  {config}
+  <script>
+    newrelic.info.jsAttributes = {'hi': 'mom'}
+  </script>
+  this is a generic page that is instrumented by the JS agent
+  <script>
+    try {
+      throw new Error("My error")
+    } catch (e) {
+      NREUM.noticeError(e)
+    }
+  </script>
+</body>
+
+</html>

--- a/tests/functional/err/attributes.test.js
+++ b/tests/functional/err/attributes.test.js
@@ -96,6 +96,86 @@ function runTests(loader, supported) {
     }
   })
 
+  testDriver.test(`set custom attribute before page load after loader before info (${loader})`, supported, function (t, browser, router) {
+    let url = router.assetURL('custom-attribute-race-condition.html', opts)
+
+    let loadPromise = browser.get(url)
+    let rumPromise = router.expectRum()
+
+    Promise.all([rumPromise, loadPromise])
+      .then(() => {
+        var errorsPromise = router.expectErrors()
+        var domPromise = browser.get(url) // forces harvest
+        return Promise.all([errorsPromise, domPromise])
+      })
+      .then(([response]) => {
+        const errorsFromPayload = getErrorsFromResponse(response, browser)
+        t.equal(errorsFromPayload[0].custom.customParamKey, 0, 'first error should have a custom parameter set with the expected value')
+
+        t.end()
+      })
+      .catch(fail)
+
+    function fail(e) {
+      t.error(e)
+      t.end()
+    }
+  })
+
+
+  testDriver.test(`set custom attribute with pre-existing attributes before page load after loader before info (${loader})`, supported, function (t, browser, router) {
+    let url = router.assetURL('pre-existing-custom-attribute-race-condition.html', opts)
+
+    let loadPromise = browser.get(url)
+    let rumPromise = router.expectRum()
+
+    Promise.all([rumPromise, loadPromise])
+      .then(() => {
+        var errorsPromise = router.expectErrors()
+        var domPromise = browser.get(url) // forces harvest
+        return Promise.all([errorsPromise, domPromise])
+      })
+      .then(([response]) => {
+        const errorsFromPayload = getErrorsFromResponse(response, browser)
+        t.equal(errorsFromPayload[0].custom.customParamKey, 0, 'first error should have a custom parameter set with the expected value')
+        t.equal(errorsFromPayload[0].custom['hi'], 'mom', 'first error should have a custom parameter set with the expected value')
+
+        t.end()
+      })
+      .catch(fail)
+
+    function fail(e) {
+      t.error(e)
+      t.end()
+    }
+  })
+
+  testDriver.test(`set custom attribute with pre-existing attributes before page load after loader before info precedence check (${loader})`, supported, function (t, browser, router) {
+    let url = router.assetURL('pre-existing-custom-attribute-race-condition-precedence.html', opts)
+
+    let loadPromise = browser.get(url)
+    let rumPromise = router.expectRum()
+
+    Promise.all([rumPromise, loadPromise])
+      .then(() => {
+        var errorsPromise = router.expectErrors()
+        var domPromise = browser.get(url) // forces harvest
+        return Promise.all([errorsPromise, domPromise])
+      })
+      .then(([response]) => {
+        const errorsFromPayload = getErrorsFromResponse(response, browser)
+        t.equal(errorsFromPayload[0].custom.customParamKey, 0, 'first error should have a custom parameter set with the expected value')
+
+        t.end()
+      })
+      .catch(fail)
+
+    function fail(e) {
+      t.error(e)
+      t.end()
+    }
+  })
+
   testDriver.test(`set multiple custom attributes before page load with multiple JS errors occurring after page load (${loader})`, supported, function (t, browser, router) {
     let url = router.assetURL('js-error-with-error-after-page-load.html', opts)
 


### PR DESCRIPTION
_Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md)._

---

### Overview
This PR Addresses a bug introduced in v1220, where a race condition between the loader and the info object could overwrite the jsAttributes object. See NEWRELIC-5682 for more info

### Related Github Issue
https://issues.newrelic.com/browse/NEWRELIC-5682
https://issues.newrelic.com/browse/NEWRELIC-5717

### Testing
3 Tests have been added to validate the case, and precedence conditions.
