### PR TITLE
[Patch] Distinguish reporting of windowUnload from pageHide to NR

### DIFF
--- a/packages/browser-agent-core/src/common/unload/eol.js
+++ b/packages/browser-agent-core/src/common/unload/eol.js
@@ -28,13 +28,13 @@ if (isWorkerScope) {
  */
 export function subscribeToEOL (cb, allowBFCache) {
   if (isBrowserScope) {
-    var oneCall = single(cb); // TO DO: stage 2 - allow more than one "final harvest"
-
     if (allowBFCache) {
-      subscribeToVisibilityChange(oneCall, true); // when user switches tab or hides window, esp. mobile scenario
-      windowAddEventListener('pagehide', oneCall);  // when user navigates away, and because safari iOS v14.4- doesn't fully support vis change
-                                                    // --this ought to be removed once support for version below 14.5 phases out
+      subscribeToVisibilityChange(cb, true);  // when user switches tab or hides window, esp. mobile scenario
+      windowAddEventListener('pagehide', cb); // when user navigates away, and because safari iOS v14.4- doesn't fully support vis change
+                                                // --this ought to be removed once support for version below 14.5 phases out
     } else {
+      var oneCall = single(cb);
+
       // Firefox has a bug wherein a slow-loading resource loaded from the 'pagehide'
       // or 'unload' event will delay the 'load' event firing on the next page load.
       // In Firefox versions that support sendBeacon, this doesn't matter, because

--- a/tests/browser/timings-lcp-cls.browser.js
+++ b/tests/browser/timings-lcp-cls.browser.js
@@ -33,7 +33,8 @@ jil.browserTest('LCP event with CLS attribute', function (t) {
   handle('cls', [{ value: 2 }], undefined, undefined, pvtAgg.ee)
 
   // invoke final harvest, which includes harvesting LCP
-  pvtAgg.finalHarvest()
+  pvtAgg.recordLcp();
+  pvtAgg.recordPageUnload(Date.now());
 
   var timing = find(pvtAgg.timings, function(t) {
     return t.name === 'lcp'

--- a/tests/browser/timings-lcp.browser.js
+++ b/tests/browser/timings-lcp.browser.js
@@ -36,11 +36,12 @@ jil.browserTest('LCP is not collected on unload when the LCP value occurs after 
     handle('lcp', [{ size: 1, startTime: 1 }], undefined, undefined, pvtAgg.ee)
 
     // invoke final harvest, which includes harvesting LCP
-    pvtAgg.finalHarvest()
+    pvtAgg.recordLcp();
+    pvtAgg.recordPageUnload(Date.now());
 
     t.equals(pvtAgg.timings.length, 2, 'there should be only 2 timings (pageHide and unload)')
-    t.ok(pvtAgg.timings[0].name === 'pageHide', 'should have pageHide timing')
-    t.ok(pvtAgg.timings[1].name === 'unload', 'should have unload timing')
+    t.ok(pvtAgg.timings[1].name === 'pageHide', 'should have pageHide timing')
+    t.ok(pvtAgg.timings[0].name === 'unload', 'should have unload timing')
 
     t.end()
   }, 1000)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Under the previous PR, our `pageHide` and `unload` had become synonymous in that doc vis change would cause both to be triggered and sent. This was not the intention, as there is a distinct difference between their triggers.
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/28714891/211929160-3e20ed21-c4ce-4ebf-bd62-1c005fc99fc4.png">
Specifically, `pageHide` can be emitted multiple times in the lifespan of one page load/restore, but `unload` should only signify the end of a load/restore's span and occur once per.

**`subscribeToEOL` also had its limiter removed under the flag to, e.g., allow multiple final harvests as either event can cause one and the total number of "final harvest" is indeterministic. (It's also necessary to decouple the two events.)

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
Patch to work done in #308 

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
When `init.allow_bfcache` is enabled, document vis change (tab, minimize, etc.) should emit `pageHide` still but _not_ `unload`. Only when the window pageHide event fires (navigating away, reload, etc.) should emit `unload` (**and** `pageHide`).