### PR TITLE
Prevent webpack mangling nrWrapper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ AJAX events for data URLs have not historically been collected due to errors in 
 ### Reduce size of builds for modern browser targets
 The agent is now compatible with _only modern web syntax (ES6+)_; **this reduces loader size for these browsers by 20% or more**. We target and test support for just the last ten versions of Chrome, Edge, Safari, and Firefox -- see [browser agent EOL policy](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/browser-agent-eol-policy/) for more details.
 
+### Fix nrWrapper exclusion in error stack traces
+Restoring previous functionality whereby the `nrWrapper` agent method should be excluded from JavaScript error stack traces.
+
 ## v1221
 
 ### Add infrastructure to run on web workers

--- a/cdn/webpack.config.js
+++ b/cdn/webpack.config.js
@@ -100,7 +100,9 @@ const commonConfig = {
     minimizer: [new TerserPlugin({
       include: [/\.min\.js$/, /^(?:[0-9])/],
       terserOptions: {
-        mangle: true
+        mangle: {
+          keep_fnames: /nrWrapper/
+        }
       }
     })],
     flagIncludedChunks: true,
@@ -122,7 +124,7 @@ const commonConfig = {
       'WEBPACK_MINOR_VERSION': JSON.stringify(SUBVERSION || ''),
       'WEBPACK_MAJOR_VERSION': JSON.stringify(VERSION || ''),
       'WEBPACK_DEBUG': JSON.stringify(IS_LOCAL || false)
-    })    
+    })
   ],
   resolve: {
     alias: {

--- a/tests/functional/err/event-listener.test.js
+++ b/tests/functional/err/event-listener.test.js
@@ -37,16 +37,14 @@ testDriver.test('reporting errors from event listener callbacks', supported, fun
         message: 'document addEventListener listener',
         stack: [
           {f: 'Object.handleEvent', u: eventListenersURL, l: 15},
-          {f: 'HTMLDocument.object', u: '<inline>', l: 13},
-          {f: 'HTMLDocument.u', u: '<inline>', l: 13}
+          {f: 'HTMLDocument.object', u: '<inline>', l: 13}
         ]
       },
       {
         message: 'global addEventListener listener',
         stack: [
           {f: 'Object.handleEvent', u: eventListenersURL, l: 8},
-          {f: 'object', u: '<inline>', l: 13},
-          {f: 'u', u: '<inline>', l: 13}
+          {f: 'object', u: '<inline>', l: 13}
         ]
       }
     ]

--- a/tests/functional/err/ignore-error.test.js
+++ b/tests/functional/err/ignore-error.test.js
@@ -34,10 +34,6 @@ testDriver.test('ignoring errors works', supported, function (t, browser, router
       stack: [{
         u: '<inline>',
         l: 23
-      }, {
-        f: 'u',
-        u: '<inline>',
-        l: 13
       }]
     }]
 

--- a/tests/functional/err/set-immediate.test.js
+++ b/tests/functional/err/set-immediate.test.js
@@ -23,10 +23,6 @@ testDriver.test('reporting errors from setImmediate callbacks', supported, funct
       stack: [{
         u: router.assetURL('js/set-immediate-error.js').split('?')[0],
         l: 10
-      },{
-        f: 'u',
-        u: '<inline>',
-        l: 12
       }]
     }]
 

--- a/tests/functional/err/set-interval.test.js
+++ b/tests/functional/err/set-interval.test.js
@@ -32,8 +32,6 @@ testDriver.test('reporting errors from setInterval callbacks', supported, functi
       stack: [{
         u: router.assetURL('js/set-interval-error.js').split('?')[0],
         l: 10
-      }, {
-        f: 'u', u: '<inline>', l: 12
       }]
     }]
 

--- a/tests/functional/err/set-timeout.test.js
+++ b/tests/functional/err/set-timeout.test.js
@@ -32,8 +32,6 @@ testDriver.test('reporting errors from setTimeout callbacks', supported, functio
       stack: [{
         u: router.assetURL('js/set-timeout-error.js').split('?')[0],
         l: 9
-      },{
-        f: 'u', u: '<inline>', l: 12
       }]
     }]
 

