### PR TITLE
Capture supportability metrics for console methods (NEWRELIC-7770)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,9 +7,16 @@ export FORCE_COLOR=1
 npm run lint
 npm test -- --onlyChanged
 
+# Update version in package.json to match VERSION file
 npm run sync:version
 git add package.json
 
+# Include updated caniuse-lite database used by browserslist
+npx browserslist@latest --update-db
+git add package.json
+git add package-lock.json
+
+# Include fresh list of supported browsers from Sauce Labs based on defined browserslist
 npm run sauce:get-browsers
 git add tools/jil/util/browsers-supported.json
 git add tools/wdio/util/browsers-supported.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -11002,9 +11002,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001470",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
-      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
+      "version": "1.0.30001474",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz",
+      "integrity": "sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==",
       "dev": true,
       "funding": [
         {
@@ -11014,6 +11014,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -40593,9 +40597,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001470",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001470.tgz",
-      "integrity": "sha512-065uNwY6QtHCBOExzbV6m236DDhYCCtPmQUCoQtwkVqzud8v5QPidoMr6CoMkC2nfp6nksjttqWQRRh75LqUmA==",
+      "version": "1.0.30001474",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001474.tgz",
+      "integrity": "sha512-iaIZ8gVrWfemh5DG3T9/YqarVZoYf0r188IjaGwx68j4Pf0SGY6CQkmJUIE+NZHkkecQGohzXmBGEwWDr9aM3Q==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/wrap/index.js
+++ b/src/common/wrap/index.js
@@ -2,17 +2,17 @@
  * @file Wraps assorted native objects and functions for instrumentation.
  */
 
+import { wrapConsole } from './wrap-console'
+import { wrapEvents } from './wrap-events'
 import { wrapFetch } from './wrap-fetch'
-import { wrapTimer } from './wrap-timer'
-import { wrapRaf } from './wrap-raf'
 import { wrapHistory } from './wrap-history'
 import { wrapJsonP } from './wrap-jsonp'
 import { wrapMutation } from './wrap-mutation'
 import { wrapPromise } from './wrap-promise'
+import { wrapRaf } from './wrap-raf'
+import { wrapTimer } from './wrap-timer'
 import { wrapXhr } from './wrap-xhr'
-import { wrapEvents } from './wrap-events'
-import { wrapConsole } from './wrap-console'
 
 export {
-  wrapEvents, wrapFetch, wrapHistory, wrapJsonP, wrapMutation, wrapPromise, wrapRaf, wrapTimer, wrapXhr, wrapConsole
+  wrapConsole, wrapEvents, wrapFetch, wrapHistory, wrapJsonP, wrapMutation, wrapPromise, wrapRaf, wrapTimer, wrapXhr
 }

--- a/src/common/wrap/index.js
+++ b/src/common/wrap/index.js
@@ -11,7 +11,8 @@ import { wrapMutation } from './wrap-mutation'
 import { wrapPromise } from './wrap-promise'
 import { wrapXhr } from './wrap-xhr'
 import { wrapEvents } from './wrap-events'
+import { wrapConsole } from './wrap-console'
 
 export {
-  wrapEvents, wrapFetch, wrapHistory, wrapJsonP, wrapMutation, wrapPromise, wrapRaf, wrapTimer, wrapXhr
+  wrapEvents, wrapFetch, wrapHistory, wrapJsonP, wrapMutation, wrapPromise, wrapRaf, wrapTimer, wrapXhr, wrapConsole
 }

--- a/src/common/wrap/wrap-console.js
+++ b/src/common/wrap/wrap-console.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * @file Wraps `debug`, `error`, `info`, `log`, `warn, and `trace` methods of the global `console` object for instrumentation.
+ * This module is used by: PageViewEvent.
+ */
+import { ee as globalEE } from '../event-emitter/contextual-ee'
+import { createWrapperWithEmitter } from './wrap-function'
+import { globalScope } from '../util/global-scope'
+
+const wrapped = {}
+const CONSOLE_METHODS = ['debug', 'error', 'info', 'log', 'warn', 'trace']
+
+/**
+ * Wraps the `debug`, `error`, `info`, `log`, `warn, and `trace` methods of global `console` object and returns a
+ * corresponding event emitter scoped to the console object.
+ * @param {Object} sharedEE - The shared event emitter on which a new scoped event emitter will be based.
+ * @returns {Object} Scoped event emitter with a debug ID of `console`.
+ */
+export function wrapConsole (sharedEE) {
+  const ee = scopedEE(sharedEE)
+
+  // We want to wrap console once and only once for each agent instance (`ee.debugId`).
+  if (wrapped[ee.debugId]) { return ee }
+  wrapped[ee.debugId] = true
+
+  var functionWrapper = createWrapperWithEmitter(ee)
+  // Because the console object exists once on the global scope, we don't need to wrap the prototype's methods.
+  // We use the global scope instead of window to accomodate service workers.
+  // The leading hyphen on '-console-' tells `inPlace` to prefix emitted event names with the method name too.
+  functionWrapper.inPlace(globalScope.console, CONSOLE_METHODS, '-console-')
+
+  return ee
+}
+
+/**
+ * Returns an event emitter scoped specifically for the `console` context. This scoping is a remnant from when all the
+ * features shared the same group in the event, to isolate events between features. It will likely be revisited.
+ * @param {Object} sharedEE - Optional event emitter on which to base the scoped emitter.
+ *    Uses `ee` on the global scope if undefined).
+ * @returns {Object} Scoped event emitter with a debug ID of 'console'.
+ */
+export function scopedEE (sharedEE) {
+  return (sharedEE || globalEE).get('console')
+}

--- a/src/common/wrap/wrap-console.js
+++ b/src/common/wrap/wrap-console.js
@@ -4,7 +4,7 @@
  */
 /**
  * @file Wraps `debug`, `error`, `info`, `log`, `warn, and `trace` methods of the global `console` object for instrumentation.
- * This module is used by: PageViewEvent.
+ * This module is used by: metrics.
  */
 import { ee as globalEE } from '../event-emitter/contextual-ee'
 import { createWrapperWithEmitter } from './wrap-function'

--- a/src/common/wrap/wrap-console.js
+++ b/src/common/wrap/wrap-console.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /**
- * @file Wraps `debug`, `error`, `info`, `log`, `warn, and `trace` methods of the global `console` object for instrumentation.
+ * @file Wraps `debug`, `error`, `info`, `log`, `trace, and `warn` methods of the global `console` object for instrumentation.
  * This module is used by: metrics.
  */
 import { ee as globalEE } from '../event-emitter/contextual-ee'
@@ -11,10 +11,10 @@ import { createWrapperWithEmitter } from './wrap-function'
 import { globalScope } from '../util/global-scope'
 
 const wrapped = {}
-const CONSOLE_METHODS = ['debug', 'error', 'info', 'log', 'warn', 'trace']
+const CONSOLE_METHODS = ['debug', 'error', 'info', 'log', 'trace', 'warn']
 
 /**
- * Wraps the `debug`, `error`, `info`, `log`, `warn, and `trace` methods of global `console` object and returns a
+ * Wraps the `debug`, `error`, `info`, `log`, `trace, and `warn` methods of global `console` object and returns a
  * corresponding event emitter scoped to the console object.
  * @param {Object} sharedEE - The shared event emitter on which a new scoped event emitter will be based.
  * @returns {Object} Scoped event emitter with a debug ID of `console`.

--- a/src/common/wrap/wrap-function.js
+++ b/src/common/wrap/wrap-function.js
@@ -110,7 +110,8 @@ export function createWrapperWithEmitter (emitter, always) {
    * Creates wrapper functions around each of an array of methods on a specified object.
    * @param {Object} obj - The object to which the specified methods belong.
    * @param {string[]} methods - An array of method names to be wrapped.
-   * @param {string} [prefix=''] - A prefix to add to the names of emitted events.
+   * @param {string} [prefix=''] - A prefix to add to the names of emitted events. If `-` is the first character, also
+   *     adds the method name before the prefix.
    * @param {function|object} [getContext] - The function or object that will serve as the 'this' context for handlers
    *     of events emitted by this wrapper.
    * @param {boolean} [bubble=false] - If `true`, emitted events should also bubble up to the old emitter upon which
@@ -118,8 +119,7 @@ export function createWrapperWithEmitter (emitter, always) {
    */
   function inPlace (obj, methods, prefix, getContext, bubble) {
     if (!prefix) prefix = ''
-    // If prefix starts with '-' set this boolean to add the method name to
-    // the prefix before passing each one to wrap.
+    // If prefix starts with '-' set this boolean to add the method name to the prefix before passing each one to wrap.
     var prependMethodPrefix = (prefix.charAt(0) === '-')
     var fn
     var method
@@ -129,8 +129,7 @@ export function createWrapperWithEmitter (emitter, always) {
       method = methods[i]
       fn = obj[method]
 
-      // Unless fn is both wrappable and unwrapped bail,
-      // so we don't add extra properties with undefined values.
+      // Unless fn is both wrappable and unwrapped, bail so we don't add extra properties with undefined values.
       if (notWrappable(fn)) continue
 
       obj[method] = wrapFn(fn, (prependMethodPrefix ? method + prefix : prefix), getContext, method, bubble)

--- a/src/features/metrics/instrument/index.js
+++ b/src/features/metrics/instrument/index.js
@@ -21,7 +21,7 @@ export class Instrument extends InstrumentBase {
     // For now we are just capturing supportability metrics on `console` usage to assess log forwarding feature.
     const consoleEE = wrapConsole(this.ee)
 
-    for (const method of ['Debug', 'Error', 'Info', 'Log', 'Warn', 'Trace']) {
+    for (const method of ['Debug', 'Error', 'Info', 'Log', 'Trace', 'Warn']) {
       consoleEE.on(`${method.toLowerCase()}-console-start`, function (args, target) {
         // Parsing the args individually into a new array ensures that functions and Error objects are represented with
         // useful string values. By default, functions stringify to null and Error objects stringify to empty objects.

--- a/src/features/metrics/instrument/index.js
+++ b/src/features/metrics/instrument/index.js
@@ -3,11 +3,42 @@ import { insertSupportMetrics } from './workers-helper'
 import { FEATURE_NAME, SUPPORTABILITY_METRIC_CHANNEL } from '../constants'
 import { handle } from '../../../common/event-emitter/handle'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { wrapConsole } from '../../../common/wrap'
+import { stringify } from '../../../common/util/stringify'
+
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator, auto = true) {
     super(agentIdentifier, aggregator, FEATURE_NAME, auto)
     insertSupportMetrics(tag => handle(SUPPORTABILITY_METRIC_CHANNEL, [tag], undefined, FEATURE_NAMES.metrics, this.ee))
+
+    this.addConsoleSupportabilityMetrics()
+
     this.importAggregator()
+  }
+
+  addConsoleSupportabilityMetrics () {
+    // For now we are just capturing supportability metrics on `console` usage to assess log forwarding feature.
+    const consoleEE = wrapConsole(this.ee)
+
+    for (const method of ['Debug', 'Error', 'Info', 'Log', 'Warn', 'Trace']) {
+      consoleEE.on(`${method.toLowerCase()}-console-start`, function (args, target) {
+        // Parsing the args individually into a new array ensures that functions and Error objects are represented with
+        // useful string values. By default, functions stringify to null and Error objects stringify to empty objects.
+        // Note that stack traces printed by the console.trace method are not captured.
+        let parsedArgs = []
+        for (const arg of args) {
+          if (typeof arg === 'function' ||
+            (arg && arg.message && arg.stack) // Duck typing for Error objects
+          ) {
+            parsedArgs.push(arg.toString())
+          } else {
+            parsedArgs.push(arg)
+          }
+        }
+        const parsedArgsJSON = stringify(parsedArgs)
+        handle(SUPPORTABILITY_METRIC_CHANNEL, [`Console/${method}/Seen`, parsedArgsJSON.length], undefined, FEATURE_NAMES.metrics, consoleEE)
+      })
+    }
   }
 }

--- a/src/features/page_view_event/instrument/index.js
+++ b/src/features/page_view_event/instrument/index.js
@@ -50,7 +50,7 @@ export class Instrument extends InstrumentBase {
           }
         }
         const parsedArgsJSON = stringify(parsedArgs)
-        handle(SUPPORTABILITY_METRIC_CHANNEL, [`Generic/Console/${method}`, parsedArgsJSON.length], undefined, FEATURE_NAMES.metrics, consoleEE)
+        handle(SUPPORTABILITY_METRIC_CHANNEL, [`Console/${method}/Seen`, parsedArgsJSON.length], undefined, FEATURE_NAMES.metrics, consoleEE)
       })
     }
 

--- a/src/features/page_view_event/instrument/index.js
+++ b/src/features/page_view_event/instrument/index.js
@@ -7,9 +7,6 @@ import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { getRuntime } from '../../../common/config/config'
 import { onDOMContentLoaded, onWindowLoad } from '../../../common/window/load'
 import { now } from '../../../common/timing/now'
-import { wrapConsole } from '../../../common/wrap'
-import { stringify } from '../../../common/util/stringify'
-import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = CONSTANTS.FEATURE_NAME
@@ -30,29 +27,6 @@ export class Instrument extends InstrumentBase {
       })
     }
     // Else, inference: inside worker or some other env where these events are irrelevant. They'll get filled in with 0s in RUM call.
-
-    // For now we are just capturing supportability metrics on `console` usage to assess log forwarding feature.
-    const consoleEE = wrapConsole(this.ee)
-
-    for (const method of ['Debug', 'Error', 'Info', 'Log', 'Warn', 'Trace']) {
-      consoleEE.on(`${method.toLowerCase()}-console-start`, function (args, target) {
-        // Parsing the args individually into a new array ensures that functions and Error objects are represented with
-        // useful string values. By default, functions stringify to null and Error objects stringify to empty objects.
-        // Note that stack traces printed by the console.trace method are not captured.
-        let parsedArgs = []
-        for (const arg of args) {
-          if (typeof arg === 'function' ||
-            (arg && arg.message && arg.stack) // Duck typing for Error objects
-          ) {
-            parsedArgs.push(arg.toString())
-          } else {
-            parsedArgs.push(arg)
-          }
-        }
-        const parsedArgsJSON = stringify(parsedArgs)
-        handle(SUPPORTABILITY_METRIC_CHANNEL, [`Console/${method}/Seen`, parsedArgsJSON.length], undefined, FEATURE_NAMES.metrics, consoleEE)
-      })
-    }
 
     this.importAggregator()
   }

