### PR TITLE
NR-86614: Implementing centralized lazy loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Some older IE-related code is removed, and so is a query param in our page view 
 Related to failed imports, a "loading chunk 629" error was thrown despite the intention to just catch it as a warning. The cause was actually an uncaught promise in the code,
 which has now been fixed and the error silenced.
 
+### Resolving google indexing of agent relative paths
+In previous version, the agent script that was injected or copied/pasted into page HTML included relative paths to the agents lazy chunks. Google indexing picked these relative paths up and attempted to index them as pages. This change removes those relatives paths from the loader and centralizes our lazy chunk loading for agent features.
+
 ## v1224
 
 ### Support SPA, XHR, and session trace features on Chrome for iOS

--- a/src/features/session_trace/constants.js
+++ b/src/features/session_trace/constants.js
@@ -12,3 +12,4 @@ export const FN_END = 'fn' + END
 export const BST_TIMER = 'bstTimer'
 export const PUSH_STATE = 'pushState'
 export const ORIG_EVENT = originals.EV
+export const ADD_EVENT_LISTENER = 'addEventListener'

--- a/src/features/session_trace/instrument/index.js
+++ b/src/features/session_trace/instrument/index.js
@@ -13,7 +13,7 @@ import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { isBrowserScope } from '../../../common/util/global-scope'
 
 const {
-  BST_RESOURCE, BST_TIMER, END, FEATURE_NAME, FN_END, FN_START,
+  BST_RESOURCE, BST_TIMER, END, FEATURE_NAME, FN_END, FN_START, ADD_EVENT_LISTENER,
   PUSH_STATE, RESOURCE, RESOURCE_TIMING_BUFFER_FULL, START, ORIG_EVENT: origEvent
 } = CONSTANTS
 const CRT = "clearResourceTimings";
