### PR TITLE
SMs - SessionTrace duration and endpoint payload sizes per page

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@
 export FORCE_COLOR=1
 
 npm run lint
-npm run unit -- --onlyChanged
+npm test
 
 npm run sync:version
 git add package.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@
 export FORCE_COLOR=1
 
 npm run lint
-npm test
+npm test -- --onlyChanged
 
 npm run sync:version
 git add package.json

--- a/src/common/config/state/runtime.js
+++ b/src/common/config/state/runtime.js
@@ -8,6 +8,7 @@ import { BUILD_ENV, DIST_METHOD, VERSION } from '../../constants/environment-var
 
 const model = agentId => { return {
   buildEnv: BUILD_ENV,
+  bytesSent: {},
   customTransaction: undefined,
   disabled: false,
   distMethod: DIST_METHOD,

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -116,6 +116,7 @@ export class Harvest extends SharedContext {
       fullUrl = url + encodeObj(payload.body, agentRuntime.maxBytes)
     }
 
+    agentRuntime.bytesSent[endpoint] = (agentRuntime.bytesSent[endpoint] || 0) + body.length
     /* Since workers don't support sendBeacon right now, or Image(), they can only use XHR method.
         Because they still do permit synch XHR, the idea is that at final harvest time (worker is closing),
         we just make a BLOCKING request--trivial impact--with the remaining data as a temp fill-in for sendBeacon. */

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -116,7 +116,7 @@ export class Harvest extends SharedContext {
       fullUrl = url + encodeObj(payload.body, agentRuntime.maxBytes)
     }
 
-    agentRuntime.bytesSent[endpoint] = (agentRuntime.bytesSent[endpoint] || 0) + body.length
+    agentRuntime.bytesSent[endpoint] = (agentRuntime.bytesSent[endpoint] || 0) + body?.length || 0
     /* Since workers don't support sendBeacon right now, or Image(), they can only use XHR method.
         Because they still do permit synch XHR, the idea is that at final harvest time (worker is closing),
         we just make a BLOCKING request--trivial impact--with the remaining data as a temp fill-in for sendBeacon. */

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -116,7 +116,9 @@ export class Harvest extends SharedContext {
       fullUrl = url + encodeObj(payload.body, agentRuntime.maxBytes)
     }
 
+    // Get bytes harvested per endpoint as a supportability metric. See metrics aggregator (on unload).
     agentRuntime.bytesSent[endpoint] = (agentRuntime.bytesSent[endpoint] || 0) + body?.length || 0
+
     /* Since workers don't support sendBeacon right now, or Image(), they can only use XHR method.
         Because they still do permit synch XHR, the idea is that at final harvest time (worker is closing),
         we just make a BLOCKING request--trivial impact--with the remaining data as a temp fill-in for sendBeacon. */

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -96,6 +96,7 @@ export class Aggregate extends AggregateBase {
     // TODO - these SMs are to be removed when we implement the actual resources feature
     try {
       if (this.resourcesSent) return
+      const agentRuntime = getRuntime(this.agentIdentifier)
       // make sure this only gets sent once
       this.resourcesSent = true
       // differentiate between internal+external and ajax+non-ajax
@@ -113,6 +114,19 @@ export class Aggregate extends AggregateBase {
           else this.storeSupportabilityMetrics('Generic/Resources/Non-Ajax/External')
         }
       })
+
+      // Capture Agent Bytes Sent
+      Object.keys(agentRuntime.bytesSent).forEach(endpoint => {
+        this.storeSupportabilityMetrics(
+          `PageSession/Endpoint/${endpoint.charAt(0).toUpperCase() + endpoint.slice(1)}/BytesSent`,
+          agentRuntime.bytesSent[endpoint]
+        )
+      })
+
+      // Capture STN metrics if avail
+      if (agentRuntime.ptid) {
+        this.storeSupportabilityMetrics('PageSession/Feature/SessionTrace/DurationMs', Math.round(performance.now()))
+      }
     } catch (e) {
       // do nothing
     }

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -115,7 +115,7 @@ export class Aggregate extends AggregateBase {
         }
       })
 