--- a/tests/assets/console-methods.html
+++ b/tests/assets/console-methods.html
@@ -1,0 +1,23 @@
+<html>
+  <head>
+    {init}
+    {config}
+    {loader}
+  </head>
+  <body>
+    <script>
+      console.debug('0123456789', 12.345, { a: 1, b: 2 })
+      console.error('0123456789', 12.345, { a: 1, b: 2 })
+      console.info('0123456789', 12.345, { a: 1, b: 2 })
+      console.log('0123456789', 12.345, { a: 1, b: 2 })
+      console.warn('0123456789', 12.345, { a: 1, b: 2 })
+      console.trace('0123456789', 12.345, { a: 1, b: 2 })
+      console.debug(() => true, new Error('error message'))
+      console.error(() => true, new Error('error message'))
+      console.info(() => true, new Error('error message'))
+      console.log(() => true, new Error('error message'))
+      console.warn(() => true, new Error('error message'))
+      console.trace(() => true, new Error('error message'))
+    </script>
+  </body>
+</html>

--- a/tests/assets/console-methods.html
+++ b/tests/assets/console-methods.html
@@ -6,18 +6,18 @@
   </head>
   <body>
     <script>
-      console.debug('0123456789', 12.345, { a: 1, b: 2 })
-      console.error('0123456789', 12.345, { a: 1, b: 2 })
-      console.info('0123456789', 12.345, { a: 1, b: 2 })
-      console.log('0123456789', 12.345, { a: 1, b: 2 })
-      console.warn('0123456789', 12.345, { a: 1, b: 2 })
-      console.trace('0123456789', 12.345, { a: 1, b: 2 })
-      console.debug(() => true, new Error('error message'))
-      console.error(() => true, new Error('error message'))
-      console.info(() => true, new Error('error message'))
-      console.log(() => true, new Error('error message'))
-      console.warn(() => true, new Error('error message'))
-      console.trace(() => true, new Error('error message'))
+      console.debug('0123456789', 12.345, { a: 1, b: 2 });
+      console.error('0123456789', 12.345, { a: 1, b: 2 });
+      console.info('0123456789', 12.345, { a: 1, b: 2 });
+      console.log('0123456789', 12.345, { a: 1, b: 2 });
+      console.warn('0123456789', 12.345, { a: 1, b: 2 });
+      console.trace('0123456789', 12.345, { a: 1, b: 2 });
+      console.debug(function () { return true }, new Error('error message'));
+      console.error(function () { return true }, new Error('error message'));
+      console.info(function () { return true }, new Error('error message'));
+      console.log(function () { return true }, new Error('error message'));
+      console.warn(function () { return true }, new Error('error message'));
+      console.trace(function () { return true }, new Error('error message'));
     </script>
   </body>
 </html>

