### PR TITLE
Add build version to runtime obj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Prevent time slice metric collection for ajax calls when such a call matches an 
 ### Bind navigator scope to sendBeacon
 Some browser versions will throw errors if sendBeacon does not have the navigator scope bound to it. A fail-safe action of binding the navigator scope to sendBeacon was added to try to support those browsers.
 
+### Expose build version to newrelic global
+The build version will now be exposed to the newrelic global object. It can be accessed under `newrelic.intializedAgents[<agentID>].runtime.version`.
+
 ## v1223
 
 ### Refactor loader architecture for improved developer experience

--- a/src/common/config/state/runtime.js
+++ b/src/common/config/state/runtime.js
@@ -6,6 +6,7 @@ import { gosNREUMInitializedAgents } from '../../window/nreum'
 import { getCurrentSessionIdOrMakeNew } from '../../window/session-storage'
 import { getConfigurationValue } from '../config'
 import { globalScope } from '../../util/global-scope';
+import { VERSION } from '../../constants/environment-variables'
 
 var XHR = globalScope?.XMLHttpRequest
 var XHR_PROTO = XHR && XHR.prototype
@@ -24,8 +25,14 @@ const model = agentId => { return {
   releaseIds: {},
   sessionId: getConfigurationValue(agentId, 'privacy.cookies_enabled') == true ?
     getCurrentSessionIdOrMakeNew() : null,  // if cookies (now session tracking) is turned off or can't get session ID, this is null
+<<<<<<< HEAD
   xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'],
   userAgent
+=======
+  xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'] && !/CriOS/.test(navigator.userAgent),
+  userAgent,
+  version: VERSION
+>>>>>>> 33d6e21 (add build version to runtime obj)
 }}
 
 const _cache = {}

--- a/src/common/config/state/runtime.js
+++ b/src/common/config/state/runtime.js
@@ -25,14 +25,9 @@ const model = agentId => { return {
   releaseIds: {},
   sessionId: getConfigurationValue(agentId, 'privacy.cookies_enabled') == true ?
     getCurrentSessionIdOrMakeNew() : null,  // if cookies (now session tracking) is turned off or can't get session ID, this is null
-<<<<<<< HEAD
   xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'],
-  userAgent
-=======
-  xhrWrappable: XHR && XHR_PROTO && XHR_PROTO['addEventListener'] && !/CriOS/.test(navigator.userAgent),
   userAgent,
   version: VERSION
->>>>>>> 33d6e21 (add build version to runtime obj)
 }}
 
 const _cache = {}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds the agent build version to the runtime object.  This has been requested by support eng team and external users. Along with `runtime.loaderType`, these properties will help identify the exact build running on the page.

