### PR TITLE
Defaulting harvest times to 5 seconds for integration tests

### DIFF
--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -16,17 +16,17 @@
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "103",
-      "browserVersion": "103"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "100",
-      "browserVersion": "100"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "101",
+      "browserVersion": "101"
     }
   ],
   "edge": [

--- a/tools/testing-server/test-handle.js
+++ b/tools/testing-server/test-handle.js
@@ -213,9 +213,23 @@ module.exports = class TestHandle {
       ),
       deepmerge(
         {
-          loader: 'full',
+          loader: 'spa',
           config: {
             licenseKey: this.#testId
+          },
+          init: {
+            harvest: {
+              tooManyRequestsDelay: 10
+            },
+            // Default all harvests to 5 seconds...this is a sweet spot between performance and race conditions
+            ajax: { enabled: true, harvestTimeSeconds: 5 },
+            jserrors: { enabled: true, harvestTimeSeconds: 5 },
+            metrics: { enabled: true, harvestTimeSeconds: 5 },
+            page_action: { enabled: true, harvestTimeSeconds: 5 },
+            page_view_event: { enabled: true },
+            page_view_timing: { enabled: true, harvestTimeSeconds: 5 },
+            session_trace: { enabled: true, harvestTimeSeconds: 5 },
+            spa: { enabled: true, harvestTimeSeconds: 5 }
           }
         },
         query
@@ -233,7 +247,7 @@ module.exports = class TestHandle {
     return urlFor(
       '/tests/assets/browser.html',
       {
-        loader: 'full',
+        loader: 'spa',
         config: {
           licenseKey: this.#testId,
           assetServerPort: this.testServer.assetServer.port,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Defaulting the harvest time to 5 seconds for all features when running integrations tests. This is a sweet spot where tests don't fail due to race conditions and timings but the tests are a bit faster.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

N/A

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Run jil tests locally and make sure nothing fails.