### PR TITLE
NEWRELIC-6934: Re-wrap promise.prototype

### DIFF
--- a/src/common/event-emitter/contextual-ee.js
+++ b/src/common/event-emitter/contextual-ee.js
@@ -46,7 +46,7 @@ function ee (old, debugId) {
     listeners: listeners,
     context: context,
     buffer: bufferEventsByGroup,
-    abort: abortIfNotLoaded,
+    abort,
     aborted: false,
     isBuffering: isBuffering,
     debugId,
@@ -148,12 +148,7 @@ function getNewContext () {
   return new EventContext()
 }
 
-// abort should be called 30 seconds after the page has started running
-// We should drop our data and stop collecting if we still have a backlog, which
-// signifies the rest of the agent wasn't loaded
-function abortIfNotLoaded () {
-  if (globalInstance.backlog.api || globalInstance.backlog.feature) {
-    globalInstance.aborted = true
-    globalInstance.backlog = {}
-  }
+function abort () {
+  globalInstance.aborted = true
+  globalInstance.backlog = {}
 }

--- a/src/common/wrap/wrap-fetch.js
+++ b/src/common/wrap/wrap-fetch.js
@@ -66,7 +66,7 @@ export function wrapFetch (sharedEE) {
         ee.emit(prefix + 'start', [args, dtPayload], origPromiseFromFetch)
 
         // Note we need to cast the returned (orig) Promise from native APIs into the current global Promise, which may or may not be our WrappedPromise.
-        return globalScope.Promise.resolve(origPromiseFromFetch).then(function (val) {
+        return origPromiseFromFetch.then(function (val) {
           ee.emit(prefix + 'end', [null, val], origPromiseFromFetch)
           return val
         }, function (err) {

--- a/src/common/wrap/wrap-promise.js
+++ b/src/common/wrap/wrap-promise.js
@@ -36,6 +36,15 @@ export function wrapPromise (sharedEE) {
     })
     WrappedPromise.toString = function () { return prevPromiseObj.toString() }
 
+    // Adds support for instanceof comparison for async functions
+    if (typeof Symbol === 'function' && typeof Symbol.hasInstance === 'symbol') {
+      Object.defineProperty(WrappedPromise, Symbol.hasInstance, {
+        value: function (instance) {
+          return instance instanceof prevPromiseObj
+        }
+      })
+    }
+
     function WrappedPromise (executor) {
       var ctx = promiseEE.context()
       var wrappedExecutor = promiseWrapper(executor, 'executor-', ctx, null, false)

--- a/src/common/wrap/wrap-promise.js
+++ b/src/common/wrap/wrap-promise.js
@@ -91,9 +91,9 @@ export function wrapPromise (sharedEE) {
     /*
      * Ideally, we create a new WrappedPromise.prototype chained off the original Promise's so that we don't alter it.
      * However, there's no way to make the (native) promise returned from async functions use our WrappedPromise,
-     * so we have to modify the original prototype in essence. This ensures that "async()"" promise functions and runs the
-     * same instance methods as "new Promise()", and also that instanceof async() is the global Promise (see GH issue #409).
-     *  In addition, this affects the fetch() promise too.
+     * so we have to modify the original prototype. This ensures that promises returned from async functions execute
+     * the same instance methods as promises created with "new Promise()", and also that instanceof async() is
+     * the global Promise (see GH issue #409). This also affects the promise returned from fetch().
      */
     WrappedPromise.prototype = prevPromiseObj.prototype
 

--- a/src/common/wrap/wrap-promise.js
+++ b/src/common/wrap/wrap-promise.js
@@ -5,7 +5,7 @@
 /**
  * This module is used by: spa
  */
-import { createWrapperWithEmitter as wrapFn } from './wrap-function'
+import { createWrapperWithEmitter as wrapFn, flag, unwrapFunction } from './wrap-function'
 import { ee as baseEE, getOrSetContext } from '../event-emitter/contextual-ee'
 import { originals } from '../config/config'
 import { globalScope } from '../util/global-scope'
@@ -36,26 +36,23 @@ export function wrapPromise (sharedEE) {
     })
     WrappedPromise.toString = function () { return prevPromiseObj.toString() }
 
-    // Adds support for instanceof comparison for async functions
-    if (typeof Symbol === 'function' && typeof Symbol.hasInstance === 'symbol') {
-      Object.defineProperty(WrappedPromise, Symbol.hasInstance, {
-        value: function (instance) {
-          return instance instanceof prevPromiseObj
-        }
-      })
-    }
-
+    /**
+     * This constitutes the global used when calling "Promise.staticMethod" or chaining off a "new Promise()" object.
+     * @param {Function} executor - to be executed by the original Promise constructor
+     * @returns A new WrappedPromise object prototyped off the original.
+     */
     function WrappedPromise (executor) {
       var ctx = promiseEE.context()
       var wrappedExecutor = promiseWrapper(executor, 'executor-', ctx, null, false)
 
-      const newCustomPromiseInst = Reflect.construct(prevPromiseObj, [wrappedExecutor], WrappedPromise) // extend the orig Promise constructor as super
+      const newCustomPromiseInst = Reflect.construct(prevPromiseObj, [wrappedExecutor], WrappedPromise) // new Promises will use WrappedPromise.prototype as theirs prototype
 
       promiseEE.context(newCustomPromiseInst).getCtx = function () {
         return ctx
       }
       return newCustomPromiseInst
     }
+
     // Make WrappedPromise inherit statics from the orig Promise.
     Object.setPrototypeOf(WrappedPromise, prevPromiseObj);
 
@@ -79,7 +76,6 @@ export function wrapPromise (sharedEE) {
         }
       }
     });
-
     ['resolve', 'reject'].forEach(function (method) {
       const prevStaticFn = prevPromiseObj[method]
       WrappedPromise[method] = function (val) { // and the same for ".resolve" and ".reject"
@@ -92,23 +88,32 @@ export function wrapPromise (sharedEE) {
       }
     })
 
-    // Mirror the orig Promise's prototype (catch, try, then, etc.) but with our own methods.
-    WrappedPromise.prototype = Object.create(prevPromiseObj.prototype)
-    WrappedPromise.prototype.constructor = WrappedPromise // calls to "new Promise()" should use our custom Promise
-    WrappedPromise.prototype.then = function (...args) {
+    /*
+     * Ideally, we create a new WrappedPromise.prototype chained off the original Promise's so that we don't alter it.
+     * However, there's no way to make the (native) promise returned from async functions use our WrappedPromise,
+     * so we have to modify the original prototype in essence. This ensures that "async()"" promise functions and runs the
+     * same instance methods as "new Promise()", and also that instanceof async() is the global Promise (see GH issue #409).
+     *  In addition, this affects the fetch() promise too.
+     */
+    WrappedPromise.prototype = prevPromiseObj.prototype
+
+    // Note that this wrapping affects the same originals.PR (prototype) object.
+    const prevPromiseOrigThen = prevPromiseObj.prototype.then
+    prevPromiseObj.prototype.then = function wrappedThen (...args) {
       var originalThis = this
       var ctx = getContext(originalThis)
       ctx.promise = originalThis
       args[0] = promiseWrapper(args[0], 'cb-', ctx, null, false)
       args[1] = promiseWrapper(args[1], 'cb-', ctx, null, false)
 
-      const origFnCallWithThis = prevPromiseObj.prototype.then.apply(this, args)
+      const origFnCallWithThis = prevPromiseOrigThen.apply(this, args)
 
       ctx.nextPromise = origFnCallWithThis
       promiseEE.emit('propagate', [originalThis, true], origFnCallWithThis, false, false)
 
       return origFnCallWithThis
     }
+    prevPromiseObj.prototype.then[flag] = prevPromiseOrigThen
 
     promiseEE.on('executor-start', function (args) {
       args[0] = promiseWrapper(args[0], 'resolve-', this, null, false)

--- a/src/common/wrap/wrap-promise.js
+++ b/src/common/wrap/wrap-promise.js
@@ -5,7 +5,7 @@
 /**
  * This module is used by: spa
  */
-import { createWrapperWithEmitter as wrapFn, flag, unwrapFunction } from './wrap-function'
+import { createWrapperWithEmitter as wrapFn, flag } from './wrap-function'
 import { ee as baseEE, getOrSetContext } from '../event-emitter/contextual-ee'
 import { originals } from '../config/config'
 import { globalScope } from '../util/global-scope'

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -33,6 +33,8 @@ export class InstrumentBase extends FeatureBase {
       } catch (e) {
         warn(`Downloading ${this.featureName} failed...`)
         this.abortHandler?.() // undo any important alterations made to the page
+
+        // not supported yet but nice to do: "abort" this agent's EE for this feature specifically
       }
     }
 

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -58,7 +58,8 @@ export class Agent {
       delete newrelic.initializedAgents[this.agentIdentifier]?.[NR_FEATURES_REF_NAME] // GC mem used internally by features
       delete this.sharedAggregator
       // Keep the initialized agent object with its configs for troubleshooting purposes.
-      delete newrelic.ee?.get(this.agentIdentifier) // clear our events storage
+      newrelic.ee?.abort() // set flag and clear global backlog
+      delete newrelic.ee?.get(this.agentIdentifier) // clear this agent's own backlog too
       return false
     }
   }

--- a/tests/assets/promise-instanceof.html
+++ b/tests/assets/promise-instanceof.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>RUM Unit Test</title>
+  {init}
+  {config}
+  {loader}
+  {script-injection}
+</head>
+<body>
+  this is a generic page that is instrumented by the JS agent
+  <script>
+    window.isPromiseResolve = Promise.resolve() instanceof Promise
+    window.isNewPromise = new Promise(function () {}) instanceof Promise
+    window.isFetchPromise = fetch("example") instanceof Promise
+
+    async function asyncP() {}; var p = asyncP(); 
+    window.isAsyncPromise = p instanceof Promise
+    </script>
+</body>
+</html>

--- a/tests/browser/contextual-ee.browser.js
+++ b/tests/browser/contextual-ee.browser.js
@@ -55,17 +55,6 @@ test('ee.abort condition met', function (t) {
   t.end()
 })
 
-test('ee.abort condition not met', function (t) {
-  ee.aborted = false
-  ee.backlog.api = null
-  ee.backlog.feature = null
-  ee.abort()
-
-  t.equal(ee.aborted, false)
-
-  t.end()
-})
-
 test('EE clears eventBuffer (ee.backlog) after abort', function (t) {
   ee.aborted = false
   if (ee.backlog) {

--- a/tests/browser/spa/fetch-body-propagation.browser.js
+++ b/tests/browser/spa/fetch-body-propagation.browser.js
@@ -25,14 +25,13 @@ bodyMethods.forEach((bodyMethod) => {
         attrs: {
           isFetch: true
         },
-        children: []
-      },
-      {
-        type: 'customTracer',
-        attrs: {
-          name: 'timer'
-        },
-        children: []
+        children: [{
+          type: 'customTracer',
+          attrs: {
+            name: 'timer'
+          },
+          children: []
+        }]
       }]
     })
 
@@ -122,14 +121,13 @@ jil.browserTest('Response.formData', function (t) {
       attrs: {
         isFetch: true
       },
-      children: []
-    },
-    {
-      type: 'customTracer',
-      attrs: {
-        name: 'timer'
-      },
-      children: []
+      children: [{
+        type: 'customTracer',
+        attrs: {
+          name: 'timer'
+        },
+        children: []
+      }]
     }]
   })
 

--- a/tests/browser/spa/fetch-rejections.browser.js
+++ b/tests/browser/spa/fetch-rejections.browser.js
@@ -60,18 +60,18 @@ jil.browserTest('fetch body.reject', function (t) {
       attrs: {
         isFetch: true
       },
-      children: []
-    }, {
-      type: 'customTracer',
-      attrs: {
-        name: 'promise'
-      },
       children: [{
         type: 'customTracer',
         attrs: {
-          name: 'timer'
+          name: 'promise'
         },
-        children: []
+        children: [{
+          type: 'customTracer',
+          attrs: {
+            name: 'timer'
+          },
+          children: []
+        }]
       }]
     }]
   })

--- a/tests/browser/spa/single-fetch.browser.js
+++ b/tests/browser/spa/single-fetch.browser.js
@@ -11,14 +11,13 @@ jil.browserTest('spa single fetch', function (t) {
     name: 'interaction',
     children: [{
       name: 'ajax',
-      children: []
-    },
-    {
-      type: 'customTracer',
-      attrs: {
-        name: 'timer'
-      },
-      children: []
+      children: [{
+        type: 'customTracer',
+        attrs: {
+          name: 'timer'
+        },
+        children: []
+      }]
     }]
   })
 

--- a/tests/functional/spa/basic.test.js
+++ b/tests/functional/spa/basic.test.js
@@ -10,175 +10,175 @@ const querypack = require('@newrelic/nr-querypack')
 let supported = testDriver.Matcher.withFeature('addEventListener')
 const notIE = testDriver.Matcher.withFeature('notInternetExplorer')
 
-// testDriver.test('capturing SPA interactions', supported, function (t, browser, router) {
-//   t.plan(22)
-//   let testStartTime = now()
+testDriver.test('capturing SPA interactions', supported, function (t, browser, router) {
+  t.plan(22)
+  let testStartTime = now()
 
-//   let rumPromise = router.expectRum()
-//   let eventsPromise = router.expectInteractionEvents()
-//   const asset = router.assetURL('spa/xhr.html', { loader: 'spa', init: { session_trace: { enabled: false } } })
-//   let loadPromise = browser.safeGet(asset).waitForFeature('loaded')
+  let rumPromise = router.expectRum()
+  let eventsPromise = router.expectInteractionEvents()
+  const asset = router.assetURL('spa/xhr.html', { loader: 'spa', init: { session_trace: { enabled: false } } })
+  let loadPromise = browser.safeGet(asset).waitForFeature('loaded')
 
-//   Promise.all([eventsPromise, rumPromise, loadPromise])
-//     .then(([{ request: eventsResult }]) => {
-//       let { body, query } = eventsResult
+  Promise.all([eventsPromise, rumPromise, loadPromise])
+    .then(([{ request: eventsResult }]) => {
+      let { body, query } = eventsResult
 
-//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-//       t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
-//       t.equal(interactionTree.children.length, 0, 'expect no child nodes')
-//       t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
+      t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
+      t.equal(interactionTree.children.length, 0, 'expect no child nodes')
+      t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
 
-//       let eventPromise = router.expectInteractionEvents()
-//       let domPromise = browser.elementByCssSelector('body').click()
+      let eventPromise = router.expectInteractionEvents()
+      let domPromise = browser.elementByCssSelector('body').click()
 
-//       return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
-//         return eventData
-//       })
-//     })
-//     .then(({ request: { query, body } }) => {
-//       let receiptTime = now()
-//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+      return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
+        return eventData
+      })
+    })
+    .then(({ request: { query, body } }) => {
+      let receiptTime = now()
+      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-//       t.ok(interactionTree.id != null, 'interaction has id')
-//       t.ok(interactionTree.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
-//         'interaction id is in uuid format')
-//       t.ok(interactionTree.nodeId, 'interaction has nodeId attribute')
+      t.ok(interactionTree.id != null, 'interaction has id')
+      t.ok(interactionTree.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
+        'interaction id is in uuid format')
+      t.ok(interactionTree.nodeId, 'interaction has nodeId attribute')
 
-//       t.ok(interactionTree.end >= interactionTree.start, 'interaction end time should be >= start')
-//       t.ok(interactionTree.callbackEnd >= interactionTree.start, 'interaaction callback end should be >= interaction start')
-//       t.ok(interactionTree.callbackEnd <= interactionTree.end, 'interaction callback end should be <= interaction end')
-//       t.equal(interactionTree.children.length, 1, 'expected one child node')
+      t.ok(interactionTree.end >= interactionTree.start, 'interaction end time should be >= start')
+      t.ok(interactionTree.callbackEnd >= interactionTree.start, 'interaaction callback end should be >= interaction start')
+      t.ok(interactionTree.callbackEnd <= interactionTree.end, 'interaction callback end should be <= interaction end')
+      t.equal(interactionTree.children.length, 1, 'expected one child node')
 
-//       var xhr = interactionTree.children[0]
+      var xhr = interactionTree.children[0]
 
-//       t.ok(xhr.nodeId, 'node has nodeId attribute')
-//       t.equal(xhr.type, 'ajax', 'should be an ajax node')
-//       t.equal(xhr.children.length, 0, 'should not have nested children')
-//       t.equal(xhr.method, 'POST', 'should be a POST request')
-//       t.equal(xhr.status, 200, 'should have a 200 status')
-//       t.equal(xhr.domain.split(':')[0], 'bam-test-1.nr-local.net', 'should have a correct hostname')
-//       var port = +xhr.domain.split(':')[1]
-//       t.ok(port > 1000 && port < 100000, 'port should be in expected range')
-//       t.equal(xhr.requestBodySize, 3, 'should have correct requestBodySize')
-//       t.equal(xhr.responseBodySize, 3, 'should have correct responseBodySize')
-//       t.equal(xhr.requestedWith, 'XMLHttpRequest', 'should indicate it was requested with xhr')
+      t.ok(xhr.nodeId, 'node has nodeId attribute')
+      t.equal(xhr.type, 'ajax', 'should be an ajax node')
+      t.equal(xhr.children.length, 0, 'should not have nested children')
+      t.equal(xhr.method, 'POST', 'should be a POST request')
+      t.equal(xhr.status, 200, 'should have a 200 status')
+      t.equal(xhr.domain.split(':')[0], 'bam-test-1.nr-local.net', 'should have a correct hostname')
+      var port = +xhr.domain.split(':')[1]
+      t.ok(port > 1000 && port < 100000, 'port should be in expected range')
+      t.equal(xhr.requestBodySize, 3, 'should have correct requestBodySize')
+      t.equal(xhr.responseBodySize, 3, 'should have correct responseBodySize')
+      t.equal(xhr.requestedWith, 'XMLHttpRequest', 'should indicate it was requested with xhr')
 
-//       let fixup = receiptTime - query.rst
-//       let estimatedInteractionTimestamp = interactionTree.start + fixup
-//       t.ok(estimatedInteractionTimestamp > testStartTime, 'estimated ixn start after test start')
-//       t.ok(estimatedInteractionTimestamp < receiptTime, 'estimated ixn start before receipt time')
-//     })
-//     .catch(fail)
+      let fixup = receiptTime - query.rst
+      let estimatedInteractionTimestamp = interactionTree.start + fixup
+      t.ok(estimatedInteractionTimestamp > testStartTime, 'estimated ixn start after test start')
+      t.ok(estimatedInteractionTimestamp < receiptTime, 'estimated ixn start before receipt time')
+    })
+    .catch(fail)
 
-//   function fail (err) {
-//     t.error(err)
-//     t.end()
-//   }
-// })
+  function fail (err) {
+    t.error(err)
+    t.end()
+  }
+})
 
-// testDriver.test('capturing SPA interactions using loader_config data', supported, function (t, browser, router) {
-//   t.plan(22)
-//   let testStartTime = now()
+testDriver.test('capturing SPA interactions using loader_config data', supported, function (t, browser, router) {
+  t.plan(22)
+  let testStartTime = now()
 
-//   let rumPromise = router.expectRum()
-//   let eventsPromise = router.expectInteractionEvents()
-//   let loadPromise = browser.safeGet(router.assetURL('spa/xhr.html', { loader: 'spa', injectUpdatedLoaderConfig: true, init: { session_trace: { enabled: false } } })).waitForFeature('loaded')
+  let rumPromise = router.expectRum()
+  let eventsPromise = router.expectInteractionEvents()
+  let loadPromise = browser.safeGet(router.assetURL('spa/xhr.html', { loader: 'spa', injectUpdatedLoaderConfig: true, init: { session_trace: { enabled: false } } })).waitForFeature('loaded')
 
-//   Promise.all([eventsPromise, rumPromise, loadPromise])
-//     .then(([{ request: eventsResult }]) => {
-//       let { body, query } = eventsResult
+  Promise.all([eventsPromise, rumPromise, loadPromise])
+    .then(([{ request: eventsResult }]) => {
+      let { body, query } = eventsResult
 
-//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-//       t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
-//       t.equal(interactionTree.children.length, 0, 'expect no child nodes')
-//       t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
+      t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
+      t.equal(interactionTree.children.length, 0, 'expect no child nodes')
+      t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
 
-//       let eventPromise = router.expectInteractionEvents()
-//       let domPromise = browser.elementByCssSelector('body').click()
+      let eventPromise = router.expectInteractionEvents()
+      let domPromise = browser.elementByCssSelector('body').click()
 
-//       return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
-//         return eventData
-//       })
-//     })
-//     .then(({ request: { query, body } }) => {
-//       let receiptTime = now()
-//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+      return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
+        return eventData
+      })
+    })
+    .then(({ request: { query, body } }) => {
+      let receiptTime = now()
+      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-//       t.ok(interactionTree.id != null, 'interaction has id')
-//       t.ok(interactionTree.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
-//         'interaction id is in uuid format')
-//       t.ok(interactionTree.nodeId, 'interaction has nodeId attribute')
+      t.ok(interactionTree.id != null, 'interaction has id')
+      t.ok(interactionTree.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
+        'interaction id is in uuid format')
+      t.ok(interactionTree.nodeId, 'interaction has nodeId attribute')
 
-//       t.ok(interactionTree.end >= interactionTree.start, 'interaction end time should be >= start')
-//       t.ok(interactionTree.callbackEnd >= interactionTree.start, 'interaaction callback end should be >= interaction start')
-//       t.ok(interactionTree.callbackEnd <= interactionTree.end, 'interaction callback end should be <= interaction end')
-//       t.equal(interactionTree.children.length, 1, 'expected one child node')
+      t.ok(interactionTree.end >= interactionTree.start, 'interaction end time should be >= start')
+      t.ok(interactionTree.callbackEnd >= interactionTree.start, 'interaaction callback end should be >= interaction start')
+      t.ok(interactionTree.callbackEnd <= interactionTree.end, 'interaction callback end should be <= interaction end')
+      t.equal(interactionTree.children.length, 1, 'expected one child node')
 
-//       var xhr = interactionTree.children[0]
+      var xhr = interactionTree.children[0]
 
-//       t.ok(xhr.nodeId, 'node has nodeId attribute')
-//       t.equal(xhr.type, 'ajax', 'should be an ajax node')
-//       t.equal(xhr.children.length, 0, 'should not have nested children')
-//       t.equal(xhr.method, 'POST', 'should be a POST request')
-//       t.equal(xhr.status, 200, 'should have a 200 status')
-//       t.equal(xhr.domain.split(':')[0], 'bam-test-1.nr-local.net', 'should have a correct hostname')
-//       var port = +xhr.domain.split(':')[1]
-//       t.ok(port > 1000 && port < 100000, 'port should be in expected range')
-//       t.equal(xhr.requestBodySize, 3, 'should have correct requestBodySize')
-//       t.equal(xhr.responseBodySize, 3, 'should have correct responseBodySize')
-//       t.equal(xhr.requestedWith, 'XMLHttpRequest', 'should indicate it was requested with xhr')
+      t.ok(xhr.nodeId, 'node has nodeId attribute')
+      t.equal(xhr.type, 'ajax', 'should be an ajax node')
+      t.equal(xhr.children.length, 0, 'should not have nested children')
+      t.equal(xhr.method, 'POST', 'should be a POST request')
+      t.equal(xhr.status, 200, 'should have a 200 status')
+      t.equal(xhr.domain.split(':')[0], 'bam-test-1.nr-local.net', 'should have a correct hostname')
+      var port = +xhr.domain.split(':')[1]
+      t.ok(port > 1000 && port < 100000, 'port should be in expected range')
+      t.equal(xhr.requestBodySize, 3, 'should have correct requestBodySize')
+      t.equal(xhr.responseBodySize, 3, 'should have correct responseBodySize')
+      t.equal(xhr.requestedWith, 'XMLHttpRequest', 'should indicate it was requested with xhr')
 
-//       let fixup = receiptTime - query.rst
-//       let estimatedInteractionTimestamp = interactionTree.start + fixup
-//       t.ok(estimatedInteractionTimestamp > testStartTime, 'estimated ixn start after test start')
-//       t.ok(estimatedInteractionTimestamp < receiptTime, 'estimated ixn start before receipt time')
-//     })
-//     .catch(fail)
+      let fixup = receiptTime - query.rst
+      let estimatedInteractionTimestamp = interactionTree.start + fixup
+      t.ok(estimatedInteractionTimestamp > testStartTime, 'estimated ixn start after test start')
+      t.ok(estimatedInteractionTimestamp < receiptTime, 'estimated ixn start before receipt time')
+    })
+    .catch(fail)
 
-//   function fail (err) {
-//     t.error(err)
-//     t.end()
-//   }
-// })
+  function fail (err) {
+    t.error(err)
+    t.end()
+  }
+})
 
