### PR TITLE
chore: Enable n/no-deprecated-api lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,7 +112,6 @@ module.exports = {
     'no-return-assign': 'off',
 
     'n/handle-callback-err': 'off',
-    'n/no-deprecated-api': 'off',
 
     'sonarjs/cognitive-complexity': 'off',
     'sonarjs/no-duplicate-string': 'off',

--- a/tools/scripts/upload-polyfills-to-nr.js
+++ b/tools/scripts/upload-polyfills-to-nr.js
@@ -8,8 +8,8 @@
 var fs = require('fs')
 var path = require('path')
 var request = require('request')
-var util = require('util')
 var yargs = require('yargs')
+const { deepmerge } = require('deepmerge-ts')
 
 var argv = yargs
   .string('environments')
@@ -169,7 +169,7 @@ function uploadLoaderToDB (filename, loader, environment, cb) {
   }
 
   console.log('Uploading loader ' + filename + ' to ' + environment + '...')
-  var options = util._extend(envOptions[environment], baseOptions)
+  var options = deepmerge(baseOptions, envOptions[environment])
 
   request(options, function (err, res, body) {
     if (err) return cb(err)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Enabling the `n/no-deprecated-api` lint rule and replacing the `util._extend` call with the `deepmerge-ts` library.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://issues.newrelic.com/browse/NR-87765

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
