### PR TITLE
Fixed incorrect passing of options to BrowserAgent and WorkerAgent

### DIFF
--- a/src/loaders/browser-agent.js
+++ b/src/loaders/browser-agent.js
@@ -1,5 +1,6 @@
 import { Agent } from './agent'
 
+import { generateRandomHexString } from '../common/ids/unique-id'
 import { Instrument as InstrumentPageViewEvent } from '../features/page_view_event/instrument'
 import { Instrument as InstrumentPageViewTiming } from '../features/page_view_timing/instrument'
 import { Instrument as InstrumentMetrics } from '../features/metrics/instrument'
@@ -10,9 +11,9 @@ import { Instrument as InstrumentSpa } from '../features/spa/instrument'
 import { Instrument as InstrumentPageAction } from '../features/page_action/instrument'
 
 export class BrowserAgent extends Agent {
-  constructor (...args) {
+  constructor (options, agentIdentifier = generateRandomHexString(16)) {
     super({
-      ...args,
+      ...options,
       features: [
         InstrumentXhr,
         InstrumentPageViewEvent,
@@ -24,6 +25,6 @@ export class BrowserAgent extends Agent {
         InstrumentSpa
       ],
       loaderType: 'browser-agent'
-    })
+    }, agentIdentifier)
   }
 }

--- a/src/loaders/browser-agent.js
+++ b/src/loaders/browser-agent.js
@@ -1,6 +1,5 @@
 import { Agent } from './agent'
 
-import { generateRandomHexString } from '../common/ids/unique-id'
 import { Instrument as InstrumentPageViewEvent } from '../features/page_view_event/instrument'
 import { Instrument as InstrumentPageViewTiming } from '../features/page_view_timing/instrument'
 import { Instrument as InstrumentMetrics } from '../features/metrics/instrument'
@@ -11,7 +10,7 @@ import { Instrument as InstrumentSpa } from '../features/spa/instrument'
 import { Instrument as InstrumentPageAction } from '../features/page_action/instrument'
 
 export class BrowserAgent extends Agent {
-  constructor (options, agentIdentifier = generateRandomHexString(16)) {
+  constructor (options) {
     super({
       ...options,
       features: [
@@ -25,6 +24,6 @@ export class BrowserAgent extends Agent {
         InstrumentSpa
       ],
       loaderType: 'browser-agent'
-    }, agentIdentifier)
+    })
   }
 }

--- a/src/loaders/worker-agent.js
+++ b/src/loaders/worker-agent.js
@@ -1,14 +1,15 @@
 import { Agent } from './agent'
 
+import { generateRandomHexString } from '../common/ids/unique-id'
 import { Instrument as InstrumentMetrics } from '../features/metrics/instrument'
 import { Instrument as InstrumentErrors } from '../features/jserrors/instrument'
 import { Instrument as InstrumentXhr } from '../features/ajax/instrument'
 import { Instrument as InstrumentPageAction } from '../features/page_action/instrument'
 
 export class WorkerAgent extends Agent {
-  constructor (...args) {
+  constructor (options, agentIdentifier = generateRandomHexString(16)) {
     super({
-      ...args,
+      ...options,
       features: [
         InstrumentMetrics,
         InstrumentErrors,
@@ -16,6 +17,6 @@ export class WorkerAgent extends Agent {
         InstrumentPageAction
       ],
       loaderType: 'worker-agent'
-    })
+    }, agentIdentifier)
   }
 }

--- a/src/loaders/worker-agent.js
+++ b/src/loaders/worker-agent.js
@@ -1,13 +1,12 @@
 import { Agent } from './agent'
 
-import { generateRandomHexString } from '../common/ids/unique-id'
 import { Instrument as InstrumentMetrics } from '../features/metrics/instrument'
 import { Instrument as InstrumentErrors } from '../features/jserrors/instrument'
 import { Instrument as InstrumentXhr } from '../features/ajax/instrument'
 import { Instrument as InstrumentPageAction } from '../features/page_action/instrument'
 
 export class WorkerAgent extends Agent {
-  constructor (options, agentIdentifier = generateRandomHexString(16)) {
+  constructor (options) {
     super({
       ...options,
       features: [
@@ -17,6 +16,6 @@ export class WorkerAgent extends Agent {
         InstrumentPageAction
       ],
       loaderType: 'worker-agent'
-    }, agentIdentifier)
+    })
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Obviously, the idea is that `args` will be an `options` object, and we pass it along with the spread operator. Unfortunately, JS [works a little differently](https://javascript.info/rest-parameters-spread), and `args` is an array of function arguments. Therefore, it becomes impossible to initiate new agent instances with the `options` that we are trying to pass there..

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
