### PR TITLE
NEWRELIC-6739: Adding other asset sizes to report

### DIFF
--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -115,10 +115,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "15.4",
-      "device": "iPhone 6s Plus",
-      "appium:deviceName": "iPhone 6s Plus Simulator",
-      "appium:platformVersion": "15.4",
+      "version": "15.5",
+      "device": "iPhone 7 Plus",
+      "appium:deviceName": "iPhone 7 Plus Simulator",
+      "appium:platformVersion": "15.5",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"
@@ -129,10 +129,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "15.2",
-      "device": "iPhone 7 Plus",
-      "appium:deviceName": "iPhone 7 Plus Simulator",
-      "appium:platformVersion": "15.2",
+      "version": "15.4",
+      "device": "iPhone 6s Plus",
+      "appium:deviceName": "iPhone 6s Plus Simulator",
+      "appium:platformVersion": "15.4",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"

--- a/tools/scripts/diff-sizes.mjs
+++ b/tools/scripts/diff-sizes.mjs
@@ -124,6 +124,17 @@ function generateDiffRows (assetSizes, buildType) {
   }).join('\n')
 }
 
+function generateOtherDiffRows (assetSizes, buildType, assetGroup) {
+  const targetBuildTypeSizes = assetSizes[buildType]
+  return Object.keys(targetBuildTypeSizes[assetGroup])
+    .filter(assetName => assetName.indexOf('nr-loader') === -1)
+    .map(assetName => {
+      const buildSizes = targetBuildTypeSizes[assetGroup][assetName]
+      const buildSizesResult = `${filesize(buildSizes.fileSize)} / ${filesize(buildSizes.gzipSize)} (gzip)`
+      return `|${assetName}|${buildSizesResult}|`
+    }).join('\n')
+}
+
 async function writeDiff (assetSizes) {
   await fs.ensureDir(config.out)
   await fs.writeJson(path.join(config.out, 'size_report.json'), assetSizes, { spaces: 2 })
@@ -136,7 +147,39 @@ ${generateDiffRows(assetSizes, 'standard')}
 ${generateDiffRows(assetSizes, 'polyfills')}
 ${generateDiffRows(assetSizes, 'worker')}
 
-<sub>This report only accounts for the minified loaders. Un-minified and async-loaded assets are not included.</sub>
+<details>
+<summary>Other Standard Assets</summary>
+
+## Released Assets
+
+| Asset Name | Asset Size |
+|------------|------------|
+${generateOtherDiffRows(assetSizes, 'standard', 'releaseStats')}
+
+## Built Assets
+
+| Asset Name | Asset Size |
+|------------|------------|
+${generateOtherDiffRows(assetSizes, 'standard', 'buildStats')}
+
+</details>
+
+<details>
+<summary>Other Polyfills Assets</summary>
+
+## Released Assets
+
+| Asset Name | Asset Size |
+|------------|------------|
+${generateOtherDiffRows(assetSizes, 'polyfills', 'releaseStats')}
+
+## Built Assets
+
+| Asset Name | Asset Size |
+|------------|------------|
+${generateOtherDiffRows(assetSizes, 'polyfills', 'buildStats')}
+
+</details>
 `
   )
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
This adds two other assets sections to the PR report that list out the released and built sizes for non-loader assets. This should make it easier for us to maintain the performance docs until we automate those doc changes.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://issues.newrelic.com/browse/NEWRELIC-6739

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
Let the CI run and check the report comment on this PR.