### PR TITLE
ALL agents must still send initial connect call - NR-95039

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## v1227
 
 ### Added INP and long tasks reporting
-The interaction-to-next-paint metric is now calculated and reported at the end of user sessions, via [Google CWV](https://github.com/GoogleChrome/web-vitals) library. In addition, long continuously executed and blocking scripts detected by the PerformanceLongTaskTiming API is also forwarded to New Relic.
+The interaction-to-next-paint metric is now calculated and reported at the end of user sessions, via [Google CWV](https://github.com/GoogleChrome/web-vitals) library. In addition, long continuously executed and blocking scripts detected by the PerformanceLongTaskTiming API is also forwarded to New Relic. This functionality is `off` by default, until a curated UI experience is created to utilize this data.
 
 ### Revert unwrapping of globals on agent abort
 Partial revert of graceful handling change made in v1225 that unwrapped modified global APIs and handlers, which caused integration issues with other wrapping libraries and code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 ## v1227
 
 ### Added INP and long tasks reporting
-The interaction-to-next-paint metric is now calculated and reported at the end of user sessions, via [Google CWV](https://github.com/GoogleChrome/web-vitals) library. In addition, long continuously executed and blocking scripts detected by the PerformanceLongTaskTiming API is also forwarded to New Relic. This functionality is `off` by default, until a curated UI experience is created to utilize this data.
+The interaction-to-next-paint metric is now calculated and reported at the end of user sessions, via the [Google CWV](https://github.com/GoogleChrome/web-vitals) library. In addition, long continuously executed and blocking scripts detected by the PerformanceLongTaskTiming API are also forwarded to New Relic. This latter functionality is `off` by default, until a curated UI experience is created to utilize this data.
 
 ### Revert unwrapping of globals on agent abort
 Partial revert of graceful handling change made in v1225 that unwrapped modified global APIs and handlers, which caused integration issues with other wrapping libraries and code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ The agent will attempt to handle niche objects throw from `unhandledPromiseRejec
 ### Disable metrics for missing entitlement
 Fixing issue where metrics harvesting was not being halted when the agent RUM call indicated the account did not have entitlement to the jserrors endpoint. Before this change, customers missing this entitlement would see network calls to the New Relic jserrors endpoint result in 403 or 409 errors.
 
+### All agents must make a connect call for NR1 entity synthesis
+This change forces all agents to call ingest at runtime to ensure that entities can be synthesized in NR1.  This particularly pertains to any bespoke agent builds that did not utilize the `page_view_event` feature.
+
 ## v1225
 
 ### Gracefully abort agent if not fully instantiated

--- a/src/common/timing/now.js
+++ b/src/common/timing/now.js
@@ -3,13 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { exists } from './performance-check'
-
 var lastTimestamp = new Date().getTime()
 var offset = lastTimestamp
 
 export function now () {
-  if (exists && performance.now) {
+  if (performance?.now) {
     return Math.round(performance.now())
   }
   // ensure a new timestamp is never smaller than a previous timestamp

--- a/src/common/timing/performance-check.js
+++ b/src/common/timing/performance-check.js
@@ -1,7 +1,0 @@
-/*
- * Copyright 2020 New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
-import { globalScope } from '../util/global-scope'
-export const exists = typeof (globalScope?.performance?.timing?.navigationStart) !== 'undefined'

--- a/src/common/timing/start-time.js
+++ b/src/common/timing/start-time.js
@@ -5,11 +5,8 @@
 
 // Use various techniques to determine the time at which this page started and whether to capture navigation timing information
 
-import { sHash } from '../util/s-hash'
 import { mark } from './stopwatch'
-import { ffVersion } from '../browser-version/firefox-version'
 import { setOffset } from './now'
-import { exists as performanceCheckExists } from './performance-check'
 import { globalScope } from '../util/global-scope'
 
 export let navCookie = true
@@ -26,66 +23,14 @@ export function findStartTime (agentId) {
 }
 
 // Find the start time from the Web Timing 'performance' object.
+// The "timeOrigin" property is the new standard timestamp property shared across main frame and workers, but is not supported in some early Safari browsers (safari<15)
+// navigationStart is deprecated, but can still be used as a fallback
 // http://test.w3.org/webperf/specs/NavigationTiming/
 // http://blog.chromium.org/2010/07/do-you-know-how-slow-your-web-page-is.html
 function findStartWebTiming () {
-  // FF 7/8 has a bug with the navigation start time, so use cookie instead of native interface
-  if (ffVersion && ffVersion < 9) return
-
-  if (performanceCheckExists) {
-    // note that we don't need to use a cookie to record navigation start time
-    navCookie = false
-    return Math.round(globalScope?.performance?.timeOrigin)
-  }
+  // note that we don't need to use a cookie to record navigation start time
+  navCookie = false
+  const timestamp = globalScope?.performance?.timeOrigin || globalScope?.performance?.timing?.navigationStart
+  if (!timestamp) return
+  return Math.round(timestamp)
 }
-/*
-// Find the start time based on a cookie set by Episodes in the unload handler.
-function findStartCookie () {
-  var aCookies = document.cookie.split(' ')
-
-  for (var i = 0; i < aCookies.length; i++) {
-    if (aCookies[i].indexOf('NREUM=') === 0) {
-      var startPage
-      var referrerPage
-      var aSubCookies = aCookies[i].substring('NREUM='.length).split('&')
-      var startTime
-      var bReferrerMatch
-
-      for (var j = 0; j < aSubCookies.length; j++) {
-        if (aSubCookies[j].indexOf('s=') === 0) {
-          startTime = aSubCookies[j].substring(2)
-        } else if (aSubCookies[j].indexOf('p=') === 0) {
-          referrerPage = aSubCookies[j].substring(2)
-          // if the sub-cookie is not the last cookie it will have a trailing ';'
-          if (referrerPage.charAt(referrerPage.length - 1) === ';') {
-            referrerPage = referrerPage.substr(0, referrerPage.length - 1)
-          }
-        } else if (aSubCookies[j].indexOf('r=') === 0) {
-          startPage = aSubCookies[j].substring(2)
-          // if the sub-cookie is not the last cookie it will have a trailing ';'
-          if (startPage.charAt(startPage.length - 1) === ';') {
-            startPage = startPage.substr(0, startPage.length - 1)
-          }
-        }
-      }
-
-      if (startPage) {
-        var docReferrer = sHash(document.referrer)
-        bReferrerMatch = (docReferrer == startPage) // eslint-disable-line
-        if (!bReferrerMatch) {
-          // Navigation did not start at the page that was just exited, check for re-load
-          // (i.e. the page just exited is the current page and the referring pages match)
-          bReferrerMatch = sHash(document.location.href) == startPage && docReferrer == referrerPage // eslint-disable-line
-        }
-      }
-      if (bReferrerMatch && startTime) {
-        var now = new Date().getTime()
-        if ((now - startTime) > 60000) {
-          return
-        }
-        return startTime
-      }
-    }
-  }
-}
-*/

--- a/src/common/timing/start-time.js
+++ b/src/common/timing/start-time.js
@@ -37,6 +37,7 @@ function findStartWebTiming () {
     navCookie = false
     return globalScope?.performance?.timing?.navigationStart
   }
+  return Math.round(globalScope?.performance?.timeOrigin)
 }
 /*
 // Find the start time based on a cookie set by Episodes in the unload handler.

--- a/src/common/timing/start-time.js
+++ b/src/common/timing/start-time.js
@@ -35,9 +35,8 @@ function findStartWebTiming () {
   if (performanceCheckExists) {
     // note that we don't need to use a cookie to record navigation start time
     navCookie = false
-    return globalScope?.performance?.timing?.navigationStart
+    return Math.round(globalScope?.performance?.timeOrigin)
   }
-  return Math.round(globalScope?.performance?.timeOrigin)
 }
 /*
 // Find the start time based on a cookie set by Episodes in the unload handler.

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -2,6 +2,7 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+import { isWorkerScope } from './global-scope'
 export const submitData = {}
 
 /**
@@ -11,12 +12,20 @@ export const submitData = {}
  * @returns {Element}
  */
 submitData.jsonp = function jsonp (url, jsonp) {
-  var element = document.createElement('script')
-  element.type = 'text/javascript'
-  element.src = url + '&jsonp=' + jsonp
-  var firstScript = document.getElementsByTagName('script')[0]
-  firstScript.parentNode.insertBefore(element, firstScript)
-  return element
+  try {
+    if (isWorkerScope) {
+      importScripts(url + '&jsonp=' + jsonp)
+    } else {
+      var element = document.createElement('script')
+      element.type = 'text/javascript'
+      element.src = url + '&jsonp=' + jsonp
+      var firstScript = document.getElementsByTagName('script')[0]
+      firstScript.parentNode.insertBefore(element, firstScript)
+      return element
+    }
+  } catch (err) {
+  // do nothing
+  }
 }
 
 /**

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -35,10 +35,10 @@ submitData.jsonp = function jsonp (url, jsonp) {
  * @param {boolean} sync
  * @returns {XMLHttpRequest}
  */
-submitData.xhr = function xhr (url, body, sync, method = 'POST') {
+submitData.xhr = function xhr (url, body, sync) {
   var request = new XMLHttpRequest()
 
-  request.open(method, url, !sync)
+  request.open('POST', url, !sync)
   try {
     // Set cookie
     if ('withCredentials' in request) request.withCredentials = true

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -14,7 +14,14 @@ export const submitData = {}
 submitData.jsonp = function jsonp (url, jsonp) {
   try {
     if (isWorkerScope) {
-      importScripts(url + '&jsonp=' + jsonp)
+      try {
+        return importScripts(url + '&jsonp=' + jsonp)
+      } catch (e) {
+        // for now theres no other way to execute the callback from ingest without jsonp, or unsafe eval / new Function calls
+        // future work needs to be conducted to allow ingest to return a more traditional JSON API-like experience for the entitlement flags
+        submitData.xhrGet(url + '&jsonp=' + jsonp)
+        return
+      }
     } else {
       var element = document.createElement('script')
       element.type = 'text/javascript'
@@ -28,6 +35,10 @@ submitData.jsonp = function jsonp (url, jsonp) {
   }
 }
 
+submitData.xhrGet = function xhrGet (url) {
+  return submitData.xhr(url, undefined, false, 'GET')
+}
+
 /**
  * Send via XHR
  * @param {string} url
@@ -35,10 +46,10 @@ submitData.jsonp = function jsonp (url, jsonp) {
  * @param {boolean} sync
  * @returns {XMLHttpRequest}
  */
-submitData.xhr = function xhr (url, body, sync) {
+submitData.xhr = function xhr (url, body, sync, method = 'POST') {
   var request = new XMLHttpRequest()
 
-  request.open('POST', url, !sync)
+  request.open(method, url, !sync)
   try {
     // Set cookie
     if ('withCredentials' in request) request.withCredentials = true

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -26,10 +26,10 @@ submitData.jsonp = function jsonp (url, jsonp) {
  * @param {boolean} sync
  * @returns {XMLHttpRequest}
  */
-submitData.xhr = function xhr (url, body, sync) {
+submitData.xhr = function xhr (url, body, sync, method = 'POST') {
   var request = new XMLHttpRequest()
 
-  request.open('POST', url, !sync)
+  request.open(method, url, !sync)
   try {
     // Set cookie
     if ('withCredentials' in request) request.withCredentials = true

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -96,7 +96,6 @@ export class Aggregate extends AggregateBase {
 
     var queryString = fromArray(chunksForQueryString, agentRuntime.maxBytes)
     const url = this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString
-    if (globalScope?.document) submitData.jsonp(url, jsonp)
-    else submitData.xhr(url, undefined, undefined, 'GET')
+    submitData.jsonp(url, jsonp)
   }
 }

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -10,6 +10,7 @@ import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
 import { getActivatedFeaturesFlags } from './initialized-features'
+import { globalScope } from '../../../common/util/global-scope'
 
 const jsonp = 'NREUM.setToken'
 
@@ -44,7 +45,6 @@ export class Aggregate extends AggregateBase {
       return '&' + metricName + '=' + measure.params.value
     }).join('')
 
-    // if (measuresQueryString) {
     // currently we only have one version of our protocol
     // in the future we may add more
     var protocol = '1'
@@ -61,16 +61,16 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('pr', info.product))
     chunksForQueryString.push(param('af', getActivatedFeaturesFlags(this.agentIdentifier).join(',')))
 
-    if (window.performance && typeof (window.performance.timing) !== 'undefined') {
+    if (globalScope.performance && typeof (globalScope.performance.timing) !== 'undefined') {
       var navTimingApiData = ({
-        timing: addPT(window.performance.timing, {}),
-        navigation: addPN(window.performance.navigation, {})
+        timing: addPT(globalScope.performance.timing, {}),
+        navigation: addPN(globalScope.performance.navigation, {})
       })
       chunksForQueryString.push(param('perf', stringify(navTimingApiData)))
     }
 
-    if (window.performance && window.performance.getEntriesByType) {
-      var entries = window.performance.getEntriesByType('paint')
+    if (globalScope.performance && globalScope.performance.getEntriesByType) {
+      var entries = globalScope.performance.getEntriesByType('paint')
       if (entries && entries.length > 0) {
         entries.forEach(function (entry) {
           if (!entry.startTime || entry.startTime <= 0) return
@@ -95,10 +95,8 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('ja', customJsAttributes === '{}' ? null : customJsAttributes))
 
     var queryString = fromArray(chunksForQueryString, agentRuntime.maxBytes)
-
-    submitData.jsonp(
-      this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString,
-      jsonp
-    )
+    const url = this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString
+    if (globalScope?.document) submitData.jsonp(url, jsonp)
+    else submitData.xhr(url, undefined, undefined, 'GET')
   }
 }

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -95,7 +95,9 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('ja', customJsAttributes === '{}' ? null : customJsAttributes))
 
     var queryString = fromArray(chunksForQueryString, agentRuntime.maxBytes)
-    const url = this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString
-    submitData.jsonp(url, jsonp)
+    submitData.jsonp(
+      this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString,
+      jsonp
+    )
   }
 }

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -100,6 +100,8 @@ export class Aggregate extends AggregateBase {
       this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString,
       jsonp
     )
+    // Usually `drain` is invoked automatically after processing feature flags contained in the JSONP callback from
+    // ingest (see `activateFeatures`), so when JSONP cannot execute (as with module workers), we drain manually.
     if (!isValidJsonp) drain(this.agentIdentifier, this.featureName)
   }
 }

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -11,6 +11,7 @@ import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
 import { getActivatedFeaturesFlags } from './initialized-features'
 import { globalScope } from '../../../common/util/global-scope'
+import { drain } from '../../../common/drain/drain'
 
 const jsonp = 'NREUM.setToken'
 
@@ -95,9 +96,10 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('ja', customJsAttributes === '{}' ? null : customJsAttributes))
 
     var queryString = fromArray(chunksForQueryString, agentRuntime.maxBytes)
-    submitData.jsonp(
+    const isValidJsonp = submitData.jsonp(
       this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString,
       jsonp
     )
+    if (!isValidJsonp) drain(this.agentIdentifier, this.featureName)
   }
 }

--- a/src/features/page_view_event/instrument/index.js
+++ b/src/features/page_view_event/instrument/index.js
@@ -13,7 +13,6 @@ export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator, auto = true) {
     super(agentIdentifier, aggregator, FEATURE_NAME, auto)
-    if (!isBrowserScope) return // initial page view times non applicable outside web env
 
     findStartTime(agentIdentifier)
     mark(agentIdentifier, 'firstbyte', getLastTimestamp())

--- a/src/features/utils/lazy-loader.js
+++ b/src/features/utils/lazy-loader.js
@@ -33,26 +33,5 @@ export function lazyLoader (featureName, featurePart) {
       default:
         throw new Error(`Attempted to load unsupported agent feature: ${featureName} ${featurePart}`)
     }
-  } else if (featurePart === 'instrument') {
-    switch (featureName) {
-      case FEATURE_NAMES.ajax:
-        return import(/* webpackChunkName: "ajax-instrument" */ '../ajax/instrument')
-      case FEATURE_NAMES.jserrors:
-        return import(/* webpackChunkName: "jserrors-instrument" */ '../jserrors/instrument')
-      case FEATURE_NAMES.metrics:
-        return import(/* webpackChunkName: "metrics-instrument" */ '../metrics/instrument')
-      case FEATURE_NAMES.pageAction:
-        return import(/* webpackChunkName: "page_action-instrument" */ '../page_action/instrument')
-      case FEATURE_NAMES.pageViewEvent:
-        return import(/* webpackChunkName: "page_view_event-instrument" */ '../page_view_event/instrument')
-      case FEATURE_NAMES.pageViewTiming:
-        return import(/* webpackChunkName: "page_view_timing-instrument" */ '../page_view_timing/instrument')
-      case FEATURE_NAMES.sessionTrace:
-        return import(/* webpackChunkName: "session_trace-instrument" */ '../session_trace/instrument')
-      case FEATURE_NAMES.spa:
-        return import(/* webpackChunkName: "spa-instrument" */ '../spa/instrument')
-      default:
-        throw new Error(`Attempted to load unsupported agent feature: ${featureName} ${featurePart}`)
-    }
   }
 }

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -3,6 +3,8 @@ import { getEnabledFeatures } from './features/enabled-features'
 import { configure } from './configure/configure'
 import { getFeatureDependencyNames } from './features/featureDependencies'
 import { featurePriority, FEATURE_NAMES } from './features/features'
+// required features
+import { Instrument as PageViewEvent } from '../features/page_view_event/instrument'
 // common files
 import { Aggregator } from '../common/aggregate/aggregator'
 import { gosNREUM, gosNREUMInitializedAgents } from '../common/window/nreum'
@@ -16,8 +18,12 @@ export class Agent {
     this.sharedAggregator = new Aggregator({ agentIdentifier: this.agentIdentifier })
     this.features = {}
 
-    this.desiredFeatures = options.features || [] // expected to be a list of static Instrument/InstrumentBase classes, see "spa.js" for example
-    this.desiredFeatures.sort((a, b) => featurePriority[a.featureName] - featurePriority[b.featureName])
+    this.desiredFeatures = new Set(options.features || []) // expected to be a list of static Instrument/InstrumentBase classes, see "spa.js" for example
+
+    // For Now... ALL agents must make the rum call whether the page_view_event feature was enabled or not.
+    // NR1 creates an index on the rum call, and if not seen for a few days, will remove the browser app!
+    // Future work is being planned to evaluate removing this behavior from the backend, but for now we must ensure this call is made
+    this.desiredFeatures.add(PageViewEvent)
 
     Object.assign(this, configure(this.agentIdentifier, options, options.loaderType || 'agent'))
 
@@ -38,8 +44,10 @@ export class Agent {
     // Attempt to initialize all the requested features (sequentially in prio order & synchronously), with any failure aborting the whole process.
     try {
       const enabledFeatures = getEnabledFeatures(this.agentIdentifier)
-      this.desiredFeatures.forEach(f => {
-        if (enabledFeatures[f.featureName]) {
+      const featuresToStart = Array.from(this.desiredFeatures)
+      featuresToStart.sort((a, b) => featurePriority[a.featureName] - featurePriority[b.featureName])
+      featuresToStart.forEach(f => {
+        if (enabledFeatures[f.featureName] || f.featureName === FEATURE_NAMES.pageViewEvent) {
           const dependencies = getFeatureDependencyNames(f.featureName)
           const hasAllDeps = dependencies.every(x => enabledFeatures[x])
           if (!hasAllDeps) warn(`${f.featureName} is enabled but one or more dependent features has been disabled (${JSON.stringify(dependencies)}). This may cause unintended consequences or missing data...`)
@@ -47,15 +55,6 @@ export class Agent {
         }
       })
       gosNREUMInitializedAgents(this.agentIdentifier, this.features, NR_FEATURES_REF_NAME)
-
-      // For Now... ALL agents must make the rum call whether the page_view_event feature is enabled or not.
-      // NR1 creates an index on the rum call, and if not seen for a few days, will remove the browser app!
-      // Future work is being planned to remove this behavior from the backend, but for now we must ensure this call is made
-      if (!this.desiredFeatures.some(x => x.featureName === FEATURE_NAMES.pageViewEvent)) {
-        import('../features/page_view_event/instrument').then(({ Instrument }) => {
-          new Instrument(this.agentIdentifier, this.sharedAggregator)
-        })
-      }
     } catch (err) {
       warn('Failed to initialize all enabled instrument classes (agent aborted) -', err)
       for (const featName in this.features) { // this.features hold only features that have been instantiated

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -47,6 +47,7 @@ export class Agent {
       const featuresToStart = Array.from(this.desiredFeatures)
       featuresToStart.sort((a, b) => featurePriority[a.featureName] - featurePriority[b.featureName])
       featuresToStart.forEach(f => {
+        // pageViewEvent must be enabled because RUM calls are not optional. See comment in constructor and PR 428.
         if (enabledFeatures[f.featureName] || f.featureName === FEATURE_NAMES.pageViewEvent) {
           const dependencies = getFeatureDependencyNames(f.featureName)
           const hasAllDeps = dependencies.every(x => enabledFeatures[x])

--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -27,10 +27,9 @@ export function configure (agentIdentifier, opts = {}, loaderType, forceDrain) {
   setAPI(agentIdentifier, api, forceDrain)
   gosNREUMInitializedAgents(agentIdentifier, nr, 'api')
   gosNREUMInitializedAgents(agentIdentifier, exposed, 'exposed')
-  if (!isWorkerScope) {
-    addToNREUM('activatedFeatures', activatedFeatures)
-    addToNREUM('setToken', (flags) => activateFeatures(flags, agentIdentifier))
-  }
+
+  addToNREUM('activatedFeatures', activatedFeatures)
+  addToNREUM('setToken', (flags) => activateFeatures(flags, agentIdentifier))
 
   return api
 }

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -43,6 +43,7 @@ export class MicroAgent {
       const enabledFeatures = getEnabledFeatures(this.agentIdentifier)
       autoFeatures.forEach(f => {
         if (enabledFeatures[f]) {
+          // TODO - THIS does not work, the instrument switch in lazy loader increases the size of the worker build.  Needs to be revisited
           import(/* webpackChunkName: "lazy-loader" */ '../features/utils/lazy-loader').then(({ lazyLoader }) => {
             return lazyLoader(f, 'instrument')
           }).then(({ Instrument }) => {
@@ -53,6 +54,7 @@ export class MicroAgent {
       })
       nonAutoFeatures.forEach(f => {
         if (enabledFeatures[f]) {
+          // TODO - THIS does not work, the instrument switch in lazy loader increases the size of the worker build.  Needs to be revisited
           import(/* webpackChunkName: "lazy-loader" */ '../features/utils/lazy-loader').then(({ lazyLoader }) => {
             return lazyLoader(f, 'aggregate')
           }).then(({ Aggregate }) => {

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -55,6 +55,7 @@ export class MicroAgent {
       nonAutoFeatures.forEach(f => {
         if (enabledFeatures[f]) {
           // TODO - THIS does not work, the instrument switch in lazy loader increases the size of the worker build.  Needs to be revisited
+          // Parts of the lazy-loader were removed because webpack was transpiling them into the worker build, errantly inflating the build size.
           import(/* webpackChunkName: "lazy-loader" */ '../features/utils/lazy-loader').then(({ lazyLoader }) => {
             return lazyLoader(f, 'aggregate')
           }).then(({ Aggregate }) => {

--- a/tests/functional/metrics.test.js
+++ b/tests/functional/metrics.test.js
@@ -64,7 +64,7 @@ testDriver.test('agent tracks resources seen', withUnload, function (t, browser,
       // depending on when metrics agg gets imported, this can be slightly different values.  Just test that its positive
       t.ok(nonAjaxInternal.stats.c > 0, 'Non-Ajax External has a value')
       t.equal(nonAjaxExternal.stats.c, 2, 'Non-Ajax Internal has the correct value')
-      t.equal(ajaxInternal.stats.c, 1, 'Ajax Internal has the correct value')
+      t.equal(ajaxInternal.stats.c, 2, 'Ajax Internal has the correct value')
       t.equal(ajaxExternal.stats.c, 1, 'Ajax External has the correct value')
       t.end()
     })

--- a/tests/functional/metrics.test.js
+++ b/tests/functional/metrics.test.js
@@ -63,9 +63,9 @@ testDriver.test('agent tracks resources seen', withUnload, function (t, browser,
 
       // depending on when metrics agg gets imported, this can be slightly different values.  Just test that its positive
       t.ok(nonAjaxInternal.stats.c > 0, 'Non-Ajax External has a value')
-      t.equal(nonAjaxExternal.stats.c, 2, 'Non-Ajax Internal has the correct value')
-      t.equal(ajaxInternal.stats.c, 2, 'Ajax Internal has the correct value')
-      t.equal(ajaxExternal.stats.c, 1, 'Ajax External has the correct value')
+      t.ok(nonAjaxExternal.stats.c >= 2, 'Non-Ajax Internal has the correct value')
+      t.ok(ajaxInternal.stats.c >= 2, 'Ajax Internal has the correct value')
+      t.equal(ajaxExternal.stats.c > 0, 'Ajax External has the correct value')
       t.end()
     })
     .catch(failWithEndTimeout(t))

--- a/tests/functional/metrics.test.js
+++ b/tests/functional/metrics.test.js
@@ -65,7 +65,7 @@ testDriver.test('agent tracks resources seen', withUnload, function (t, browser,
       t.ok(nonAjaxInternal.stats.c > 0, 'Non-Ajax External has a value')
       t.ok(nonAjaxExternal.stats.c >= 2, 'Non-Ajax Internal has the correct value')
       t.ok(ajaxInternal.stats.c >= 2, 'Ajax Internal has the correct value')
-      t.equal(ajaxExternal.stats.c > 0, 'Ajax External has the correct value')
+      t.ok(ajaxExternal.stats.c > 0, 'Ajax External has the correct value')
       t.end()
     })
     .catch(failWithEndTimeout(t))

--- a/tests/functional/worker/ajax-events.test.js
+++ b/tests/functional/worker/ajax-events.test.js
@@ -35,8 +35,9 @@ function ajaxEventsEnabled (type, browserVersionMatcher) {
 
       const loadPromise = browser.get(assetURL)
       const ajaxPromise = router.expectAjaxEvents(7000)
+      const rumPromise = router.expectRum()
 
-      Promise.all([ajaxPromise, loadPromise])
+      Promise.all([ajaxPromise, rumPromise, loadPromise])
         .then(([{ request }]) => {
           const requests = querypack.decode(request.body)
 
@@ -87,8 +88,9 @@ function ajaxEventsPayload (type, browserVersionMatcher) {
         router.expectAjaxEvents(7000),
         router.expectAjaxEvents(14000)
       ])
+      const rumPromise = router.expectRum()
 
-      Promise.all([ajaxPromise, loadPromise])
+      Promise.all([ajaxPromise, rumPromise, loadPromise])
         .then(([responses]) => {
           t.ok(responses)
       	t.end()
@@ -128,8 +130,9 @@ function ajaxDTInfo (type, browserVersionMatcher) {
 
       const loadPromise = browser.get(assetURL)
       const ajaxPromise = router.expectAjaxEvents(7000)
+      const rumPromise = router.expectRum()
 
-      Promise.all([ajaxPromise, loadPromise])
+      Promise.all([ajaxPromise, rumPromise, loadPromise])
         .then(([{ request }]) => {
           const requests = querypack.decode(request.body)
             .filter(r => r.path === '/json')

--- a/tests/functional/worker/all-uncategorized.test.js
+++ b/tests/functional/worker/all-uncategorized.test.js
@@ -31,8 +31,9 @@ function apiFinished (type, browserVersionMatcher) {
 
       let loadPromise = browser.get(assetURL)
       let insPromise = router.expectIns()
+      const rumPromise = router.expectRum()
 
-      Promise.all([loadPromise, insPromise])
+      Promise.all([loadPromise, insPromise, rumPromise])
         .then(([/* loadPromise junk */, { request: { body } }]) => {
           let insData = JSON.parse(body).ins
           t.equal(insData.length, 1, 'exactly 1 PageAction was submitted')
@@ -61,8 +62,9 @@ function apiAddReleaseTooMany (type, browserVersionMatcher) {
 
       let loadPromise = browser.get(assetURL)
       let errPromise = router.expectErrors()
+      const rumPromise = router.expectRum()
 
-      Promise.all([loadPromise, errPromise])
+      Promise.all([loadPromise, errPromise, rumPromise])
         .then(([, { request: { query } }]) => {
           const queryRi = JSON.parse(query.ri)
           const ri = {}
@@ -97,11 +99,12 @@ function apiAddReleaseTooLong (type, browserVersionMatcher) {
 
       let loadPromise = browser.get(assetURL)
       let errPromise = router.expectErrors()
+      const rumPromise = router.expectRum()
       const ninetyNineY = 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy'
       const oneHundredX = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
       const twoHundredCharacterString = ninetyNineY + oneHundredX + 'q'
 
-      Promise.all([loadPromise, errPromise])
+      Promise.all([loadPromise, errPromise, rumPromise])
         .then(([, { request: { query } }]) => {
           const queryRi = JSON.parse(query.ri)
           const ri = {
@@ -132,8 +135,9 @@ function apiAddReleaseNotUsed (type, browserVersionMatcher) {
 
       let loadPromise = browser.get(assetURL)
       let errPromise = router.expectErrors()
+      const rumPromise = router.expectRum()
 
-      Promise.all([loadPromise, errPromise])
+      Promise.all([loadPromise, errPromise, rumPromise])
         .then(([, { request: { query } }]) => {
           t.notOk('ri' in query, 'should not have ri query param')
       	t.end()
@@ -158,7 +162,7 @@ function harvestReferrerSent (type, browserVersionMatcher) {
       const loadPromise = browser.get(assetURL)
       const ajaxPromise = router.expectAjaxEvents()	// used in place of RUM call that dne in workers
 
-      Promise.all([ajaxPromise, loadPromise])
+      Promise.all([ajaxPromise, loadPromise, router.expectRum()])
         .then(([{ request: { query } }]) => {
           t.ok(query.ref, 'The query string should include the ref attribute.')
 
@@ -186,7 +190,7 @@ function harvestSessionIsNullWhenEnabled (type, browserVersionMatcher) {
       const loadPromise = browser.get(assetURL)
       const ajaxPromise = router.expectAjaxEvents()	// used in place of RUM call that dne in workers
 
-      Promise.all([ajaxPromise, loadPromise])
+      Promise.all([ajaxPromise, loadPromise, router.expectRum()])
         .then(([{ request: { query } }]) => {
           t.equal(query.ck, '0', "The cookie flag ('ck') should equal 0.")
     		t.equal(query.s, '0', "The session id attr 's' should be 0.")
@@ -244,7 +248,7 @@ function obfuscateAll (type, browserVersionMatcher) {
       const errorsPromise = router.expectErrors()
       const insPromise = router.expectIns()
 
-      Promise.all([loadPromise, ajaxPromise, errorsPromise, insPromise])
+      Promise.all([loadPromise, ajaxPromise, errorsPromise, insPromise, router.expectRum()])
         .then(([, ajaxResponse, errorsResponse, insResponse]) => {
           checkPayload(t, ajaxResponse.request.body, 'AJAX')
           checkPayload(t, errorsResponse.request.body, 'Errors')

--- a/tests/functional/worker/auto-instrumented-errors.test.js
+++ b/tests/functional/worker/auto-instrumented-errors.test.js
@@ -45,7 +45,7 @@ function referenceErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request: errResponse }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request: errResponse }]) => {
       const { err } = JSON.parse(errResponse.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')
@@ -76,7 +76,7 @@ function unhandledPromiseRejectionTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    timedPromiseAll([errPromise, loadPromise], 6000).then(([{ request: errResponse }]) => {
+    timedPromiseAll([errPromise, loadPromise, router.expectRum()], 6000).then(([{ request: errResponse }]) => {
       const { err } = JSON.parse(errResponse.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')
@@ -111,7 +111,7 @@ function rangeErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request: errResponse }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request: errResponse }]) => {
       const { err } = JSON.parse(errResponse.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')
@@ -145,7 +145,7 @@ function typeErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request: errResponse }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request: errResponse }]) => {
       const { err } = JSON.parse(errResponse.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')
@@ -178,7 +178,7 @@ function uriErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request: errResponse }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request: errResponse }]) => {
       const { err } = JSON.parse(errResponse.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')
@@ -216,7 +216,7 @@ function memoryLeakTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    timedPromiseAll([errPromise, loadPromise], 6000).then(([{ request: errResponse }]) => {
+    timedPromiseAll([errPromise, loadPromise, router.expectRum()], 6000).then(([{ request: errResponse }]) => {
       const { err } = JSON.parse(errResponse.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')
@@ -250,7 +250,7 @@ function syntaxErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request: errResponse }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request: errResponse }]) => {
       const { err } = JSON.parse(errResponse.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')
@@ -281,7 +281,7 @@ function thrownErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request: errResponse }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request: errResponse }]) => {
       const { err } = JSON.parse(errResponse.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')

--- a/tests/functional/worker/circular.test.js
+++ b/tests/functional/worker/circular.test.js
@@ -38,7 +38,7 @@ function circularTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const actualErrors = getErrorsFromResponse(request, browser)
 
       t.equal(actualErrors.length, 1, 'exactly one error')

--- a/tests/functional/worker/disable-errors.test.js
+++ b/tests/functional/worker/disable-errors.test.js
@@ -39,7 +39,7 @@ function disabledJsErrorsTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    timedPromiseAll([errPromise, loadPromise], 6000).then((response) => {
+    timedPromiseAll([errPromise, loadPromise, router.expectRum()], 6000).then((response) => {
       if (response) {
         // will be null if timed out, so a payload here means it sent and error
         t.fail('Should not have generated "error" payload')

--- a/tests/functional/worker/dt-headers-fetch.test.js
+++ b/tests/functional/worker/dt-headers-fetch.test.js
@@ -87,7 +87,7 @@ function fetchDTHeader (type, testCase, browserVersionMatcher) {
             }
           })
 
-          Promise.all([ajaxPromise, loadPromise])
+          Promise.all([ajaxPromise, loadPromise, router.expectRum()])
             .then(([{ request: { headers } }]) => {
               if (testCase.newrelicHeader) {
                 validateNewrelicHeader(t, headers, config)

--- a/tests/functional/worker/eol-harvest.test.js
+++ b/tests/functional/worker/eol-harvest.test.js
@@ -33,7 +33,7 @@ function finalHarvest (type, browserVersionMatcher) {
       const ajaxPromise = router.expectAjaxEvents()
       const insPromise = router.expectIns()
 
-      Promise.all([loadPromise, metrPromise, errPromise, ajaxPromise, insPromise])
+      Promise.all([loadPromise, metrPromise, errPromise, ajaxPromise, insPromise, router.expectRum()])
         .then(([, metrResponse, errResponse, ajaxResponse, insResponse]) => {
           let body
 

--- a/tests/functional/worker/errors-harvest-retries.test.js
+++ b/tests/functional/worker/errors-harvest-retries.test.js
@@ -38,7 +38,7 @@ function errorRetryTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([response]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([response]) => {
       t.equal(response.reply.statusCode, 429, 'server responded with 429')
       firstBody = JSON.parse(response.request.body).err
       return router.expectErrors()

--- a/tests/functional/worker/errors-have-custom-attributes.test.js
+++ b/tests/functional/worker/errors-have-custom-attributes.test.js
@@ -33,7 +33,7 @@ function setCustomAttributeTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const actualErrors = getErrorsFromResponse(request, browser)
 
       t.equal(actualErrors.length, 1, 'exactly one error')

--- a/tests/functional/worker/event-listener-errors.test.js
+++ b/tests/functional/worker/event-listener-errors.test.js
@@ -35,7 +35,7 @@ function eventListenerTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const actualErrors = getErrorsFromResponse(request, browser)
 
       t.equal(actualErrors.length, 1, 'exactly one error')

--- a/tests/functional/worker/external-error.test.js
+++ b/tests/functional/worker/external-error.test.js
@@ -34,7 +34,7 @@ function externalTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const { err } = JSON.parse(request.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 1, 'Should have seen 1 error')

--- a/tests/functional/worker/metrics.test.js
+++ b/tests/functional/worker/metrics.test.js
@@ -143,7 +143,7 @@ function metricsInvalidObfuscationCreatesSM (type, browserVersionMatcher) {
       const loadPromise = browser.get(assetURL)
       const metricsPromise = router.expectMetrics(5000)
 
-      Promise.all([metricsPromise, loadPromise])
+      Promise.all([metricsPromise, loadPromise, router.expectRum()])
         .then(([{ request: data }]) => {
           const supportabilityMetrics = getMetricsFromResponse(data, true)
           t.ok(supportabilityMetrics && !!supportabilityMetrics.length, 'SupportabilityMetrics object(s) were generated')

--- a/tests/functional/worker/notice-error.test.js
+++ b/tests/functional/worker/notice-error.test.js
@@ -35,7 +35,7 @@ function noticeErrorTest (type, supportRegOrESMWorker) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const { err } = JSON.parse(request.body)
       checkBasics(t, err)
       t.deepEqual(err[0].custom, { ...workerCustomAttrs }, 'Should not have correct custom attributes')
@@ -54,7 +54,7 @@ function noticeErrorStringTest (type, supportRegOrESMWorker) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const { err } = JSON.parse(request.body)
       checkBasics(t, err)
       t.deepEqual(err[0].custom, { ...workerCustomAttrs }, 'Should not have correct custom attributes')
@@ -75,7 +75,7 @@ function noticeErrorWithParamsTest (type, supportRegOrESMWorker) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const { err } = JSON.parse(request.body)
       checkBasics(t, err)
       t.deepEqual(err[0].custom, { hi: 'mom', ...workerCustomAttrs }, 'Should have correct custom attributes')
@@ -98,7 +98,7 @@ function multipleMatchingErrorsTest (type, supportRegOrESMWorker) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const { err } = JSON.parse(request.body)
       t.equal(err.length, 1, 'Should have 1 error obj')
       t.equal(err[0].metrics.count, 3, 'Should have aggregated 3 errors')

--- a/tests/functional/worker/page-action.test.js
+++ b/tests/functional/worker/page-action.test.js
@@ -23,7 +23,7 @@ function paSubmission (type, supportRegOrESMWorker) {
     let loadPromise = browser.get(assetURL)
     let insPromise = router.expectIns()
 
-    Promise.all([loadPromise, insPromise])
+    Promise.all([loadPromise, insPromise, router.expectRum()])
       .then(([/* loadPromise junk */, { request }]) => {
         t.equal(request.method, 'POST', 'first PageAction submission is a POST')
         t.notOk(request.query.ins, 'query string does not include ins parameter')
@@ -52,7 +52,7 @@ function paRetry (type, supportRegOrESMWorker) {
     let insPromise = router.expectIns()
     let firstBody
 
-    Promise.all([loadPromise, insPromise])
+    Promise.all([loadPromise, insPromise, router.expectRum()])
       .then(([, insResult]) => {
         t.equal(insResult.reply.statusCode, 429, 'server responded with 429')
         firstBody = JSON.parse(insResult.request.body)
@@ -87,7 +87,7 @@ function paPrecedence (type, supportRegOrESMWorker) {
     let loadPromise = browser.get(assetURL)
     let insPromise = router.expectIns()
 
-    Promise.all([loadPromise, insPromise])
+    Promise.all([loadPromise, insPromise, router.expectRum()])
       .then(([, { request }]) => {
         precValidatePageActionData(JSON.parse(request.body).ins)
         t.end()

--- a/tests/functional/worker/set-error-handler-ignore.test.js
+++ b/tests/functional/worker/set-error-handler-ignore.test.js
@@ -46,7 +46,7 @@ function ignoreErrorsTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       assertErrorAttributes(t, request.query, 'has errors')
 
       const actualErrors = getErrorsFromResponse(request, browser)

--- a/tests/functional/worker/set-interval-error.test.js
+++ b/tests/functional/worker/set-interval-error.test.js
@@ -37,7 +37,7 @@ function setIntervalErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const actualErrors = getErrorsFromResponse(request, browser)
 
       t.equal(actualErrors.length, 1, 'exactly one error')

--- a/tests/functional/worker/set-timeout-error.test.js
+++ b/tests/functional/worker/set-timeout-error.test.js
@@ -36,7 +36,7 @@ function setTimeoutErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const actualErrors = getErrorsFromResponse(request, browser)
 
       t.equal(actualErrors.length, 1, 'exactly one error')

--- a/tests/functional/worker/xhr-assorted.test.js
+++ b/tests/functional/worker/xhr-assorted.test.js
@@ -59,7 +59,7 @@ function addEventListenerPatched (type, browserVersionMatcher) {
       const loadPromise = browser.get(assetURL)
       const xhrMetricsPromise = router.expectAjaxTimeSlices()
 
-      Promise.all([loadPromise, xhrMetricsPromise])
+      Promise.all([loadPromise, xhrMetricsPromise, router.expectRum()])
         .then(([, { request }]) => {
           t.ok(!!getXhrFromResponse(request), 'got XHR data')
       	t.end()
@@ -97,7 +97,7 @@ function constructorRuntimePatched (type, browserVersionMatcher) {
       const loadPromise = browser.get(assetURL)
       const xhrMetricsPromise = router.expectAjaxTimeSlices()
 
-      Promise.all([loadPromise, xhrMetricsPromise])
+      Promise.all([loadPromise, xhrMetricsPromise, router.expectRum()])
         .then(([, { request }]) => {
           t.ok(!!getXhrFromResponse(request), 'got XHR data')
       	t.end()
@@ -132,7 +132,7 @@ function catCors (type, browserVersionMatcher) {
         }
       })
 
-      Promise.all([ajaxPromise, loadPromise])
+      Promise.all([ajaxPromise, loadPromise, router.expectRum()])
         .then(([{ request }]) => {
           t.notok(request.headers['x-newrelic-id'], 'cross-origin XHR should not have CAT header')
       	t.end()
@@ -172,7 +172,7 @@ function harvestRetried (type, browserVersionMatcher) {
       const ajaxPromise = router.expectAjaxEvents()
       let firstBody
 
-      Promise.all([ajaxPromise, loadPromise])
+      Promise.all([ajaxPromise, loadPromise, router.expectRum()])
         .then(([result]) => {
           t.equal(result.reply.statusCode, 429, 'server responded with 429')
           firstBody = querypack.decode(result.request.body)
@@ -218,7 +218,7 @@ function abortCalled (type, browserVersionMatcher) {
       const loadPromise = browser.get(assetURL)
       const xhrPromise = router.expectAjaxTimeSlices()
 
-      Promise.all([xhrPromise, loadPromise])
+      Promise.all([xhrPromise, loadPromise, router.expectRum()])
         .then(([{ request }]) => {
           const parsedXhrs = getXhrFromResponse(request, browser)
           t.ok(parsedXhrs, 'got XHR data')

--- a/tests/functional/worker/xhr-jserror.test.js
+++ b/tests/functional/worker/xhr-jserror.test.js
@@ -46,7 +46,7 @@ function xhrErrorTest (type, matcher) {
     let loadPromise = browser.get(assetURL)
     let errPromise = router.expectErrors()
 
-    Promise.all([errPromise, loadPromise]).then(([{ request }]) => {
+    Promise.all([errPromise, loadPromise, router.expectRum()]).then(([{ request }]) => {
       const actualErrors = getErrorsFromResponse(request, browser)
 
       t.equal(actualErrors.length, 1, 'exactly one error')


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Recent revelations from ingest have indicated that the current architecture of downstream teams relies on all reporting apps to call the `/1` endpoint to mark the entity for internal storage and avoid garbage collection. Niche builds of the agent that did not include that initial call were subject to be garbage collected in NR1, and as such, we need to enforce that the `/1` call not be able to be disabled until another solution is reached.

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://issues.newrelic.com/browse/NR-95039
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Workers tests were modified to also expect a RUM call.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
