### PR TITLE
Bind navigator to sendBeacon to prevent illegal invocation errors on …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Fixed an issue where multiple custom interactions harvested at the same time wou
 ### Prevent ajax time slice metrics based on deny list
 Prevent time slice metric collection for ajax calls when such a call matches an entry in the ajax deny list.
 
-### Prevent ajax time slice metrics based on deny list
+### Bind navigator scope to sendBeacon
 Some browser versions will throw errors if sendBeacon does not have the navigator scope bound to it. A fail-safe action of binding the navigator scope to sendBeacon was added to try to support those browsers.
 
 ## v1223

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Fixed an issue where multiple custom interactions harvested at the same time wou
 ### Prevent ajax time slice metrics based on deny list
 Prevent time slice metric collection for ajax calls when such a call matches an entry in the ajax deny list.
 
+### Prevent ajax time slice metrics based on deny list
+Some browser versions will throw errors if sendBeacon does not have the navigator scope bound to it. A fail-safe action of binding the navigator scope to sendBeacon was added to try to support those browsers.
+
 ## v1223
 
 ### Refactor loader architecture for improved developer experience

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -2,11 +2,13 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import globalScope from "./global-scope"
 export const submitData = {}
 
 /**
- * Do NOT call this function outside of a guaranteed web window environment.
+ * Send via JSONP. Do NOT call this function outside of a guaranteed web window environment.
+ * @param {string} url 
+ * @param {string} jsonp 
+ * @returns {Element}
  */
 submitData.jsonp = function jsonp (url, jsonp) {
   var element = document.createElement('script')
@@ -17,6 +19,13 @@ submitData.jsonp = function jsonp (url, jsonp) {
   return element
 }
 
+/**
+ * Send via XHR
+ * @param {string} url 
+ * @param {string} body 
+ * @param {boolean} sync 
+ * @returns {XMLHttpRequest}
+ */
 submitData.xhr = function xhr (url, body, sync) {
   var request = new XMLHttpRequest()
 
@@ -41,7 +50,9 @@ submitData.xhr = function xhr (url, body, sync) {
 // }
 
 /**
- * Do NOT call this function outside of a guaranteed web window environment.
+ * Send by appending an <img> element to the page. Do NOT call this function outside of a guaranteed web window environment.
+ * @param {string} url 
+ * @returns {Element}
  */
 submitData.img = function img (url) {
   var element = new Image()
@@ -50,7 +61,10 @@ submitData.img = function img (url) {
 }
 
 /**
- * Do NOT call this function outside of a guaranteed web window environment.
+ * Send via sendBeacon. Do NOT call this function outside of a guaranteed web window environment.
+ * @param {string} url 
+ * @param {string} body 
+ * @returns {boolean}
  */
 submitData.beacon = function (url, body) {
   // Navigator has to be bound to ensure it does not error in some browsers

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -2,7 +2,7 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
+import globalScope from "./global-scope"
 export const submitData = {}
 
 /**
@@ -53,5 +53,8 @@ submitData.img = function img (url) {
  * Do NOT call this function outside of a guaranteed web window environment.
  */
 submitData.beacon = function (url, body) {
-  return window.navigator.sendBeacon(url, body)
+  // Navigator has to be bound to ensure it does not error in some browsers
+  // https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch
+  const send = globalScope.navigator.sendBeacon.bind(navigator)
+  return send(url, body)
 }

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -55,6 +55,6 @@ submitData.img = function img (url) {
 submitData.beacon = function (url, body) {
   // Navigator has to be bound to ensure it does not error in some browsers
   // https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch
-  const send = globalScope.navigator.sendBeacon.bind(navigator)
+  const send = window.navigator.sendBeacon.bind(navigator)
   return send(url, body)
 }

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -41,8 +41,8 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "106",
-      "browserVersion": "106"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -93,7 +93,7 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "102"
+      "version": "101"
     },
     {
       "browserName": "firefox",

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -41,8 +41,8 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -93,7 +93,7 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "101"
+      "version": "102"
     },
     {
       "browserName": "firefox",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Some browser versions will throw errors if sendBeacon does not have the navigator scope bound to it.  This is just a fail-safe action to try to support those browsers. See `Links` for more context 

### Related Issue(s)

https://issues.newrelic.com/browse/NEWRELIC-4686

### Links 
[Issues with Navigator Context](https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch)
[How next.js handled this](https://github.com/vercel/next.js/pull/26601/files)


### Testing

final-harvest.test.js tests the calling of sendBeacon on unload.  The behavior should be unchanged in our testing suite, and this ticket should just be treated as a "try our best to do-no-harm" effort and nothing more.