### PR TITLE
Remove deprecated timing APIs - NEWRELIC-8115

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10370,9 +10370,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001478",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz",
-      "integrity": "sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==",
+      "version": "1.0.30001480",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz",
+      "integrity": "sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==",
       "dev": true,
       "funding": [
         {
@@ -36240,9 +36240,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001478",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz",
-      "integrity": "sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==",
+      "version": "1.0.30001480",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz",
+      "integrity": "sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==",
       "dev": true
     },
     "capital-case": {

--- a/tools/jil/util/browsers-all.json
+++ b/tools/jil/util/browsers-all.json
@@ -650,15 +650,15 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "102",
-      "browserVersion": "102"
+      "version": "103",
+      "browserVersion": "103"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -1016,12 +1016,12 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "105"
+      "version": "106"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "102"
+      "version": "103"
     },
     {
       "browserName": "firefox",

--- a/tools/jil/util/browsers-supported.json
+++ b/tools/jil/util/browsers-supported.json
@@ -48,15 +48,15 @@
       "browserName": "MicrosoftEdge",
       "platform": "Windows 10",
       "platformName": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
       "platform": "Windows 11",
       "platformName": "Windows 11",
-      "version": "102",
-      "browserVersion": "102"
+      "version": "103",
+      "browserVersion": "103"
     }
   ],
   "safari": [
@@ -87,12 +87,12 @@
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "105"
+      "version": "106"
     },
     {
       "browserName": "firefox",
       "platform": "Windows 10",
-      "version": "102"
+      "version": "103"
     }
   ],
   "android": [


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR removes the deprecated performance.timing and performance.navigation API references, in favor of the performance -- Navigation Timing API data.  This has a benefit of no longer needing to calculate an offset against the timings, and they will never be negative.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NEWRELIC-8115
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Existing tests should still apply.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
