### PR TITLE
Run LT behind a config flag - NR-95944

### DIFF
--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -19,7 +19,7 @@ const model = {
   metrics: { enabled: true },
   page_action: { enabled: true, harvestTimeSeconds: 30 },
   page_view_event: { enabled: true },
-  page_view_timing: { enabled: true, harvestTimeSeconds: 30 },
+  page_view_timing: { enabled: true, harvestTimeSeconds: 30, long_task: false },
   session_trace: { enabled: true, harvestTimeSeconds: 10 },
   spa: { enabled: true, harvestTimeSeconds: 10 }
 }

--- a/src/features/page_view_timing/instrument/index.js
+++ b/src/features/page_view_timing/instrument/index.js
@@ -6,7 +6,7 @@ import { handle } from '../../../common/event-emitter/handle'
 import { subscribeToVisibilityChange, initializeHiddenTime } from '../../../common/window/page-visibility'
 import { documentAddEventListener, windowAddEventListener } from '../../../common/event-listener/event-listener-opts'
 import { getOffset, now } from '../../../common/timing/now'
-import { originals } from '../../../common/config/config'
+import { getConfigurationValue, originals } from '../../../common/config/config'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
@@ -62,9 +62,11 @@ export class Instrument extends InstrumentBase {
       handle('timing', [name.toLowerCase(), value, { metricId: id }], undefined, FEATURE_NAMES.pageViewTiming, this.ee)
     })
 
-    onLongTask(({ name, value, info }) => {
-      handle('timing', [name.toLowerCase(), value, info], undefined, FEATURE_NAMES.pageViewTiming, this.ee) // lt context is passed as attrs in the timing node
-    })
+    if (getConfigurationValue(this.agentIdentifier, 'page_view_timing.long_task') === true) {
+      onLongTask(({ name, value, info }) => {
+        handle('timing', [name.toLowerCase(), value, info], undefined, FEATURE_NAMES.pageViewTiming, this.ee) // lt context is passed as attrs in the timing node
+      })
+    }
 
     // Document visibility state becomes hidden
     subscribeToVisibilityChange(() => {

--- a/tests/functional/pvt/timings.test.js
+++ b/tests/functional/pvt/timings.test.js
@@ -685,7 +685,7 @@ function runLcpTests (loader) {
 function runLongTasksTest (loader) {
   testDriver.test(`${loader}: emits long task timings when observed`, supportsLT, function (t, browser, router) {
     const rumPromise = router.expectRum()
-    const loadPromise = browser.safeGet(router.assetURL('long-tasks.html', { loader: loader }))
+    const loadPromise = browser.safeGet(router.assetURL('long-tasks.html', { loader: loader, init: { page_view_timing: { long_task: true } } }))
       .waitForConditionInBrowser('window.tasksDone === true')
 
     Promise.all([rumPromise, loadPromise])


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR puts the `Long Task` API behind a config flag under the `page_view_timing` setting.  It can be configured at `init.page_view_timing.long_task: bool` which defaults to `false`
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://issues.newrelic.com/browse/NR-95944
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Long task tests needed the flag to be set to run correctly now, so that adjustment has been made to the existing tests.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
