### PR TITLE
Increase harvest timeout due to race condition.

### DIFF
--- a/tests/functional/worker/xhr-assorted.test.js
+++ b/tests/functional/worker/xhr-assorted.test.js
@@ -149,7 +149,7 @@ function harvestRetried (type, browserVersionMatcher) {
         init: {
           harvest: { tooManyRequestsDelay: 10 },
           ajax: {
-            harvestTimeSeconds: 2,
+            harvestTimeSeconds: 5,
             enabled: true
           },
           metrics: { enabled: false }


### PR DESCRIPTION
### Overview

This PR addresses a race condition that was resulting in a brittle test. This was a problem with the test, not with agent code.

The `harvestRetried` test in `tests/functional/worker/xhr-assorted.test.js` would fail on `second body should include the contents of the first retried harvest` about 30% of the time. This was due to a too-short harvest interval of 2 seconds, which for module workers in particular, was causing the first AJAX harvest to capture the recently added RUM call but not the call to `/json` the test was looking for. (Previously the harvest cycle would run multiple times before picking up the call to `/json`, but after adding the RUM call for workers in PR 428, the RUM call satisfies the first harvest cycle part of the time). Increasing the interval to 5 seconds allows time for the call to `/json` to be made, so that the first AJAX harvest picks up both that and the RUM call and can do a valid comparison of the second harvest body with the first, finding `/json` in both.

### Related Issue(s)

N/A

### Testing

Tests in `tests/functional/worker/xhr-assorted.test.js` should pass consistently.