### PR TITLE
Add SMs for detecting build type

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,30 @@
+name: Smoke Test
+
+on:
+  pull_request_target:
+    types: [labeled]
+  workflow_dispatch:
+
+env:
+  BUILD_NUMBER: PR${{ github.event.number }}-job-${{ github.run_number }}-attempt-${{ github.run_attempt }}
+
+jobs:
+  chrome:
+    if: contains(fromJson('["workflow_dispatch"]'), github.event_name) || contains(github.event.pull_request.labels.*.name, 'smoke test')
+    runs-on: ubuntu-latest
+    container: node:14
+    
+    env:
+      NEWRELIC_ENVIRONMENT: ci
+      JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
+      JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
+      NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
+
+      - name: run tests
+        run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b chrome@latest -s -t 85000 --concurrent=30
+  

--- a/cdn/agent-loader/lite.js
+++ b/cdn/agent-loader/lite.js
@@ -16,9 +16,10 @@ import { Instrument as InstrumentMetrics } from '@newrelic/browser-agent-core/sr
 import { getEnabledFeatures } from '@newrelic/browser-agent-core/src/common/util/enabled-features'
 import globalScope from '@newrelic/browser-agent-core/src/common/util/global-scope'
 
+const loaderType = 'lite'
 try {
     // set up the NREUM, api, and internal configs
-    configure()
+    configure(loaderType)
     const enabledFeatures = getEnabledFeatures(agentIdentifier)
     // instantiate auto-instrumentation specific to this loader...
     if (enabledFeatures['page_view_event']) new InstrumentPageViewEvent(agentIdentifier) // document load (page view event + metrics)
@@ -26,7 +27,7 @@ try {
     if (enabledFeatures.metrics) new InstrumentMetrics(agentIdentifier, PolyfillFeatures)   // supportability & custom metrics
 
     // lazy-loads the aggregator features for 'lite' if no other aggregator takes precedence
-    stageAggregator('lite')
+    stageAggregator(loaderType)
 } catch (err) {
     if (globalScope?.newrelic?.ee?.abort) globalScope.newrelic.ee.abort()
     // todo

--- a/cdn/agent-loader/pro.js
+++ b/cdn/agent-loader/pro.js
@@ -21,8 +21,9 @@ import { getEnabledFeatures } from '@newrelic/browser-agent-core/src/common/util
 import globalScope from '@newrelic/browser-agent-core/src/common/util/global-scope'
 
 // set up the NREUM, api, and internal configs
+const loaderType = 'pro'
 try {
-    configure()
+    configure(loaderType)
 
     const enabledFeatures = getEnabledFeatures(agentIdentifier)
     // lite features
@@ -36,7 +37,7 @@ try {
     if (enabledFeatures['page_action']) new InstrumentPageAction(agentIdentifier) // ins (apis)
 
     // imports the aggregator for 'lite' if no other aggregator takes precedence
-    stageAggregator('pro')
+    stageAggregator(loaderType)
 } catch (err) {
     if (globalScope?.newrelic?.ee?.abort) globalScope.newrelic.ee.abort()
     // todo

--- a/cdn/agent-loader/spa.js
+++ b/cdn/agent-loader/spa.js
@@ -22,8 +22,9 @@ import { configure } from './utils/configure'
 import globalScope from '@newrelic/browser-agent-core/src/common/util/global-scope'
 
 // set up the NREUM, api, and internal configs
+const loaderType = 'spa'
 try {
-    configure()
+    configure(loaderType)
     const enabledFeatures = getEnabledFeatures(agentIdentifier)
     // lite features
     if (enabledFeatures['page_view_event']) new InstrumentPageViewEvent(agentIdentifier) // document load (page view event + metrics)
@@ -38,7 +39,7 @@ try {
     if (enabledFeatures.spa) new InstrumentSpa(agentIdentifier) // spa
 
     // imports the aggregator for 'lite' if no other aggregator takes precedence
-    stageAggregator('spa')
+    stageAggregator(loaderType)
 } catch (err) {
     if (globalScope?.newrelic?.ee?.abort) globalScope.newrelic.ee.abort()
     // todo

--- a/cdn/agent-loader/utils/configure.js
+++ b/cdn/agent-loader/utils/configure.js
@@ -8,7 +8,7 @@ import { isWorkerScope } from '@newrelic/browser-agent-core/src/common/util/glob
 
 let configured = false
 
-export function configure() {
+export function configure(loaderType) {
     if (configured) return
     const nr = gosCDN()
 
@@ -20,7 +20,7 @@ export function configure() {
         setInfo(agentIdentifier, nr.info)
         setConfiguration(agentIdentifier, nr.init)
         setLoaderConfig(agentIdentifier, nr.loader_config)
-        setRuntime(agentIdentifier, {})
+        setRuntime(agentIdentifier, {loaderType})
 
         // add api calls to the NREUM object
         setAPI(agentIdentifier)

--- a/packages/browser-agent-core/src/common/config/state/runtime.js
+++ b/packages/browser-agent-core/src/common/config/state/runtime.js
@@ -14,6 +14,7 @@ const model = agentId => { return {
   customTransaction: undefined,
   disabled: false,
   features: {},
+  loaderType: undefined,
   maxBytes: ieVersion === 6 ? 2000 : 30000,
   offset: getLastTimestamp(),
   onerror: undefined,

--- a/packages/browser-agent-core/src/features/metrics/instrument/index.js
+++ b/packages/browser-agent-core/src/features/metrics/instrument/index.js
@@ -8,6 +8,7 @@ import { VERSION } from '../../../common/constants/environment-variables'
 import { onDOMContentLoaded } from '../../../common/window/load'
 import { windowAddEventListener } from '../../../common/event-listener/event-listener-opts'
 import { isBrowserScope } from '../../../common/util/global-scope'
+import { getRuntime } from '../../../common/config/config'
 import { insertSupportMetrics } from './workers-helper'
 
 var SUPPORTABILITY_METRIC = 'sm'
@@ -60,8 +61,12 @@ export class Instrument extends FeatureBase {
     }
 
     singleChecks() {
+        // report generic info about the agent itself
         // note the browser agent version
         this.recordSupportability(`Generic/Version/${VERSION}/Detected`)
+        // report loaderType 
+        const {loaderType} = getRuntime(this.agentIdentifier)
+        if (loaderType) this.recordSupportability(`Generic/LoaderType/${loaderType}/Detected`)
 
         // frameworks on page
         if(isBrowserScope) onDOMContentLoaded(() => {

--- a/tests/browser/protocol.browser.js
+++ b/tests/browser/protocol.browser.js
@@ -21,7 +21,7 @@ var fileLocation = {
 jil.browserTest('isFileProtocol returns coorectly when detecting file protocol', function (t) {
   setScope({ location: fileLocation })
 
-  t.ok(protocol.isFileProtocol(), 'Returned false when protocol is not file protocol')
+  t.ok(protocol.isFileProtocol(), 'Returned true when protocol is file protocol')
   t.ok(protocol.supportabilityMetricSent, 'isFileProtocol should send supportability metric if file protocol is detected')
 
   resetScope()


### PR DESCRIPTION

### Overview

This PR adds supportability metrics (SM) that report what build type was loaded on the page (lite, pro, spa).  This behavior should happen only once, at metric feature inst runtime.

### Related Issue(s)

NEWRELIC-6163

### Testing

Tests have been updated to account for the new metric