@@ -79,7 +79,7 @@ export class Instrument extends InstrumentBase {
       observeResourceTimings()
     } else {
       // collect resource timings once when buffer is full
-      if (window.performance[CRT])
+      if (window.performance[CRT] && window.performance[ADD_EVENT_LISTENER])
         window.performance.addEventListener(RESOURCE_TIMING_BUFFER_FULL, this.onResourceTimingBufferFull, eventListenerOpts(false));
     }
 

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -20,15 +20,15 @@ export class InstrumentBase extends FeatureBase {
   importAggregator() {
     if (this.hasAggregator || !this.auto) return
     this.hasAggregator = true
-    const importLater = async () => {
-      /** Note this try-catch differs from the one in Agent.start() in that it's placed later in a page's lifecycle and
-       *  it's only responsible for aborting its one specific feature, rather than all. */
+    const lazyLoad = async () => {
       try {
-        const { Aggregate } = await import(`../../features/${this.featureName}/aggregate`)
-        new Aggregate(this.agentIdentifier, this.aggregator)
+        const { lazyLoader } = await import(/* webpackChunkName: "lazy-loader" */ './lazy-loader')
+        const { Aggregate } = await lazyLoader(this.featureName, 'aggregate');
+        new Aggregate(this.agentIdentifier, this.aggregator);
+        this.resolve();
       } catch (e) {
-        warn(`Downloading ${this.featureName} failed...`);
-        this.abortHandler?.();  // undo any important alterations made to the page
+        warn('Something prevented the agent from being downloaded.')
+        return null
       }
     }
 

--- a/src/features/utils/lazy-loader.js
+++ b/src/features/utils/lazy-loader.js
@@ -1,0 +1,50 @@
+import { FEATURE_NAMES } from "../../loaders/features/features";
+
+/**
+ * Centralizes the lazy loading of agent feature aggregate and instrument sources.
+ *
+ * This function uses two defined switch cases to allow us to easily name our chunks and re-use these
+ * chunks for different agent types. We do not use template strings or string concatenation here because
+ * doing so makes it much more difficult to name the chunks and forces Webpack to "guess" what the chunks
+ * should be.
+ * @param featureName Name of the feature to import such as ajax or session_trace
+ * @param featurePart Name of the feature part to load; should be either instrument or aggregate
+ * @returns {Promise<InstrumentBase|AggregateBase|null>}
+ */
+export function lazyLoader(featureName, featurePart) {
+  if (featurePart === 'aggregate') {
+    switch (featureName) {
+      case FEATURE_NAMES.ajax:
+        return import(/* webpackChunkName: "ajax-aggregate" */ '../ajax/aggregate');
+      case FEATURE_NAMES.jserrors:
+        return import(/* webpackChunkName: "jserrors-aggregate" */ '../jserrors/aggregate');
+      case FEATURE_NAMES.metrics:
+        return import(/* webpackChunkName: "metrics-aggregate" */ '../metrics/aggregate');
+      case FEATURE_NAMES.pageAction:
+        return import(/* webpackChunkName: "page_action-aggregate" */ '../page_action/aggregate');
+      case FEATURE_NAMES.pageViewEvent:
+        return import(/* webpackChunkName: "page_view_event-aggregate" */ '../page_view_event/aggregate');
+      case FEATURE_NAMES.sessionTrace:
+        return import(/* webpackChunkName: "session_trace-aggregate" */ '../session_trace/aggregate');
+      case FEATURE_NAMES.spa:
+        return import(/* webpackChunkName: "spa-aggregate" */ '../spa/aggregate');
+    }
+  } else if (featurePart === 'instrument') {
+    switch (featureName) {
+      case FEATURE_NAMES.ajax:
+        return import(/* webpackChunkName: "ajax-instrument" */ '../ajax/instrument');
+      case FEATURE_NAMES.jserrors:
+        return import(/* webpackChunkName: "jserrors-instrument" */ '../jserrors/instrument');
+      case FEATURE_NAMES.metrics:
+        return import(/* webpackChunkName: "metrics-instrument" */ '../metrics/instrument');
+      case FEATURE_NAMES.pageAction:
+        return import(/* webpackChunkName: "page_action-instrument" */ '../page_action/instrument');
+      case FEATURE_NAMES.pageViewEvent:
+        return import(/* webpackChunkName: "page_view_event-instrument" */ '../page_view_event/instrument');
+      case FEATURE_NAMES.sessionTrace:
+        return import(/* webpackChunkName: "session_trace-instrument" */ '../session_trace/instrument');
+      case FEATURE_NAMES.spa:
+        return import(/* webpackChunkName: "spa-instrument" */ '../spa/instrument');
+    }
+  }
+}

--- a/src/features/utils/lazy-loader.js
+++ b/src/features/utils/lazy-loader.js
@@ -24,10 +24,14 @@ export function lazyLoader(featureName, featurePart) {
         return import(/* webpackChunkName: "page_action-aggregate" */ '../page_action/aggregate');
       case FEATURE_NAMES.pageViewEvent:
         return import(/* webpackChunkName: "page_view_event-aggregate" */ '../page_view_event/aggregate');
+      case FEATURE_NAMES.pageViewTiming:
+        return import(/* webpackChunkName: "page_view_timing-aggregate" */ '../page_view_timing/aggregate');
       case FEATURE_NAMES.sessionTrace:
         return import(/* webpackChunkName: "session_trace-aggregate" */ '../session_trace/aggregate');
       case FEATURE_NAMES.spa:
         return import(/* webpackChunkName: "spa-aggregate" */ '../spa/aggregate');
+      default:
+        throw new Error(`Attempted to load unsupported agent feature: ${featureName} ${featurePart}`);
     }
   } else if (featurePart === 'instrument') {
     switch (featureName) {
@@ -41,10 +45,14 @@ export function lazyLoader(featureName, featurePart) {
         return import(/* webpackChunkName: "page_action-instrument" */ '../page_action/instrument');
       case FEATURE_NAMES.pageViewEvent:
         return import(/* webpackChunkName: "page_view_event-instrument" */ '../page_view_event/instrument');
+      case FEATURE_NAMES.pageViewTiming:
+        return import(/* webpackChunkName: "page_view_timing-instrument" */ '../page_view_timing/instrument');
       case FEATURE_NAMES.sessionTrace:
         return import(/* webpackChunkName: "session_trace-instrument" */ '../session_trace/instrument');
       case FEATURE_NAMES.spa:
         return import(/* webpackChunkName: "spa-instrument" */ '../spa/instrument');
+      default:
+        throw new Error(`Attempted to load unsupported agent feature: ${featureName} ${featurePart}`);
     }
   }
 }

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -123,15 +123,9 @@ export function setAPI(agentIdentifier, nr, forceDrain) {
   else onWindowLoad(() => lazyLoad(), true)
 
   function lazyLoad() {
-    import('./apiAsync').then(({ setAPI }) => {
+    import(/* webpackChunkName: "async-api" */'./apiAsync').then(({ setAPI }) => {
       setAPI(agentIdentifier)
       drain(agentIdentifier, 'api')
     }).catch(() => warn("Downloading runtime APIs failed..."));
   }
-
-  // experimental feature -- not ready
-  // nr.BrowserAgentInstance = async function (){
-  //   const { BrowserAgent } = await import('@newrelic/browser-agent')
-  //   return new BrowserAgent()
-  // }
 }

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -43,15 +43,19 @@ export class MicroAgent {
             const enabledFeatures = getEnabledFeatures(this.agentIdentifier)
             autoFeatures.forEach(f => {
                 if (enabledFeatures[f]) {
-                    import(`../features/${f}/instrument`).then(({ Instrument }) => {
+                    import(/* webpackChunkName: "lazy-loader" */ '../features/utils/lazy-loader').then(({lazyLoader}) => {
+                        return lazyLoader(f, 'instrument')
+                    }).then(({ Instrument }) => {
                         this.features[f] = new Instrument(this.agentIdentifier, this.sharedAggregator)
-                    }).catch(err => 
+                    }).catch(err =>
                         warn('Something prevented the agent from being downloaded.'))
                 }
             })
             nonAutoFeatures.forEach(f => {
                 if (enabledFeatures[f]) {
-                    import(`../features/${f}/aggregate`).then(({ Aggregate }) => {
+                    import(/* webpackChunkName: "lazy-loader" */ '../features/utils/lazy-loader').then(({lazyLoader}) => {
+                        return lazyLoader(f, 'aggregate')
+                    }).then(({ Aggregate }) => {
                         this.features[f] = new Aggregate(this.agentIdentifier, this.sharedAggregator)
                     }).catch(err =>
                         warn('Something prevented the agent from being downloaded.'))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,7 +82,7 @@ if (PR_NAME) console.log("PR_NAME", PR_NAME)
 const instantiateSourceMapPlugin = (filename) => {
   return new webpack.SourceMapDevToolPlugin({
     append: MAP_PATH, // sourceMappingURL CDN route vs local route (for sourceMappingURL)
-    filename: filename || (SUBVERSION === 'PROD' ? `[name].[hash:8].map` : `[name].map`),
+    filename: filename || (SUBVERSION === 'PROD' ? `[name].[chunkhash:8].map` : `[name].map`),
     ...(JSON.parse(SOURCEMAPS) === false && { exclude: new RegExp(".*") }) // Exclude all files if disabled.
   })
 }
@@ -120,7 +120,7 @@ const commonConfig = {
   },
   output: {
     filename: `[name].js`,
-    chunkFilename: SUBVERSION === 'PROD' ? `[name].[hash:8]${PATH_VERSION}.js` : `[name]${PATH_VERSION}.js`,
+    chunkFilename: SUBVERSION === 'PROD' ? `[name].[chunkhash:8]${PATH_VERSION}.min.js` : `[name]${PATH_VERSION}.js`,
     path: path.resolve(__dirname, './build'),
     publicPath: PUBLIC_PATH, // CDN route vs local route (for linking chunked assets)
     clean: false
@@ -242,12 +242,12 @@ const polyfillsConfig = merge(commonConfig, {
      * overwrite with either an ES5 or ES6 target. For differentiated transpilation of dynamically loaded dependencies
      * in non-production builds, we can tag output filenames for chunks of the polyfills bundle with `-es5`.
      */
-    chunkFilename: SUBVERSION === 'PROD' ? `[name].[hash:8]${PATH_VERSION}.js` : `[name]-es5${PATH_VERSION}.js`
+    chunkFilename: SUBVERSION === 'PROD' ? `[name].[chunkhash:8]-es5${PATH_VERSION}.min.js` : `[name]-es5${PATH_VERSION}.js`
   },
   plugins: [
     instantiateBundleAnalyzerPlugin('polyfills'),
     // Source map outputs must also must be tagged to prevent standard/polyfill filename collisions in non-production.
-    instantiateSourceMapPlugin(SUBVERSION === 'PROD' ? `[name].[hash:8].map` : `[name]-es5.map`)
+    instantiateSourceMapPlugin(SUBVERSION === 'PROD' ? `[name].[chunkhash:8].map` : `[name]-es5.map`)
   ],
   target: 'browserslist:ie >= 11' // Applies to webpack's own runtime output; babel-loader only impacts bundled modules.
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

This centralizes the lazy loading logic into a function that can be used by all agent types. This uses defined logic blocks and switch cases instead of template strings or string concatenation on purpose. Doing it this way ensures webpack does not need to "guess" what our chunks are and also allows us to easily name those chunks.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-86614

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

All the tests cases should still pass.
