### PR TITLE
Handle sendBeacon more gracefully - NR-95365

### DIFF
--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -84,7 +84,7 @@ submitData.img = function img (url) {
  * Send via sendBeacon. Do NOT call this function outside of a guaranteed web window environment.
  * @param {string} url
  * @param {string} body
- * @returns {function}
+ * @returns {boolean}
  */
 submitData.beacon = function (url, body) {
   // Navigator has to be bound to ensure it does not error in some browsers
@@ -96,6 +96,6 @@ submitData.beacon = function (url, body) {
     // if sendBeacon still trys to throw an illegal invocation error,
     // we can catch here and return.  The harvest module will fallback to use
     // .img to try to send
-    return
+    return false
   }
 }

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -84,11 +84,18 @@ submitData.img = function img (url) {
  * Send via sendBeacon. Do NOT call this function outside of a guaranteed web window environment.
  * @param {string} url
  * @param {string} body
- * @returns {boolean}
+ * @returns {function}
  */
 submitData.beacon = function (url, body) {
   // Navigator has to be bound to ensure it does not error in some browsers
   // https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch
-  const send = window.navigator.sendBeacon.bind(navigator)
-  return send(url, body)
+  const send = window.navigator.sendBeacon.bind(window.navigator)
+  try {
+    return send(url, body)
+  } catch (err) {
+    // if sendBeacon still trys to throw an illegal invocation error,
+    // we can catch here and return.  The harvest module will fallback to use
+    // .img to try to send
+    return
+  }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Illegal Invocation errors still pop up from time to time on sendBeacon calls, even after work to bind scope to the beacon caller. There is nothing more we can do to get around this, besides failing gracefully and falling back to another call type.  This PR addresses that workflow.

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
Nr-95365
