### PR TITLE
Format unhandled promise rejection reasons as readable err messages

### DIFF
--- a/tests/assets/unhandled-promise-rejection-readable.html
+++ b/tests/assets/unhandled-promise-rejection-readable.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init} {config} {loader}
+  </head>
+
+  <body>
+    <script>
+      new Promise((res, rej) => rej("Test"));
+      new Promise((res, rej) => rej(1));
+      new Promise((res, rej) => rej({ a: 1, b: { a: 1 } }));
+      new Promise((res, rej) => rej([1, 2, 3]));
+      new Promise((res, rej) => rej(new Error("test")));
+      new Promise((res, rej) => rej());
+      new Promise((res, rej) => rej(null));
+      new Promise((res, rej) => rej(new Error()));
+      new Promise((res, rej) => rej(new Map()));
+      new Promise((res, rej) => {
+        function Foo() {
+          this.abc = "Hello";
+        }
+        rej(new Foo());
+      });
+      new Promise((res, rej) => {
+        function Foo() {
+          this.abc = "Hello";
+          this.circular = this;
+        }
+        rej(Foo);
+      });
+      new Promise((res, rej) => {
+        function Foo() {
+          this.abc = "Hello";
+          this.circular = this;
+        }
+        rej(new Foo());
+      });
+    </script>
+    this is a generic page that is instrumented by the JS agent
+  </body>
+</html>

--- a/tests/functional/err/unhandled-rejection-readable.test.js
+++ b/tests/functional/err/unhandled-rejection-readable.test.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const testDriver = require('../../../tools/jil/index')
+const { assertErrorAttributes, assertExpectedErrors, getErrorsFromResponse } = require('./assertion-helpers')
+
+let supported = testDriver.Matcher.withFeature('sendBeacon')
+
+testDriver.test('unhandledPromiseRejections are caught and are readable', supported, function (t, browser, router) {
+  let assetURL = router.assetURL('unhandled-promise-rejection-readable.html', {
+    init: {
+      page_view_timing: {
+        enabled: false
+      },
+      metrics: {
+        enabled: false
+      }
+    }
+  })
+
+  let rumPromise = router.expectRum()
+  let errorPromise = router.expectErrors()
+  let loadPromise = browser.get(assetURL)
+
+  Promise.all([errorPromise, rumPromise, loadPromise]).then(([response]) => {
+    assertErrorAttributes(t, response.query)
+    const actualErrors = getErrorsFromResponse(response, browser)
+    const expectedErrorMessages = [
+      { message: 'Unhandled Promise Rejection: "Test"', tested: false, meta: 'string' },
+      { message: 'Unhandled Promise Rejection: 1', tested: false, meta: 'number' },
+      { message: 'Unhandled Promise Rejection: {"a":1,"b":{"a":1}}', tested: false, meta: 'nested obj' },
+      { message: 'Unhandled Promise Rejection: [1,2,3]', tested: false, meta: 'array' },
+      { message: 'Unhandled Promise Rejection: test', tested: false, meta: 'error with message' },
+      { message: 'Unhandled Promise Rejection: ', tested: false, meta: 'undefined' },
+      { message: 'Unhandled Promise Rejection: null', tested: false, meta: 'null' },
+      { message: 'Unhandled Promise Rejection: ', tested: false, meta: 'error with no message' },
+      { message: 'Unhandled Promise Rejection: {}', tested: false, meta: 'map object' },
+      { message: 'Unhandled Promise Rejection: {"abc":"Hello"}', tested: false, meta: 'factory function' },
+      { message: 'Unhandled Promise Rejection: undefined', tested: false, meta: 'uncalled function' },
+      { message: 'Unhandled Promise Rejection: ', tested: false, meta: 'circular object' }
+    ]
+    actualErrors.forEach(err => {
+      const targetError = expectedErrorMessages.find(x => !x.tested && x.message === err.params.message)
+      if (targetError) targetError.tested = true
+      t.ok(!!targetError, `expected ${targetError?.meta} message exists (${err.params.message})`)
+      t.ok(!!err.params.stack_trace, `stack_trace exists`)
+      t.ok(!!err.params.stackHash, `stackHash exists`)
+    })
+    t.ok(expectedErrorMessages.every(x => x.tested), 'All expected error messages were found')
+    t.end()
+  }).catch(fail)
+
+  function fail(err) {
+    t.error(err)
+    t.end()
+  }
+})


### PR DESCRIPTION

<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR attempts to preserve `unhandledPromiseRejection` messages as human-readable messages on the Error object that gets harvested. The previous strategy did not always work, because Promise.reject can pass any value, not just strings.

### Related Issue(s)

NEWRELIC-5921

### Testing

A new test has been added that checks that unhandledPromiseRejections that pass various data types still produce human-readable Error messages.
