### PR TITLE
Update test coverage

### DIFF
--- a/cdn/webpack.config.js
+++ b/cdn/webpack.config.js
@@ -139,7 +139,7 @@ const standardConfig = merge(commonConfig, {
       [`nr-loader-full${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/pro.js'),
       [`nr-loader-full${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/pro.js'),
       [`nr-loader-spa${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/spa.js'),
-      [`nr-loader-spa${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/spa.js'),
+      [`nr-loader-spa${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/spa.js')
   },
   module: {
     rules: [
@@ -183,7 +183,7 @@ const polyfillsConfig = merge(commonConfig, {
     [`nr-loader-spa-polyfills${PATH_VERSION}`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
     [`nr-loader-spa-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
     [`nr-loader-spa-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills/spa.js'),
-    [`nr-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills.js'),
+    [`nr-polyfills${PATH_VERSION}.min`]: path.resolve(__dirname, './agent-loader/polyfills.js')
   },
   module: {
     rules: [
@@ -217,7 +217,7 @@ const polyfillsConfig = merge(commonConfig, {
      * overwrite with either an ES5 or ES6 target. For differentiated transpilation of dynamically loaded dependencies
      * in non-production builds, we can tag output filenames for chunks of the polyfills bundle with `-es5`.
      */
-    chunkFilename: SUBVERSION === 'PROD' ? `[name].[hash:8]${PATH_VERSION}.js` : `[name]-es5${PATH_VERSION}.js`,
+    chunkFilename: SUBVERSION === 'PROD' ? `[name].[hash:8]${PATH_VERSION}.js` : `[name]-es5${PATH_VERSION}.js`
   },
   plugins: [
     instantiateBundleAnalyzerPlugin('polyfills'),

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -91,18 +91,6 @@
       "platform": "Mac 11",
       "version": "14",
       "acceptInsecureCerts": false
-    },
-    {
-      "browserName": "safari",
-      "platform": "Mac 10.13",
-      "version": "13",
-      "acceptInsecureCerts": false
-    },
-    {
-      "browserName": "safari",
-      "platform": "Mac 10.14",
-      "version": "12",
-      "acceptInsecureCerts": false
     }
   ],
   "firefox": [

--- a/tools/jil/util/sauce-browsers.js
+++ b/tools/jil/util/sauce-browsers.js
@@ -69,7 +69,7 @@ const minVersion = name => {
         case "safari":
         case 'ios':
         case 'iphone':
-            return 12
+            return 14
     }
 }
 const maxVersion = name => {


### PR DESCRIPTION
### Overview

Changing support to last 10 versions of Chrome, Edge, Firefox and Safari means a [minimum of Safari 14](https://browsersl.ist/#q=last+10+Safari%2C+versions). Safari 12 and 13 no longer need to be tested. This PR sets the minimum test version to 14.

### Related Issue(s)

N/A

### Testing

Running tests against safari@12 and safari@13 should result in "No browsers matched". Tests against safari@14 should run.
