### PR TITLE
remove metrics from lite build to support legacy account parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The agent is now compatible with _only modern web syntax (ES6+)_; **this reduces
 ### Fix nrWrapper exclusion in error stack traces
 Restoring previous functionality whereby the `nrWrapper` agent method should be excluded from JavaScript error stack traces.
 
+### Remove metrics feature from the "lite" agent build
+To support legacy lite accounts, internal metric collections have been removed from the "lite" agent build.
+
 ## v1221
 
 ### Add infrastructure to run on web workers

--- a/cdn/agent-aggregator/util/features.js
+++ b/cdn/agent-aggregator/util/features.js
@@ -18,7 +18,7 @@ export const modules = {
 }
 
 const lite = [modules.pageViewEvent, modules.pageViewTiming] // lite agent cannot currently use metrics endpoint, because legacy lite customers are not provisioned access to that endpoint
-const pro = [...lite, modules.jsErrors, modules.ajax, modules.pageAction, modules.sessionTrace]
+const pro = [...lite, modules.metrics, modules.jsErrors, modules.ajax, modules.pageAction, modules.sessionTrace]
 const spa = [...pro, modules.spa]
 const worker = [ modules.metrics, modules.jsErrors, modules.ajax, modules.pageAction]
 

--- a/cdn/agent-loader/lite.js
+++ b/cdn/agent-loader/lite.js
@@ -2,8 +2,6 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { detectPolyfillFeatures } from './utils/feature-detection'
-const PolyfillFeatures = detectPolyfillFeatures();
 // cdn specific utility files
 import agentIdentifier from '../shared/agentIdentifier'
 import { stageAggregator } from './utils/importAggregator'
@@ -11,7 +9,6 @@ import { configure } from './utils/configure'
 // feature modules
 import { Instrument as InstrumentPageViewEvent } from '@newrelic/browser-agent-core/src/features/page-view-event/instrument'
 import { Instrument as InstrumentPageViewTiming } from '@newrelic/browser-agent-core/src/features/page-view-timing/instrument'
-import { Instrument as InstrumentMetrics } from '@newrelic/browser-agent-core/src/features/metrics/instrument'
 // common modules
 import { getEnabledFeatures } from '@newrelic/browser-agent-core/src/common/util/enabled-features'
 
@@ -22,7 +19,6 @@ try {
     // instantiate auto-instrumentation specific to this loader...
     if (enabledFeatures['page_view_event']) new InstrumentPageViewEvent(agentIdentifier) // document load (page view event + metrics)
     if (enabledFeatures['page_view_timing']) new InstrumentPageViewTiming(agentIdentifier) // page view timings instrumentation (/loader/timings.js)
-    if (enabledFeatures.metrics) new InstrumentMetrics(agentIdentifier, PolyfillFeatures)   // supportability & custom metrics
 
     // lazy-loads the aggregator features for 'lite' if no other aggregator takes precedence
     stageAggregator('lite')

--- a/tests/browser/features.browser.js
+++ b/tests/browser/features.browser.js
@@ -72,7 +72,6 @@ test("initializing features - lite", function (t) {
   let aggregators = mockImportFeatures("lite");
 
   checkEverythingInitialized(aggregators, t);
-  t.ok(aggregators.initialized[featName.metrics], `"${featName.metrics}" expected to be initialized.`);
   t.ok(aggregators.initialized[featName.pageViewEvent], `"${featName.pageViewEvent}" expected to be initialized.`);
   t.ok(aggregators.initialized[featName.pageViewTiming], `"${featName.pageViewTiming}" expected to be initialized.`);
   t.notOk(aggregators.initialized[featName.jsErrors], `"${featName.jsErrors}" was not initialized in this build.`);

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -18,15 +18,15 @@
       "browserName": "chrome",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "102",
-      "browserVersion": "102"
+      "version": "101",
+      "browserVersion": "101"
     },
     {
       "browserName": "chrome",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "99",
-      "browserVersion": "99"
+      "version": "98",
+      "browserVersion": "98"
     }
   ],
   "edge": [
@@ -46,17 +46,17 @@
     },
     {
       "browserName": "MicrosoftEdge",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "102",
-      "browserVersion": "102"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "101",
+      "browserVersion": "101"
     },
     {
       "browserName": "MicrosoftEdge",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "99",
-      "browserVersion": "99"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "98",
+      "browserVersion": "98"
     }
   ],
   "safari": [
@@ -88,7 +88,7 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "105"
+      "version": "104"
     },
     {
       "browserName": "firefox",
@@ -98,7 +98,7 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "98"
+      "version": "97"
     }
   ],
   "android": [
@@ -149,10 +149,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.4",
-      "device": "iPhone Simulator",
-      "appium:deviceName": "iPhone Simulator",
-      "appium:platformVersion": "14.4",
+      "version": "14.3",
+      "device": "iPhone 11",
+      "appium:deviceName": "iPhone 11 Simulator",
+      "appium:platformVersion": "14.3",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"
@@ -163,10 +163,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.0",
-      "device": "iPhone XR",
-      "appium:deviceName": "iPhone XR Simulator",
-      "appium:platformVersion": "14.0",
+      "version": "13.4",
+      "device": "iPhone XS Max",
+      "appium:deviceName": "iPhone XS Max Simulator",
+      "appium:platformVersion": "13.4",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -18,15 +18,15 @@
       "browserName": "chrome",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "101",
-      "browserVersion": "101"
+      "version": "102",
+      "browserVersion": "102"
     },
     {
       "browserName": "chrome",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "98",
-      "browserVersion": "98"
+      "version": "99",
+      "browserVersion": "99"
     }
   ],
   "edge": [
@@ -46,17 +46,17 @@
     },
     {
       "browserName": "MicrosoftEdge",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "101",
-      "browserVersion": "101"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "102",
+      "browserVersion": "102"
     },
     {
       "browserName": "MicrosoftEdge",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "98",
-      "browserVersion": "98"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "99",
+      "browserVersion": "99"
     }
   ],
   "safari": [
@@ -88,7 +88,7 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "104"
+      "version": "105"
     },
     {
       "browserName": "firefox",
@@ -98,7 +98,7 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "97"
+      "version": "98"
     }
   ],
   "android": [
@@ -149,10 +149,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.3",
-      "device": "iPhone 11",
-      "appium:deviceName": "iPhone 11 Simulator",
-      "appium:platformVersion": "14.3",
+      "version": "14.4",
+      "device": "iPhone Simulator",
+      "appium:deviceName": "iPhone Simulator",
+      "appium:platformVersion": "14.4",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"
@@ -163,10 +163,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "13.4",
-      "device": "iPhone XS Max",
-      "appium:deviceName": "iPhone XS Max Simulator",
-      "appium:platformVersion": "13.4",
+      "version": "14.0",
+      "device": "iPhone XR",
+      "appium:deviceName": "iPhone XR Simulator",
+      "appium:platformVersion": "14.0",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

This PR addresses an issue where 1220+ agents have added metrics to the lite agent build, but legacy "lite" customers do not have access to the metrics endpoint, causing 403 network codes.  This is handled beyond the scope of the browser agent team, by assigning entitlements that are enforced at ingest time.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://discuss.newrelic.com/t/bam-nr-data-net-post-returns-403-error/161276

