### PR TITLE
NR-78867: Safe sessionStorage writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Restoring previous functionality whereby the `nrWrapper` agent method should be 
 ### Fix errors with global self redefinition
 Fixing an issue where external code redefining the `self` global variable causes the agent async loading to fail and the agent to crash.
 
+### Fix check for sessionStorage object
+Ensure the agent does not crash when sessionStorage is not available or when the quota has been exceeded or set to 0. Safari has been known to set the sessionStorage quota to 0 in private browsing windows.
+
 ## v1221
 
 ### Add infrastructure to run on web workers

--- a/packages/browser-agent-core/src/common/window/session-storage.js
+++ b/packages/browser-agent-core/src/common/window/session-storage.js
@@ -10,22 +10,30 @@ import { isBrowserScope } from '../util/global-scope'
 
 export { getCurrentSessionIdOrMakeNew };
 
-const ss = isBrowserScope ? window.sessionStorage : undefined;
 const SESS_ID = "NRBA_SESSION_ID"; // prevents potential key collisions in session storage
 
 /**
  * @returns {string} This tab|window's session identifier, or a new ID if not found in storage
  */
 function getCurrentSessionIdOrMakeNew() {
-  if (!ss) return null; // indicates sessionStoage API not avail
-
-  let sessionId;
-  if ((sessionId = ss.getItem(SESS_ID)) === null) {
-    // Generate a new one if storage is empty (no previous ID was created or currently exists)
-    sessionId = generateRandomHexString(16);
-    ss.setItem(SESS_ID, sessionId);
+  if (!isBrowserScope) {
+    return null;
   }
-  return sessionId;
+
+  try {
+    let sessionId;
+    if ((sessionId = window.sessionStorage.getItem(SESS_ID)) === null) {
+      // Generate a new one if storage is empty (no previous ID was created or currently exists)
+      sessionId = generateRandomHexString(16);
+      window.sessionStorage.setItem(SESS_ID, sessionId);
+    }
+    return sessionId;
+  } catch (ex) {
+    // Session storage quota most likely 0mb and cannot be written to
+    // OR the agent is running in a security context that does not allow
+    // access to the browser sessionStorage
+    return null;
+  }
 }
 
 // In the future, we may expand sessionStorage to, say, auto-save some other agent data between page refreshes.

--- a/tests/assets/api/session-storage-disallowed.html
+++ b/tests/assets/api/session-storage-disallowed.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <script>
+    if (window.sessionStorage) {
+      window.sessionStorage.clear();
+      window.sessionStorage.setItem = function () {
+        throw new Error('session storage not allowed')
+      }
+    }
+  </script>
+  <title>RUM Unit Test</title>
+  {init}
+  {config}
+  {loader}
+</head>
+<body>
+Api test!
+</body>
+</html>
+

--- a/tests/functional/api.test.js
+++ b/tests/functional/api.test.js
@@ -7,6 +7,7 @@ const testDriver = require('../../tools/jil/index')
 const {fail, getTime} = require('./uncat-internal-help.cjs')
 const {getErrorsFromResponse} = require('./err/assertion-helpers')
 
+const asserters = testDriver.asserters
 let withUnload = testDriver.Matcher.withFeature('reliableUnloadEvent')
 
 testDriver.test('customTransactionName 1 arg', function (t, browser, router) {
@@ -327,6 +328,20 @@ testDriver.test('no query param when release is not set', withUnload, function (
     })
     .then(({query, body}) => {
       t.notOk('ri' in query, 'should not have ri query param')
+      t.end()
+    })
+    .catch(fail(t));
+})
+
+testDriver.test('api is available when sessionStorage is not', function (t, browser, router) {
+  let rumPromise = router.expectRum()
+  let loadPromise = browser.get(router.assetURL('api/session-storage-disallowed.html'));
+
+  Promise.all([loadPromise, rumPromise])
+    .then(() =>
+      browser.waitFor(asserters.jsCondition('typeof window.newrelic.addToTrace === \'function\''))
+    ).then((result) => {
+      t.ok(result)
       t.end()
     })
     .catch(fail(t));

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -18,15 +18,15 @@
       "browserName": "chrome",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "102",
-      "browserVersion": "102"
+      "version": "103",
+      "browserVersion": "103"
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "99",
-      "browserVersion": "99"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "100",
+      "browserVersion": "100"
     }
   ],
   "edge": [
@@ -93,12 +93,12 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "101"
+      "version": "102"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "98"
+      "version": "99"
     }
   ],
   "android": [

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -2,17 +2,17 @@
   "chrome": [
     {
       "browserName": "chrome",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "108",
-      "browserVersion": "108"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "109",
+      "browserVersion": "109"
     },
     {
       "browserName": "chrome",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "chrome",
@@ -107,8 +107,8 @@
       "platform": "Android",
       "platformName": "Android",
       "version": "9.0",
-      "device": "GalaxyS9FHDGoogleAPI",
-      "appium:deviceName": "Samsung Galaxy S9 FHD GoogleAPI Emulator",
+      "device": "GalaxyTabS3GoogleAPI",
+      "appium:deviceName": "Samsung Galaxy Tab S3 GoogleAPI Emulator",
       "appium:platformVersion": "9.0",
       "appium:automationName": "UiAutomator2",
       "sauce:options": {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Wrapping our access of and write to sessionStorage in a `try..catch` to ensure it does not cause the agent to crash when sessionStorage is not available or when the quota has been exceeded or set to 0. Safari has been know to set the sessionStorage quota to 0 in private browsing windows. This was causing the agent to crash and the API to not be attached to the window.newrelic object.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-78867
https://issues.newrelic.com/browse/NR-78872

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
A functional test has been added to ensure we no longer have this issue. To reproduce the error, comment out the `try..catch` wrapper added in this PR, rebuild, and load the new test page. After loading, check the window.newrelic object to see if the API methods were added.