### PR TITLE
chore: add support for saucelabs extended debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10574,9 +10574,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001486",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
-      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
       "dev": true,
       "funding": [
         {
@@ -36990,9 +36990,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001486",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001486.tgz",
-      "integrity": "sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==",
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
       "dev": true
     },
     "capital-case": {

--- a/tests/assets/ignored-error.html
+++ b/tests/assets/ignored-error.html
@@ -15,11 +15,11 @@
     var count = 0
     setTimeout(function () {
       throw new Error('ignore')
-    }, 0)
+    }, 100)
 
     setTimeout(function () {
       throw new Error('report')
-    }, 0)
+    }, 100)
 
     newrelic.setErrorHandler(function (err) {
       if (++count === 2) window.errorsThrown = true

--- a/tests/assets/worker/js/module-worker.js
+++ b/tests/assets/worker/js/module-worker.js
@@ -3,9 +3,8 @@
 onmessage = function (e) {
   if (e.data.type === 'startAgent') {
     self.NREUM = e.data.payload
-    import('../../../../../../../../web-worker-agent').then(() => {
-      self.postMessage({ type: 'ready' })
-    })
+    importScripts('/web-worker-agent') // JIL's endpoint to fetch the single bundle web worker pkg
+    self.postMessage({ type: 'ready' })
   } else if (e.data.type === 'command') {
     // Let errors go unhandled so bad commands crashes the tests for troubleshooting.
     let retVal = eval(e.data.fn) // run the literal string cmd

--- a/tests/assets/worker/js/module-worker.js
+++ b/tests/assets/worker/js/module-worker.js
@@ -3,8 +3,10 @@
 onmessage = function (e) {
   if (e.data.type === 'startAgent') {
     self.NREUM = e.data.payload
-    importScripts('/web-worker-agent') // JIL's endpoint to fetch the single bundle web worker pkg
-    self.postMessage({ type: 'ready' })
+    // Module workers do not support importScripts, need to import directly
+    import('../../../../../../../../web-worker-agent').then(() => {
+      self.postMessage({ type: 'ready' })
+    })
   } else if (e.data.type === 'command') {
     // Let errors go unhandled so bad commands crashes the tests for troubleshooting.
     let retVal = eval(e.data.fn) // run the literal string cmd

--- a/tests/functional/disable-harvest.test.js
+++ b/tests/functional/disable-harvest.test.js
@@ -69,7 +69,7 @@ testDriver.test('SPA - Kills feature if entitlements flag is 0', supported, func
     .then(() => spaPromise)
     .then(() => t.fail('should not have received spa data'))
     .catch((e) => {
-      if (e.toString().indexOf('Expect for bamServer timed out') > -1) {
+      if (e.toString().indexOf('for bamServer timed out') > -1) {
         t.pass('did not received spa data :)')
       } else {
         t.fail('unknown error', e)
@@ -105,7 +105,7 @@ testDriver.test('PAGE ACTIONS - Kills feature if entitlements flag is 0', suppor
     .then(() => insPromise)
     .then(() => t.fail('should not have received spa data'))
     .catch((e) => {
-      if (e.toString().indexOf('Expect for bamServer timed out') > -1) {
+      if (e.toString().indexOf('for bamServer timed out') > -1) {
         t.pass('did not received ins data :)')
       } else {
         t.fail('unknown error', e)

--- a/tests/functional/final-harvest.test.js
+++ b/tests/functional/final-harvest.test.js
@@ -267,13 +267,13 @@ testDriver.test('final harvest sends resources', reliableResourcesHarvest.and(st
   let url = router.assetURL('final-harvest.html')
   let loadPromise = browser.safeGet(url).catch(fail)
   let rumPromise = router.expectRum()
+  let resourcesPromise = router.expectResources()
 
-  Promise.all([rumPromise, loadPromise])
-    .then(() => {
-      t.equal(router.requestCounts.bamServer.resources, 1, 'resources harvest is sent on startup')
+  Promise.all([resourcesPromise, rumPromise, loadPromise])
+    .then(([{ request: { body } }]) => {
+      t.ok(body, 'received res harvest')
 
-      let resourcesPromise = router.expectResources()
-
+      resourcesPromise = router.expectResources()
       let domPromise = browser
         .setAsyncScriptTimeout(10000) // the default is too low for IE
         .elementById('resourcesBtn')
@@ -283,9 +283,8 @@ testDriver.test('final harvest sends resources', reliableResourcesHarvest.and(st
 
       return Promise.all([resourcesPromise, domPromise])
     })
-    .then((results) => {
-      t.equal(router.requestCounts.bamServer.resources, 2, 'received second resources harvest')
-      t.ok(results[0].request.body, 'received res harvest')
+    .then(([{ request: { body } }]) => {
+      t.ok(body, 'received res harvest')
       t.end()
     })
     .catch(fail)
@@ -340,13 +339,14 @@ testDriver.test('final harvest sends multiple', reliableResourcesHarvest.and(stn
   let url = router.assetURL('final-harvest-timings.html', { init: { metrics: { enabled: false } } })
   let loadPromise = browser.safeGet(url).catch(fail)
   let rumPromise = router.expectRum()
+  let resourcesPromise = router.expectResources()
 
-  Promise.all([rumPromise, loadPromise])
-    .then(() => {
-      t.equal(router.requestCounts.bamServer.resources, 1, 'resources harvest is sent on startup')
+  Promise.all([resourcesPromise, rumPromise, loadPromise])
+    .then(([{ request: { body }}]) => {
+      t.ok(body, 'resources harvest is sent on startup')
       t.equal(router.requestCounts.bamServer.jserrors, undefined, 'no errors harvest yet')
 
-      let resourcesPromise = router.expectResources()
+      resourcesPromise = router.expectResources()
       let errorsPromise = router.expectErrors()
 
       let domPromise = browser

--- a/tests/functional/final-harvest.test.js
+++ b/tests/functional/final-harvest.test.js
@@ -271,7 +271,7 @@ testDriver.test('final harvest sends resources', reliableResourcesHarvest.and(st
 
   Promise.all([resourcesPromise, rumPromise, loadPromise])
     .then(([{ request: { body } }]) => {
-      t.ok(body, 'received res harvest')
+      t.ok(body, 'received first resources harvest on startup')
 
       resourcesPromise = router.expectResources()
       let domPromise = browser
@@ -284,7 +284,7 @@ testDriver.test('final harvest sends resources', reliableResourcesHarvest.and(st
       return Promise.all([resourcesPromise, domPromise])
     })
     .then(([{ request: { body } }]) => {
-      t.ok(body, 'received res harvest')
+      t.ok(body, 'received second res harvest on interval')
       t.end()
     })
     .catch(fail)

--- a/tools/browsers-lists/browsers-all.json
+++ b/tools/browsers-lists/browsers-all.json
@@ -883,6 +883,13 @@
       "platform": "Windows 11",
       "version": "112",
       "browserVersion": "112"
+    },
+    {
+      "browserName": "MicrosoftEdge",
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "113",
+      "browserVersion": "113"
     }
   ],
   "firefox": [
@@ -1620,6 +1627,13 @@
       "platform": "Windows 10",
       "version": "112",
       "browserVersion": "112"
+    },
+    {
+      "browserName": "firefox",
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "113",
+      "browserVersion": "113"
     }
   ],
   "safari": [

--- a/tools/browsers-lists/browsers-all.json
+++ b/tools/browsers-lists/browsers-all.json
@@ -1851,7 +1851,7 @@
       "appium:platformVersion": "13.0",
       "appium:automationName": "UiAutomator2",
       "sauce:options": {
-        "appiumVersion": "1.22.3"
+        "appiumVersion": "2.0.0"
       }
     }
   ],

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -46,17 +46,17 @@
     },
     {
       "browserName": "MicrosoftEdge",
-      "platformName": "Windows 11",
-      "platform": "Windows 11",
-      "version": "109",
-      "browserVersion": "109"
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "110",
+      "browserVersion": "110"
     },
     {
       "browserName": "MicrosoftEdge",
-      "platformName": "Windows 11",
-      "platform": "Windows 11",
-      "version": "112",
-      "browserVersion": "112"
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "113",
+      "browserVersion": "113"
     }
   ],
   "firefox": [
@@ -64,29 +64,29 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "103",
-      "browserVersion": "103"
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "106",
-      "browserVersion": "106"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "109",
-      "browserVersion": "109"
+      "version": "110",
+      "browserVersion": "110"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "112",
-      "browserVersion": "112"
+      "version": "113",
+      "browserVersion": "113"
     }
   ],
   "safari": [

--- a/tools/browsers-lists/extended-debugging.mjs
+++ b/tools/browsers-lists/extended-debugging.mjs
@@ -1,0 +1,19 @@
+import browsersAll from './browsers-all.json' assert { type: "json" }
+
+export default function browserSupportsExtendedDebugging ({ browserName, browserVersion, version }) {
+  if (!['chrome', 'firefox'].includes(browserName)) {
+    return false
+  }
+
+  if (browserVersion === 'latest') {
+    return true
+  }
+
+  if (browserName === 'firefox' && (Number(browserVersion) >= 53 || Number(version) >= 53)) {
+    return true
+  }
+
+  const latestChrome = browsersAll.chrome
+    .reduce((aggregator, sauceBrowser) => aggregator = Math.max(Number(sauceBrowser.version), Number(sauceBrowser.browserVersion), aggregator), 0)
+  return (Number(browserVersion) || Number(version)) >= latestChrome - 2
+}

--- a/tools/browsers-lists/extended-debugging.mjs
+++ b/tools/browsers-lists/extended-debugging.mjs
@@ -9,8 +9,8 @@ export default function browserSupportsExtendedDebugging ({ browserName, browser
     return true
   }
 
-  if (browserName === 'firefox' && (Number(browserVersion) >= 53 || Number(version) >= 53)) {
-    return true
+  if (browserName === 'firefox') {
+    return Number(browserVersion) >= 53 || Number(version) >= 53
   }
 
   const latestChrome = browsersAll.chrome

--- a/tools/jil/driver/TestRun.js
+++ b/tools/jil/driver/TestRun.js
@@ -113,6 +113,7 @@ class TestRun extends EventEmitter {
 
       const id = self._generateID()
       const handle = router.createTestHandle(id)
+      self.driver.output.log(`# Running test [${id}]: ${testName}`)
 
       harness.pause()
       observeTapeTest(t, onTestFinished, onTestResult)

--- a/tools/jil/runner/args.js
+++ b/tools/jil/runner/args.js
@@ -16,6 +16,11 @@ module.exports = yargs
   .alias('v', 'verbose')
   .describe('v', 'if true, prints all output from each browser above summary')
 
+  .boolean('D')
+  .default('D', false)
+  .alias('D', 'sauce-extended-debugging')
+  .describe('D', 'Run tests with sauce labs extended debugging enabled')
+
   .string('b')
   .alias('b', 'browsers')
   .requiresArg('b')

--- a/tools/jil/runner/index.js
+++ b/tools/jil/runner/index.js
@@ -134,6 +134,10 @@ function loadBrowsersAndRunTests () {
     } else {
       let sauceCreds = getSauceLabsCreds()
       connectionInfo = `http://${sauceCreds.username}:${sauceCreds.accessKey}@ondemand.saucelabs.com/wd/hub`
+
+      if (config.sauceExtendedDebugging && desired.browserName === 'chrome') {
+        desired.extendedDebugging = true
+      }
     }
 
     if (browser.allowsExtendedDebugging()) desired.extendedDebugging = true // turn on JS console logs & HAR files in SauceLabs

--- a/tools/jil/runner/index.js
+++ b/tools/jil/runner/index.js
@@ -135,12 +135,10 @@ function loadBrowsersAndRunTests () {
       let sauceCreds = getSauceLabsCreds()
       connectionInfo = `http://${sauceCreds.username}:${sauceCreds.accessKey}@ondemand.saucelabs.com/wd/hub`
 
-      if (config.sauceExtendedDebugging && desired.browserName === 'chrome') {
-        desired.extendedDebugging = true
+      if (config.sauceExtendedDebugging && browser.allowsExtendedDebugging()) {
+        desired.extendedDebugging = true // turn on JS console logs & HAR files in SauceLabs
       }
     }
-
-    if (browser.allowsExtendedDebugging()) desired.extendedDebugging = true // turn on JS console logs & HAR files in SauceLabs
 
     desired.build = buildIdentifier
     desired.name = `${buildIdentifier}-${browser.toString()}`

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.231.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.232.0.tgz"
   }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.231.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.232.0.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.231.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.232.0.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/tools/testing-server/routes/mock-apis.js
+++ b/tools/testing-server/routes/mock-apis.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('fs-extra')
 const path = require('path')
 const fp = require('fastify-plugin')
 const { PassThrough } = require('stream')
@@ -142,7 +142,7 @@ module.exports = fp(async function (fastify, testServer) {
     stream.end()
   })
   fastify.get('/web-worker-agent', async (request, reply) => {
-    const contents = await fs.promises.readFile(
+    const contents = await fs.readFile(
       path.join(paths.builtAssetsDir, 'nr-loader-worker.min.js')
     )
     reply

--- a/tools/testing-server/test-handle.js
+++ b/tools/testing-server/test-handle.js
@@ -184,7 +184,7 @@ module.exports = class TestHandle {
     if (testServerExpect.timeout !== false) {
       setTimeout(() => {
         deferred.reject(new Error(
-          `Expect for ${serverId} timed out for test ${this.#testId}`
+          `Expect ${testServerExpect.test.name} for ${serverId} timed out after ${testServerExpect.timeout || this.#testServer.config.timeout}ms for test ${this.#testId}`
         ))
       }, testServerExpect.timeout || this.#testServer.config.timeout)
     }

--- a/tools/testing-server/utils/expect-tests.js
+++ b/tools/testing-server/utils/expect-tests.js
@@ -12,12 +12,12 @@
  *
  */
 
-module.exports.testRumRequest = function (request) {
+module.exports.testRumRequest = function testRumRequest (request) {
   const url = new URL(request.url, 'resolve://')
   return url.pathname === `/1/${this.testId}`
 }
 
-module.exports.testEventsRequest = function (request) {
+module.exports.testEventsRequest = function testEventsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/events/1/${this.testId}`) {
     return false
@@ -37,7 +37,7 @@ module.exports.testEventsRequest = function (request) {
   }
 }
 
-module.exports.testTimingEventsRequest = function (request) {
+module.exports.testTimingEventsRequest = function testTimingEventsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/events/1/${this.testId}`) {
     return false
@@ -63,7 +63,7 @@ module.exports.testTimingEventsRequest = function (request) {
   }
 }
 
-module.exports.testAjaxEventsRequest = function (request) {
+module.exports.testAjaxEventsRequest = function testAjaxEventsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/events/1/${this.testId}`) {
     return false
@@ -89,7 +89,7 @@ module.exports.testAjaxEventsRequest = function (request) {
   }
 }
 
-module.exports.testInteractionEventsRequest = function (request) {
+module.exports.testInteractionEventsRequest = function testInteractionEventsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/events/1/${this.testId}`) {
     return false
@@ -115,7 +115,7 @@ module.exports.testInteractionEventsRequest = function (request) {
   }
 }
 
-module.exports.testMetricsRequest = function (request) {
+module.exports.testMetricsRequest = function testMetricsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/jserrors/1/${this.testId}`) {
     return false
@@ -148,7 +148,7 @@ module.exports.testMetricsRequest = function (request) {
   }
 }
 
-module.exports.testCustomMetricsRequest = function (request) {
+module.exports.testCustomMetricsRequest = function testCustomMetricsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/jserrors/1/${this.testId}`) {
     return false
@@ -168,7 +168,7 @@ module.exports.testCustomMetricsRequest = function (request) {
   }
 }
 
-module.exports.testSupportMetricsRequest = function (request) {
+module.exports.testSupportMetricsRequest = function testSupportMetricsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/jserrors/1/${this.testId}`) {
     return false
@@ -188,7 +188,7 @@ module.exports.testSupportMetricsRequest = function (request) {
   }
 }
 
-module.exports.testErrorsRequest = function (request) {
+module.exports.testErrorsRequest = function testErrorsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/jserrors/1/${this.testId}`) {
     return false
@@ -208,7 +208,7 @@ module.exports.testErrorsRequest = function (request) {
   }
 }
 
-module.exports.testAjaxTimeSlicesRequest = function (request) {
+module.exports.testAjaxTimeSlicesRequest = function testAjaxTimeSlicesRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/jserrors/1/${this.testId}`) {
     return false
@@ -228,7 +228,7 @@ module.exports.testAjaxTimeSlicesRequest = function (request) {
   }
 }
 
-module.exports.testInsRequest = function (request) {
+module.exports.testInsRequest = function testInsRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/ins/1/${this.testId}`) {
     return false
@@ -248,7 +248,7 @@ module.exports.testInsRequest = function (request) {
   }
 }
 
-module.exports.testResourcesRequest = function (request) {
+module.exports.testResourcesRequest = function testResourcesRequest (request) {
   const url = new URL(request.url, 'resolve://')
   if (url.pathname !== `/resources/1/${this.testId}`) {
     return false

--- a/tools/wdio/args.mjs
+++ b/tools/wdio/args.mjs
@@ -14,6 +14,11 @@ const jilArgs = yargs(process.argv.slice(2))
   .alias('L', 'log-requests')
   .describe('l', 'if true, prints data about requests to the test server')
 
+  .boolean('D')
+  .default('D', false)
+  .alias('D', 'sauce-extended-debugging')
+  .describe('D', 'Run tests with sauce labs extended debugging enabled')
+
   .string('b')
   .alias('b', 'browsers')
   .requiresArg('b')

--- a/tools/wdio/config/sauce.conf.mjs
+++ b/tools/wdio/config/sauce.conf.mjs
@@ -30,7 +30,14 @@ function sauceCapabilities () {
       platform: undefined,
       version: undefined,
       'sauce:options': !jilArgs.sauce
-        ? { tunnelName: getSauceConnectTunnelName() }
+        ? {
+            tunnelName: getSauceConnectTunnelName(),
+            ...(() => {
+              if (jilArgs.sauceExtendedDebugging && sauceBrowser.browserName === 'chrome') {
+                return { extendedDebugging: true }
+              }
+            })()
+          }
         : {}
     }))
 }

--- a/tools/wdio/config/sauce.conf.mjs
+++ b/tools/wdio/config/sauce.conf.mjs
@@ -2,6 +2,7 @@ import browsersSupported from '../../browsers-lists/browsers-supported.json' ass
 import browsersAll from '../../browsers-lists/browsers-all.json' assert { type: "json" }
 import browsersPolyfill from '../../browsers-lists/browsers-polyfill.json' assert { type: "json" }
 import browsersList from '../../browsers-lists/browsers-list.mjs'
+import browserSupportsExtendedDebugging from '../../browsers-lists/extended-debugging.mjs'
 import jilArgs from '../args.mjs'
 import {
   getSauceConnectTunnelName,
@@ -33,7 +34,7 @@ function sauceCapabilities () {
         ? {
             tunnelName: getSauceConnectTunnelName(),
             ...(() => {
-              if (jilArgs.sauceExtendedDebugging && sauceBrowser.browserName === 'chrome') {
+              if (jilArgs.sauceExtendedDebugging && browserSupportsExtendedDebugging(sauceBrowser)) {
                 return { extendedDebugging: true }
               }
             })()


### PR DESCRIPTION
Adding support for SauceLabs extended debugging feature.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
This PR adds support for SauceLabs [extended debugging](https://docs.saucelabs.com/insights/debug/) feature. It also adds an extra log entry when running tests using JIL to show which test is related to which testId (license key). This will make it easier to track down tests that are failing due to BAM expect timeouts. The expects have also been updated to provide each function a proper name so the log entry for a timeout will show which BAM endpoint timed out.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
N/A

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
