### PR TITLE
Fix APM DB script

### DIFF
--- a/.github/workflows/publish-apm.yml
+++ b/.github/workflows/publish-apm.yml
@@ -29,4 +29,4 @@ jobs:
             --staging-api-key=${{ secrets.NR_API_KEY_STAGING }} \
             --production-api-key=${{ secrets.NR_API_KEY_PRODUCTION }} \
             --eu-api-key=${{ secrets.NR_API_KEY_EU }} \
-            --version=${{ github.event.inputs.version }}
+            --v=${{ github.event.inputs.version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -117,7 +117,7 @@ jobs:
             --staging-api-key=${{ secrets.NR_API_KEY_STAGING }} \
             --production-api-key=${{ secrets.NR_API_KEY_PRODUCTION }} \
             --eu-api-key=${{ secrets.NR_API_KEY_EU }} \
-            --version=$(cat VERSION)
+            --v=$(cat VERSION)
       - name: validate file
         run: |
           node tools/scripts/check-nrdb.js -v $(cat VERSION)

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -18,15 +18,15 @@
       "browserName": "chrome",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "103",
-      "browserVersion": "103"
+      "version": "102",
+      "browserVersion": "102"
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "100",
-      "browserVersion": "100"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "99",
+      "browserVersion": "99"
     }
   ],
   "edge": [
@@ -93,12 +93,12 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "102"
+      "version": "101"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "99"
+      "version": "98"
     }
   ],
   "android": [

--- a/tools/scripts/upload-to-nr.js
+++ b/tools/scripts/upload-to-nr.js
@@ -22,8 +22,8 @@ var argv = yargs
   .string('eu-api-key')
   .describe('eu-api-key', 'API key to use for talking to EU RPM site to upload loaders')
 
-  .string('version')
-  .describe('version', 'Browser Agent version number')
+  .string('v')
+  .describe('v', 'Browser Agent version number')
 
   .boolean('skip-upload-failures')
   .describe('skip-upload-failures', "Don't bail out after the first failure, keep trying other requests")
@@ -177,7 +177,7 @@ async function run() {
    */
   async function loaderFilenames() {
     const loaderTypes = ['rum', 'full', 'spa']
-    const version = argv['version']
+    const version = argv['v']
     const fileNames = loaderTypes.map(type => [
       `nr-loader-${type}-${version}.min.js`, 
       `nr-loader-${type}-polyfills-${version}.min.js`,


### PR DESCRIPTION

### Overview

An update to `yargs` has disallowed the usage of `version` as an argument.  Changed to `v`

