### PR TITLE
Add polyfill for Set, now used for desiredFeatures.

### DIFF
--- a/src/cdn/polyfills.js
+++ b/src/cdn/polyfills.js
@@ -9,6 +9,7 @@ import 'core-js/stable/object/entries'
 import 'core-js/stable/object/values'
 import 'core-js/stable/map'
 import 'core-js/stable/reflect'
+import 'core-js/stable/set'
 
 // promise
 // ie - none


### PR DESCRIPTION
### Overview

As of [PR 428](https://github.com/newrelic/newrelic-browser-agent/pull/428), the `Set` object is used for `desiredFeatures`. IE 11 requires a polyfill for this object.

### Related Issue(s)

N/A

### Testing

Standard automated tests should pass, especially polyfill tests.