### PR TITLE
Reverting "scrap old runtime.features from RUM query"

### DIFF
--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -9,7 +9,7 @@ import { getConfigurationValue, getInfo, getRuntime } from '../../../common/conf
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
-import { getFeatureFlags } from './initialized-features'
+import { getActivatedFeaturesFlags } from './initialized-features'
 
 const jsonp = 'NREUM.setToken'
 
@@ -59,7 +59,7 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('us', info.user))
     chunksForQueryString.push(param('ac', info.account))
     chunksForQueryString.push(param('pr', info.product))
-    chunksForQueryString.push(param('af', getFeatureFlags(this.agentIdentifier).join(',')))
+    chunksForQueryString.push(param('af', getActivatedFeaturesFlags(this.agentIdentifier).join(',')))
 
     if (window.performance && typeof (window.performance.timing) !== 'undefined') {
       var navTimingApiData = ({

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -9,6 +9,7 @@ import { getConfigurationValue, getInfo, getRuntime } from '../../../common/conf
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
+import { getFeatureFlags } from './initialized-features'
 
 const jsonp = 'NREUM.setToken'
 
@@ -58,6 +59,7 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('us', info.user))
     chunksForQueryString.push(param('ac', info.account))
     chunksForQueryString.push(param('pr', info.product))
+    chunksForQueryString.push(param('af', getFeatureFlags(this.agentIdentifier).join(',')))
 
     if (window.performance && typeof (window.performance.timing) !== 'undefined') {
       var navTimingApiData = ({

--- a/src/features/page_view_event/aggregate/initialized-features.js
+++ b/src/features/page_view_event/aggregate/initialized-features.js
@@ -6,7 +6,7 @@ import { FEATURE_NAMES } from '../../../loaders/features/features'
  * @param {String} agentId - the ID of the initialized agent on the page, mapping to the one under the global 'newrelic' object
  * @returns {String[]} Up to 5 short strings corresponding to ingest mapping of features.
  */
-export function getFeatureFlags (agentId) {
+export function getActivatedFeaturesFlags (agentId) {
   const flagArr = []
 
   Object.keys(newrelic.initializedAgents[agentId].features).forEach(featName => {

--- a/src/features/page_view_event/aggregate/initialized-features.js
+++ b/src/features/page_view_event/aggregate/initialized-features.js
@@ -1,0 +1,31 @@
+import { FEATURE_NAMES } from '../../../loaders/features/features'
+
+/**
+ * Get an array of flags required by downstream (NR UI) based on the features initialized in this agent
+ * (aka what is running on the page).
+ * @param {String} agentId - the ID of the initialized agent on the page, mapping to the one under the global 'newrelic' object
+ * @returns {Array} Up to 5 short strings corresponding to ingest mapping of features.
+ */
+export function getFeatureFlags (agentId) {
+  const flagArr = []
+
+  Object.keys(newrelic.initializedAgents[agentId].features).forEach(featName => {
+    switch (featName) {
+      case FEATURE_NAMES.ajax:
+        flagArr.push('xhr'); break
+      case FEATURE_NAMES.jserrors:
+        flagArr.push('err'); break
+      case FEATURE_NAMES.pageAction:
+        flagArr.push('ins'); break
+      case FEATURE_NAMES.sessionTrace:
+        flagArr.push('stn'); break
+      case FEATURE_NAMES.spa:
+        flagArr.push('spa'); break
+    }
+  })
+
+  return flagArr
+}
+
+// Note: this module and the "af" param in src/features/page_view_event/aggregate/index.js can be removed in the future at such time
+// that it's no longer being used. For the browser agent, this is an unused flag system.

--- a/src/features/page_view_event/aggregate/initialized-features.js
+++ b/src/features/page_view_event/aggregate/initialized-features.js
@@ -4,7 +4,7 @@ import { FEATURE_NAMES } from '../../../loaders/features/features'
  * Get an array of flags required by downstream (NR UI) based on the features initialized in this agent
  * (aka what is running on the page).
  * @param {String} agentId - the ID of the initialized agent on the page, mapping to the one under the global 'newrelic' object
- * @returns {Array} Up to 5 short strings corresponding to ingest mapping of features.
+ * @returns {String[]} Up to 5 short strings corresponding to ingest mapping of features.
  */
 export function getFeatureFlags (agentId) {
   const flagArr = []


### PR DESCRIPTION
### Overview

Following #391 , some flags required by downstream UI logic is put back into the agent to not break things.

### Related Issue(s)

These flags get turned into `entity.agentFeature` by ingest and then used for displays in NR1.

### Testing

Pre-391 and current existing tests all ignore these flags, as it's not relevant to the browser agent.
