### PR TITLE
Clean up warning messages and test inconsistencies

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -29,18 +29,5 @@ jobs:
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b chrome@latest -s -t 85000 --concurrent=10
-  check-failures:
-    runs-on: ubuntu-latest
-    container: node:14
-    if: contains(github.event.pull_request.labels.*.name, 'safe to test') && ${{ !failure() }}  # final check if each needed test either pass or cancelled (special circumstance) and didn't outright fail
-    needs: [chrome]
-    env:
-      NRQL_API_KEY: ${{ secrets.NRQL_API_KEY }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: checkout and build
-        uses: ./.github/actions/test-setup
 
-      - name: check failed tests
-        run: node --max-old-space-size=8192 ./tools/jil/util/get-failed-tests.js
   

--- a/.github/workflows/tests-polyfill.yml
+++ b/.github/workflows/tests-polyfill.yml
@@ -13,7 +13,6 @@ env:
 jobs:
   ie-functional:
     timeout-minutes: 90
-    continue-on-error: true
     runs-on: ubuntu-latest
     container: node:14
 
@@ -32,7 +31,6 @@ jobs:
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -P -b ie@* -s -t 85000 --concurrent=5 --functional-only
   ie-unit:
     timeout-minutes: 90
-    continue-on-error: true
     runs-on: ubuntu-latest
     container: node:14
 
@@ -49,19 +47,3 @@ jobs:
 
       - name: run tests
         run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -P -b ie@* -s -t 85000 --concurrent=5 --unit-only
-#  polyfill-check-failures:
-#    runs-on: ubuntu-latest
-#    continue-on-error: true
-#    container: node:14
-#    if: ${{ !failure() }}  # final check if each needed test either pass or cancelled (special circumstance) and didn't outright fail
-#    needs: [ie-functional, ie-unit]
-#    env:
-#
-#      NRQL_API_KEY: ${{ secrets.NRQL_API_KEY }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: checkout and build
-#        uses: ./.github/actions/test-setup
-#
-#      - name: check failed tests
-#        run: node --max-old-space-size=8192 ./tools/jil/util/get-failed-tests.js

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -27,7 +27,7 @@ export class InstrumentBase extends FeatureBase {
           new Aggregate(this.agentIdentifier, this.aggregator)
           this.resolve()
         } catch (e) {
-          warn(`Failed to import aggregator class for ${this.featureName}`, e)
+          warn(`Something prevented the agent from being downloaded`)
         }
       }
       // theres no window.load event on non-browser scopes, lazy load immediately

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -27,7 +27,7 @@ export class InstrumentBase extends FeatureBase {
           new Aggregate(this.agentIdentifier, this.aggregator)
           this.resolve()
         } catch (e) {
-          warn(`Something prevented the agent from being downloaded`)
+          warn('Something prevented the agent from being downloaded.')
         }
       }
       // theres no window.load event on non-browser scopes, lazy load immediately

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -45,14 +45,16 @@ export class MicroAgent {
                 if (enabledFeatures[f]) {
                     import(`../features/${f}/instrument`).then(({ Instrument }) => {
                         this.features[f] = new Instrument(this.agentIdentifier, this.sharedAggregator)
-                    }).catch(err => warn(`Failed to import ${f}`, err))
+                    }).catch(err => 
+                        warn(`Something prevented the agent from being downloaded`))
                 }
             })
             nonAutoFeatures.forEach(f => {
                 if (enabledFeatures[f]) {
                     import(`../features/${f}/aggregate`).then(({ Aggregate }) => {
                         this.features[f] = new Aggregate(this.agentIdentifier, this.sharedAggregator)
-                    }).catch(err => warn(`Failed to import ${f}`, err))
+                    }).catch(err =>
+                        warn(`Something prevented the agent from being downloaded`))
                 }
             })
             gosNREUMInitializedAgents(this.agentIdentifier, this.features, 'features')

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -46,7 +46,7 @@ export class MicroAgent {
                     import(`../features/${f}/instrument`).then(({ Instrument }) => {
                         this.features[f] = new Instrument(this.agentIdentifier, this.sharedAggregator)
                     }).catch(err => 
-                        warn(`Something prevented the agent from being downloaded`))
+                        warn('Something prevented the agent from being downloaded.'))
                 }
             })
             nonAutoFeatures.forEach(f => {
@@ -54,13 +54,13 @@ export class MicroAgent {
                     import(`../features/${f}/aggregate`).then(({ Aggregate }) => {
                         this.features[f] = new Aggregate(this.agentIdentifier, this.sharedAggregator)
                     }).catch(err =>
-                        warn(`Something prevented the agent from being downloaded`))
+                        warn('Something prevented the agent from being downloaded.'))
                 }
             })
             gosNREUMInitializedAgents(this.agentIdentifier, this.features, 'features')
             return this
         } catch (err) {
-            warn(`Failed to initialize instrument classes`, err)
+            warn('Failed to initialize instrument classes.', err)
             return false
         }
     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR cleans up warning messages about blocked scripts from CSP/ad blockers, and gets rid of false positives from cron tests

The warning no longer includes an error body + stack trace to diffuse tensions among customer that were artificially created by including that information in the message when it has nothing to do with the agent executing, and more to do with content-blocking on the page preventing lazy chunks from being imported.

Test workflows were modified to alleviate false positives that were occurring. Allowing a concrete pass-fail state is useful in these tests because they are directly linked to changelog badges, and are used to determine status for cutting a release.  