--- a/tests/functional/err/uncaught.test.js
+++ b/tests/functional/err/uncaught.test.js
@@ -27,9 +27,9 @@ testDriver.test('reporting uncaught errors', supported, function (t, browser, ro
     assertErrorAttributes(t, response.query)
     const actualErrors = getErrorsFromResponse(response, browser)
     const expectedErrorMessages = [
-      { message: 'original onerror', tested: false }, 
-      { message: 'uncaught error', tested: false }, 
-      { message: 'fake', tested: false }, 
+      { message: 'original onerror', tested: false },
+      { message: 'uncaught error', tested: false },
+      { message: 'fake', tested: false },
       { message: 'original return false', tested: false }
     ]
     actualErrors.forEach(err => {
@@ -51,58 +51,3 @@ testDriver.test('reporting uncaught errors', supported, function (t, browser, ro
     t.end()
   }
 })
-
-function expectedErrorsForBrowser(router, browser) {
-  let uncaught1URL = router.assetURL('js/uncaught1.js').split('?')[0]
-  let uncaught2URL = router.assetURL('js/uncaught2.js').split('?')[0]
-
-  let expected = [
-    {
-      message: 'uncaught error',
-      stack: [{ u: uncaught1URL, l: 12 }]
-    },
-    {
-      message: 'fake',
-      stack: [{ f: 'evaluated code' }]
-    },
-    {
-      message: 'original onerror',
-      stack: [
-        { f: 'originalOnerrorHandler', u: '<inline>', l: 17 },
-        { f: 'window.onerror', u: '<inline>', l: 28 }
-      ]
-    },
-    {
-      message: 'original onerror',
-      stack: [
-        { f: 'originalOnerrorHandler', u: '<inline>', l: 17 },
-        { f: 'window.onerror', u: '<inline>', l: 28 }
-      ]
-    },
-    {
-      message: 'original return abc',
-      stack: [{ u: uncaught2URL, l: 17 }]
-    }
-  ]
-
-
-  if (browser.match('ie@<10')) {
-    expected[2].stack = [{}]
-  }
-  if (browser.match('safari@<7')) {
-    expected[2].stack = [{ u: '<inline>', l: 19 }]
-  }
-
-  if (browser.hasFeature('uncaughtErrorObject')) {
-    expected[0].stack[0].f = 'uncaughtError'
-    expected[0].stack[1] = { u: uncaught1URL, l: 12 }
-    expected[3].stack[0].f = 'onerrorReturn'
-    expected[3].stack[1] = { u: uncaught2URL, l: 17 }
-    if (browser.match('ie@11')) {
-      expected[0].stack[1].f = 'code'
-      expected[3].stack[1].f = 'code'
-    }
-  }
-
-  return expected
-}

--- a/tests/functional/err/xhr.test.js
+++ b/tests/functional/err/xhr.test.js
@@ -32,8 +32,7 @@ testDriver.test('reporting errors from XHR callbacks', supported, function (t, b
       name: 'Error',
       message: 'xhr onload',
       stack: [
-        {f: 'XMLHttpRequest.goodxhr', u: xhrJSURL, l: 9},
-        {f: 'XMLHttpRequest.u', u: "<inline>", l: 12}
+        {f: 'XMLHttpRequest.goodxhr', u: xhrJSURL, l: 9}
       ]
     }]
 

--- a/tools/jil/server/asset-server.js
+++ b/tools/jil/server/asset-server.js
@@ -167,22 +167,22 @@ class AgentInjectorTransform extends AssetTransform {
       })()
       var origOnError = window.onerror
       window.onerror = function() {
-        NRDEBUG(\`error thrown: \${JSON.stringify(arguments)}\`)
+        NRDEBUG('error thrown: ' + JSON.stringify(arguments))
         origOnError(arguments)
       }
       var origLog = window.console.log
       window.console.log = function() {
-        NRDEBUG(\`console.log: \${JSON.stringify(arguments)}\`)
+        NRDEBUG('console.log: ' + JSON.stringify(arguments))
         origLog(arguments)
       }
       var origWarn = window.console.warn
       window.console.warn = function() {
-        NRDEBUG(\`console.warn: \${JSON.stringify(arguments)}\`)
+        NRDEBUG('console.warn: ' + JSON.stringify(arguments))
         origWarn(arguments)
       }
       var origErr = window.console.error
       window.console.error = function() {
-        NRDEBUG(\`console.error: \${JSON.stringify(arguments)}\`)
+        NRDEBUG('console.warn: ' + JSON.stringify(arguments))
         origErr(arguments)
       }
     `


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Updating the webpack config so the `nrWrapper` method is not mangled. This was preventing the `jserrors` feature from properly excluding the `nrWrapper` and subsequent agent code from error stack traces.

Also including an update to the debug script the asset test server injects that was causing errors in IE11. IE does not support template strings.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://issues.newrelic.com/browse/NEWRELIC-5929

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
Run the JIL test suite in GH. Optionally, should probably also run the polyfills tests.