--- a/tests/assets/console-methods.html
+++ b/tests/assets/console-methods.html
@@ -10,14 +10,14 @@
       console.error('0123456789', 12.345, { a: 1, b: 2 });
       console.info('0123456789', 12.345, { a: 1, b: 2 });
       console.log('0123456789', 12.345, { a: 1, b: 2 });
-      console.warn('0123456789', 12.345, { a: 1, b: 2 });
       console.trace('0123456789', 12.345, { a: 1, b: 2 });
+      console.warn('0123456789', 12.345, { a: 1, b: 2 });
       console.debug(function () { return true }, new Error('error message'));
       console.error(function () { return true }, new Error('error message'));
       console.info(function () { return true }, new Error('error message'));
       console.log(function () { return true }, new Error('error message'));
-      console.warn(function () { return true }, new Error('error message'));
       console.trace(function () { return true }, new Error('error message'));
+      console.warn(function () { return true }, new Error('error message'));
     </script>
   </body>
 </html>

--- a/tests/functional/metrics.test.js
+++ b/tests/functional/metrics.test.js
@@ -268,12 +268,12 @@ testDriver.test('agent captures log forwarding supportability metrics', withUnlo
         { name: 'Warn', count: 2, size: 89 },
         { name: 'Trace', count: 2, size: 89 }
       ]) {
-        // E.g.:  {"params":{"name":"Generic/Console/Debug"},"stats":{"t":89,"min":35,"max":54,"sos":4141,"c":2}}
-        // IE11:  {"params":{"name":"Generic/Console/Debug"},"stats":{"t":98,"min":35,"max":63,"sos":5194,"c":2}}
-        const metric = supportabilityMetrics.find(x => x.params.name.includes(`Generic/Console/${method.name}`))
+        // E.g.:  {"params":{"name":"Console/Debug/Seen"},"stats":{"t":89,"min":35,"max":54,"sos":4141,"c":2}}
+        // IE11:  {"params":{"name":"Console/Debug/Seen"},"stats":{"t":98,"min":35,"max":63,"sos":5194,"c":2}}
+        const metric = supportabilityMetrics.find(x => x.params.name.includes(`Console/${method.name}/Seen`))
         t.ok(!!metric, `Console/${method.name} was captured`)
-        t.ok(metric.stats.c === method.count, `Generic/Console/${method.name} count is correct`) // number of calls
-        t.ok(metric.stats.t >= method.size, `Generic/Console/${method.name} size is correct`) // total of values
+        t.ok(metric.stats.c === method.count, `Console/${method.name}/Seen count is correct`) // number of calls
+        t.ok(metric.stats.t >= method.size, `Console/${method.name}/Seen size is correct`) // total of values
       }
       t.end()
     })

