### PR TITLE
Add ci action to publish changelog items to changelog branch

### DIFF
--- a/.github/workflows/add-changelog-item.yml
+++ b/.github/workflows/add-changelog-item.yml
@@ -8,11 +8,20 @@ on:
 jobs:
   add-changelog-item:
     runs-on: ubuntu-latest
-    container: node:14
+    container:
+      image: ubuntu:latest
+    defaults:
+      run:
+        shell: bash
     steps:
+      - name: Setup Container
+        run: apt update && apt install -y git
       - uses: actions/checkout@v3
         with:
           ref: changelog
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
       - name: install
         run: npm ci
       - name: add changelog item

--- a/.github/workflows/add-changelog-item.yml
+++ b/.github/workflows/add-changelog-item.yml
@@ -26,6 +26,6 @@ jobs:
       - name: push
         run: |
           git add .
-          git commit -a -m "Add changelog item for PR-${{github.event.number}}"
+          git commit -m "Add changelog item for PR-${{github.event.number}}"
           git push
         

--- a/.github/workflows/add-changelog-item.yml
+++ b/.github/workflows/add-changelog-item.yml
@@ -27,7 +27,7 @@ jobs:
       - name: add changelog item
         run: node scripts/create-changelog-item.js \
           -p ${{ github.event.number}} \
-          -c ${{ github.event.head_commit.message }}
+          -c "${{ github.event.head_commit.message }}"
       - name: login
         run: |
           git config user.name "${{ github.actor }}"

--- a/.github/workflows/add-changelog-item.yml
+++ b/.github/workflows/add-changelog-item.yml
@@ -1,0 +1,31 @@
+name: Add changelog item
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  add-changelog-item:
+    runs-on: ubuntu-latest
+    container: node:14
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: changelog
+      - name: install
+        run: npm ci
+      - name: add changelog item
+        run: node scripts/create-changelog-item.js \
+          -p ${{ github.event.number}} \
+          -c ${{ github.event.head_commit.message }}
+      - name: login
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+      - name: push
+        run: |
+          git add .
+          git commit -a -m "Add changelog item for PR-${{github.event.number}}"
+          git push
+        


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds a CI action to add a changelog item to the [changelog branch](https://github.com/newrelic/newrelic-browser-agent/tree/changelog) when PRs are merged to main.

The structure of the final merge commit message is what will determine the output of the changelog item.

The `main commit message` will serve as the item "heading" while the `extended description` will serve as the item "body".
The changelog item will also create a link to the PR itself, and you can also include helpful external links in the extended description if needed.

### Related Issue(s)
This is part of an Innovation Project
