### PR TITLE
Implement and verify support for Chrome on iOS (NEWRELIC-6276).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## v1224
+
+### Support SPA, XHR, and session trace features on Chrome for iOS.
+Previously, the agent did not collect SPA browser interactions, XHR events, or session trace data in Chrome for iOS (which uses the webkit engine with modifications). The agent will now collect the same data in Chrome for iOS as in other supported browsers.
+
 ## v1223
 
 ### Refactor loader architecture for improved developer experience

--- a/src/common/config/state/runtime.js
+++ b/src/common/config/state/runtime.js
@@ -24,7 +24,7 @@ const model = agentId => { return {
   releaseIds: {},
   sessionId: getConfigurationValue(agentId, 'privacy.cookies_enabled') == true ?
     getCurrentSessionIdOrMakeNew() : null,  // if cookies (now session tracking) is turned off or can't get session ID, this is null
-  xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'] && !/CriOS/.test(navigator.userAgent),
+  xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'],
   userAgent
 }}
 

--- a/src/common/wrap/wrap-history.js
+++ b/src/common/wrap/wrap-history.js
@@ -3,30 +3,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// History pushState wrapper
-import {ee as baseEE} from '../event-emitter/contextual-ee'
-import {createWrapperWithEmitter as wfn} from './wrap-function'
+/**
+ * Wrapper for pushState and replaceState methods of window.history object
+ */
+
+import { ee as globalEE } from '../event-emitter/contextual-ee'
+import { createWrapperWithEmitter as wfn } from './wrap-function'
 import { isBrowserScope } from '../util/global-scope'
 
 const wrapped = {}
 
+/**
+ * Wraps the `pushState` and `replaceState` methods of `window.history` and returns a corresponding event emitter
+ * scoped to the history object.
+ * @param {Object} sharedEE - The shared event emitter.
+ * @returns {Object} Scoped event emitter with a debug ID of `history`.
+ */
 export function wrapHistory(sharedEE){
   const ee = scopedEE(sharedEE)
   if (wrapped[ee.debugId] || !isBrowserScope) return ee; // History API is only relevant within web env
   wrapped[ee.debugId] = true
   var wrapFn = wfn(ee)
 
-  var prototype = window.history && window.history.constructor && window.history.constructor.prototype
-  var object = window.history
-  if (prototype && prototype.pushState && prototype.replaceState) {
-    object = prototype
-  }
-
-  wrapFn.inPlace(object, [ 'pushState', 'replaceState' ], '-')
+  /**
+   * For objects that will be instantiated more than once, we wrap the object's prototype methods. The history object
+   * is instantiated only once, so we can wrap its methods directly--and we must wrap the history methods directly as
+   * long as [Chromium issue 783382](https://bugs.chromium.org/p/chromium/issues/detail?id=783382) remains unresolved.
+   */
+  wrapFn.inPlace(window.history, [ 'pushState', 'replaceState' ], '-')
 
   return ee
 }
 
