### PR TITLE
chore: testing server logging

### DIFF
--- a/tools/browsers-lists/browsers-all.json
+++ b/tools/browsers-lists/browsers-all.json
@@ -1826,6 +1826,19 @@
       "sauce:options": {
         "appiumVersion": "1.22.3"
       }
+    },
+    {
+      "browserName": "Chrome",
+      "platformName": "Android",
+      "platform": "Android",
+      "version": "13.0",
+      "device": "Pixel6ProGoogleAPI",
+      "appium:deviceName": "Google Pixel 6 Pro GoogleAPI Emulator",
+      "appium:platformVersion": "13.0",
+      "appium:automationName": "UiAutomator2",
+      "sauce:options": {
+        "appiumVersion": "1.22.3"
+      }
     }
   ],
   "ios": [

--- a/tools/testing-server/index.js
+++ b/tools/testing-server/index.js
@@ -3,6 +3,7 @@ const { urlFor } = require('./utils/url')
 const waitOn = require('wait-on')
 const { paths, defaultAgentConfig } = require('./constants')
 const TestHandle = require('./test-handle')
+const TestServerLogger = require('./logger')
 
 /**
  * Test server configuration options
@@ -64,12 +65,14 @@ class TestServer {
    */
   #testHandles = new Map()
 
-  constructor (config) {
-    if (!config.logger) {
-      config.logger = console
-    }
+  /**
+   * Custom logger for the test server
+   */
+  #logger
 
+  constructor (config) {
     this.#config = config
+    this.#logger = new TestServerLogger(config)
 
     this.#createAssetServer()
     this.#createCorsServer()
@@ -196,10 +199,11 @@ class TestServer {
     this.#assetServer = fastify({
       maxParamLength: Number.MAX_SAFE_INTEGER,
       bodyLimit: Number.MAX_SAFE_INTEGER,
-      logger: this.#config.logRequests ? this.#config.logger : false
+      logger: false
     })
 
     this.#assetServer.decorate('testServerId', 'assetServer')
+    this.#assetServer.decorate('testServerLogger', this.#logger)
     this.#assetServer.register(require('@fastify/multipart'), {
       addToBody: true
     })
@@ -221,16 +225,18 @@ class TestServer {
     this.#assetServer.register(require('./routes/mock-apis'), this)
     this.#assetServer.register(require('./plugins/test-handle'), this)
     this.#assetServer.register(require('./plugins/no-cache'))
+    this.#assetServer.register(require('./plugins/request-logger'))
   }
 
   #createCorsServer () {
     this.#corsServer = fastify({
       maxParamLength: Number.MAX_SAFE_INTEGER,
       bodyLimit: Number.MAX_SAFE_INTEGER,
-      logger: this.#config.logRequests ? this.#config.logger : false
+      logger: false
     })
 
     this.#corsServer.decorate('testServerId', 'corsServer')
+    this.#corsServer.decorate('testServerLogger', this.#logger)
     this.#corsServer.register(require('@fastify/multipart'), {
       addToBody: true
     })
@@ -241,16 +247,18 @@ class TestServer {
     })
     this.#corsServer.register(require('./routes/mock-apis'), this)
     this.#corsServer.register(require('./plugins/no-cache'))
+    this.#corsServer.register(require('./plugins/request-logger'))
   }
 
   #createBamServer () {
     this.#bamServer = fastify({
       maxParamLength: Number.MAX_SAFE_INTEGER,
       bodyLimit: Number.MAX_SAFE_INTEGER,
-      logger: this.#config.logRequests ? this.#config.logger : false
+      logger: false
     })
 
     this.#bamServer.decorate('testServerId', 'bamServer')
+    this.#bamServer.decorate('testServerLogger', this.#logger)
     this.#bamServer.register(require('@fastify/multipart'), {
       addToBody: true
     })
@@ -263,18 +271,21 @@ class TestServer {
     this.#bamServer.register(require('./routes/bam-apis'), this)
     this.#bamServer.register(require('./plugins/test-handle'), this)
     this.#bamServer.register(require('./plugins/no-cache'))
+    this.#bamServer.register(require('./plugins/request-logger'))
   }
 
   #createCommandServer () {
     this.#commandServer = fastify({
       maxParamLength: Number.MAX_SAFE_INTEGER,
       bodyLimit: Number.MAX_SAFE_INTEGER,
-      logger: this.#config.logRequests ? this.#config.logger : false
+      logger: false
     })
 
     this.#commandServer.decorate('testServerId', 'commandServer')
+    this.#commandServer.decorate('testServerLogger', this.#logger)
     this.#commandServer.register(require('./routes/command-apis'), this)
     this.#commandServer.register(require('./plugins/no-cache'))
