### PR TITLE
Append list of browsers to support statement (NEWRELIC-7258)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10370,9 +10370,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001478",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz",
-      "integrity": "sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==",
+      "version": "1.0.30001480",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz",
+      "integrity": "sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==",
       "dev": true,
       "funding": [
         {
@@ -36240,9 +36240,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001478",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz",
-      "integrity": "sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==",
+      "version": "1.0.30001480",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz",
+      "integrity": "sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==",
       "dev": true
     },
     "capital-case": {

--- a/tools/jil/util/browsers-all.json
+++ b/tools/jil/util/browsers-all.json
@@ -650,15 +650,15 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "102",
-      "browserVersion": "102"
+      "version": "103",
+      "browserVersion": "103"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -1016,12 +1016,12 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "105"
+      "version": "106"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "102"
+      "version": "103"
     },
     {
       "browserName": "firefox",

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -48,15 +48,15 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "102",
-      "browserVersion": "102"
+      "version": "103",
+      "browserVersion": "103"
     }
   ],
   "safari": [
@@ -87,12 +87,12 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "105"
+      "version": "106"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "102"
+      "version": "103"
     }
   ],
   "android": [

--- a/tools/scripts/docs-website/create-docs-pr.js
+++ b/tools/scripts/docs-website/create-docs-pr.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const fs = require('fs-extra')
+const fse = require('fs-extra')
 const path = require('path')
 // const { program } = require('commander')
 
@@ -148,7 +148,7 @@ function validateTag (version, force) {
 async function getReleaseNotes (version, releaseNotesFile) {
   console.log('Retrieving release notes from file: ', releaseNotesFile)
 
-  const data = await fs.readFile(process.cwd() + '/' + releaseNotesFile, 'utf8')
+  const data = await fse.readFile(process.cwd() + '/' + releaseNotesFile, 'utf8')
 
   const sections = data.split('\n## ')
   // Iterate over all past releases to find the version we want
@@ -171,7 +171,7 @@ async function getReleaseNotes (version, releaseNotesFile) {
 async function getBrowserTargetStatement (version, browsersFile) {
   console.log('Retrieving supported browser targets from file: ', browsersFile)
 
-  const browserData = await fs.readJson(process.cwd() + '/' + browsersFile)
+  const browserData = await fse.readJson(process.cwd() + '/' + browsersFile)
 
   const min = {}
   const max = {}
@@ -193,8 +193,7 @@ async function getBrowserTargetStatement (version, browsersFile) {
     'Consistent with our [browser support policy](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#browser-types), ' +
     `version ${version} of the Browser agent was built for and tested against these browsers and version ranges: ` +
     `Chrome ${min.chrome}-${max.chrome}, Edge ${min.edge}-${max.edge}, Safari ${min.safari}-${max.safari}, Firefox ${min.firefox}-${max.firefox}; ` +
-    `and for mobile devices, Android Chrome ${ANDROID_CHROME_VERSION} and iOS Safari ${min.ios}-${max.ios}. ` +
-    'Instrumentation and specific features may be compatible with other browsers or versions.'
+    `and for mobile devices, Android Chrome ${ANDROID_CHROME_VERSION} and iOS Safari ${min.ios}-${max.ios}.`
   )
 }
 
@@ -207,8 +206,8 @@ async function getBrowserTargetStatement (version, browsersFile) {
  * @param {boolean} dryRun skip branch creation
  */
 async function createBranch (filePath, remote, version, dryRun, email, name) {
-  fs.rmSync(filePath, { recursive: true, force: true })
-  fs.mkdirSync(filePath)
+  fse.rmSync(filePath, { recursive: true, force: true })
+  fse.mkdirSync(filePath)
   filePath = path.resolve(filePath)
   console.log(`Changing to ${filePath}`)
   process.chdir(filePath)
@@ -265,7 +264,7 @@ function formatReleaseNotes (releaseDate, version, body) {
 function addReleaseNotesFile (body, version) {
   const FILE = getFileName(version)
   return new Promise((resolve, reject) => {
-    fs.writeFile(FILE, body, 'utf8', (writeErr) => {
+    fse.writeFile(FILE, body, 'utf8', (writeErr) => {
       if (writeErr) {
         reject(writeErr)
       }

--- a/tools/scripts/docs-website/create-docs-pr.js
+++ b/tools/scripts/docs-website/create-docs-pr.js
@@ -148,7 +148,7 @@ function validateTag (version, force) {
 async function getReleaseNotes (version, releaseNotesFile) {
   console.log('Retrieving release notes from file: ', releaseNotesFile)
 
-  const data = await readReleaseNoteFile(process.cwd() + '/' + releaseNotesFile)
+  const data = await fs.readFile(process.cwd() + '/' + releaseNotesFile, 'utf8')
 
   const sections = data.split('\n## ')
   // Iterate over all past releases to find the version we want
@@ -163,23 +163,6 @@ async function getReleaseNotes (version, releaseNotesFile) {
 }
 
 /**
- * Reads the contents of NEWS.md
- *
- * @param {string} file path to NEWS.md
- */
-async function readReleaseNoteFile (file) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(file, 'utf8', (err, data) => {
-      if (err) {
-        return reject(err)
-      }
-
-      return resolve(data)
-    })
-  })
-}
-
-/**
  * Extracts the supported browser versions from the specified JSON file and creates a support string.
  *
  * @param {string} version The new version.
@@ -188,7 +171,7 @@ async function readReleaseNoteFile (file) {
 async function getBrowserTargetStatement (version, browsersFile) {
   console.log('Retrieving supported browser targets from file: ', browsersFile)
 
-  const browserData = await readBrowsersFile(process.cwd() + '/' + browsersFile)
+  const browserData = await fs.readJson(process.cwd() + '/' + browsersFile)
 
   const min = {}
   const max = {}
@@ -213,28 +196,6 @@ async function getBrowserTargetStatement (version, browsersFile) {
     `and for mobile devices, Android Chrome ${ANDROID_CHROME_VERSION} and iOS Safari ${min.ios}-${max.ios}. ` +
     'Instrumentation and specific features may be compatible with other browsers or versions.'
   )
-}
-
-/**
- * Reads the contents of a JSON file with data on supported browsers into a JavaScript object
- *
- * @param {string} File path to a JSON file.
- * @returns a JavaScript object representing the file
- */
-async function readBrowsersFile (filename) {
-  return new Promise((resolve, reject) => {
-    fs.readJson(filename, (err, jsonData) => {
-      if (err) {
-        return reject(err)
-      }
-
-      try {
-        return resolve(jsonData)
-      } catch (e) {
-        return reject(e)
-      }
-    })
-  })
 }
 
 /**

--- a/tools/scripts/docs-website/create-docs-pr.js
+++ b/tools/scripts/docs-website/create-docs-pr.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const fs = require('fs')
+const fs = require('fs-extra')
 const path = require('path')
 // const { program } = require('commander')
 
@@ -188,7 +188,7 @@ async function readReleaseNoteFile (file) {
 async function getBrowserTargetStatement (version, browsersFile) {
   console.log('Retrieving supported browser targets from file: ', browsersFile)
 
-  const browserData = await readJsonFile(process.cwd() + '/' + browsersFile)
+  const browserData = await readBrowsersFile(process.cwd() + '/' + browsersFile)
 
   const min = {}
   const max = {}
@@ -216,21 +216,20 @@ async function getBrowserTargetStatement (version, browsersFile) {
 }
 
 /**
- * Reads the contents of a JSON file into a JavaScript object
+ * Reads the contents of a JSON file with data on supported browsers into a JavaScript object
  *
  * @param {string} File path to a JSON file.
  * @returns a JavaScript object representing the file
  */
-async function readJsonFile (filename) {
+async function readBrowsersFile (filename) {
   return new Promise((resolve, reject) => {
-    fs.readFile(filename, 'utf8', (err, data) => {
+    fs.readJson(filename, (err, jsonData) => {
       if (err) {
         return reject(err)
       }
 
       try {
-        const obj = JSON.parse(data)
-        return resolve(obj)
+        return resolve(jsonData)
       } catch (e) {
         return reject(e)
       }

--- a/tools/scripts/docs-website/create-docs-pr.js
+++ b/tools/scripts/docs-website/create-docs-pr.js
@@ -207,11 +207,11 @@ async function getBrowserTargetStatement (version, browsersFile) {
   const ANDROID_CHROME_VERSION = 100 // SauceLabs only offers one Android Chrome version
 
   return (
-    `Version ${version} of the Browser agent was built for and tested against these browsers and version ranges: ` +
+    'Consistent with our [browser support policy](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#browser-types), ' +
+    `version ${version} of the Browser agent was built for and tested against these browsers and version ranges: ` +
     `Chrome ${min.chrome}-${max.chrome}, Edge ${min.edge}-${max.edge}, Safari ${min.safari}-${max.safari}, Firefox ${min.firefox}-${max.firefox}; ` +
     `and for mobile devices, Android Chrome ${ANDROID_CHROME_VERSION} and iOS Safari ${min.ios}-${max.ios}. ` +
-    'Instrumentation and specific features may be compatible with other browsers or versions. ' +
-    'See our list of [officially supported browsers](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#browser-types) for more info.'
+    'Instrumentation and specific features may be compatible with other browsers or versions.'
   )
 }
 

--- a/tools/scripts/docs-website/create-docs-pr.js
+++ b/tools/scripts/docs-website/create-docs-pr.js
@@ -210,7 +210,8 @@ async function getBrowserTargetStatement (version, browsersFile) {
     `Version ${version} of the Browser agent was built for and tested against these browsers and version ranges: ` +
     `Chrome ${min.chrome}-${max.chrome}, Edge ${min.edge}-${max.edge}, Safari ${min.safari}-${max.safari}, Firefox ${min.firefox}-${max.firefox}; ` +
     `and for mobile devices, Android Chrome ${ANDROID_CHROME_VERSION} and iOS Safari ${min.ios}-${max.ios}. ` +
-    'Instrumentation and specific features may be compatible with other browsers or versions.'
+    'Instrumentation and specific features may be compatible with other browsers or versions. ' +
+    'See our list of [officially supported browsers](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#browser-types) for more info.'
   )
 }
 


### PR DESCRIPTION
### Overview

Adds a statement like this to the end of the support statement when raising the release notes PR:

`Consistent with our [browser support policy](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#browser-types), version 1.230.0 of the Browser agent was built for and tested against these browsers and version ranges: Chrome 103-112, Edge 102-111, Safari 15-16, Firefox 102-111; and for mobile devices, Android Chrome 100 and iOS Safari 15-15.5.`

The browser versions are derived from the `browsers-supported.json` file.

### Related Issue(s)

[NEWRELIC-7258](https://issues.newrelic.com/browse/NEWRELIC-7258)

### Testing

Dry run should produce the correct verbiage by pulling from the file `browsers-supported.json` file.
