### PR TITLE
Handle XHR events with undefined hostnames - NR-63240

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+## v1222
+
+### Do not collect XHR events for data URLs
+AJAX events for data URLs have not historically been collected due to errors in the agent when handling URLs without hostnames. Going forward, XHR calls to data URLs will not cause agent errors and will continue to be excluded from collection.
+
 ## v1221
 
 ### Add infrastructure to run on web workers

--- a/packages/browser-agent-core/src/common/deny-list/deny-list.js
+++ b/packages/browser-agent-core/src/common/deny-list/deny-list.js
@@ -4,7 +4,8 @@ export function shouldCollectEvent(params) {
   if (denyList.length === 0) {
     return true
   }
-
+  
+  // XHR requests with an undefined hostname (e.g., data URLs) should not be collected.
   if (params.hostname === undefined) {
     return false
   }

--- a/packages/browser-agent-core/src/common/deny-list/deny-list.js
+++ b/packages/browser-agent-core/src/common/deny-list/deny-list.js
@@ -1,5 +1,14 @@
+/** An array of filter objects {hostname, pathname} for identifying XHR events to be excluded from collection.
+ * @see {@link https://docs.newrelic.com/docs/browser/new-relic-browser/configuration/filter-ajax-request-events/ Filter AjaxRequest events}
+ * @type {Array.<{hostname: string, pathname: string}>}
+ */
 var denyList = []
 
+/**
+ * Evaluates whether an XHR event should be included for collection based on the {@link denyList|AjaxRequest deny list}.
+ * @param {Object} params - object with properties of the XHR event
+ * @returns {boolean} `true` if request does not match any entries of {@link denyList|deny list}; else `false`
+ */
 export function shouldCollectEvent(params) {
   if (denyList.length === 0) {
     return true
@@ -12,30 +21,42 @@ export function shouldCollectEvent(params) {
 
   for (var i = 0; i < denyList.length; i++) {
     var parsed = denyList[i]
+
     if (parsed.hostname === '*') {
       return false
     }
-    if (domainMatchesPattern(parsed.hostname, params.hostname) &&
-        comparePath(parsed.pathname, params.pathname)) {
+    
+    if (domainMatchesPattern(parsed.hostname, params.hostname)
+      && comparePath(parsed.pathname, params.pathname)) {
       return false
     }
   }
+
   return true
 }
 
+/**
+ * Initializes the {@link denyList|XHR deny list} by extracting hostname and pathname from an array of filter strings.
+ * @param {string[]} denyListConfig - array of URL filters to identify XHR requests to be excluded from collection
+ */
 export function setDenyList(denyListConfig) {
   denyList = []
+
   if (!denyListConfig || !denyListConfig.length) {
     return
   }
+
   for (var i = 0; i < denyListConfig.length; i++) {
     var url = denyListConfig[i]
+
     if (url.indexOf('http://') === 0) {
       url = url.substring(7)
     } else if (url.indexOf('https://') === 0) {
       url = url.substring(8)
     }
+
     var firstSlash = url.indexOf('/')
+
     if (firstSlash > 0) {
       denyList.push({
         hostname: url.substring(0, firstSlash),
@@ -49,8 +70,12 @@ export function setDenyList(denyListConfig) {
     }
   }
 }
-
-// returns true if the right side of the domain matches the pattern
+/**
+ * Returns true if the right side of `domain` (end of string) matches `pattern`.
+ * @param {string} pattern - a string to be matched against the end of `domain` string
+ * @param {string} domain - a domain string with no protocol or path (e.g., app1.example.com)
+ * @returns {boolean} `true` if domain matches pattern; else `false`
+ */
 function domainMatchesPattern(pattern, domain) {
   if (pattern.length > domain.length) {
     return false
@@ -59,9 +84,16 @@ function domainMatchesPattern(pattern, domain) {
   if (domain.indexOf(pattern) === (domain.length - pattern.length)) {
     return true
   }
+
   return false
 }
 
+/**
+ * Returns true if a URL path matches a pattern string, disregarding leading slashes.
+ * @param {string} pattern - a string to compare with path (e.g., api/v1)
+ * @param {string} path - a string representing a URL path (e.g., /api/v1)
+ * @returns {boolean} `true` if path and pattern are an exact string match (except for leading slashes); else `false`
+ */
 function comparePath(pattern, path) {
   if (pattern.indexOf('/') === 0) {
     pattern = pattern.substring(1)
@@ -71,7 +103,7 @@ function comparePath(pattern, path) {
     path = path.substring(1)
   }
 
-  // no path in pattern means match all paths
+  // No path in pattern means match all paths.
   if (pattern === '') {
     return true
   }

--- a/packages/browser-agent-core/src/common/deny-list/deny-list.js
+++ b/packages/browser-agent-core/src/common/deny-list/deny-list.js
@@ -5,6 +5,10 @@ export function shouldCollectEvent(params) {
     return true
   }
 
+  if (params.hostname === undefined) {
+    return false
+  }
+
   for (var i = 0; i < denyList.length; i++) {
     var parsed = denyList[i]
     if (parsed.hostname === '*') {

--- a/tests/assets/xhr-data-url.html
+++ b/tests/assets/xhr-data-url.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init}
+    <script type="text/javascript">
+      // Setting a deny list is necessary or `shouldCollectEvent` is never invoked.
+      NREUM.init||(NREUM.init = {});
+      NREUM.init.ajax||(NREUM.init.ajax = {});
+      NREUM.init.ajax.deny_list = ["example.com"];
+    </script>
+    {config}
+    {loader}
+      
+    <script type="text/javascript">
+      const xhr = new XMLHttpRequest();
+      xhr.addEventListener('load', function() {
+        console.log(this.responseText);
+      })
+      xhr.open('GET', 'data:,Hello%2C%20World%21');
+      xhr.send();
+    </script>
+  </head>
+  <body>
+    This page makes an XHR call to a data URL, which has no hostname. Such a request should not cause the agent to error and should not be sent for collection.
+  </body>
+</html>

--- a/tests/functional/xhr/xhr-data-url.test.js
+++ b/tests/functional/xhr/xhr-data-url.test.js
@@ -1,0 +1,64 @@
+const testDriver = require('../../../tools/jil/index')
+
+const init = {
+  metrics: {
+    enabled: false
+  },
+  page_view_timing: {
+    enabled: false
+  },
+  ajax: {
+    harvestTimeSeconds: 1,
+    enabled: true
+  }
+}
+
+var timedPromiseAll = (promises, ms) => Promise.race([
+  new Promise((resolve) => {
+    setTimeout(() => resolve(), ms)
+  }),
+  Promise.all(promises)
+])
+
+/**
+ * Data URLs should not be included in XHR collection. In addition, because these are not typical URLs with a hostname,
+ * the agent must be able to handle them gracefully. This test confirms that no event is collected for the page's XHR
+ * call to a data URL and that the the data URL does not cause the agent to fail before the next harvest.
+ */
+testDriver.test('Ignoring data url XHR events.', function (t, browser, router) {
+  let url = router.assetURL('xhr-data-url.html', { loader: 'full', init })
+
+  const loadPromise = browser.get(url)
+  const rumPromise = router.expectRum()
+
+  Promise.all([loadPromise, rumPromise])
+    .then(() => {
+      // XHR events harvest every 1 second. If 2 seconds pass and the promise is not resolved, no XHR response was received.
+      const ajaxPromise = router.expectSpecificEvents({ condition: (e) => e.type === 'ajax' && e.domain === 'undefined:undefined' })
+      return timedPromiseAll([ajaxPromise], 2000)
+    })
+    .then((response) => {
+      if (response) {
+        // A payload here is unwanted because data URLs should not be included in XHR collection.
+        t.fail(`Should not have received an XHR event with undefined hostname.`)
+      } else {
+        t.pass(`Did not receive an XHR event for data URL.`)
+      }
+      // XHR events harvest every 1 second. If 2 seconds pass and the promise is not resolved, no XHR response was received.
+      const harvestPromise = router.expectSpecificEvents({ condition: (e) => e.type === 'ajax' && e.path.substring(0, 7) === '/events' })
+      return timedPromiseAll([harvestPromise], 2000)
+    })
+    .then((response) => {
+      if (response) {
+        // A payload here is wanted.
+        t.pass(`Received events harvest.`)
+      } else {
+        t.fail(`Did not receive events harvest.`)
+      }
+      t.end()
+    })
+    .catch((e) => {
+      t.error(e)
+      t.end()
+    })
+})

--- a/tests/functional/xhr/xhr-data-url.test.js
+++ b/tests/functional/xhr/xhr-data-url.test.js
@@ -1,5 +1,6 @@
 const testDriver = require('../../../tools/jil/index')
 
+// Used to initialize the agent in the asset page.
 const init = {
   metrics: {
     enabled: false
@@ -8,11 +9,19 @@ const init = {
     enabled: false
   },
   ajax: {
-    harvestTimeSeconds: 1,
+    harvestTimeSeconds: 1, // Speed up harvest.
     enabled: true
   }
 }
 
+/**
+ * Takes an iterable (e.g., array) of promises and returns a single promise that fulfills when all
+ * the input's promises fulfill; or if the specified milliseconds have elapsed first, returns a
+ * single promise that fulfills with a value of `undefined`.
+ * @param {Promise[]} promises - iterable (e.g. array) of promises to be resolved.
+ * @param {number} ms - milliseconds before resolving with undefined.
+ * @returns 
+ */
 var timedPromiseAll = (promises, ms) => Promise.race([
   new Promise((resolve) => {
     setTimeout(() => resolve(), ms)


### PR DESCRIPTION
### Overview
We've seen support tickets where the expected hostname doesn't exist on XHR request events. In our deny-list.js, we try to get the .length of the hostname, causing an exception and our agent to fail.

- Added a fix for errors on string comparison of undefined hostname.
- Created a functional test for the one known reproduction of the bug condition (data URLs).
- Add JSDoc blocks to deny-list.js.

### Related Jira Issue
[NR-63240](https://issues.newrelic.com/browse/NR-63240)

### Testing
Functional test `xhr-data-url.test.js` relies on asset `xhr-data-url.html`.