### PR TITLE
Update publish to internal prod envs script

### DIFF
--- a/.github/workflows/publish-internal-prod.yml
+++ b/.github/workflows/publish-internal-prod.yml
@@ -11,7 +11,7 @@ on:
         required: true
 
 jobs:
-  pr-dev-build:
+  publish-build:
     runs-on: ubuntu-latest
     container: node:14
     env:
@@ -25,14 +25,14 @@ jobs:
         run: |
           node ./tools/scripts/check-file.js \
             -p https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.current }}.min.js \
-            -p https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.next }}.min.js
+            -p https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.next }}.min.js 
       - name: re-publish internal loader (prod)
         run: |
           node ./tools/scripts/upload-ab-to-s3.js \
             --env prod \
-            --current https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.current }}.min.js
-            --next https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.next }}.min.js
-            --appId ${{ secrets.INTERNAL_DEV_APPLICATION_ID }} \
+            --current https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.current }}.min.js \
+            --next https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.next }}.min.js \
+            --appId ${{ secrets.INTERNAL_PRODUCTION_APPLICATION_ID }} \
             --licenseKey ${{ secrets.INTERNAL_LICENSE_KEY }} \
             --bucket ${{ secrets.AWS_BUCKET }} \
             --role ${{ secrets.AWS_ROLE_ARN }}
@@ -42,7 +42,19 @@ jobs:
             --env eu-prod \
             --current https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.current }}.min.js
             --next https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.next }}.min.js
-            --appId ${{ secrets.INTERNAL_DEV_APPLICATION_ID }} \
+            --appId ${{ secrets.INTERNAL_EU_PRODUCTION_APPLICATION_ID }} \
             --licenseKey ${{ secrets.INTERNAL_LICENSE_KEY }} \
             --bucket ${{ secrets.AWS_BUCKET }} \
             --role ${{ secrets.AWS_ROLE_ARN }}
+      - name: purge fastly cache url
+        run: |
+          node ./tools/scripts/fastly.js \
+            --fastly-key ${{ secrets.FASTLY_PURGE_KEY }} \
+            --env prod \
+            --purge-internal
+      - name: purge fastly cache url
+        run: |
+          node ./tools/scripts/fastly.js \
+            --fastly-key ${{ secrets.FASTLY_PURGE_KEY }} \
+            --env eu-prod \
+            --purge-internal

--- a/.github/workflows/publish-internal-prod.yml
+++ b/.github/workflows/publish-internal-prod.yml
@@ -40,8 +40,8 @@ jobs:
         run: |
           node ./tools/scripts/upload-ab-to-s3.js \
             --env eu-prod \
-            --current https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.current }}.min.js
-            --next https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.next }}.min.js
+            --current https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.current }}.min.js \
+            --next https://js-agent.newrelic.com/nr-loader-spa-${{ github.event.inputs.next }}.min.js \
             --appId ${{ secrets.INTERNAL_EU_PRODUCTION_APPLICATION_ID }} \
             --licenseKey ${{ secrets.INTERNAL_LICENSE_KEY }} \
             --bucket ${{ secrets.AWS_BUCKET }} \

--- a/tools/scripts/upload-ab-to-s3.js
+++ b/tools/scripts/upload-ab-to-s3.js
@@ -86,6 +86,8 @@ function getIdFromUrl(url) {
   if (url.includes("PR-")) return 'PR-' + url.split('/').find(x => x.includes("PR-")).split("-")[1]
   if (url.includes("/dev/")) return "dev"
   if (url.includes("-current")) return "current"
+  if (url.match(/\d+/)) return url.match(/\d+/)[0]
+  return `${counter++}`
 }
 
 (async function () {

--- a/tools/scripts/upload-ab-to-s3.js
+++ b/tools/scripts/upload-ab-to-s3.js
@@ -41,6 +41,11 @@ let counter = 1
 
 if (!env || !appId || !licenseKey || !bucket || !role) {
   console.log("missing required param")
+  if (!env) console.log("env")
+  if (!appId) console.log("appId")
+  if (!licenseKey) console.log("licenseKey")
+  if (!bucket) console.log("bucket")
+  if (!role) console.log("role")
   process.exit(1)
 }
 


### PR DESCRIPTION
### Overview
This PR updates the action to add our builds to NR Internal Prod.  A manual workflow dispatch must be triggered (this can be tied to cutting a GH release later).  The output of this action uploads `2` scripts to `https://js-agent.newrelic.com/internal/prod.js` and `https://js-agent.newrelic.com/internal/eu-prod.js`.  These scripts have a 50/50 chance of loading `current` agent version or the `next` version code (which are inputs to the GH action), for the purpose of A/B testing. 

#### The old process to get the agent into internal envs:
1. Upload build to CDN
2. Trigger a build in Grand Central + Jenkins
4. Use Grand Central to link and release the new build for each env (dev, staging, prod, eu-prod)

#### The New process to get the agent into internal envs:
*New Notes* `dev` and `staging` are now auto-released on PR builds and merges to main respectively.
1. Evaluate `dev` and `staging` status.
2. Cut a release
    - Upload build to CDN (will be triggered by release action)
    - Run `publish-internal-prod.yml` GHA.  (will eventually be triggered by upload to CDN, manually now).  This will auto-update the script that production internal envs use for the browser agent. This should only be done if `dev` and `staging` look good and are approved.