### PR TITLE
feat: adding query parameter supportability metrics

### DIFF
--- a/src/common/config/state/runtime.js
+++ b/src/common/config/state/runtime.js
@@ -6,7 +6,9 @@ import { BUILD_ENV, DIST_METHOD, VERSION } from '../../constants/env'
 
 const model = {
   buildEnv: BUILD_ENV,
-  bytesSent: {},
+  bytesSent: {}, // Used for SM to capture body bytes sent per endpoint
+  queryBytesSent: {}, // Used for SM to capture query parameter bytes sent per endpoint
+  imgMethodCount: 0, // Used for SM to capture count of time img network method is used
   customTransaction: undefined,
   disabled: false,
   distMethod: DIST_METHOD,

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -118,6 +118,8 @@ export class Harvest extends SharedContext {
 
     // Get bytes harvested per endpoint as a supportability metric. See metrics aggregator (on unload).
     agentRuntime.bytesSent[endpoint] = (agentRuntime.bytesSent[endpoint] || 0) + body?.length || 0
+    // Get query bytes harvested per endpoint as a supportability metric. See metrics aggregator (on unload).
+    agentRuntime.queryBytesSent[endpoint] = (agentRuntime.queryBytesSent[endpoint] || 0) + fullUrl.split('?').slice(-1)[0]?.length || 0
 
     /* Since workers don't support sendBeacon right now, or Image(), they can only use XHR method.
         Because they still do permit synch XHR, the idea is that at final harvest time (worker is closing),
@@ -144,6 +146,7 @@ export class Harvest extends SharedContext {
 
     // if beacon request failed, retry with an alternative method -- will not happen for workers
     if (!result && method === submitData.beacon) {
+      agentRuntime.imgMethodCount += 1
       method = submitData.img
       result = method(url + encodeObj(payload.body, agentRuntime.maxBytes))
     }

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -130,7 +130,10 @@ export class Aggregate extends FeatureBase {
     var queryString = fromArray(chunksForQueryString, agentRuntime.maxBytes)
 
     // Capture bytes sent to RUM call endpoint (currently `1`) as a supportability metric. See metrics aggregator (on unload).
-    agentRuntime.bytesSent[protocol] = (agentRuntime.bytesSent[protocol] || 0) + queryString?.length || 0
+    agentRuntime.bytesSent[protocol] = 0 // Set to zero for now until RUM is moved to POST
+
+    // Capture query bytes sent to RUM call endpoint (currently `1`) as a supportability metric. See metrics aggregator (on unload).
+    agentRuntime.queryBytesSent[protocol] = (agentRuntime.queryBytesSent[protocol] || 0) + queryString?.length || 0
 
     const isValidJsonp = submitData.jsonp(
       this.getScheme() + '://' + info.beacon + '/' + protocol + '/' + info.licenseKey + queryString,

--- a/src/loaders/api/apiAsync.js
+++ b/src/loaders/api/apiAsync.js
@@ -64,6 +64,7 @@ export function setAPI (agentIdentifier) {
     cycle += 1
 
     const agentInfo = getInfo(agentIdentifier)
+    const agentRuntime = getRuntime(this.sharedContext.agentIdentifier)
     if (!agentInfo.beacon) return
 
     var url = scheme + '://' + agentInfo.beacon + '/1/' + agentInfo.licenseKey
@@ -76,6 +77,8 @@ export function setAPI (agentIdentifier) {
     url += 'dc=' + ~~dom_time + '&'
     url += 'fe=' + ~~fe_time + '&'
     url += 'c=' + cycle
+
+    agentRuntime.imgMethodCount += 1
 
     submitData.img(url)
   }


### PR DESCRIPTION
Adding supportability metrics to capture legacy network method usage, query parameter size statistics, and custom data size statistics.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Adding supportability metrics (SMs) to capture the number of times the img network method is used, the bytes sent to each endpoint as query parameters, and the size of custom data.

The SM for RUM bytes sent `PageSession/Endpoint/1/BytesSent` has been updated to always send `0` since we do not send anything in the body of the RUM call. That will be updated later when we migrate the RUM call to a POST.

The SM for the img method does not account for the unload call on purpose because that is too late in the page and harvest lifecycle to account for it.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://issues.newrelic.com/browse/NEWRELIC-8477
https://issues.newrelic.com/browse/NEWRELIC-8478
https://issues.newrelic.com/browse/NEWRELIC-8479

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
