### PR TITLE
update upload NR script to grab from CDN instead of build folder

### DIFF
--- a/.github/workflows/publish-apm.yml
+++ b/.github/workflows/publish-apm.yml
@@ -2,6 +2,10 @@ name: Build and publish PROD to APM DB
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Browser Agent version number to publish (ex. 1221)'
+        required: true
 
 jobs:
   publish-to-s3:
@@ -30,4 +34,5 @@ jobs:
           node tools/scripts/upload-to-nr.js \
             --staging-api-key=${{ secrets.NR_API_KEY_STAGING }} \
             --production-api-key=${{ secrets.NR_API_KEY_PRODUCTION }} \
-            --eu-api-key=${{ secrets.NR_API_KEY_EU }}
+            --eu-api-key=${{ secrets.NR_API_KEY_EU }} \
+            --version=${{ github.event.inputs.version }}

--- a/tools/scripts/upload-to-nr.js
+++ b/tools/scripts/upload-to-nr.js
@@ -158,7 +158,10 @@ async function run() {
     }
 
     console.log('Uploading loader ' + filename + ' to ' + environment + '...')
-    var options = util._extend(envOptions[environment], baseOptions)
+    var options = {
+      ...envOptions[environment],
+      ...baseOptions
+    }
 
     request(options, function (err, res, body) {
       if (err) return cb(err)

--- a/tools/scripts/upload-to-nr.js
+++ b/tools/scripts/upload-to-nr.js
@@ -25,6 +25,9 @@ var argv = yargs
   .string('eu-api-key')
   .describe('eu-api-key', 'API key to use for talking to EU RPM site to upload loaders')
 
+  .string('version')
+  .describe('version', 'Browser Agent version number')
+
   .boolean('skip-upload-failures')
   .describe('skip-upload-failures', "Don't bail out after the first failure, keep trying other requests")
 
@@ -33,137 +36,153 @@ var argv = yargs
 
   .argv
 
-var loaders = loaderFilenames()
-var targetEnvironments = argv.environments.split(',')
+async function run() {
+  var loaders = await loaderFilenames()
+  var targetEnvironments = argv.environments.split(',')
 
-var uploadErrors = []
-var uploadErrorCallback = null
-if (argv['skip-upload-failures']) {
-  uploadErrorCallback = function (err) {
-    uploadErrors.push(err)
+  var uploadErrors = []
+  var uploadErrorCallback = null
+  if (argv['skip-upload-failures']) {
+    uploadErrorCallback = function (err) {
+      uploadErrors.push(err)
+    }
   }
-}
 
-var fileData = {}
+  var fileData = {}
 
-var steps = [ loadFiles ]
+  var steps = []
 
-targetEnvironments.forEach(function (env) {
-  console.log('Will upload loaders to ' + env)
-  steps.push(function (cb) {
-    uploadAllLoadersToDB(env, cb)
+  targetEnvironments.forEach(function (env) {
+    console.log('Will upload loaders to ' + env)
+    steps.push(function (cb) {
+      uploadAllLoadersToDB(env, cb)
+    })
   })
-})
 
-asyncForEach(steps, function (fn, next) {
-  fn(next)
-}, function (err) {
-  if (err) throw err
-  console.log('All steps finished.')
+  asyncForEach(steps, function (fn, next) {
+    fn(next)
+  }, function (err) {
+    if (err) throw err
+    console.log('All steps finished.')
 
-  if (uploadErrorCallback && uploadErrors.length > 0) {
-    console.log('Failures:')
-    uploadErrors.forEach(function (e) {
-      console.log(e)
-    })
-    process.exit(1)
+    if (uploadErrorCallback && uploadErrors.length > 0) {
+      console.log('Failures:')
+      uploadErrors.forEach(function (e) {
+        console.log(e)
+      })
+      process.exit(1)
+    }
+  })
+
+
+  function uploadAllLoadersToDB(environment, cb) {
+    asyncForEach(loaders, function (data, next) {
+      const filename = Object.keys(data)[0]
+      const fileData = data[filename]
+      uploadLoaderToDB(filename, fileData, environment, next)
+    }, cb, uploadErrorCallback)
   }
-})
 
-function loadFiles (cb) {
-  var allFiles = loaders
+  function getFile(path, fileName) {
+    var opts = {
+      uri: path,
+      method: 'GET',
+      gzip: true
+    }
 
-  asyncForEach(allFiles, readFile, cb)
+    console.log('downloading ', path)
 
-  function readFile (file, next) {
-    fs.readFile(path.resolve(__dirname, '../../build/', file), function (err, data) {
-      if (err) return next(err)
-      fileData[file] = data
-      next()
+    return new Promise((resolve, reject) => {
+      request(opts, (err, res, body) => {
+        if (err || res.statusCode !== 200) {
+          reject(err)
+          return
+        }
+        resolve([path, fileName, body])
+      })
     })
   }
-}
 
-function uploadAllLoadersToDB (environment, cb) {
-  asyncForEach(loaders, function (filename, next) {
-    uploadLoaderToDB(filename, fileData[filename], environment, next)
-  }, cb, uploadErrorCallback)
-}
+  function uploadLoaderToDB(filename, loader, environment, cb) {
+    var baseOptions = {
+      method: 'PUT',
+      followAllRedirects: true,
+      json: {
+        js_agent_loader: {
+          version: filename, // sic
+          loader
+        },
+        set_current: false
+      }
+    }
 
-function uploadLoaderToDB (filename, loader, environment, cb) {
-  var baseOptions = {
-    method: 'PUT',
-    followAllRedirects: true,
-    json: {
-      js_agent_loader: {
-        version: filename, // sic
-        loader: loader.toString()
+    var envOptions = {
+      staging: {
+        url: 'https://staging-api.newrelic.com/v2/js_agent_loaders/create.json',
+        headers: {
+          'X-Api-Key': argv['staging-api-key']
+        }
       },
-      set_current: false
-    }
-  }
-
-  var envOptions = {
-    staging: {
-      url: 'https://staging-api.newrelic.com/v2/js_agent_loaders/create.json',
-      headers: {
-        'X-Api-Key': argv['staging-api-key']
-      }
-    },
-    eu: {
-      url: 'https://api.eu.newrelic.com/v2/js_agent_loaders/create.json',
-      headers: {
-        'X-Api-Key': argv['eu-api-key']
-      }
-    },
-    production: {
-      url: 'https://api.newrelic.com/v2/js_agent_loaders/create.json',
-      headers: {
-        'X-Api-Key': argv['production-api-key']
-      }
-    }
-  }
-
-  console.log('Uploading loader ' + filename + ' to ' + environment + '...')
-  var options = util._extend(envOptions[environment], baseOptions)
-
-  request(options, function (err, res, body) {
-    if (err) return cb(err)
-    if (res.statusCode === 200) {
-      console.log('Uploaded loader version ' + filename + ' to ' + environment)
-      return cb()
-    }
-
-    cb(new Error('Failed to upload ' + filename + ' loader to ' + environment + ' db: (' + res.statusCode + ') ' + JSON.stringify(body)))
-  })
-}
-
-function loaderFilenames() {
-  const buildDir = path.resolve(__dirname, '../../build/')
-  return fs.readdirSync(buildDir).filter(x => x.startsWith('nr-loader') && x.endsWith('.js')) 
-}
-
-// errorCallback is optional
-// If not specified, processing will terminate on the first error.
-// If specified, the errorCallback will be invoked once for each error error,
-// and the done callback will be invoked once each item has been processed.
-function asyncForEach (list, op, done, errorCallback) {
-  var index = 0
-
-  process.nextTick(next)
-
-  function next (err) {
-    if (err) {
-      if (errorCallback) {
-        errorCallback(err)
-      } else {
-        return done(err)
+      eu: {
+        url: 'https://api.eu.newrelic.com/v2/js_agent_loaders/create.json',
+        headers: {
+          'X-Api-Key': argv['eu-api-key']
+        }
+      },
+      production: {
+        url: 'https://api.newrelic.com/v2/js_agent_loaders/create.json',
+        headers: {
+          'X-Api-Key': argv['production-api-key']
+        }
       }
     }
 
-    if (index >= list.length) return done(null)
-    op(list[index++], function (err, result) {
-      next(err)
+    console.log('Uploading loader ' + filename + ' to ' + environment + '...')
+    var options = util._extend(envOptions[environment], baseOptions)
+
+    request(options, function (err, res, body) {
+      if (err) return cb(err)
+      if (res.statusCode === 200) {
+        console.log('Uploaded loader version ' + filename + ' to ' + environment)
+        return cb()
+      }
+
+      cb(new Error('Failed to upload ' + filename + ' loader to ' + environment + ' db: (' + res.statusCode + ') ' + JSON.stringify(body)))
     })
   }
+
+  async function loaderFilenames() {
+    const loaderTypes = ['rum', 'full', 'spa']
+    const version = argv['version']
+    const fileNames = loaderTypes.map(type => [`nr-loader-${type}-${version}.min.js`, `nr-loader-${type}-polyfills-${version}.min.js`]).flat()
+    const loaders = (await Promise.all(fileNames.map(fileName => getFile(`https://js-agent.newrelic.com/${fileName}`, fileName)))).map(([url, fileName, body]) => ({ [fileName]: body }))
+    return loaders
+  }
+
+  // errorCallback is optional
+  // If not specified, processing will terminate on the first error.
+  // If specified, the errorCallback will be invoked once for each error error,
+  // and the done callback will be invoked once each item has been processed.
+  function asyncForEach(list, op, done, errorCallback) {
+    var index = 0
+
+    process.nextTick(next)
+
+    function next(err) {
+      if (err) {
+        if (errorCallback) {
+          errorCallback(err)
+        } else {
+          return done(err)
+        }
+      }
+
+      if (index >= list.length) return done(null)
+      op(list[index++], function (err, result) {
+        next(err)
+      })
+    }
+  }
 }
+
+run()

--- a/tools/scripts/upload-to-nr.js
+++ b/tools/scripts/upload-to-nr.js
@@ -50,8 +50,6 @@ async function run() {
     }
   }
 
-  var fileData = {}
-
   var steps = []
 
   targetEnvironments.forEach(function (env) {

--- a/tools/scripts/upload-to-nr.js
+++ b/tools/scripts/upload-to-nr.js
@@ -6,7 +6,6 @@
  */
 
 var request = require('request')
-var util = require('util')
 var yargs = require('yargs')
 
 var argv = yargs


### PR DESCRIPTION

### Overview
This PR updates the `publish-apm` flow to pull data from the CDN instead of building on the fly.  This is to ensure that changes in the trunk branch are not accidentally pulled in at execution time.  CDN assets need to be published to the CDN before running this script. The intended browser agent version needs to be included as an input to the workflow, ie "1221".
