### PR TITLE
chore: enable no-useless-constructor lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,7 +98,6 @@ module.exports = {
     'new-cap': 'off',
     'no-new': 'off',
     'no-useless-return': 'off',
-    'no-useless-constructor': 'off',
     'dot-notation': 'off',
     'spaced-comment': 'off',
     'no-unused-expressions': 'off',

--- a/src/common/util/obfuscate.js
+++ b/src/common/util/obfuscate.js
@@ -8,10 +8,6 @@ var fileProtocolRule = {
   replacement: 'file://OBFUSCATED'
 }
 export class Obfuscator extends SharedContext {
-  constructor (parent) {
-    super(parent) // gets any allowed properties from the parent and stores them in `sharedContext`
-  }
-
   shouldObfuscate () {
     return getRules(this.sharedContext.agentIdentifier).length > 0
   }

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -9,13 +9,13 @@ import { handle } from '../../../common/event-emitter/handle'
 import { getConfigurationValue, getInfo } from '../../../common/config/config'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { setDenyList, shouldCollectEvent } from '../../../common/deny-list/deny-list'
-import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
 import { drain } from '../../../common/drain/drain'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
+import { FeatureBase } from '../../utils/feature-base'
 
-export class Aggregate extends AggregateBase {
+export class Aggregate extends FeatureBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, FEATURE_NAME)

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -18,12 +18,12 @@ import { getInfo, getConfigurationValue, getRuntime } from '../../../common/conf
 import { now } from '../../../common/timing/now'
 import { globalScope } from '../../../common/util/global-scope'
 
-import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
 import { drain } from '../../../common/drain/drain'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { FeatureBase } from '../../utils/feature-base'
 
-export class Aggregate extends AggregateBase {
+export class Aggregate extends FeatureBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, FEATURE_NAME)

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -1,7 +1,6 @@
 import { getRuntime } from '../../../common/config/config'
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
-import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL } from '../constants'
 import { drain } from '../../../common/drain/drain'
 import { getFrameworks } from '../../../common/metrics/framework-detection'
@@ -11,7 +10,9 @@ import { VERSION } from '../../../common/constants/env'
 import { onDOMContentLoaded } from '../../../common/window/load'
 import { windowAddEventListener } from '../../../common/event-listener/event-listener-opts'
 import { isBrowserScope } from '../../../common/util/global-scope'
-export class Aggregate extends AggregateBase {
+import { FeatureBase } from '../../utils/feature-base'
+
+export class Aggregate extends FeatureBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, FEATURE_NAME)

--- a/src/features/page_action/aggregate/index.js
+++ b/src/features/page_action/aggregate/index.js
@@ -9,12 +9,12 @@ import { registerHandler as register } from '../../../common/event-emitter/regis
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { cleanURL } from '../../../common/url/clean-url'
 import { getConfigurationValue, getInfo, getRuntime } from '../../../common/config/config'
-import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
 import { drain } from '../../../common/drain/drain'
 import { isBrowserScope } from '../../../common/util/global-scope'
+import { FeatureBase } from '../../utils/feature-base'
 
-export class Aggregate extends AggregateBase {
+export class Aggregate extends FeatureBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, FEATURE_NAME)

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -10,15 +10,15 @@ import { paintMetrics } from '../../../common/metrics/paint-metrics'
 import { submitData } from '../../../common/util/submit-data'
 import { getConfigurationValue, getInfo, getRuntime } from '../../../common/config/config'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
-import { AggregateBase } from '../../utils/aggregate-base'
 import * as CONSTANTS from '../constants'
 import { getActivatedFeaturesFlags } from './initialized-features'
 import { globalScope, isBrowserScope } from '../../../common/util/global-scope'
 import { drain } from '../../../common/drain/drain'
+import { FeatureBase } from '../../utils/feature-base'
 
 const jsonp = 'NREUM.setToken'
 
-export class Aggregate extends AggregateBase {
+export class Aggregate extends FeatureBase {
   static featureName = CONSTANTS.FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, CONSTANTS.FEATURE_NAME)

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -14,12 +14,12 @@ import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { cleanURL } from '../../../common/url/clean-url'
 import { handle } from '../../../common/event-emitter/handle'
 import { getInfo, getConfigurationValue, getRuntime } from '../../../common/config/config'
-import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
 import { drain } from '../../../common/drain/drain'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { FeatureBase } from '../../utils/feature-base'
 
-export class Aggregate extends AggregateBase {
+export class Aggregate extends FeatureBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, FEATURE_NAME)

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -11,12 +11,12 @@ import { supportsPerformanceObserver } from '../../../common/window/supports-per
 import slice from 'lodash._slice'
 import { getConfigurationValue, getInfo, getRuntime } from '../../../common/config/config'
 import { now } from '../../../common/timing/now'
-import { AggregateBase } from '../../utils/aggregate-base'
 import { FEATURE_NAME } from '../constants'
 import { drain } from '../../../common/drain/drain'
 import { HandlerCache } from '../../utils/handler-cache'
+import { FeatureBase } from '../../utils/feature-base'
 
-export class Aggregate extends AggregateBase {
+export class Aggregate extends FeatureBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, FEATURE_NAME)

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -13,19 +13,19 @@ import { paintMetrics } from '../../../common/metrics/paint-metrics'
 import { Interaction } from './interaction'
 import { getConfigurationValue, getRuntime } from '../../../common/config/config'
 import { eventListenerOpts } from '../../../common/event-listener/event-listener-opts'
-import { AggregateBase } from '../../utils/aggregate-base'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { Serializer } from './serializer'
 import { ee } from '../../../common/event-emitter/contextual-ee'
 import * as CONSTANTS from '../constants'
 import { drain } from '../../../common/drain/drain'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { FeatureBase } from '../../utils/feature-base'
 
 const {
   FEATURE_NAME, INTERACTION_EVENTS, MAX_TIMER_BUDGET, FN_START, FN_END, CB_START, INTERACTION_API, REMAINING,
   INTERACTION, SPA_NODE, JSONP_NODE, FETCH_START, FETCH_DONE, FETCH_BODY, JSONP_END, originalSetTimeout
 } = CONSTANTS
-export class Aggregate extends AggregateBase {
+export class Aggregate extends FeatureBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, FEATURE_NAME)

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -1,7 +1,0 @@
-import { FeatureBase } from './feature-base'
-
-export class AggregateBase extends FeatureBase {
-  constructor (agentIdentifier, aggregator, featureName) {
-    super(agentIdentifier, aggregator, featureName)
-  }
-}

--- a/src/features/utils/feature-base.js
+++ b/src/features/utils/feature-base.js
@@ -28,7 +28,7 @@ export class FeatureBase {
    * loader configurations may appear after the loader code is executed.
    */
   checkConfiguration () {
-    // NOTE: This check has to happen at aggregator load time, but could be moved to `AggregateBase`.
+    // NOTE: This check has to happen at aggregator load time
     if (!isConfigured(this.agentIdentifier)) {
       let jsAttributes = { ...gosCDN().info?.jsAttributes }
       try {

--- a/src/features/utils/lazy-loader.js
+++ b/src/features/utils/lazy-loader.js
@@ -9,7 +9,7 @@ import { FEATURE_NAMES } from '../../loaders/features/features'
  * should be.
  * @param featureName Name of the feature to import such as ajax or session_trace
  * @param featurePart Name of the feature part to load; should be either instrument or aggregate
- * @returns {Promise<InstrumentBase|AggregateBase|null>}
+ * @returns {Promise<InstrumentBase|FeatureBase|null>}
  */
 export function lazyLoader (featureName, featurePart) {
   if (featurePart === 'aggregate') {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Enabling the `no-useless-constructor` lint rule and resolving lint errors. The `AggregateBase` class was empty and so was removed. It can be added back later if and when it becomes needed for centralizing some logic across all the aggregators.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://issues.newrelic.com/browse/NR-87754
### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