+    this.#commandServer.register(require('./plugins/request-logger'))
   }
 
   /**

--- a/tools/testing-server/logger.js
+++ b/tools/testing-server/logger.js
@@ -1,0 +1,28 @@
+class TestServerLogger {
+  level = 'info'
+
+  #config
+  #parentLogger
+
+  constructor (config) {
+    this.#config = config
+
+    if (!config.logger) {
+      this.#parentLogger = console
+    } else {
+      this.#parentLogger = config.logger
+    }
+  }
+
+  logNetworkRequest (request) {
+    if (this.#config.logRequests) {
+      this.#parentLogger.info(`${request.server.testServerId} -> ${request.method} ${request.url}`)
+    }
+  }
+
+  logDebugShimMessage (request) {
+    this.#parentLogger.info(`DEBUG [${request.query.testId}](${request.query.ix}): ${request.query.m}`)
+  }
+}
+
+module.exports = TestServerLogger

--- a/tools/testing-server/plugins/request-logger/index.js
+++ b/tools/testing-server/plugins/request-logger/index.js
@@ -1,0 +1,14 @@
+const fp = require('fastify-plugin')
+
+/**
+ * Fastify plugin to log requests when the cli option `-L` is set.
+ * @param {module:fastify.FastifyInstance} fastify the fastify server instance
+ */
+module.exports = fp(async function (fastify) {
+  fastify.addHook('preHandler', (request, reply, done) => {
+    if (!request.url.startsWith('/debug')) {
+      fastify.testServerLogger.logNetworkRequest(request)
+    }
+    done()
+  })
+})

--- a/tools/testing-server/routes/bam-apis.js
+++ b/tools/testing-server/routes/bam-apis.js
@@ -6,7 +6,15 @@ const { rumFlags } = require('../constants')
  * @param {module:fastify.FastifyInstance} fastify the fastify server instance
  * @param {TestServer} testServer test server instance
  */
-module.exports = fp(async function (fastify, testServer) {
+module.exports = fp(async function (fastify) {
+  fastify.route({
+    method: ['GET', 'POST'],
+    url: '/debug',
+    handler: async function (request, reply) {
+      fastify.testServerLogger.logDebugShimMessage(request)
+      reply.code(200).send()
+    }
+  })
   fastify.route({
     method: ['GET', 'POST'],
     url: '/1/:testId',

--- a/tools/wdio/args.mjs
+++ b/tools/wdio/args.mjs
@@ -10,6 +10,10 @@ const jilArgs = yargs(process.argv.slice(2))
   .alias('v', 'verbose')
   .describe('v', 'if true, prints all output from each browser above summary')
 
+  .boolean('L')
+  .alias('L', 'log-requests')
+  .describe('l', 'if true, prints data about requests to the test server')
+
   .string('b')
   .alias('b', 'browsers')
   .requiresArg('b')

--- a/tools/wdio/config/base.conf.mjs
+++ b/tools/wdio/config/base.conf.mjs
@@ -18,7 +18,18 @@ export default function config () {
     maxInstances: jilArgs.concurrency || 1,
     maxInstancesPerCapability: 100,
     capabilities: [],
-    logLevel: jilArgs.verbose ? 'debug' : jilArgs.silent ? 'silent' : 'error',
+    logLevel: (() => {
+      if (jilArgs.verbose) {
+        return 'debug'
+      }
+      if (jilArgs.logRequests || jilArgs.debugShim) {
+        return 'info'
+      }
+      if (jilArgs.silent) {
+        return 'silent'
+      }
+      return 'error'
+    })(),
     waitforTimeout: 10000,
     connectionRetryTimeout: 120000,
     connectionRetryCount: 3,

--- a/tools/wdio/plugins/testing-server/launcher.mjs
+++ b/tools/wdio/plugins/testing-server/launcher.mjs
@@ -7,22 +7,13 @@ const log = logger('jil-testing-server')
  * This is a WDIO launcher plugin that starts the testing servers.
  */
 export default class TestingServerLauncher {
-  static #defaultAgentConfig = {
-    licenseKey: 'asdf',
-    applicationID: 42,
-    accountID: 123,
-    agentID: 456,
-    trustKey: 789
-  }
-
   #testingServer
 
   constructor (opts) {
-    this.#testingServer = new TestServer(
-      opts,
-      TestingServerLauncher.#defaultAgentConfig,
-      log
-    )
+    this.#testingServer = new TestServer({
+      ...opts,
+      logger: log
+    })
   }
 
   async onPrepare (_, capabilities) {


### PR DESCRIPTION
Adding back support for the debug shim in the test server and improving test server logging.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Adding a new testing server logger class that will log out network requests and debug messages from test assets separate from the fastify built-in logger. The fastify logger is not very human readable and very verbose. When running the server or tests with the `-L` cli flag, network requests will be logged in the pattern of `{serverId} -> {requestMethod} {requestUrl}`. For debug messages from the test assets, pass the `-d` cli flag and debug messages will be logged in the pattern of `DEBUG [{licenseKey}]({messageIndex}): {debugMethod} {debugMethodParameters}`.

Examples:
`DEBUG [3984b89d-1fce-464f-a8b2-d27e7b785ae3](1): console.log: {"0":"THIS IS FOOBAR"}`
`commandServer -> POST /test-handle/377be80d-de29-4ec1-b23b-94bd39b42b89/expect`

If you pass the `-L` flag, any BAM expect errors that happen will be easier to trace to a specific test since the log will include entries for which test is executing and the license key that was generated for that test.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://issues.newrelic.com/browse/NEWRELIC-8503
https://issues.newrelic.com/browse/NEWRELIC-7596

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

1. Add a console log to the `tests/assets/api.html` file
2. Run jil, wdio, or the test server with the `-d` flag
3. Verify you are getting debug messages logged in the console from the debug-shim
4. Run jil, wdio, or the test server with the `-L` flag
5. Verify you are getting info messages logged for each network request to the test server
