### PR TITLE
Fix RerenceError: returnsVals is not defined

### DIFF
--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -35,7 +35,7 @@ export function setTopLevelCallers () {
         returnVals.push(val.api[fnName](...args))
       }
     })
-    return returnVals.length > 1 ? returnsVals : returnVals[0]
+    return returnVals.length > 1 ? returnVals : returnVals[0]
   }
 }
 


### PR DESCRIPTION
I am not sure about what exactly needs to be returned here but this fixes the error thrown when calling `NREUM.noticeError`.

<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
