### PR TITLE
chore: Session entity supportability metrics - NEWRELIC-8334

### DIFF
--- a/src/common/config/state/configurable.js
+++ b/src/common/config/state/configurable.js
@@ -1,5 +1,6 @@
 import { getFrozenAttributes } from '../../../loaders/features/featureDependencies'
 import { warn } from '../../util/console'
+import { stringify } from '../../util/stringify'
 
 export class Configurable {
   constructor (obj, model) {
@@ -24,7 +25,7 @@ function setValues (obj, model) {
           }
         })
       }
-      if (typeof state[key] === 'object' && typeof value === 'object') state[key] = setValues(value, state[key])
+      if (typeof state[key] === 'object' && typeof value === 'object') state[key] = JSON.parse(stringify(value))
       else state[key] = value
     })
     return state

--- a/src/common/config/state/configurable.js
+++ b/src/common/config/state/configurable.js
@@ -14,6 +14,7 @@ function setValues (obj, model) {
     if (!model || typeof model !== 'object') return warn('Setting a Configurable requires a model to set its initial properties')
     Object.assign(state, model)
     Object.entries(obj).forEach(([key, value]) => {
+      if (!Object.keys(model).includes(key)) return
       const frozenAttrs = getFrozenAttributes(key)
       if (frozenAttrs.length && value && typeof value === 'object') {
         frozenAttrs.forEach(attr => {

--- a/src/common/config/state/configurable.js
+++ b/src/common/config/state/configurable.js
@@ -25,8 +25,7 @@ function setValues (obj, model) {
           }
         })
       }
-      if (typeof state[key] === 'object' && typeof value === 'object') state[key] = JSON.parse(stringify(value))
-      else state[key] = value
+      state[key] = value
     })
     return state
   } catch (err) {

--- a/src/common/config/state/configurable.js
+++ b/src/common/config/state/configurable.js
@@ -1,6 +1,5 @@
 import { getFrozenAttributes } from '../../../loaders/features/featureDependencies'
 import { warn } from '../../util/console'
-import { stringify } from '../../util/stringify'
 
 export class Configurable {
   constructor (obj, model) {

--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -182,7 +182,7 @@ export class SessionEntity {
       if (this.initialized) this.ee.emit('session-reset')
 
       this.storage.remove(this.lookupKey)
-      this.inactiveTimer?.clear?.(true)
+      this.inactiveTimer?.abort?.()
       this.expiresTimer?.clear?.()
       delete this.custom
       delete this.value

--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -83,7 +83,7 @@ export class SessionEntity {
       this.inactiveTimer = new InteractionTimer({
         // When the inactive timer ends, collect a SM and reset the session
         onEnd: () => {
-          this.collectSM('expired')
+          this.collectSM('inactive')
           this.reset()
         },
         // When the inactive timer refreshes, it will update the storage values with an update timestamp

--- a/src/common/timer/interaction-timer.js
+++ b/src/common/timer/interaction-timer.js
@@ -66,9 +66,10 @@ export class InteractionTimer extends Timer {
     this.onRefresh?.()
   }
 
-  resume () {
-    if (!this.remainingMs || !this.isValid()) return
-    this.timer = this.create(this.cb, this.remainingMs)
-    this.remainingMs = undefined
-  }
+  // NOT CURRENTLY UTILIZED BY ANYTHING
+  // resume () {
+  //   if (!this.remainingMs || !this.isValid()) return
+  //   this.timer = this.create(this.cb, this.remainingMs)
+  //   this.remainingMs = undefined
+  // }
 }

--- a/src/common/timer/interaction-timer.js
+++ b/src/common/timer/interaction-timer.js
@@ -47,10 +47,9 @@ export class InteractionTimer extends Timer {
     }
   }
 
-  clear (abort) {
-    clearTimeout(this.timer)
-    this.timer = null
-    if (abort) this.abortController?.abort()
+  abort () {
+    this.clear()
+    this.abortController?.abort()
   }
 
   pause () {

--- a/src/common/timer/timer.js
+++ b/src/common/timer/timer.js
@@ -6,8 +6,6 @@ export class Timer {
     this.onEnd = opts.onEnd
     this.initialMs = ms
     this.startTimestamp = Date.now()
-    // used by pause/resume
-    this.remainingMs = undefined
 
     this.timer = this.create(this.onEnd, ms)
   }
@@ -15,17 +13,6 @@ export class Timer {
   create (cb, ms) {
     if (this.timer) this.clear()
     return setTimeout(() => cb ? cb() : this.onEnd(), ms || this.initialMs)
-  }
-
-  pause () {
-    clearTimeout(this.timer)
-    this.remainingMs = this.initialMs - (Date.now() - this.startTimestamp)
-  }
-
-  resume () {
-    if (!this.remainingMs || !this.isValid()) return
-    this.timer = this.create(this.cb, this.remainingMs)
-    this.remainingMs = undefined
   }
 
   clear () {

--- a/src/common/timer/timer.test.js
+++ b/src/common/timer/timer.test.js
@@ -69,23 +69,6 @@ describe('create()', () => {
   })
 })
 
-describe('pause()', () => {
-  test('pause prevents the callback from firing', () => {
-    const timer = new Timer({ onEnd: jest.fn() }, 100)
-    expect(timer.onEnd).toHaveBeenCalledTimes(0)
-    timer.pause()
-    jest.advanceTimersByTime(150)
-    expect(timer.onEnd).toHaveBeenCalledTimes(0)
-  })
-
-  test('pause sets remainingMs timestamp', () => {
-    const timer = new Timer({ onEnd: jest.fn() }, 100)
-    expect(timer.remainingMs).toEqual(undefined)
-    timer.pause()
-    expect(timer.remainingMs).toEqual(timer.initialMs - (now - timer.startTimestamp))
-  })
-})
-
 describe('clear()', () => {
   test('clear prevents the callback from firing and deletes the pointer', () => {
     const timer = new Timer({ onEnd: jest.fn() }, 100)

--- a/tests/browser/config.browser.js
+++ b/tests/browser/config.browser.js
@@ -10,25 +10,38 @@ import { setConfiguration, getConfigurationValue } from '../../src/common/config
 const { agentIdentifier } = setup()
 
 test('getConfiguration', function (t) {
-  t.test('returns value from NREUM.init using provided path', function (t) {
+  t.test('does not set value for property not in model', function (t) {
     setConfiguration(agentIdentifier, { a: 123 })
-    t.equal(getConfigurationValue(agentIdentifier, 'a'), 123)
+    t.equal(getConfigurationValue(agentIdentifier, 'a'), undefined)
 
     setConfiguration(agentIdentifier, { a: { b: 123 } })
-    t.equal(getConfigurationValue(agentIdentifier, 'a.b'), 123)
+    t.equal(getConfigurationValue(agentIdentifier, 'a.b'), undefined)
 
     setConfiguration(agentIdentifier, { a: { b: { c: 123 } } })
-    t.equal(getConfigurationValue(agentIdentifier, 'a.b.c'), 123)
+    t.equal(getConfigurationValue(agentIdentifier, 'a.b.c'), undefined)
+
+    t.end()
+  })
+
+  t.test('returns value from NREUM.init using provided path', function (t) {
+    setConfiguration(agentIdentifier, { ajax: 123 })
+    t.equal(getConfigurationValue(agentIdentifier, 'ajax'), 123)
+
+    setConfiguration(agentIdentifier, { ajax: { a: true } })
+    t.equal(getConfigurationValue(agentIdentifier, 'ajax.a'), true)
+
+    setConfiguration(agentIdentifier, { ajax: { a: { b: 123 } } })
+    t.equal(getConfigurationValue(agentIdentifier, 'ajax.a.b'), 123)
 
     t.end()
   })
 
   t.test('returns undefined when path does not match', function (t) {
-    setConfiguration(agentIdentifier, { a: 123 })
+    setConfiguration(agentIdentifier, { ajax: 123 })
     t.equal(getConfigurationValue(agentIdentifier, 'b', 456), undefined)
 
-    setConfiguration(agentIdentifier, { a: { b: 123 } })
-    t.equal(getConfigurationValue(agentIdentifier, 'a.c', 456), undefined)
+    setConfiguration(agentIdentifier, { ajax: { b: 123 } })
+    t.equal(getConfigurationValue(agentIdentifier, 'ajax.c', 456), undefined)
 
     t.end()
   })


### PR DESCRIPTION
Internal metrics are collected for session duration and termination statistics
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds internal SMs for Session duration (ms), expiration count, and inactivity count.  As part of this work, some inconsistencies were cleaned up in the session entity class.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NEWRELIC-8334
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Existing tests should continue passing.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
