### PR TITLE
Update babel targets and tests to match support statement (NEWRELIC-5417)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -235,60 +235,46 @@ jobs:
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b ios@* -s -t 85000 --unit-only
-  # android-functional:
-    # if: contains(fromJson('["workflow_dispatch"]'), github.event_name) || contains(github.event.pull_request.labels.*.name, 'safe to test')
-  #   timeout-minutes: 30
-  #   continue-on-error: true
-  #   runs-on: ubuntu-latest
-  #   container: node:14
-  #   
-  #   env:
-  #     NEWRELIC_ENVIRONMENT: ci
-  #     JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
-  #     JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
-  #     NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
+  android-functional:
+    if: contains(fromJson('["workflow_dispatch"]'), github.event_name) || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    timeout-minutes: 30
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    container: node:14
+    
+    env:
+      NEWRELIC_ENVIRONMENT: ci
+      JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
+      JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
+      NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
-  #     - name: install
-  #       run: npm ci --cache ./.npm
+      - name: run tests
+        run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b android@* -s -t 85000 --concurrent=10 --functional-only
+  android-unit:
+    if: contains(fromJson('["workflow_dispatch"]'), github.event_name) || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    timeout-minutes: 30
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    container: node:14
+   
+    env:
+      NEWRELIC_ENVIRONMENT: ci
+      JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
+      JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
+      NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
 
-  #     
-      # - name: build
-      #   run: npm run build:all
+    steps:
+      - uses: actions/checkout@v3
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
 
-  #     - name: run tests
-  #       run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b android@* -s -t 85000 --concurrent=10 --functional-only
-  # android-unit:
-  #   if: contains(fromJson('["workflow_dispatch"]'), github.event_name) || contains(github.event.pull_request.labels.*.name, 'safe to test')
-  #   timeout-minutes: 30
-  #   continue-on-error: true
-  #   runs-on: ubuntu-latest
-  #   container: node:14
-  #   
-  #   env:
-  #     NEWRELIC_ENVIRONMENT: ci
-  #     JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
-  #     JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
-  #     NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
-
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.event.pull_request.head.sha }}
-
-  #     - name: install
-  #       run: npm ci --cache ./.npm
-
-  #     
-      # - name: build
-      #   run: npm run build:all
-
-  #     - name: run tests
-  #       run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b android@* -s -t 85000 --concurrent=10 --unit-only
+      - name: run tests
+        run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b android@* -s -t 85000 --concurrent=10 --unit-only
   check-failures:
     runs-on: ubuntu-latest
     container: node:14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     container: node:14
     if: contains(github.event.pull_request.labels.*.name, 'safe to test') && ${{ !failure() }}  # final check if each needed test either pass or cancelled (special circumstance) and didn't outright fail
-    needs: [chrome-functional, chrome-unit, firefox-functional, firefox-unit, safari-functional, safari-unit, edge-functional, edge-unit, ios-functional, ios-unit]
+    needs: [chrome-functional, chrome-unit, firefox-functional, firefox-unit, safari-functional, safari-unit, edge-functional, edge-unit, ios-functional, ios-unit, android-functional, android-unit]
     env:
       NRQL_API_KEY: ${{ secrets.NRQL_API_KEY }}
     steps:

--- a/cdn/webpack.config.js
+++ b/cdn/webpack.config.js
@@ -158,7 +158,9 @@ const standardConfig = merge(commonConfig, {
                     "last 10 Chrome versions",
                     "last 10 Safari versions",
                     "last 10 Firefox versions",
-                    "last 10 Edge versions"
+                    "last 10 Edge versions",
+                    "last 10 ChromeAndroid versions",
+                    "last 10 iOS versions"
                   ]
                 }
               }]

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Dec 21 2022 11:49:30 GMT-0600 (Central Standard Time)",
+  "lastUpdated": "Wed Jan 04 2023 16:45:27 GMT-0800 (Pacific Standard Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -139,6 +139,20 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
+      "version": "15.2",
+      "device": "iPhone 7 Plus",
+      "appium:deviceName": "iPhone 7 Plus Simulator",
+      "appium:platformVersion": "15.2",
+      "appium:automationName": "XCUITest",
+      "sauce:options": {
+        "appiumVersion": "1.22.3"
+      },
+      "acceptInsecureCerts": false
+    },
+    {
+      "browserName": "Safari",
+      "platform": "iOS",
+      "platformName": "iOS",
       "version": "15.0",
       "device": "iPhone 11",
       "appium:deviceName": "iPhone 11 Simulator",
@@ -153,10 +167,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.4",
-      "device": "iPhone Simulator",
-      "appium:deviceName": "iPhone Simulator",
-      "appium:platformVersion": "14.4",
+      "version": "14.5",
+      "device": "iPhone 12",
+      "appium:deviceName": "iPhone 12 Simulator",
+      "appium:platformVersion": "14.5",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"
@@ -171,20 +185,6 @@
       "device": "iPhone XR",
       "appium:deviceName": "iPhone XR Simulator",
       "appium:platformVersion": "14.0",
-      "appium:automationName": "XCUITest",
-      "sauce:options": {
-        "appiumVersion": "1.22.3"
-      },
-      "acceptInsecureCerts": false
-    },
-    {
-      "browserName": "Safari",
-      "platform": "iOS",
-      "platformName": "iOS",
-      "version": "13.4",
-      "device": "iPhone XS Max",
-      "appium:deviceName": "iPhone XS Max Simulator",
-      "appium:platformVersion": "13.4",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -101,6 +101,21 @@
       "version": "98"
     }
   ],