+/**
+ * Returns an event emitter scoped specifically for the history object. This scoping is a remnant from when all the
+ * features shared the same group in the event, to isolate events between features. It will likely be revisited.
+ * 
+ * @param {Object} sharedEE - Optional event emitter on which to base the scoped emitter. Uses `ee` on the global scope if undefined).
+ * @returns {Object} Scoped event emitter with a debug ID of 'history'.
+ */
 export function scopedEE(sharedEE){
-  return (sharedEE || baseEE).get('history')
+  return (sharedEE || globalEE).get('history')
 }

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -22,8 +22,6 @@ export class Instrument extends InstrumentBase {
         if (!isBrowserScope) return; // SPA not supported outside web env
 
         const agentRuntime = getRuntime(this.agentIdentifier);
-        // loader.xhrWrappable will be false in chrome for ios, but addEventListener is still available.
-        // sauce does not have a browser to test this case against, so be careful when modifying this check
         if (!win[ADD_EVENT_LISTENER] || !agentRuntime.xhrWrappable ) return
         agentRuntime.features.spa = true;
 

--- a/tests/browser/wrap-history.browser.js
+++ b/tests/browser/wrap-history.browser.js
@@ -23,7 +23,7 @@ jil.browserTest('history functions are wrapped', function (t) {
   t.end()
 })
 
-jil.browserTest('a new property is not shown in the history object', function (t) {
+jil.browserTest('two modified properties are shown on the history object', function (t) {
   // wrap
   const {setup} = require('./utils/setup')
   const {wrapHistory} = require('../../src/common/wrap/wrap-history')
@@ -31,17 +31,17 @@ jil.browserTest('a new property is not shown in the history object', function (t
   const {baseEE} = setup()
   wrapHistory(baseEE)
 
-  var proto = window.history.constructor && window.history.constructor.prototype
-  if (proto.pushState) {
-    t.equal(window.history.hasOwnProperty('pushState'), false)
-    t.equal(window.history.hasOwnProperty('replaceState'), false)
+
+  if (window.history && window.history.pushState) {
+    t.equal(window.history.hasOwnProperty('pushState'), true)
+    t.equal(window.history.hasOwnProperty('replaceState'), true)
   } else {
-    t.pass('not on constructor')
+    t.pass('no history functions')
   }
 
   t.end()
 })
-
+ 
 function isWrapped(fn) {
   return fn && (typeof fn['nr@original'] === 'function')
 }

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -11,8 +11,8 @@
       "browserName": "chrome",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "chrome",
@@ -25,8 +25,8 @@
       "browserName": "chrome",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "98",
-      "browserVersion": "98"
+      "version": "99",
+      "browserVersion": "99"
     }
   ],
   "edge": [
@@ -41,8 +41,8 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -55,8 +55,8 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "98",
-      "browserVersion": "98"
+      "version": "99",
+      "browserVersion": "99"
     }
   ],
   "safari": [
@@ -93,12 +93,12 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "101"
+      "version": "102"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "97"
+      "version": "98"
     }
   ],
   "android": [
@@ -149,10 +149,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.3",
-      "device": "iPhone 11",
-      "appium:deviceName": "iPhone 11 Simulator",
-      "appium:platformVersion": "14.3",
+      "version": "14.4",
+      "device": "iPhone Simulator",
+      "appium:deviceName": "iPhone Simulator",
+      "appium:platformVersion": "14.4",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"
@@ -163,10 +163,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "13.4",
-      "device": "iPhone XS Max",
-      "appium:deviceName": "iPhone XS Max Simulator",
-      "appium:platformVersion": "13.4",
+      "version": "14.0",
+      "device": "iPhone XR",
+      "appium:deviceName": "iPhone XR Simulator",
+      "appium:platformVersion": "14.0",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"


### PR DESCRIPTION
### Overview

This PR introduces support for Chrome for iOS by removing feature gates that previously restricted three features: XHR, SPA and STN (session trace). It also addresses one of the chromium bugs that led to the the feature gates to begin with.

Apart from removing feature gating, the operative change is to wrap the methods of `history` directly rather than wrapping the methods of that object's prototype. This was necessary because Chrome on iOS itself modifies `history` directly, thus ignoring our changes to the prototype.

For more discussion of the bugs that led to feature gating, as well as the rationale for the change in how we wrap history methods, see the comments on related JIRA tickets.

- Remove CriOS feature gate from `xhrWrappable` in `common/config/state/runtime.js`.
- Remove comment warning about CriOS and xhrWrappable in `features/spa/instrument/index.js`.
- Wrap `window.history` methods directly, not the prototype methods in `common/wrap/wrap-history.js`.
- Refactor `hasOwnProperty(...)` test for `window.history` methods in `browser/wrap-history.browser.js`.
- Add JSDoc comments to `common/wrap/wrap-history.js`.
- Update change log.

### Related Issue(s)

- [NEWRELIC-6276](https://issues.newrelic.com/browse/NEWRELIC-6276): Implement and verify support for Chrome on iOS.
- [NEWRELIC-6192](https://issues.newrelic.com/browse/NEWRELIC-6192): Validate status of bugs with Chrome on iOS.
- [Chrome Issue 471591](https://bugs.chromium.org/p/chromium/issues/detail?id=471591): Original bug that led to gating XHR.
- [Chrome Issue 783382](https://bugs.chromium.org/p/chromium/issues/detail?id=783382): Original bug that led to gating SPA, STN.

### Testing

After this PR's modifications, both JIL browser tests and a live implementation show the previously gated features (XHR, SPA, and STN) working properly on Chrome for iOS, with no consequences to existing browser support.

Because SauceLabs does not offer a browser-platform configuration for Chrome on iOS, testing must be semi- or fully-manual. It involves an iOS device connecting to JIL (for the suite of browser tests) as well as to an Angular server (for live testing), both running on a locally networked dev machine. The Angular server is the same one attached to PR 315.

Another form of testing is the inverse: ensuring other automated browser tests do not fail as a result of the changes. See the standard _Tests_ and _Polyfill Tests_ actions on this branch.
- Standard [Tests](https://github.com/newrelic/newrelic-browser-agent/actions/runs/3963303499)
- [Polyfill Tests](https://github.com/newrelic/newrelic-browser-agent/actions/runs/3964611717)

Please see the attached ticket and its predecessor for a more thorough discussion of testing decisions.