### PR TITLE
Checkout & test future merge when adding "safe to test" - take #2

### DIFF
--- a/.github/actions/test-setup/action.yml
+++ b/.github/actions/test-setup/action.yml
@@ -11,7 +11,7 @@ runs:
     # For workflow_dispatch, it's assume that the dispatch branch is already checked out.
 
     - name: install
-      run: npm ci --cache ./.npm
+      run: npm ci --no-fund --no-audit --no-progress
       shell: bash
 
     - name: build

--- a/.github/actions/test-setup/action.yml
+++ b/.github/actions/test-setup/action.yml
@@ -1,0 +1,19 @@
+name: Testing setup
+descriptions: Checkout the appropriate commit and build it before testing
+
+runs:
+  using: "composite"
+  steps:
+    - if: github.event_name == 'pull_request_target'  # checkout the would-be merge instead of PR branch head
+      uses: actions/checkout@v3
+      with:
+        ref: refs/pull/${{ github.event.number }}/merge
+    # For workflow_dispatch, it's assume that the dispatch branch is already checked out.
+
+    - name: install
+      run: npm ci --cache ./.npm
+      shell: bash
+
+    - name: build
+      run: npm run build:all
+      shell: bash

--- a/.github/workflows/tests-polyfill.yml
+++ b/.github/workflows/tests-polyfill.yml
@@ -21,12 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -P -b ie@* -s -t 85000 --concurrent=2 --functional-only
@@ -44,12 +40,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -P -b ie@* -s -t 85000 --concurrent=2 --unit-only
@@ -64,11 +56,8 @@ jobs:
       NRQL_API_KEY: ${{ secrets.NRQL_API_KEY }}
     steps:
       - uses: actions/checkout@v3
-
-      - name: install
-        run: npm ci --cache ./.npm
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: check failed tests
         run: node --max-old-space-size=8192 ./tools/jil/util/get-failed-tests.js
-
-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,14 +17,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: lint
         run: npm run lint
@@ -36,14 +30,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: test
         run: npm run packages:test
@@ -62,14 +50,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b chrome@* -s -t 85000 --concurrent=10 --functional-only
@@ -88,14 +70,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b chrome@* -s -t 85000 --concurrent=10 --unit-only
@@ -114,14 +90,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b firefox@* -s -t 85000 --concurrent=10 --functional-only
@@ -140,14 +110,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b firefox@* -s -t 85000 --concurrent=10 --unit-only
@@ -166,14 +130,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b edge@* -s -t 85000 --concurrent=10 --functional-only
@@ -192,14 +150,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b edge@* -s -t 85000 --concurrent=10 --unit-only
@@ -218,14 +170,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b safari@* -s -t 85000 --concurrent=10 --functional-only
@@ -244,14 +190,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b safari@* -s -t 85000 --concurrent=10 --unit-only
@@ -270,14 +210,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b ios@* -s -t 85000 --functional-only
@@ -296,14 +230,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
-
-      - name: build
-        run: npm run build:all
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b ios@* -s -t 85000 --unit-only
@@ -370,11 +298,8 @@ jobs:
       NRQL_API_KEY: ${{ secrets.NRQL_API_KEY }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: install
-        run: npm ci --cache ./.npm
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
       - name: check failed tests
         run: node --max-old-space-size=8192 ./tools/jil/util/get-failed-tests.js


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Re-do of #337 that was unwounded on trunk due to failure.
The previous reusable workflow is converted to a composite action instead.

### Related Issue(s)

[NR-72380](https://issues.newrelic.com/browse/NR-72380)

### Testing

Since the new action does not yet exist in `main`, you can only test `workflow_dispatch` works. But you may have to add the proper `ref` to the initial checkout step for each job of the launched workflow: 
<img width="271" alt="image" src="https://user-images.githubusercontent.com/28714891/208733569-11e6bf49-7bf4-4876-a6a9-22289fcfe6b1.png">