+  "android": [
+    {
+      "browserName": "Chrome",
+      "platform": "Android",
+      "platformName": "Android",
+      "version": "9.0",
+      "device": "GalaxyS9FHDGoogleAPI",
+      "appium:deviceName": "Samsung Galaxy S9 FHD GoogleAPI Emulator",
+      "appium:platformVersion": "9.0",
+      "appium:automationName": "UiAutomator2",
+      "sauce:options": {
+        "appiumVersion": "1.22.1"
+      }
+    }
+  ],
   "ios": [
     {
       "browserName": "Safari",

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -11,15 +11,8 @@
       "browserName": "chrome",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "106",
-      "browserVersion": "106"
-    },
-    {
-      "browserName": "chrome",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "chrome",
@@ -48,15 +41,8 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "106",
-      "browserVersion": "106"
-    },
-    {
-      "browserName": "MicrosoftEdge",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -102,22 +88,17 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "106"
+      "version": "105"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "104"
+      "version": "101"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "102"
-    },
-    {
-      "browserName": "firefox",
-      "platform": "Windows 10",
-      "version": "99"
+      "version": "98"
     }
   ],
   "ios": [
@@ -129,20 +110,6 @@
       "device": "iPhone 6s Plus",
       "appium:deviceName": "iPhone 6s Plus Simulator",
       "appium:platformVersion": "15.4",
-      "appium:automationName": "XCUITest",
-      "sauce:options": {
-        "appiumVersion": "1.22.3"
-      },
-      "acceptInsecureCerts": false
-    },
-    {
-      "browserName": "Safari",
-      "platform": "iOS",
-      "platformName": "iOS",
-      "version": "15.2",
-      "device": "iPhone 7 Plus",
-      "appium:deviceName": "iPhone 7 Plus Simulator",
-      "appium:platformVersion": "15.2",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"
@@ -167,10 +134,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.5",
-      "device": "iPhone 12",
-      "appium:deviceName": "iPhone 12 Simulator",
-      "appium:platformVersion": "14.5",
+      "version": "14.4",
+      "device": "iPhone Simulator",
+      "appium:deviceName": "iPhone Simulator",
+      "appium:platformVersion": "14.4",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -91,18 +91,6 @@
       "platform": "Mac 11",
       "version": "14",
       "acceptInsecureCerts": false
-    },
-    {
-      "browserName": "safari",
-      "platform": "Mac 10.13",
-      "version": "13",
-      "acceptInsecureCerts": false
-    },
-    {
-      "browserName": "safari",
-      "platform": "Mac 10.14",
-      "version": "12",
-      "acceptInsecureCerts": false
     }
   ],
   "firefox": [
@@ -151,20 +139,6 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "15.2",
-      "device": "iPhone 7 Plus",
-      "appium:deviceName": "iPhone 7 Plus Simulator",
-      "appium:platformVersion": "15.2",
-      "appium:automationName": "XCUITest",
-      "sauce:options": {
-        "appiumVersion": "1.22.3"
-      },
-      "acceptInsecureCerts": false
-    },
-    {
-      "browserName": "Safari",
-      "platform": "iOS",
-      "platformName": "iOS",
       "version": "15.0",
       "device": "iPhone 11",
       "appium:deviceName": "iPhone 11 Simulator",
@@ -179,10 +153,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.5",
-      "device": "iPhone 12",
-      "appium:deviceName": "iPhone 12 Simulator",
-      "appium:platformVersion": "14.5",
+      "version": "14.4",
+      "device": "iPhone Simulator",
+      "appium:deviceName": "iPhone Simulator",
+      "appium:platformVersion": "14.4",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"
@@ -193,10 +167,24 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.4",
-      "device": "iPhone Simulator",
-      "appium:deviceName": "iPhone Simulator",
-      "appium:platformVersion": "14.4",
+      "version": "14.0",
+      "device": "iPhone XR",
+      "appium:deviceName": "iPhone XR Simulator",
+      "appium:platformVersion": "14.0",
+      "appium:automationName": "XCUITest",
+      "sauce:options": {
+        "appiumVersion": "1.22.3"
+      },
+      "acceptInsecureCerts": false
+    },
+    {
+      "browserName": "Safari",
+      "platform": "iOS",
+      "platformName": "iOS",
+      "version": "13.4",
+      "device": "iPhone XS Max",
+      "appium:deviceName": "iPhone XS Max Simulator",
+      "appium:platformVersion": "13.4",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"

--- a/tools/jil/util/sauce-browsers.js
+++ b/tools/jil/util/sauce-browsers.js
@@ -71,7 +71,7 @@ const minSupportedVersion = apiName => {
         case "MicrosoftEdge":
             return browserslistMinVersion('last 10 Edge versions')
         case "safari":
-            return browserslistMinVersion('last 10 Safari versions')
+            return Math.floor(browserslistMinVersion('last 10 Safari versions'))
         case 'ios':
         case 'iphone':
             return browserslistMinVersion('last 10 iOS versions')

--- a/tools/jil/util/sauce-browsers.js
+++ b/tools/jil/util/sauce-browsers.js
@@ -27,7 +27,7 @@ const browsers = {
     edge: [],
     safari: [],
     firefox: [],
-    // android: [], // no longer works with W3C commands.... need to change JIL or do deeper dive to get this to work
+    android: [], // no longer works with W3C commands.... need to change JIL or do deeper dive to get this to work
     ios: []
 }
 
@@ -74,6 +74,12 @@ const minSupportedVersion = apiName => {
             return browserslistMinVersion('last 10 Edge versions')
         case "safari":
             return Math.floor(browserslistMinVersion('last 10 Safari versions'))
+        case "android":
+            // browserslist only ever provides the most recent ChromeAndroid version.
+            // Sauce Labs provides only a single Chrome Android version (100) on all emulators.
+            // Android version <= 9 on Sauce Labs uses the JSON Wire Protocol by default.
+            // https://changelog.saucelabs.com/en/update-to-google-chrome-version-100-on-android-emulators
+            return 9
         case 'ios':
         case 'iphone':
             return browserslistMinVersion('last 10 iOS versions')
@@ -90,6 +96,8 @@ const maxSupportedVersion = apiName => {
         case 'ios':
         case 'iphone':      // Sauce only uses Appium 2.0 for ios16 which requires W3C that we don't comply with yet
             return 15.9     // TO DO: this can be removed once that work is incorporated into JIL
+        case 'android':
+            return 9        // See min value above.
         default:
             return 9999
     }

--- a/tools/testing-server/src/asset-server.js
+++ b/tools/testing-server/src/asset-server.js
@@ -315,7 +315,9 @@ class BrowserifyTransform extends AssetTransform {
                 "last 10 Chrome versions",
                 "last 10 Safari versions",
                 "last 10 Firefox versions",
-                "last 10 Edge versions"
+                "last 10 Edge versions",
+                "last 10 ChromeAndroid versions",
+                "last 10 iOS versions"
               ]
             }
           }]