--- a/tests/functional/metrics.test.js
+++ b/tests/functional/metrics.test.js
@@ -265,8 +265,8 @@ testDriver.test('agent captures log forwarding supportability metrics', withUnlo
         { name: 'Error', count: 2, size: 89 },
         { name: 'Info', count: 2, size: 89 },
         { name: 'Log', count: 2, size: 89 },
-        { name: 'Warn', count: 2, size: 89 },
-        { name: 'Trace', count: 2, size: 89 }
+        { name: 'Trace', count: 2, size: 89 },
+        { name: 'Warn', count: 2, size: 89 }
       ]) {
         // E.g.:  {"params":{"name":"Console/Debug/Seen"},"stats":{"t":89,"min":35,"max":54,"sos":4141,"c":2}}
         // IE11:  {"params":{"name":"Console/Debug/Seen"},"stats":{"t":98,"min":35,"max":63,"sos":5194,"c":2}}

--- a/tests/functional/metrics.test.js
+++ b/tests/functional/metrics.test.js
@@ -261,18 +261,19 @@ testDriver.test('agent captures log forwarding supportability metrics', withUnlo
       t.ok(supportabilityMetrics && !!supportabilityMetrics.length, 'SupportabilityMetrics object(s) were generated')
       // We want to verify the number of times each method was called and the aggregate size of the payloads.
       for (method of [
-        { name: 'Debug', count: 2, size: 72 },
-        { name: 'Error', count: 2, size: 72 },
-        { name: 'Info', count: 2, size: 72 },
-        { name: 'Log', count: 2, size: 72 },
-        { name: 'Warn', count: 2, size: 72 },
-        { name: 'Trace', count: 2, size: 72 }
+        { name: 'Debug', count: 2, size: 89 },
+        { name: 'Error', count: 2, size: 89 },
+        { name: 'Info', count: 2, size: 89 },
+        { name: 'Log', count: 2, size: 89 },
+        { name: 'Warn', count: 2, size: 89 },
+        { name: 'Trace', count: 2, size: 89 }
       ]) {
-        // E.g.: {"params":{"name":"Generic/Console/Debug"},"stats":{"t":72,"min":35,"max":37,"sos":2594,"c":2}}
+        // E.g.:  {"params":{"name":"Generic/Console/Debug"},"stats":{"t":89,"min":35,"max":54,"sos":4141,"c":2}}
+        // IE11:  {"params":{"name":"Generic/Console/Debug"},"stats":{"t":98,"min":35,"max":63,"sos":5194,"c":2}}
         const metric = supportabilityMetrics.find(x => x.params.name.includes(`Generic/Console/${method.name}`))
         t.ok(!!metric, `Console/${method.name} was captured`)
         t.ok(metric.stats.c === method.count, `Generic/Console/${method.name} count is correct`) // number of calls
-        t.ok(metric.stats.t === method.size, `Generic/Console/${method.name} size is correct`) // total of values
+        t.ok(metric.stats.t >= method.size, `Generic/Console/${method.name} size is correct`) // total of values
       }
       t.end()
     })

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -143,10 +143,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "15.0",
-      "device": "iPhone 11",
-      "appium:deviceName": "iPhone 11 Simulator",
-      "appium:platformVersion": "15.0",
+      "version": "15.2",
+      "device": "iPhone 7 Plus",
+      "appium:deviceName": "iPhone 7 Plus Simulator",
+      "appium:platformVersion": "15.2",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"
@@ -157,10 +157,10 @@
       "browserName": "Safari",
       "platform": "iOS",
       "platformName": "iOS",
