### PR TITLE
Kill features on 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Unblock instrumented pages from the back/forward cache (w/ feature flag)
 An instrumented page's back-forward cache eligibility was hampered by the agent's `unload` listener, which will be _removed_ when a feature flag is on. With the `allow_bfcache` enabled in the `init` config, the agent's definition of (the end of) an user's session is more refined, and it will no longer be blocking the browser from utilizing its respective b/f cache.
 
+### Prevent feature from collecting and harvesting future data if 403 response is received
+The agent will now attempt to shut down an initialized feature if a 403 response is received from ingest.
+
 ### Do not collect XHR events for data URLs
 AJAX events for data URLs have not historically been collected due to errors in the agent when handling URLs without hostnames. Going forward, XHR calls to data URLs will not cause agent errors and will continue to be excluded from collection.
 

--- a/packages/browser-agent-core/src/common/harvest/harvest-scheduler.js
+++ b/packages/browser-agent-core/src/common/harvest/harvest-scheduler.js
@@ -23,6 +23,12 @@ export class HarvestScheduler extends SharedContext {
 
     this.harvest = new Harvest(this.sharedContext)
 
+    this.onHarvestBlocked = () => {
+      // This feature got a 403... dont stage for next harvest
+      clearTimeout(this.timeoutHandle)
+      parent.blocked = true
+    }
+
     subscribeToEOL(() => {
       // If opts.onUnload is defined, these are special actions to execute before attempting to send the final payload.
       if (this.opts.onUnload) this.opts.onUnload();
@@ -83,7 +89,8 @@ export class HarvestScheduler extends SharedContext {
     return;
 
     function onHarvestFinished(result) {
-      scheduler.onHarvestFinished(opts, result)
+      if (result.blocked) scheduler.onHarvestBlocked(opts, result)
+      else scheduler.onHarvestFinished(opts, result)
     }
   }
 

--- a/packages/browser-agent-core/src/common/harvest/harvest.js
+++ b/packages/browser-agent-core/src/common/harvest/harvest.js
@@ -33,6 +33,7 @@ export class Harvest extends SharedContext {
     this.getScheme = () => (getConfigurationValue(this.sharedContext.agentIdentifier, 'ssl') === false) ? 'http' : 'https'
 
     this._events = {}
+    this.blocked = false
   }
 
   /**
@@ -134,6 +135,8 @@ export class Harvest extends SharedContext {
           result.delay = this.tooManyRequestsDelay
         } else if (this.status === 408 || this.status === 500 || this.status === 503) {
           result.retry = true
+        } else if (this.status === 403) {
+          result.blocked = true
         }
 
         if (opts.needResponse) {

--- a/packages/browser-agent-core/src/common/util/feature-base.js
+++ b/packages/browser-agent-core/src/common/util/feature-base.js
@@ -6,5 +6,6 @@ export class FeatureBase {
     this.aggregator = aggregator
     this.ee = ee.get(agentIdentifier)
     this.externalFeatures = externalFeatures
+    this.blocked = false
   }
 }

--- a/packages/browser-agent-core/src/features/ajax/aggregate/index.js
+++ b/packages/browser-agent-core/src/features/ajax/aggregate/index.js
@@ -67,6 +67,7 @@ export class Aggregate extends FeatureBase {
     }
 
     function storeXhr(params, metrics, startTime, endTime, type) {
+      if (this.blocked) return
       metrics.time = startTime
 
       // send to session traces

--- a/packages/browser-agent-core/src/features/jserrors/aggregate/index.js
+++ b/packages/browser-agent-core/src/features/jserrors/aggregate/index.js
@@ -195,6 +195,7 @@ export class Aggregate extends FeatureBase {
     // and spa annotates the error with interaction info
     handle('errorAgg', [type, bucketHash, params, newMetrics], undefined, undefined, this.ee)
 
+    if (this.blocked) return
     if (params._interactionId != null) {
       // hold on to the error until the interaction finishes
       this.errorCache[params._interactionId] = this.errorCache[params._interactionId] || []
@@ -219,7 +220,7 @@ export class Aggregate extends FeatureBase {
   }
 
   onInteractionSaved (interaction) {
-    if (!this.errorCache[interaction.id]) return
+    if (!this.errorCache[interaction.id] || this.blocked) return
 
     this.errorCache[interaction.id].forEach( (item) => {
       var customParams = {}
@@ -253,7 +254,7 @@ export class Aggregate extends FeatureBase {
   }
 
   onInteractionDiscarded (interaction) {
-    if (!this.errorCache || !this.errorCache[interaction.id]) return
+    if (!this.errorCache || !this.errorCache[interaction.id] || this.blocked) return
 
     this.errorCache[interaction.id].forEach( (item) => {
       var customParams = {}

--- a/packages/browser-agent-core/src/features/metrics/aggregate/index.js
+++ b/packages/browser-agent-core/src/features/metrics/aggregate/index.js
@@ -18,10 +18,12 @@ export class Aggregate extends FeatureBase {
     }
 
     storeMetric(type, name, params, value) {
+        if (this.blocked) return
         this.aggregator.storeMetric(type, name, params, value)
     }
 
     storeEventMetrics(type, name, params, metrics) {
+        if (this.blocked) return
         this.aggregator.store(type, name, params, metrics)
     }
 }

--- a/packages/browser-agent-core/src/features/page-action/aggregate/index.js
+++ b/packages/browser-agent-core/src/features/page-action/aggregate/index.js
@@ -27,11 +27,11 @@ export class Aggregate extends FeatureBase {
 
     if (isBrowserScope && document.referrer) this.referrerUrl = cleanURL(document.referrer)
 
-      register('api-addPageAction', (...args) => this.addPageAction(...args), undefined, this.ee)
+    register('api-addPageAction', (...args) => this.addPageAction(...args), undefined, this.ee)
 
-      var scheduler = new HarvestScheduler('ins', {onFinished: (...args) => this.onHarvestFinished(...args)}, this)
-      scheduler.harvest.on('ins', (...args) => this.onHarvestStarted(...args))
-      scheduler.startTimer(this.harvestTimeSeconds, 0)
+    var scheduler = new HarvestScheduler('ins', {onFinished: (...args) => this.onHarvestFinished(...args)}, this)
+    scheduler.harvest.on('ins', (...args) => this.onHarvestStarted(...args))
+    scheduler.startTimer(this.harvestTimeSeconds, 0)
   }
 
   onHarvestStarted (options) {
@@ -63,7 +63,7 @@ export class Aggregate extends FeatureBase {
 
   // WARNING: Insights times are in seconds. EXCEPT timestamp, which is in ms.
   addPageAction (t, name, attributes) {
-    if (this.events.length >= this.eventsPerHarvest) return
+    if (this.events.length >= this.eventsPerHarvest || this.blocked) return
     var width
     var height
     var eventAttributes = {}

--- a/packages/browser-agent-core/src/features/page-view-timing/aggregate/index.js
+++ b/packages/browser-agent-core/src/features/page-view-timing/aggregate/index.js
@@ -147,6 +147,7 @@ export class Aggregate extends FeatureBase {
   }
 
   addTiming(name, value, attrs, addCls) {
+    if (this.blocked) return
     attrs = attrs || {}
     // collect 0 only when CLS is supported, since 0 is a valid score
     if ((this.cls > 0 || this.clsSupported) && addCls) {

--- a/packages/browser-agent-core/src/features/session-trace/aggregate/index.js
+++ b/packages/browser-agent-core/src/features/session-trace/aggregate/index.js
@@ -289,6 +289,7 @@ export class Aggregate extends FeatureBase {
   }
 
   storeSTN(stn) {
+    if (this.blocked) return
   // limit the number of data that is stored
     if (this.nodeCount >= this.maxNodesPerHarvest) return
 

--- a/tests/functional/disable-harvest.test.js
+++ b/tests/functional/disable-harvest.test.js
@@ -1,0 +1,191 @@
+const testDriver = require('jil')
+
+let supported = testDriver.Matcher.withFeature('notInternetExplorer')
+
+var timedPromiseAll = (promises, ms = 5000) => Promise.race([
+  new Promise((resolve, reject) => {
+    setTimeout(() => {
+      reject()
+    }, ms)
+  }),
+  Promise.all(promises)
+])
+
+testDriver.test('METRICS -  Kills feature if 403', supported, function (t, browser, router) {
+  const init = {
+    metrics: { enabled: true, harvestTimeSeconds: 5 },
+    jserrors: { enabled: false, harvestTimeSeconds: 5 }
+  }
+  router.scheduleResponse('jserrors', 403)
+
+  const assetURL = router.assetURL('instrumented.html', { loader: 'full', init })
+  const rumPromise = router.expectRum()
+  const loadPromise = browser.get(assetURL)
+  const errPromise = router.expectErrors()
+
+  Promise.all([errPromise, rumPromise, loadPromise]).then(([errors]) => {
+    t.equal(errors.res.statusCode, 403, 'server responded with 403')
+    // wait 15 seconds to ensure time to retry (retry should not happen)
+    timedPromiseAll([router.expectErrors()], 15000)
+      .then(errors => {
+        t.fail('should not have recieved more metrics')
+      }).catch(() => {
+        t.pass('did not recieve more metrics :)')
+      }).finally(() => {
+        t.end()
+      })
+  }).catch(fail)
+
+  function fail(err) {
+    t.error(err)
+    t.end()
+  }
+})
+
+testDriver.test('SPA -  Kills feature if 403', supported, function (t, browser, router) {
+  const init = {
+    ajax: { enabled: false, harvestTimeSeconds: 5 },
+    spa: {enabled: true, harvestTimeSeconds: 5},
+    page_view_timing: {enabled: false, harvestTimeSeconds: 5}
+  }
+  router.scheduleResponse('events', 403)
+
+  const assetURL = router.assetURL('instrumented.html', { loader: 'spa', init })
+  const rumPromise = router.expectRum()
+  const loadPromise = browser.get(assetURL)
+  const spaPromise = router.expectEvents()
+
+  Promise.all([spaPromise, rumPromise, loadPromise]).then(([errors]) => {
+    t.equal(errors.res.statusCode, 403, 'server responded with 403')
+    // wait 15 seconds to ensure time to retry (retry should not happen)
+    timedPromiseAll([router.expectEvents()], 15000)
+      .then(errors => {
+        t.fail('should not have recieved more pvts')
+      }).catch(() => {
+        t.pass('did not recieve more pvts :)')
+      }).finally(() => {
+        t.end()
+      })
+  }).catch(fail)
+
+  function fail(err) {
+    t.error(err)
+    t.end()
+  }
+})
+
+testDriver.test('ALL OTHER FEATURES - Kills feature if 403', supported, function (t, browser, router) {
+
+  const init = {
+    metrics: {enabled: false},
+    jserrors: { harvestTimeSeconds: 5 },
+    ajax: { harvestTimeSeconds: 5 },
+    session_trace: {harvestTimeSeconds: 5},
+    ins: {harvestTimeSeconds: 5},
+    spa: {enabled: false},
+    page_view_timing: {enabled: false}
+  }
+  router.scheduleResponse('jserrors', 403)
+  router.scheduleResponse('events', 403)
+  router.scheduleResponse('resources', 403)
+  router.scheduleResponse('ins', 403)
+
+  const assetURL = router.assetURL('instrumented.html', { loader: 'full', init })
+  const rumPromise = router.expectRum()
+  const loadPromise = browser.get(assetURL)
+  const errPromise = router.expectErrors()
+  const ajaxPromise = router.expectAjaxEvents()
+  const stnPromise = router.expectResources()
+  const pageActionPromise = router.expectIns()
+
+  Promise.all([
+    Promise.all([errPromise, rumPromise, loadPromise]).then(([errors]) => {
+      t.equal(errors.res.statusCode, 403, 'errors - server responded with 403')
+      // wait 15 seconds to ensure time to retry (retry should not happen)
+      timedPromiseAll([router.expectErrors()], 15000)
+        .then(errors => {
+          t.fail('should not have recieved more errors')
+        }).catch(() => {
+          t.pass('did not recieve more errors :)')
+        })
+    }).catch(fail),
+
+    Promise.all([ajaxPromise, rumPromise, loadPromise]).then(([data]) => {
+      t.equal(data.res.statusCode, 403, 'ajax - server responded with 403')
+      // wait 15 seconds to ensure time to retry (retry should not happen)
+      timedPromiseAll([router.expectAjaxEvents()], 15000)
+        .then(ajax => {
+          t.fail('should not have recieved more ajax')
+        }).catch(() => {
+          t.pass('did not recieve more ajax :)')
+        }).finally(() => {
+          t.end()
+        })
+    }).catch(fail),
+
+    Promise.all([stnPromise, rumPromise, loadPromise]).then(([data]) => {
+      t.equal(data.res.statusCode, 403, 'session_trace - server responded with 403')
+      // wait 15 seconds to ensure time to retry (retry should not happen)
+      timedPromiseAll([router.expectResources()], 15000)
+        .then(ajax => {
+          t.fail('should not have recieved more stn')
+        }).catch(() => {
+          t.pass('did not recieve more stn :)')
+        }).finally(() => {
+          t.end()
+        })
+    }).catch(fail),
+
+    Promise.all([pageActionPromise, rumPromise, loadPromise]).then(([data]) => {
+      t.equal(data.res.statusCode, 403, 'page_action - server responded with 403')
+      // wait 15 seconds to ensure time to retry (retry should not happen)
+      timedPromiseAll([router.expectIns()], 15000)
+        .then(ajax => {
+          t.fail('should not have recieved more page_actions...')
+        }).catch(() => {
+          t.pass('did not recieve more page_actions :)')
+        }).finally(() => {
+          t.end()
+        })
+    }).catch(fail)
+  ]).then(() => {
+    t.end()
+  }).catch(() => {
+    t.end()
+  })
+
+  function fail(err) {
+    t.error(err)
+    t.end()
+  }
+})
+
+// testDriver.test('SESSION_TRACE - Does not retry if 403', supported, function (t, browser, router) {
+//   const init = {
+//     session_trace: { enabled: true, harvestTimeSeconds: 5 }
+//   }
+//   router.scheduleResponse('resources', 403)
+
+//   const assetURL = router.assetURL('instrumented.html', { loader: 'full', init })
+//   const rumPromise = router.expectRum()
+//   const loadPromise = browser.get(assetURL)
+//   const ajaxPromise = router.expectAjaxEvents()
+
+//   Promise.all([ajaxPromise, rumPromise, loadPromise]).then(([data]) => {
+//     t.equal(data.res.statusCode, 403, 'server responded with 403')
+//     // wait 15 seconds to ensure time to retry (retry should not happen)
+//     timedPromiseAll([router.expectAjaxEvents()], 15000)
+//       .then(errors => {
+//         t.fail('should not have recieved more ajax')
+//       }).catch(() => {
+//         t.pass('did not recieve more ajax :)')
+//       }).finally(() => {
+//         t.end()
+//       })
+//   }).catch(fail)
+
+//   function fail(err) {
+//     t.error(err)
+//     t.end()
+//   }
+// })

--- a/tests/functional/disable-harvest.test.js
+++ b/tests/functional/disable-harvest.test.js
@@ -159,33 +159,3 @@ testDriver.test('ALL OTHER FEATURES - Kills feature if 403', supported, function
     t.end()
   }
 })
-
-// testDriver.test('SESSION_TRACE - Does not retry if 403', supported, function (t, browser, router) {
-//   const init = {
-//     session_trace: { enabled: true, harvestTimeSeconds: 5 }
-//   }
-//   router.scheduleResponse('resources', 403)
-
-//   const assetURL = router.assetURL('instrumented.html', { loader: 'full', init })
-//   const rumPromise = router.expectRum()
-//   const loadPromise = browser.get(assetURL)
-//   const ajaxPromise = router.expectAjaxEvents()
-
-//   Promise.all([ajaxPromise, rumPromise, loadPromise]).then(([data]) => {
-//     t.equal(data.res.statusCode, 403, 'server responded with 403')
-//     // wait 15 seconds to ensure time to retry (retry should not happen)
-//     timedPromiseAll([router.expectAjaxEvents()], 15000)
-//       .then(errors => {
-//         t.fail('should not have recieved more ajax')
-//       }).catch(() => {
-//         t.pass('did not recieve more ajax :)')
-//       }).finally(() => {
-//         t.end()
-//       })
-//   }).catch(fail)
-
-//   function fail(err) {
-//     t.error(err)
-//     t.end()
-//   }
-// })


### PR DESCRIPTION

### Overview
This PR adds functionality to kill running features if a 403 response is received from ingest.  Features should be blocked from aggregating data, as well as harvesting data.  Other feature functionality should remain in place, and events emitted to be used by other features should still occur.

### Related Issues
https://issues.newrelic.com/browse/NR-70879

### Testing
A new test has been added to check that features stop reporting after 403 is detected.