### PR TITLE
fix: Add X-NewRelic-ID header only if defined - NEWRELIC-8521

### DIFF
--- a/src/features/ajax/instrument/index.js
+++ b/src/features/ajax/instrument/index.js
@@ -99,7 +99,7 @@ function subscribeToEvents (agentIdentifier, ee, handler, dt) {
 
   function onOpenXhrEnd (args, xhr) {
     var loader_config = getLoaderConfig(agentIdentifier)
-    if ('xpid' in loader_config && this.sameOrigin) {
+    if (loader_config.xpid && this.sameOrigin) {
       xhr.setRequestHeader('X-NewRelic-ID', loader_config.xpid)
     }
 

--- a/tests/assets/cat-same-origin.html
+++ b/tests/assets/cat-same-origin.html
@@ -6,11 +6,15 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>CAT header on CORS XHR</title>
+    <title>CAT header on same-origin XHR</title>
     {init}
     <script type="text/javascript">
       if (!NREUM.loader_config) NREUM.loader_config = {}
-      NREUM.loader_config.xpid = '12#34'
+      try {
+        NREUM.loader_config.xpid = window.location.search.match(/xpid=([^&]*)/)[1]
+      } catch (e) {
+        NREUM.loader_config.xpid = '12#36'
+      }
     </script>
     {config}
     {loader}
@@ -18,7 +22,7 @@
       var xhr = new XMLHttpRequest()
       var testIdMatches = window.location.search.match(/testId=([^&]*)/)
       var testId = testIdMatches ? testIdMatches[1] : ''
-      var url = 'http://' + NREUM.info.beacon + '/cat-cors/' + testId
+      var url = '/same-origin/' + testId
       xhr.open('GET', url)
       xhr.send()
     </script>

--- a/tests/functional/xhr/cat-cors.test.js
+++ b/tests/functional/xhr/cat-cors.test.js
@@ -8,6 +8,7 @@ const { fail } = require('./helpers')
 
 testDriver.test('does not set CAT header on cross-origin XHRs', function (t, browser, router) {
   t.plan(1)
+
   const ajaxPromise = router.expect('bamServer', {
     test: function (request) {
       const url = new URL(request.url, 'resolve://')
@@ -25,6 +26,7 @@ testDriver.test('does not set CAT header on cross-origin XHRs', function (t, bro
 
 testDriver.test('sets CAT header on same origin XHRs if xpid is defined', function (t, browser, router) {
   t.plan(1)
+
   const ajaxPromise = router.expect('assetServer', {
     test: function (request) {
       const url = new URL(request.url, 'resolve://')
@@ -42,6 +44,7 @@ testDriver.test('sets CAT header on same origin XHRs if xpid is defined', functi
 
 testDriver.test('does not set CAT header on same origin XHRs if xpid is undefined', function (t, browser, router) {
   t.plan(1)
+  
   const ajaxPromise = router.expect('assetServer', {
     test: function (request) {
       const url = new URL(request.url, 'resolve://')

--- a/tests/functional/xhr/cat-cors.test.js
+++ b/tests/functional/xhr/cat-cors.test.js
@@ -14,9 +14,7 @@ testDriver.test('does not set CAT header on cross-origin XHRs', function (t, bro
       return url.pathname === `/cat-cors/${router.testId}`
     }
   })
-  let loadPromise = browser.safeGet(router.assetURL(
-    'cat-cors.html', { testId: router.testId })
-  )
+  let loadPromise = browser.get(router.assetURL('cat-cors.html', { testId: router.testId }))
 
   Promise.all([ajaxPromise, loadPromise])
     .then(([{ request }]) => {
@@ -33,9 +31,7 @@ testDriver.test('sets CAT header on same origin XHRs if xpid is defined', functi
       return url.pathname === `/same-origin/${router.testId}`
     }
   })
-  let loadPromise = browser.safeGet(router.assetURL(
-    'cat-same-origin.html', { testId: router.testId })
-  )
+  let loadPromise = browser.get(router.assetURL('cat-same-origin.html', { testId: router.testId }))
 
   Promise.all([ajaxPromise, loadPromise])
     .then(([{ request }]) => {
@@ -52,9 +48,7 @@ testDriver.test('does not set CAT header on same origin XHRs if xpid is undefine
       return url.pathname === `/same-origin/${router.testId}`
     }
   })
-  let loadPromise = browser.safeGet(router.assetURL(
-    'cat-same-origin.html', { testId: router.testId, xpid: '' })
-  )
+  let loadPromise = browser.get(router.assetURL('cat-same-origin.html', { testId: router.testId, xpid: '' }))
 
   Promise.all([ajaxPromise, loadPromise])
     .then(([{ request }]) => {

--- a/tests/functional/xhr/cat-cors.test.js
+++ b/tests/functional/xhr/cat-cors.test.js
@@ -6,20 +6,59 @@
 const testDriver = require('../../../tools/jil/index')
 const { fail } = require('./helpers')
 
-testDriver.test('does not set CAT headers on outbound XHRs to different origin', function (t, browser, router) {
+testDriver.test('does not set CAT header on cross-origin XHRs', function (t, browser, router) {
   t.plan(1)
-
   const ajaxPromise = router.expect('bamServer', {
     test: function (request) {
       const url = new URL(request.url, 'resolve://')
       return url.pathname === `/cat-cors/${router.testId}`
     }
   })
-  let loadPromise = browser.get(router.assetURL('cat-cors.html', { testId: router.testId }))
+  let loadPromise = browser.safeGet(router.assetURL(
+    'cat-cors.html', { testId: router.testId })
+  )
 
   Promise.all([ajaxPromise, loadPromise])
     .then(([{ request }]) => {
       t.notok(request.headers['x-newrelic-id'], 'cross-origin XHR should not have CAT header')
+    })
+    .catch(fail(t, 'unexpected error'))
+})
+
+testDriver.test('sets CAT header on same origin XHRs if xpid is defined', function (t, browser, router) {
+  t.plan(1)
+  const ajaxPromise = router.expect('assetServer', {
+    test: function (request) {
+      const url = new URL(request.url, 'resolve://')
+      return url.pathname === `/same-origin/${router.testId}`
+    }
+  })
+  let loadPromise = browser.safeGet(router.assetURL(
+    'cat-same-origin.html', { testId: router.testId })
+  )
+
+  Promise.all([ajaxPromise, loadPromise])
+    .then(([{ request }]) => {
+      t.ok(request.headers['x-newrelic-id'], 'same-origin XHR should have CAT header if xpid is specified')
+    })
+    .catch(fail(t, 'unexpected error'))
+})
+
+testDriver.test('does not set CAT header on same origin XHRs if xpid is undefined', function (t, browser, router) {
+  t.plan(1)
+  const ajaxPromise = router.expect('assetServer', {
+    test: function (request) {
+      const url = new URL(request.url, 'resolve://')
+      return url.pathname === `/same-origin/${router.testId}`
+    }
+  })
+  let loadPromise = browser.safeGet(router.assetURL(
+    'cat-same-origin.html', { testId: router.testId, xpid: '' })
+  )
+
+  Promise.all([ajaxPromise, loadPromise])
+    .then(([{ request }]) => {
+      t.notok(request.headers['x-newrelic-id'], 'same-origin XHR should not have CAT header if xpid is undefined')
     })
     .catch(fail(t, 'unexpected error'))
 })

--- a/tools/browsers-lists/browsers-all.json
+++ b/tools/browsers-lists/browsers-all.json
@@ -1851,7 +1851,7 @@
       "appium:platformVersion": "13.0",
       "appium:automationName": "UiAutomator2",
       "sauce:options": {
-        "appiumVersion": "1.22.3"
+        "appiumVersion": "2.0.0"
       }
     }
   ],

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -2,17 +2,17 @@
   "chrome": [
     {
       "browserName": "chrome",
-      "platformName": "Windows 10",
-      "platform": "Windows 10",
-      "version": "103",
-      "browserVersion": "103"
+      "platformName": "Windows 11",
+      "platform": "Windows 11",
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "chrome",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "106",
-      "browserVersion": "106"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "chrome",
@@ -34,15 +34,15 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "103",
-      "browserVersion": "103"
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "106",
-      "browserVersion": "106"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "103",
+      "browserVersion": "103"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "firefox",

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "103",
-      "browserVersion": "103"
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "106",
-      "browserVersion": "106"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "firefox",

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -21,7 +21,8 @@ module.exports.loaderConfigKeys = [
   'agentID',
   'applicationID',
   'licenseKey',
-  'trustKey'
+  'trustKey',
+  'xpid'
 ]
 
 module.exports.loaderOnlyConfigKeys = ['accountID', 'agentID', 'trustKey']

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -21,8 +21,7 @@ module.exports.loaderConfigKeys = [
   'agentID',
   'applicationID',
   'licenseKey',
-  'trustKey',
-  'xpid'
+  'trustKey'
 ]
 
 module.exports.loaderOnlyConfigKeys = ['accountID', 'agentID', 'trustKey']


### PR DESCRIPTION
The agent will now set the `X-NewRelic-ID` header on XHR requests only when a truthy `xpid` value is explicitly set in the loader configuration. Previously the header was added even if undefined.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

As described in the bug linked below, the `X-NewRelic-ID` header was getting set even when the xpid configuration value had not been set. This is likely an artifact of an earlier agent architecture in which there was no default model for the configuration, which meant `xpid` was not set except manually. Now with a model, `xpid` always exists with at least a default value of `undefined`.

### Related Issue(s)

- https://github.com/newrelic/newrelic-browser-agent/issues/526
- [NEWRELIC-8521](https://issues.newrelic.com/browse/NEWRELIC-8521)

### Testing

- Automated tests should pass.
- The linked bug provides manual replication steps.