-      "version": "14.5",
-      "device": "iPhone 12",
-      "appium:deviceName": "iPhone 12 Simulator",
-      "appium:platformVersion": "14.5",
+      "version": "15.0",
+      "device": "iPhone 11",
+      "appium:deviceName": "iPhone 11 Simulator",
+      "appium:platformVersion": "15.0",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "1.22.3"

--- a/tools/testing-server/plugins/browserify/browserify-transform.js
+++ b/tools/testing-server/plugins/browserify/browserify-transform.js
@@ -31,6 +31,8 @@ function browserifyScript (scriptPath, enablePolyfills) {
           '@babel/plugin-syntax-dynamic-import',
           '@babel/plugin-transform-modules-commonjs',
           '@babel/plugin-proposal-optional-chaining',
+          // Addresses a problem handling static class properties.
+          '@babel/plugin-proposal-class-properties',
           // Replaces template literals with concatenated strings. Some customers enclose snippet in backticks when
           // assigning to a variable, which conflicts with template literals.
           '@babel/plugin-transform-template-literals',

--- a/tools/testing-server/plugins/browserify/browserify-transform.js
+++ b/tools/testing-server/plugins/browserify/browserify-transform.js
@@ -33,6 +33,8 @@ function browserifyScript (scriptPath, enablePolyfills) {
           '@babel/plugin-proposal-optional-chaining',
           // Addresses a problem handling static class properties.
           '@babel/plugin-proposal-class-properties',
+          // Enables class private methods.
+          '@babel/plugin-proposal-private-methods',
           // Replaces template literals with concatenated strings. Some customers enclose snippet in backticks when
           // assigning to a variable, which conflicts with template literals.
           '@babel/plugin-transform-template-literals',


### PR DESCRIPTION
### Overview

This PR adds supportability metrics for assorted console methods to inform future decisions around capturing logs.
- Wraps methods `debug`, `error`, `info`, `log`, `trace`,  and `warn` on `console` in the global scope.
- Captures **count** and **size** metrics as part of metrics feature instrumentation.
- New tests assess accurate number and size of each method.

Also adds a pre-commit hook in the husky config to update the caniuse-lite database, which is what browserslist targets are based on. After updating the DB we lost `ios_saf 14.5-14.8` as targets, which introduced the need to add browserify plugin support for `class-properties` and `private-methods`.

### Related Issue(s)

- [NEWRELIC-7770](https://issues.newrelic.com/browse/NEWRELIC-7770)
- [Angler PR 432](https://source.datanerd.us/agents/angler/pull/432)

### Testing

A new functional test has been added in `metrics.test.js`.