### PR TITLE
Fix niche getter error in unhandledPromiseRejections - NR-89675

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     'tests/assets/js/internal/**/*',
     'tests/assets/js/vendor/**/*',
     'tests/assets/modular/js-errors/js/vendor/**/*',
+    'tools/test-builds/**/*',
 
     // Remove the below ignores once lint errors are fixed
     'tools/scripts/publish-current.js',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ### Enable back/forward cache
 Updating the agent default configuration to enable the back/forward cache feature previously released in version 1222 by default.
 
+### Handle unhandledPromiseRejections more gracefully
+The agent will attempt to handle niche objects throw from `unhandledPromiseRejection` events more gracefully. These cases could include objects with frozen or static properties, or custom extensions of the Error class without a `set` method in place.
+
 ## v1225
 
 ### Gracefully abort agent if not fully instantiated

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -144,10 +144,7 @@ function notice (err, doNotStamp, ee) {
  */
 function castReasonToError (reason) {
   let prefix = 'Unhandled Promise Rejection: '
-  if (reason instanceof Error) {
-    reason.message = prefix + reason.message
-    return reason
-  }
+  if (reason instanceof Error) return reason
   if (typeof reason === 'undefined') return new Error(prefix)
   try {
     return new Error(prefix + JSON.stringify(reason))

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -144,7 +144,14 @@ function notice (err, doNotStamp, ee) {
  */
 function castReasonToError (reason) {
   let prefix = 'Unhandled Promise Rejection: '
-  if (reason instanceof Error) return reason
+  if (reason instanceof Error) {
+    try {
+      reason.message = prefix + reason.message
+      return reason
+    } catch (e) {
+      return reason
+    }
+  }
   if (typeof reason === 'undefined') return new Error(prefix)
   try {
     return new Error(prefix + JSON.stringify(reason))

--- a/tests/assets/unhandled-promise-rejection-readable.html
+++ b/tests/assets/unhandled-promise-rejection-readable.html
@@ -11,11 +11,21 @@
 
   <body>
     <script>
+      "use strict";
       new Promise((res, rej) => rej("Test"));
       new Promise((res, rej) => rej(1));
       new Promise((res, rej) => rej({ a: 1, b: { a: 1 } }));
       new Promise((res, rej) => rej([1, 2, 3]));
       new Promise((res, rej) => rej(new Error("test")));
+      new Promise((res, rej) => {
+        class MyError extends Error {
+          constructor(message){
+              super(message)
+              Object.defineProperty(this, 'message', {get: () => message});
+          }
+        }
+        rej(new MyError("test"))
+      });
       new Promise((res, rej) => rej());
       new Promise((res, rej) => rej(null));
       new Promise((res, rej) => rej(new Error()));

--- a/tests/assets/unhandled-promise-rejection-readable.html
+++ b/tests/assets/unhandled-promise-rejection-readable.html
@@ -12,38 +12,38 @@
   <body>
     <script>
       "use strict";
-      new Promise((res, rej) => rej("Test"));
-      new Promise((res, rej) => rej(1));
-      new Promise((res, rej) => rej({ a: 1, b: { a: 1 } }));
-      new Promise((res, rej) => rej([1, 2, 3]));
-      new Promise((res, rej) => rej(new Error("test")));
-      new Promise((res, rej) => {
+      new Promise(function(res, rej) { rej("Test") });
+      new Promise(function(res, rej) { rej(1) });
+      new Promise(function(res, rej) { rej({ a: 1, b: { a: 1 } }) });
+      new Promise(function(res, rej) { rej([1, 2, 3]) });
+      new Promise(function(res, rej) { rej(new Error("test")) });
+      new Promise(function(res, rej) { 
         class MyError extends Error {
           constructor(message){
               super(message)
-              Object.defineProperty(this, 'message', {get: () => message});
+              Object.defineProperty(this, 'message', {get: function(){ message } });
           }
         }
         rej(new MyError("test"))
       });
-      new Promise((res, rej) => rej());
-      new Promise((res, rej) => rej(null));
-      new Promise((res, rej) => rej(new Error()));
-      new Promise((res, rej) => rej(new Map()));
-      new Promise((res, rej) => {
+      new Promise(function(res, rej) { rej() });
+      new Promise(function(res, rej) { rej(null) });
+      new Promise(function(res, rej) { rej(new Error()) });
+      new Promise(function(res, rej) { rej(new Map()) });
+      new Promise(function(res, rej) {
         function Foo() {
           this.abc = "Hello";
         }
         rej(new Foo());
       });
-      new Promise((res, rej) => {
+      new Promise(function(res, rej) {
         function Foo() {
           this.abc = "Hello";
           this.circular = this;
         }
         rej(Foo);
       });
-      new Promise((res, rej) => {
+      new Promise(function(res, rej) {
         function Foo() {
           this.abc = "Hello";
           this.circular = this;

--- a/tests/functional/err/unhandled-rejection-readable.test.js
+++ b/tests/functional/err/unhandled-rejection-readable.test.js
@@ -33,6 +33,7 @@ testDriver.test('unhandledPromiseRejections are caught and are readable', suppor
       { message: 'Unhandled Promise Rejection: {"a":1,"b":{"a":1}}', tested: false, meta: 'nested obj' },
       { message: 'Unhandled Promise Rejection: [1,2,3]', tested: false, meta: 'array' },
       { message: 'Unhandled Promise Rejection: test', tested: false, meta: 'error with message' },
+      { message: 'test', tested: false, meta: 'error with no setter with message' },
       { message: 'Unhandled Promise Rejection: ', tested: false, meta: 'undefined' },
       { message: 'Unhandled Promise Rejection: null', tested: false, meta: 'null' },
       { message: 'Unhandled Promise Rejection: ', tested: false, meta: 'error with no message' },


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR fixes an issue where niche browsers will throw an error when trying to set the message on the promise error.  We can avoid this by simply just returning the error if present without modifying it.

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
* https://newrelic-neworg.lightning.force.com/lightning/r/Case/5008W000011bs99QAA/view
* https://issues.newrelic.com/browse/NR-89675
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

