### PR TITLE
Adding props to sauce connect

### DIFF
--- a/tools/jil/server/asset-server.js
+++ b/tools/jil/server/asset-server.js
@@ -152,7 +152,7 @@ class AgentInjectorTransform extends AssetTransform {
           if (typeof msg === 'object') {
             msg = JSON.stringify(msg)
           }
-          var url = 'http://' + NREUM.info.beacon + '/debug?m=' + escape(msg) + '&testId=' + NREUM.info.licenseKey + '&r=' + Math.random() + '&ix=' + count
+          var url = 'http://' + NREUM.info.beacon + '/debug?m=' + escape(msg) + '&l=' + window.location.href + '&testId=' + NREUM.info.licenseKey + '&r=' + Math.random() + '&ix=' + count
           if (!sync) {
             var img = new window.Image()
             img.src = url

--- a/tools/jil/server/router.js
+++ b/tools/jil/server/router.js
@@ -36,7 +36,7 @@ class Router extends BaseServer {
     let parsed = url.parse(req.url, true)
     if (parsed.pathname.match(/^\/debug/)) {
       let ix = parseInt(parsed.query.ix)
-      this.log(parsed.query.testId, `DEBUG [${ix}]: ${parsed.query.m}`)
+      this.log(parsed.query.testId, `DEBUG [${ix}](${parsed.query.l}): ${parsed.query.m}`)
       res.end()
       return
     }
@@ -177,8 +177,8 @@ class RouterHandle {
   }
 
   async expectSpecificEvents({
-    appID, 
-    condition=(e) => e.type === 'ajax', 
+    appID,
+    condition=(e) => e.type === 'ajax',
     expecter='expectAjaxEvents'
   }){
     const {body, query} = await this[expecter](appID)
@@ -186,7 +186,7 @@ class RouterHandle {
     let matches = ajaxEvents.filter(condition)
     if (!matches.length) matches = this.expectSpecificEvents({expecter, condition})
     return matches
-  }  
+  }
 
   expectErrors(appID) {
     // errors harvest at 60s

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -2,75 +2,75 @@
   "chrome": [
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "107",
-      "browserVersion": "107"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "chrome",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "105",
-      "browserVersion": "105"
-    },
-    {
-      "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "103",
-      "browserVersion": "103"
-    },
-    {
-      "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "101",
-      "browserVersion": "101"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "chrome",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "98",
-      "browserVersion": "98"
+      "version": "104",
+      "browserVersion": "104"
+    },
+    {
+      "browserName": "chrome",
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "102",
+      "browserVersion": "102"
+    },
+    {
+      "browserName": "chrome",
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "99",
+      "browserVersion": "99"
     }
   ],
   "edge": [
     {
       "browserName": "MicrosoftEdge",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "103",
-      "browserVersion": "103"
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "MicrosoftEdge",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "101",
-      "browserVersion": "101"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "102",
+      "browserVersion": "102"
     },
     {
       "browserName": "MicrosoftEdge",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "98",
-      "browserVersion": "98"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "99",
+      "browserVersion": "99"
     }
   ],
   "safari": [
@@ -109,27 +109,27 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "107"
+      "version": "108"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "105"
+      "version": "106"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "103"
+      "version": "104"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "101"
+      "version": "102"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "98"
+      "version": "99"
     }
   ],
   "ios": [

--- a/tools/jil/util/external-services.js
+++ b/tools/jil/util/external-services.js
@@ -51,8 +51,10 @@ function startSauce (config, cb) {
   var opts = {
     username: sauceCreds.username,
     accessKey: sauceCreds.accessKey,
-    tunnelIdentifier: tunnelIdentifier,
-    noSslBumpDomains: 'all'
+    tunnelName: tunnelIdentifier,
+    noSslBumpDomains: 'all',
+    logger: console.log,
+    tunnelDomains: config.host || 'bam-test-1.nr-local.net'
   }
 
   if (config.verbose) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Adding additional properties to the sauce connect launch script:

- tunnelName: tunnelIdentifier is deprecated in the sauce connect binary, this is just a rename
- logger: connecting the sauce connect launcher logger to console.log so we actually get output
- tunnelDomains: adding our internal test domain so only traffic for that domain is routed through the tunnel to the local server
  - Without this, SL forwards all network traffic through the tunnel. Setting this to our domain only will cut down on the amount of traffic coming through the tunnel and may help with performance and stability in the tests.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
None

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
Start sauce connect with `npm run sauce:connect -- -v` to see the log output. To test the change in general, run some of the JIL tests.