### PR TITLE
Allow db upload to be more granular

### DIFF
--- a/.github/workflows/publish-apm.yml
+++ b/.github/workflows/publish-apm.yml
@@ -2,6 +2,15 @@ name: Build and publish PROD to APM DB
 
 on:
   workflow_dispatch:
+    inputs:
+      db_env:
+        description: 'DB Environment'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+          - eu
 
 jobs:
   publish-to-s3:
@@ -30,4 +39,5 @@ jobs:
           node tools/scripts/upload-to-nr.js \
             --staging-api-key=${{ secrets.NR_API_KEY_STAGING }} \
             --production-api-key=${{ secrets.NR_API_KEY_PRODUCTION }} \
-            --eu-api-key=${{ secrets.NR_API_KEY_EU }}
+            --eu-api-key=${{ secrets.NR_API_KEY_EU }} \
+            --environments=${{ github.event.inputs.db_env }}


### PR DESCRIPTION
### Overview
This PR updates the db upload GHA to add an environment input, allowing us to ship to each db env separately and better support a staggered release flow.