### PR TITLE
NR-93365: Adding safety around interaction node cancelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ The interaction-to-next-paint metric is now calculated and reported at the end o
 
 ### Revert unwrapping of globals on agent abort
 Partial revert of graceful handling change made in v1225 that unwrapped modified global APIs and handlers, which caused integration issues with other wrapping libraries and code.
+
 ### Add internal metrics to evaluate feasibility page resource harvests
 Internal metrics were added to track the feasibility and impact of collecting page resource information using the PerformanceObserver resource timings, such as scripts, images, network calls, and more. 
+
+### Add resiliency around SPA interaction saving
+Added resiliency code around SPA interaction node save functionality to ensure a cancelled interaction node without a parent further up the interaction tree does not cause an exception to be raised from the agent.
 
 ## v1226
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,10 @@
 module.exports = {
   clearMocks: true,
   coverageDirectory: 'coverage',
+  collectCoverageFrom: [
+    'src/**/*.js',
+    '!src/**/*.test.js'
+  ],
   testEnvironment: 'jsdom',
   testMatch: ['<rootDir>/src/**/?(*.)+(spec|test).[tj]s?(x)'],
   transform: {

--- a/src/features/spa/aggregate/interaction-node.js
+++ b/src/features/spa/aggregate/interaction-node.js
@@ -69,19 +69,12 @@ InteractionNodePrototype.finish = function finish (timestamp) {
   node.end = timestamp
 
   // Find the next parent node that is not cancelled
-  if (node.parent) {
-    let parent = node.parent
-    while (parent.cancelled) {
-      if (!parent.parent) break
-      parent = parent.parent
-    }
+  let parent = node.parent
+  while (parent?.cancelled) parent = parent.parent
 
-    // Assign the node to the non-cancelled parent node
-    if (!parent.cancelled) {
-      parent.children.push(node)
-    }
-    node.parent = null
-  }
+  // Assign the node to the non-cancelled parent node
+  if (parent) parent.children.push(node)
+  node.parent = null
 
   // Update the interaction remaining counter
   var interaction = this.interaction

--- a/src/features/spa/aggregate/interaction-node.js
+++ b/src/features/spa/aggregate/interaction-node.js
@@ -67,11 +67,23 @@ InteractionNodePrototype.finish = function finish (timestamp) {
   var node = this
   if (node.end) return
   node.end = timestamp
-  var parent = node.parent
-  while (parent.cancelled) parent = parent.parent
-  parent.children.push(node)
-  node.parent = null
 
+  // Find the next parent node that is not cancelled
+  if (node.parent) {
+    let parent = node.parent
+    while (parent.cancelled) {
+      if (!parent.parent) break
+      parent = parent.parent
+    }
+
+    // Assign the node to the non-cancelled parent node
+    if (!parent.cancelled) {
+      parent.children.push(node)
+    }
+    node.parent = null
+  }
+
+  // Update the interaction remaining counter
   var interaction = this.interaction
   interaction.remaining--
   interaction.lastFinish = timestamp

--- a/src/features/spa/aggregate/interaction-node.test.js
+++ b/src/features/spa/aggregate/interaction-node.test.js
@@ -1,0 +1,17 @@
+import { faker } from '@faker-js/faker'
+import { InteractionNode } from './interaction-node'
+
+test('finishing node with cancelled parent should not throw an error', () => {
+  const interaction = {
+    remaining: 0,
+    onNodeAdded: jest.fn(),
+    checkFinish: jest.fn()
+  }
+  const interactionRootNode = new InteractionNode(interaction, null, 'interaction', faker.date.past().getUTCSeconds())
+  const interactionNode = interactionRootNode.child('test', faker.date.past().getUTCSeconds(), 'test', false)
+
+  interactionRootNode.cancel()
+  interactionNode.finish()
+
+  expect(interactionRootNode.children.length).toEqual(0)
+})

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -16,17 +16,17 @@
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "103",
-      "browserVersion": "103"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "100",
-      "browserVersion": "100"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "101",
+      "browserVersion": "101"
     }
   ],
   "edge": [
@@ -48,15 +48,15 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "103",
-      "browserVersion": "103"
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "100",
-      "browserVersion": "100"
+      "version": "101",
+      "browserVersion": "101"
     }
   ],
   "safari": [
@@ -87,12 +87,12 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "103"
+      "version": "104"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "100"
+      "version": "101"
     }
   ],
   "android": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Adding in some safety around the possibility that a SPA interaction node could `finish()` with a parent node that has been cancelled. This could cause an exception but the possibility of this happening is un-reproducible. This is a do-no-harm best-effort to ensure this error can never happen.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://issues.newrelic.com/browse/NR-93365
https://issues.newrelic.com/browse/NR-91546

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Added a jest test to reproduce and test the issue. I could not consistently reproduce the issue in integration tests.