### PR DESCRIPTION
### Overview

Our working support statement is `last 10 versions of Chrome, Safari, Firefox, and Edge on mobile and desktop`. This PR:
- Updates the babel targets in the webpack configuration and JIL asset server to include missing ChromeAndroid and iOS specs.
- Modifies `sauce-browsers.js` to generate `browsers-supported.json` using the same browserslist source that we use to calculate version targets for babel transpilation--ensuring version-range parity.
- Enables Android functional and unit tests. Previously these were disabled, but [specifying Android 9 ensures that Sauce defaults to JSON Wire Protocol](https://changelog.saucelabs.com/en/update-to-google-chrome-version-100-on-android-emulators), which works with our current JIL.

### Related Issue(s)

[NEWRELIC-5417](https://issues.newrelic.com/browse/NEWRELIC-5417)

### Testing

Automated tests should pass prior to merge.

### Notes on reintroduced Android Chrome testing support

- This PR uses browerslist to derive version numbers for testing, and browserslist uses caniuse—which always [only has info about the latest ChromeAndroid version](https://github.com/browserslist/browserslist/issues/156). This means "Last 10" for ChromeAndroid is equivalent to "latest" from a transpilation perspective. So we can't trust browserslist to give us a complete version list for Android Chrome.
- Because Chrome version releases sync between desktop and mobile [within a day or two](https://en.wikipedia.org/wiki/Google_Chrome_version_history) in the real world, our support statement (including last 10 Chrome mobile) effectively means we support, and thus wish to test, the same versions of Chrome on Android mobile as on desktop.
- SauceLabs has [just one version](https://changelog.saucelabs.com/en/update-to-google-chrome-version-100-on-android-emulators) of ChromeAndroid on all their emulators: 100, and it's not the latest (108). So with Sauce the best we can do is test the version they offer.
- The Sauce api we use to select browsers does not give Chrome version numbers for android, but rather Android version numbers. So we just have to pick a browser-platform definition arbitrarily (version <= 9).
- Presently, I've confirmed that using an Android 9 browser-platform Sauce definition is compatible with JIL, whereas an Android 12 definition fails with W3C-specific errors. This PR specifies min and max versions for Android both as 9. When W3C compatibility updates are made for JIL, we can test Android 12. However, this will not impact the version of ChromeAndroid we are testing, as Sauce Labs uses the same version of ChromeAndroid on all its emulators (see above).