-// testDriver.test('child nodes in SPA interaction does not exceed set limit', supported, function (t, browser, router) {
-//   let rumPromise = router.expectRum()
-//   let eventsPromise = router.expectInteractionEvents()
-//   let loadPromise = browser.safeGet(router.assetURL('spa/fetch-exceed-max-spa-nodes.html', { loader: 'spa' })).waitForFeature('loaded')
+testDriver.test('child nodes in SPA interaction does not exceed set limit', supported, function (t, browser, router) {
+  let rumPromise = router.expectRum()
+  let eventsPromise = router.expectInteractionEvents()
+  let loadPromise = browser.safeGet(router.assetURL('spa/fetch-exceed-max-spa-nodes.html', { loader: 'spa' })).waitForFeature('loaded')
 
-//   Promise.all([eventsPromise, rumPromise, loadPromise])
-//     .then(([{ request: eventsResult }]) => {
-//       let { body, query } = eventsResult
+  Promise.all([eventsPromise, rumPromise, loadPromise])
+    .then(([{ request: eventsResult }]) => {
+      let { body, query } = eventsResult
 
-//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-//       t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
-//       t.equal(interactionTree.children.length, 0, 'expect no child nodes')
-//       t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
+      t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
+      t.equal(interactionTree.children.length, 0, 'expect no child nodes')
+      t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
 
-//       let eventPromise = router.expectInteractionEvents()
-//       let domPromise = browser
-//         .elementByCssSelector('body')
-//         .click()
+      let eventPromise = router.expectInteractionEvents()
+      let domPromise = browser
+        .elementByCssSelector('body')
+        .click()
 
-//       return Promise.all([eventPromise, domPromise]).then(([eventData]) => {
-//         return eventData
-//       })
-//     })
-//     .then(({ request: { query, body } }) => {
-//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
-//       t.ok(interactionTree.children.length <= 128, 'interaction should have no more than 128 child nodes')
-//       t.end()
-//     })
-//     .catch(fail)
+      return Promise.all([eventPromise, domPromise]).then(([eventData]) => {
+        return eventData
+      })
+    })
+    .then(({ request: { query, body } }) => {
+      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+      t.ok(interactionTree.children.length <= 128, 'interaction should have no more than 128 child nodes')
+      t.end()
+    })
+    .catch(fail)
 
-//   function fail (err) {
-//     t.error(err)
-//     t.end()
-//   }
-// })
+  function fail (err) {
+    t.error(err)
+    t.end()
+  }
+})
 
 testDriver.test('promise wrapper should support instanceof comparison', notIE, function (t, browser, router) {
   let rumPromise = router.expectRum()

--- a/tests/functional/spa/basic.test.js
+++ b/tests/functional/spa/basic.test.js
@@ -187,20 +187,20 @@ testDriver.test('promise wrapper should support instanceof comparison', function
     .then(async () => {
       await browser.safeEval('var p = new Promise(function () {}); p instanceof Promise', (err, res) => {
         t.notOk(err, 'should not get an error')
-        t.ok(res, 'wrapped promise is instance of Promise global')
+        t.ok(res, 'new Promise is an instance of global Promise')
       })
       await browser.safeEval('var p = Promise.resolve(); p instanceof Promise', (err, res) => {
         t.notOk(err, 'should not get an error')
-        t.ok(res, 'wrapped promise is instance of Promise global')
+        t.ok(res, 'static Promise methods return is instanceof global Promise')
       })
-      await browser.safeEval('var p = Promise.reject(); p instanceof Promise', (err, res) => {
+      await browser.safeEval('var p = fetch("example.com"); p instanceof Promise', (err, res) => {
         t.notOk(err, 'should not get an error')
-        t.ok(res, 'wrapped promise is instance of Promise global')
+        t.ok(res, 'fetch returned promise is an instance of global Promise')
       })
       if (!browser.match('ie@*')) {
         await browser.safeEval('async function asyncP() {}; var p = asyncP(); p instanceof Promise', (err, res) => {
           t.notOk(err, 'should not get an error')
-          t.ok(res, 'wrapped promise is instance of Promise global')
+          t.ok(res, 'async function returned promise is an instance of global Promise')
         })
       }
       t.end()

--- a/tests/functional/spa/basic.test.js
+++ b/tests/functional/spa/basic.test.js
@@ -10,197 +10,195 @@ const querypack = require('@newrelic/nr-querypack')
 let supported = testDriver.Matcher.withFeature('addEventListener')
 const notIE = testDriver.Matcher.withFeature('notInternetExplorer')
 
-testDriver.test('capturing SPA interactions', supported, function (t, browser, router) {
-  t.plan(22)
-  let testStartTime = now()
+// testDriver.test('capturing SPA interactions', supported, function (t, browser, router) {
+//   t.plan(22)
+//   let testStartTime = now()
 
-  let rumPromise = router.expectRum()
-  let eventsPromise = router.expectInteractionEvents()
-  const asset = router.assetURL('spa/xhr.html', { loader: 'spa', init: { session_trace: { enabled: false } } })
-  let loadPromise = browser.safeGet(asset).waitForFeature('loaded')
+//   let rumPromise = router.expectRum()
+//   let eventsPromise = router.expectInteractionEvents()
+//   const asset = router.assetURL('spa/xhr.html', { loader: 'spa', init: { session_trace: { enabled: false } } })
+//   let loadPromise = browser.safeGet(asset).waitForFeature('loaded')
 
-  Promise.all([eventsPromise, rumPromise, loadPromise])
-    .then(([{ request: eventsResult }]) => {
-      let { body, query } = eventsResult
+//   Promise.all([eventsPromise, rumPromise, loadPromise])
+//     .then(([{ request: eventsResult }]) => {
+//       let { body, query } = eventsResult
 
-      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-      t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
-      t.equal(interactionTree.children.length, 0, 'expect no child nodes')
-      t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
+//       t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
+//       t.equal(interactionTree.children.length, 0, 'expect no child nodes')
+//       t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
 
-      let eventPromise = router.expectInteractionEvents()
-      let domPromise = browser.elementByCssSelector('body').click()
+//       let eventPromise = router.expectInteractionEvents()
+//       let domPromise = browser.elementByCssSelector('body').click()
 
-      return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
-        return eventData
-      })
-    })
-    .then(({ request: { query, body } }) => {
-      let receiptTime = now()
-      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+//       return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
+//         return eventData
+//       })
+//     })
+//     .then(({ request: { query, body } }) => {
+//       let receiptTime = now()
+//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-      t.ok(interactionTree.id != null, 'interaction has id')
-      t.ok(interactionTree.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
-        'interaction id is in uuid format')
-      t.ok(interactionTree.nodeId, 'interaction has nodeId attribute')
+//       t.ok(interactionTree.id != null, 'interaction has id')
+//       t.ok(interactionTree.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
+//         'interaction id is in uuid format')
+//       t.ok(interactionTree.nodeId, 'interaction has nodeId attribute')
 
-      t.ok(interactionTree.end >= interactionTree.start, 'interaction end time should be >= start')
-      t.ok(interactionTree.callbackEnd >= interactionTree.start, 'interaaction callback end should be >= interaction start')
-      t.ok(interactionTree.callbackEnd <= interactionTree.end, 'interaction callback end should be <= interaction end')
-      t.equal(interactionTree.children.length, 1, 'expected one child node')
+//       t.ok(interactionTree.end >= interactionTree.start, 'interaction end time should be >= start')
+//       t.ok(interactionTree.callbackEnd >= interactionTree.start, 'interaaction callback end should be >= interaction start')
+//       t.ok(interactionTree.callbackEnd <= interactionTree.end, 'interaction callback end should be <= interaction end')
+//       t.equal(interactionTree.children.length, 1, 'expected one child node')
 
-      var xhr = interactionTree.children[0]
+//       var xhr = interactionTree.children[0]
 
-      t.ok(xhr.nodeId, 'node has nodeId attribute')
-      t.equal(xhr.type, 'ajax', 'should be an ajax node')
-      t.equal(xhr.children.length, 0, 'should not have nested children')
-      t.equal(xhr.method, 'POST', 'should be a POST request')
-      t.equal(xhr.status, 200, 'should have a 200 status')
-      t.equal(xhr.domain.split(':')[0], 'bam-test-1.nr-local.net', 'should have a correct hostname')
-      var port = +xhr.domain.split(':')[1]
-      t.ok(port > 1000 && port < 100000, 'port should be in expected range')
-      t.equal(xhr.requestBodySize, 3, 'should have correct requestBodySize')
-      t.equal(xhr.responseBodySize, 3, 'should have correct responseBodySize')
-      t.equal(xhr.requestedWith, 'XMLHttpRequest', 'should indicate it was requested with xhr')
+//       t.ok(xhr.nodeId, 'node has nodeId attribute')
+//       t.equal(xhr.type, 'ajax', 'should be an ajax node')
+//       t.equal(xhr.children.length, 0, 'should not have nested children')
+//       t.equal(xhr.method, 'POST', 'should be a POST request')
+//       t.equal(xhr.status, 200, 'should have a 200 status')
+//       t.equal(xhr.domain.split(':')[0], 'bam-test-1.nr-local.net', 'should have a correct hostname')
+//       var port = +xhr.domain.split(':')[1]
+//       t.ok(port > 1000 && port < 100000, 'port should be in expected range')
+//       t.equal(xhr.requestBodySize, 3, 'should have correct requestBodySize')
+//       t.equal(xhr.responseBodySize, 3, 'should have correct responseBodySize')
+//       t.equal(xhr.requestedWith, 'XMLHttpRequest', 'should indicate it was requested with xhr')
 
-      let fixup = receiptTime - query.rst
-      let estimatedInteractionTimestamp = interactionTree.start + fixup
-      t.ok(estimatedInteractionTimestamp > testStartTime, 'estimated ixn start after test start')
-      t.ok(estimatedInteractionTimestamp < receiptTime, 'estimated ixn start before receipt time')
-    })
-    .catch(fail)
+//       let fixup = receiptTime - query.rst
+//       let estimatedInteractionTimestamp = interactionTree.start + fixup
+//       t.ok(estimatedInteractionTimestamp > testStartTime, 'estimated ixn start after test start')
+//       t.ok(estimatedInteractionTimestamp < receiptTime, 'estimated ixn start before receipt time')
+//     })
+//     .catch(fail)
 
-  function fail (err) {
-    t.error(err)
-    t.end()
-  }
-})
+//   function fail (err) {
+//     t.error(err)
+//     t.end()
+//   }
+// })
 
-testDriver.test('capturing SPA interactions using loader_config data', supported, function (t, browser, router) {
-  t.plan(22)
-  let testStartTime = now()
+// testDriver.test('capturing SPA interactions using loader_config data', supported, function (t, browser, router) {
+//   t.plan(22)
+//   let testStartTime = now()
 
-  let rumPromise = router.expectRum()
-  let eventsPromise = router.expectInteractionEvents()
-  let loadPromise = browser.safeGet(router.assetURL('spa/xhr.html', { loader: 'spa', injectUpdatedLoaderConfig: true, init: { session_trace: { enabled: false } } })).waitForFeature('loaded')
+//   let rumPromise = router.expectRum()
+//   let eventsPromise = router.expectInteractionEvents()
+//   let loadPromise = browser.safeGet(router.assetURL('spa/xhr.html', { loader: 'spa', injectUpdatedLoaderConfig: true, init: { session_trace: { enabled: false } } })).waitForFeature('loaded')
 
-  Promise.all([eventsPromise, rumPromise, loadPromise])
-    .then(([{ request: eventsResult }]) => {
-      let { body, query } = eventsResult
+//   Promise.all([eventsPromise, rumPromise, loadPromise])
+//     .then(([{ request: eventsResult }]) => {
+//       let { body, query } = eventsResult
 
-      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-      t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
-      t.equal(interactionTree.children.length, 0, 'expect no child nodes')
-      t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
+//       t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
+//       t.equal(interactionTree.children.length, 0, 'expect no child nodes')
+//       t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
 
-      let eventPromise = router.expectInteractionEvents()
-      let domPromise = browser.elementByCssSelector('body').click()
+//       let eventPromise = router.expectInteractionEvents()
+//       let domPromise = browser.elementByCssSelector('body').click()
 
-      return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
-        return eventData
-      })
-    })
-    .then(({ request: { query, body } }) => {
-      let receiptTime = now()
-      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+//       return Promise.all([eventPromise, domPromise]).then(([eventData, domData]) => {
+//         return eventData
+//       })
+//     })
+//     .then(({ request: { query, body } }) => {
+//       let receiptTime = now()
+//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-      t.ok(interactionTree.id != null, 'interaction has id')
-      t.ok(interactionTree.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
-        'interaction id is in uuid format')
-      t.ok(interactionTree.nodeId, 'interaction has nodeId attribute')
+//       t.ok(interactionTree.id != null, 'interaction has id')
+//       t.ok(interactionTree.id.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
+//         'interaction id is in uuid format')
+//       t.ok(interactionTree.nodeId, 'interaction has nodeId attribute')
 
-      t.ok(interactionTree.end >= interactionTree.start, 'interaction end time should be >= start')
-      t.ok(interactionTree.callbackEnd >= interactionTree.start, 'interaaction callback end should be >= interaction start')
-      t.ok(interactionTree.callbackEnd <= interactionTree.end, 'interaction callback end should be <= interaction end')
-      t.equal(interactionTree.children.length, 1, 'expected one child node')
+//       t.ok(interactionTree.end >= interactionTree.start, 'interaction end time should be >= start')
+//       t.ok(interactionTree.callbackEnd >= interactionTree.start, 'interaaction callback end should be >= interaction start')
+//       t.ok(interactionTree.callbackEnd <= interactionTree.end, 'interaction callback end should be <= interaction end')
+//       t.equal(interactionTree.children.length, 1, 'expected one child node')
 
-      var xhr = interactionTree.children[0]
+//       var xhr = interactionTree.children[0]
 
-      t.ok(xhr.nodeId, 'node has nodeId attribute')
-      t.equal(xhr.type, 'ajax', 'should be an ajax node')
-      t.equal(xhr.children.length, 0, 'should not have nested children')
-      t.equal(xhr.method, 'POST', 'should be a POST request')
-      t.equal(xhr.status, 200, 'should have a 200 status')
-      t.equal(xhr.domain.split(':')[0], 'bam-test-1.nr-local.net', 'should have a correct hostname')
-      var port = +xhr.domain.split(':')[1]
-      t.ok(port > 1000 && port < 100000, 'port should be in expected range')
-      t.equal(xhr.requestBodySize, 3, 'should have correct requestBodySize')
-      t.equal(xhr.responseBodySize, 3, 'should have correct responseBodySize')
-      t.equal(xhr.requestedWith, 'XMLHttpRequest', 'should indicate it was requested with xhr')
+//       t.ok(xhr.nodeId, 'node has nodeId attribute')
+//       t.equal(xhr.type, 'ajax', 'should be an ajax node')
+//       t.equal(xhr.children.length, 0, 'should not have nested children')
+//       t.equal(xhr.method, 'POST', 'should be a POST request')
+//       t.equal(xhr.status, 200, 'should have a 200 status')
+//       t.equal(xhr.domain.split(':')[0], 'bam-test-1.nr-local.net', 'should have a correct hostname')
+//       var port = +xhr.domain.split(':')[1]
+//       t.ok(port > 1000 && port < 100000, 'port should be in expected range')
+//       t.equal(xhr.requestBodySize, 3, 'should have correct requestBodySize')
+//       t.equal(xhr.responseBodySize, 3, 'should have correct responseBodySize')
+//       t.equal(xhr.requestedWith, 'XMLHttpRequest', 'should indicate it was requested with xhr')
 
-      let fixup = receiptTime - query.rst
-      let estimatedInteractionTimestamp = interactionTree.start + fixup
-      t.ok(estimatedInteractionTimestamp > testStartTime, 'estimated ixn start after test start')
-      t.ok(estimatedInteractionTimestamp < receiptTime, 'estimated ixn start before receipt time')
-    })
-    .catch(fail)
+//       let fixup = receiptTime - query.rst
+//       let estimatedInteractionTimestamp = interactionTree.start + fixup
+//       t.ok(estimatedInteractionTimestamp > testStartTime, 'estimated ixn start after test start')
+//       t.ok(estimatedInteractionTimestamp < receiptTime, 'estimated ixn start before receipt time')
+//     })
+//     .catch(fail)
 
-  function fail (err) {
-    t.error(err)
-    t.end()
-  }
-})
+//   function fail (err) {
+//     t.error(err)
+//     t.end()
+//   }
+// })
 
-testDriver.test('child nodes in SPA interaction does not exceed set limit', supported, function (t, browser, router) {
-  let rumPromise = router.expectRum()
-  let eventsPromise = router.expectInteractionEvents()
-  let loadPromise = browser.safeGet(router.assetURL('spa/fetch-exceed-max-spa-nodes.html', { loader: 'spa' })).waitForFeature('loaded')
+// testDriver.test('child nodes in SPA interaction does not exceed set limit', supported, function (t, browser, router) {
+//   let rumPromise = router.expectRum()
+//   let eventsPromise = router.expectInteractionEvents()
+//   let loadPromise = browser.safeGet(router.assetURL('spa/fetch-exceed-max-spa-nodes.html', { loader: 'spa' })).waitForFeature('loaded')
 
-  Promise.all([eventsPromise, rumPromise, loadPromise])
-    .then(([{ request: eventsResult }]) => {
-      let { body, query } = eventsResult
+//   Promise.all([eventsPromise, rumPromise, loadPromise])
+//     .then(([{ request: eventsResult }]) => {
+//       let { body, query } = eventsResult
 
-      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
 
-      t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
-      t.equal(interactionTree.children.length, 0, 'expect no child nodes')
-      t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
+//       t.equal(interactionTree.trigger, 'initialPageLoad', 'initial page load should be tracked with an interaction')
+//       t.equal(interactionTree.children.length, 0, 'expect no child nodes')
+//       t.notOk(interactionTree.isRouteChange, 'The interaction does not include a route change.')
 
-      let eventPromise = router.expectInteractionEvents()
-      let domPromise = browser
-        .elementByCssSelector('body')
-        .click()
+//       let eventPromise = router.expectInteractionEvents()
+//       let domPromise = browser
+//         .elementByCssSelector('body')
+//         .click()
 
-      return Promise.all([eventPromise, domPromise]).then(([eventData]) => {
-        return eventData
-      })
-    })
-    .then(({ request: { query, body } }) => {
-      let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
-      t.ok(interactionTree.children.length <= 128, 'interaction should have no more than 128 child nodes')
-      t.end()
-    })
-    .catch(fail)
+//       return Promise.all([eventPromise, domPromise]).then(([eventData]) => {
+//         return eventData
+//       })
+//     })
+//     .then(({ request: { query, body } }) => {
+//       let interactionTree = querypack.decode(body && body.length ? body : query.e)[0]
+//       t.ok(interactionTree.children.length <= 128, 'interaction should have no more than 128 child nodes')
+//       t.end()
+//     })
+//     .catch(fail)
 
-  function fail (err) {
-    t.error(err)
-    t.end()
-  }
-})
+//   function fail (err) {
+//     t.error(err)
+//     t.end()
+//   }
+// })
 
 testDriver.test('promise wrapper should support instanceof comparison', notIE, function (t, browser, router) {
   let rumPromise = router.expectRum()
-  let loadPromise = browser.safeGet(router.assetURL('instrumented.html', { loader: 'spa' }))
+  let loadPromise = browser.safeGet(router.assetURL('promise-instanceof.html', { loader: 'spa' }))
 
   Promise.all([rumPromise, loadPromise])
     .then(async () => {
-      await browser.safeEval('var p = new Promise(function () {}); p instanceof Promise', (err, res) => {
+      await browser.safeEval('window.isNewPromise', (err, res) => {
         t.notOk(err, 'should not get an error')
         t.ok(res, 'new Promise is an instance of global Promise')
       })
-      await browser.safeEval('var p = Promise.resolve(); p instanceof Promise', (err, res) => {
+      await browser.safeEval('window.isPromiseResolve', (err, res) => {
         t.notOk(err, 'should not get an error')
         t.ok(res, 'static Promise methods return is instanceof global Promise')
       })
-      if (!browser.match('firefox@*')) { // *cli - FF over Sauce have trouble evaluating this to be 'true', even though it is when tested manually on local & SL
-        await browser.safeEval('var p = fetch("example.com"); p instanceof Promise', (err, res) => {
-          t.notOk(err, 'should not get an error')
-          t.ok(res, 'fetch returned promise is an instance of global Promise')
-        })
-      }
-      await browser.safeEval('async function asyncP() {}; var p = asyncP(); p instanceof Promise', (err, res) => {
+      await browser.safeEval('window.isFetchPromise', (err, res) => {
+        t.notOk(err, 'should not get an error')
+        t.ok(res, 'fetch returned promise is an instance of global Promise')
+      })
+      await browser.safeEval('window.isAsyncPromise', (err, res) => {
         t.notOk(err, 'should not get an error')
         t.ok(res, 'async function returned promise is an instance of global Promise')
       })

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -16,17 +16,17 @@
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "104",
-      "browserVersion": "104"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "103",
+      "browserVersion": "103"
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "101",
-      "browserVersion": "101"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "100",
+      "browserVersion": "100"
     }
   ],
   "edge": [

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -16,17 +16,17 @@
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "103",
-      "browserVersion": "103"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "100",
-      "browserVersion": "100"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "101",
+      "browserVersion": "101"
     }
   ],
   "edge": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Issue 409 pointed out that `instanceof` the promise returned from `async` functions failed against the global (NR wrapped) Promise.

This led to our re-evaluation of the recent Promise wrapping re-do, which attempted to leave the original Promise unmodified and instead create a prototype chain. While we are able to replace the `fetch` promise, it would seem `async()` promise constructors are not replace-able, so the end result is that we switch back to directly modifying the original promise.prototype.

This ensures that all 3 (new Promise, fetch, and async function) promises are `instanceof` our wrapped promise and gets instrumented, once again.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NEWRELIC-6934
#409

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Added an integration test to check the `instanceof` comparison.