-      // Capture Agent Bytes Sent
+      // Capture per-agent bytes sent for each endpoint (see harvest) and RUM call (see page_view_event aggregator).
       Object.keys(agentRuntime.bytesSent).forEach(endpoint => {
         this.storeSupportabilityMetrics(
           `PageSession/Endpoint/${endpoint.charAt(0).toUpperCase() + endpoint.slice(1)}/BytesSent`,

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -123,7 +123,7 @@ export class Aggregate extends AggregateBase {
         )
       })
 
-      // Capture STN metrics if avail
+      // Capture metrics for session trace if active (`ptid` is set when returned by replay ingest).
       if (agentRuntime.ptid) {
         this.storeSupportabilityMetrics('PageSession/Feature/SessionTrace/DurationMs', Math.round(performance.now()))
       }

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -119,7 +119,10 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('ja', customJsAttributes === '{}' ? null : customJsAttributes))
 
     var queryString = fromArray(chunksForQueryString, agentRuntime.maxBytes)
+
+    // Capture bytes sent to RUM call endpoint (currently `1`) as a supportability metric. See metrics aggregator (on unload).
     agentRuntime.bytesSent[protocol] = (agentRuntime.bytesSent[protocol] || 0) + queryString?.length || 0
+
     const isValidJsonp = submitData.jsonp(
       this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString,
       jsonp

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -119,6 +119,7 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('ja', customJsAttributes === '{}' ? null : customJsAttributes))
 
     var queryString = fromArray(chunksForQueryString, agentRuntime.maxBytes)
+    agentRuntime.bytesSent[protocol] = (agentRuntime.bytesSent[protocol] || 0) + queryString.length
     const isValidJsonp = submitData.jsonp(
       this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString,
       jsonp

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -119,7 +119,7 @@ export class Aggregate extends AggregateBase {
     chunksForQueryString.push(param('ja', customJsAttributes === '{}' ? null : customJsAttributes))
 
     var queryString = fromArray(chunksForQueryString, agentRuntime.maxBytes)
-    agentRuntime.bytesSent[protocol] = (agentRuntime.bytesSent[protocol] || 0) + queryString.length
+    agentRuntime.bytesSent[protocol] = (agentRuntime.bytesSent[protocol] || 0) + queryString?.length || 0
     const isValidJsonp = submitData.jsonp(
       this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString,
       jsonp

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -2,17 +2,17 @@
   "chrome": [
     {
       "browserName": "chrome",
-      "platform": "Windows 11",
-      "platformName": "Windows 11",
-      "version": "111",
-      "browserVersion": "111"
+      "platform": "Windows 10",
+      "platformName": "Windows 10",
+      "version": "112",
+      "browserVersion": "112"
     },
     {
       "browserName": "chrome",
-      "platform": "Windows 10",
-      "platformName": "Windows 10",
-      "version": "108",
-      "browserVersion": "108"
+      "platform": "Windows 11",
+      "platformName": "Windows 11",
+      "version": "109",
+      "browserVersion": "109"
     },
     {
       "browserName": "chrome",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
#### This PR is in support of Session Replay COGS investigation.  

Aspect 1: The intent is to capture the length end-to-end of session traces, to be able to evaluate what the "average" session trace duration is today per "page session".

Aspect 2: This PR begins tallying bytesSent for each endpoint, which will give us raw figures per endpoint per "page session"

SMs added:
* `PageSession/Endpoint/1/BytesSent`
* `PageSession/Endpoint/Resources/BytesSent`
* `PageSession/Endpoint/Events/BytesSent`
* `PageSession/Endpoint/Jserrors/BytesSent`
* `PageSession/Feature/SessionTrace/DurationMs`
