### PR TITLE
Add jest test for data-size (NEWRELIC-7841)

### DIFF
--- a/src/common/util/data-size.js
+++ b/src/common/util/data-size.js
@@ -5,6 +5,12 @@
 
 import { stringify } from './stringify'
 
+/**
+ * Returns the size of the provided data. Designed for measuring XHR responses.
+ *
+ * @param {*} data - The data to be measured.
+ * @returns {(number|undefined)} - The size of the data or undefined if size cannot be determined.
+ */
 export function dataSize (data) {
   if (typeof data === 'string' && data.length) return data.length
   if (typeof data !== 'object') return undefined

--- a/src/common/util/data-size.test.js
+++ b/src/common/util/data-size.test.js
@@ -8,7 +8,7 @@ describe('dataSize', () => {
 
   test('returns undefined for non-object, number, or empty string', () => {
     expect(dataSize(Infinity)).toBeUndefined()
-    expect(dataSize(12345)).toBeUndefined()
+    expect(dataSize(12345)).toBeUndefined() // might not actually be by design, but this is how it works today
     expect(dataSize('')).toBeUndefined()
   })
 

--- a/src/common/util/data-size.test.js
+++ b/src/common/util/data-size.test.js
@@ -1,0 +1,50 @@
+import { dataSize } from './data-size'
+
+describe('dataSize', () => {
+  test('returns length of string', () => {
+    const str = 'Hello, world!'
+    expect(dataSize(str)).toBe(str.length)
+  })
+
+  test('returns undefined for non-object, number, or empty string', () => {
+    expect(dataSize(Infinity)).toBeUndefined()
+    expect(dataSize(12345)).toBeUndefined()
+    expect(dataSize('')).toBeUndefined()
+  })
+
+  test('returns byte length of ArrayBuffer object', () => {
+    const buffer = new ArrayBuffer(8)
+    expect(dataSize(buffer)).toBe(8)
+  })
+
+  test('returns size of Blob object', () => {
+    const blob = new Blob(['Hello, world!'], { type: 'text/plain' })
+    expect(dataSize(blob)).toBe(blob.size)
+  })
+
+  test('returns undefined for FormData object', () => {
+    const formData = new FormData()
+    expect(dataSize(formData)).toBeUndefined()
+  })
+
+  test('returns length of JSON string representation of object', () => {
+    const obj = {
+      str: 'Hello, world!',
+      num: 12345,
+      nestedObj: {
+        arr: [1, 2, 3]
+      }
+    }
+    const expectedSize = JSON.stringify(obj).length
+    expect(dataSize(obj)).toBe(expectedSize)
+  })
+
+  test('returns undefined for object with toJSON method that throws an error', () => {
+    const obj = {
+      toJSON: () => {
+        throw new Error('Error in toJSON')
+      }
+    }
+    expect(dataSize(obj)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Overview

Adds jest tests for the dataSize function. Also adds some comments.

Note, there are no existing "browser" tests to replace.

### Related Issue(s)

[NEWRELIC-7841](https://issues.newrelic.com/browse/NEWRELIC-7841)

### Testing

`npm test src/common/util/data-size.test.js`
