### PR TITLE
chore: Workers tests

### DIFF
--- a/.github/workflows/tests-worker.yml
+++ b/.github/workflows/tests-worker.yml
@@ -1,0 +1,37 @@
+name: Workers Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs every day at 3AM
+    - cron: '0 4 * * *'
+
+env:
+  BUILD_NUMBER: event-${{ github.event.number }}-job-${{ github.run_number }}-attempt-${{ github.run_attempt }}
+
+jobs:
+  chrome:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      NEWRELIC_ENVIRONMENT: ci
+      JIL_SAUCE_LABS_USERNAME: ${{ secrets.JIL_SAUCE_LABS_USERNAME }}
+      JIL_SAUCE_LABS_ACCESS_KEY: ${{ secrets.JIL_SAUCE_LABS_ACCESS_KEY }}
+      NEW_RELIC_LICENSE_KEY: ${{ secrets.JIL_NODE_NEW_RELIC_LICENSE_KEY }}
+
+    steps:
+      - name: Setup Container
+        run: apt update && apt install -y git
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - name: checkout and build
+        uses: ./.github/actions/test-setup
+      - name: run tests
+        run: node --max-old-space-size=8192 ./tools/jil/bin/cli.js -f merged -b '*@*' -t 85000 tests/worker/**/*.test.js --concurrent=30

--- a/package-lock.json
+++ b/package-lock.json
@@ -10573,9 +10573,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001487",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
+      "version": "1.0.30001488",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
+      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
       "dev": true,
       "funding": [
         {
@@ -36984,9 +36984,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001487",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
-      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
+      "version": "1.0.30001488",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
+      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
       "dev": true
     },
     "capital-case": {

--- a/tests/functional/worker/ajax-events.test.js
+++ b/tests/functional/worker/ajax-events.test.js
@@ -1,6 +1,6 @@
-const testDriver = require('../../../tools/jil/index')
+const testDriver = require('../../tools/jil/index')
 const { workerTypes, typeToMatcher } = require('./helpers')
-const { fail } = require('../xhr/helpers')
+const { fail } = require('../functional/xhr/helpers')
 const querypack = require('@newrelic/nr-querypack')
 
 workerTypes.forEach(type => {

--- a/tests/functional/worker/all-uncategorized.test.js
+++ b/tests/functional/worker/all-uncategorized.test.js
@@ -1,6 +1,6 @@
-const testDriver = require('../../../tools/jil/index')
+const testDriver = require('../../tools/jil/index')
 const { workerTypes, typeToMatcher } = require('./helpers')
-const { fail, checkPayload, url } = require('../uncat-internal-help.cjs')
+const { fail, checkPayload, url } = require('../functional/uncat-internal-help.cjs')
 
 const fetchExt = testDriver.Matcher.withFeature('fetchExt')
 const FAIL_MSG = 'unexpected error'

--- a/tests/functional/worker/auto-instrumented-errors.test.js
+++ b/tests/functional/worker/auto-instrumented-errors.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
+const testDriver = require('../../tools/jil/index')
 const { workerTypes, typeToMatcher, workerCustomAttrs } = require('./helpers')
 
 const init = {

--- a/tests/functional/worker/circular.test.js
+++ b/tests/functional/worker/circular.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { getErrorsFromResponse } = require('../err/assertion-helpers')
+const testDriver = require('../../tools/jil/index')
+const { getErrorsFromResponse } = require('../functional/err/assertion-helpers')
 const { workerTypes, typeToMatcher } = require('./helpers')
 
 const init = {

--- a/tests/functional/worker/dt-headers-fetch.test.js
+++ b/tests/functional/worker/dt-headers-fetch.test.js
@@ -1,6 +1,6 @@
-const testDriver = require('../../../tools/jil/index')
+const testDriver = require('../../tools/jil/index')
 const { workerTypes, typeToMatcher } = require('./helpers')
-const { fail, testCases, validateNewrelicHeader, validateNoNewrelicHeader, validateTraceContextHeaders, validateNoTraceContextHeaders } = require('../xhr/helpers')
+const { fail, testCases, validateNewrelicHeader, validateNoNewrelicHeader, validateTraceContextHeaders, validateNoTraceContextHeaders } = require('../functional/xhr/helpers')
 
 const fetchBrowsers = testDriver.Matcher.withFeature('fetch')
 

--- a/tests/functional/worker/eol-harvest.test.js
+++ b/tests/functional/worker/eol-harvest.test.js
@@ -1,6 +1,6 @@
-const testDriver = require('../../../tools/jil/index')
+const testDriver = require('../../tools/jil/index')
 const { workerTypes, typeToMatcher } = require('./helpers')
-const { fail } = require('../uncat-internal-help.cjs')
+const { fail } = require('../functional/uncat-internal-help.cjs')
 
 const withFetch = testDriver.Matcher.withFeature('fetch')
 

--- a/tests/functional/worker/errors-harvest-retries.test.js
+++ b/tests/functional/worker/errors-harvest-retries.test.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { getErrorsFromResponse } = require('../err/assertion-helpers')
+const testDriver = require('../../tools/jil/index')
+const { getErrorsFromResponse } = require('../functional/err/assertion-helpers')
 const { workerTypes, typeToMatcher } = require('./helpers')
-const { testErrorsRequest } = require('../../../tools/testing-server/utils/expect-tests')
+const { testErrorsRequest } = require('../../tools/testing-server/utils/expect-tests')
 
 const init = {
   jserrors: {

--- a/tests/functional/worker/errors-have-custom-attributes.test.js
+++ b/tests/functional/worker/errors-have-custom-attributes.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { getErrorsFromResponse } = require('../err/assertion-helpers')
+const testDriver = require('../../tools/jil/index')
+const { getErrorsFromResponse } = require('../functional/err/assertion-helpers')
 const { workerTypes, typeToMatcher, workerCustomAttrs } = require('./helpers')
 
 const init = {

--- a/tests/functional/worker/event-listener-errors.test.js
+++ b/tests/functional/worker/event-listener-errors.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { fail, getErrorsFromResponse } = require('../err/assertion-helpers')
+const testDriver = require('../../tools/jil/index')
+const { fail, getErrorsFromResponse } = require('../functional/err/assertion-helpers')
 const { workerTypes, typeToMatcher } = require('./helpers')
 
 const init = {

--- a/tests/functional/worker/external-error.test.js
+++ b/tests/functional/worker/external-error.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { getErrorsFromResponse } = require('../err/assertion-helpers')
+const testDriver = require('../../tools/jil/index')
+const { getErrorsFromResponse } = require('../functional/err/assertion-helpers')
 const { workerTypes, typeToMatcher, workerCustomAttrs } = require('./helpers')
 
 const init = {

--- a/tests/functional/worker/notice-error.test.js
+++ b/tests/functional/worker/notice-error.test.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
+const testDriver = require('../../tools/jil/index')
 const { workerTypes, typeToMatcher, workerCustomAttrs } = require('./helpers')
-const { fail } = require('../err/assertion-helpers') // shared from jserrors feat tests
+const { fail } = require('../functional/err/assertion-helpers') // shared from jserrors feat tests
 
 const init = {
   jserrors: {

--- a/tests/functional/worker/page-action.test.js
+++ b/tests/functional/worker/page-action.test.js
@@ -1,7 +1,7 @@
-const testDriver = require('../../../tools/jil/index')
+const testDriver = require('../../tools/jil/index')
 const { workerTypes, typeToMatcher } = require('./helpers')
-const { validatePageActionData, fail } = require('../ins/ins-internal-help.cjs')
-const { testInsRequest } = require('../../../tools/testing-server/utils/expect-tests')	// shared helpers
+const { validatePageActionData, fail } = require('../functional/ins/ins-internal-help.cjs')
+const { testInsRequest } = require('../../tools/testing-server/utils/expect-tests')	// shared helpers
 
 workerTypes.forEach(type => { // runs all test for classic & module workers & use the 'workers' browser-matcher for classic and the 'workersFull' for module
   const browsersWithOrWithoutModuleSupport = typeToMatcher(type)

--- a/tests/functional/worker/set-error-handler-ignore.test.js
+++ b/tests/functional/worker/set-error-handler-ignore.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { assertErrorAttributes, assertExpectedErrors, getErrorsFromResponse } = require('../err/assertion-helpers')
+const testDriver = require('../../tools/jil/index')
+const { assertErrorAttributes, assertExpectedErrors, getErrorsFromResponse } = require('../functional/err/assertion-helpers')
 const { workerTypes, typeToMatcher } = require('./helpers')
 
 const init = {

--- a/tests/functional/worker/set-interval-error.test.js
+++ b/tests/functional/worker/set-interval-error.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { getErrorsFromResponse } = require('../err/assertion-helpers')
+const testDriver = require('../../tools/jil/index')
+const { getErrorsFromResponse } = require('../functional/err/assertion-helpers')
 const { workerTypes, typeToMatcher } = require('./helpers')
 
 const init = {

--- a/tests/functional/worker/set-timeout-error.test.js
+++ b/tests/functional/worker/set-timeout-error.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { getErrorsFromResponse } = require('../err/assertion-helpers')
+const testDriver = require('../../tools/jil/index')
+const { getErrorsFromResponse } = require('../functional/err/assertion-helpers')
 const { workerTypes, typeToMatcher } = require('./helpers')
 
 const init = {

--- a/tests/functional/worker/xhr-assorted.test.js
+++ b/tests/functional/worker/xhr-assorted.test.js
@@ -1,7 +1,7 @@
-const testDriver = require('../../../tools/jil/index')
+const testDriver = require('../../tools/jil/index')
 const { workerTypes, typeToMatcher } = require('./helpers')
-const { fail, querypack, getXhrFromResponse } = require('../xhr/helpers')
-const { testEventsRequest } = require('../../../tools/testing-server/utils/expect-tests')
+const { fail, querypack, getXhrFromResponse } = require('../functional/xhr/helpers')
+const { testEventsRequest } = require('../../tools/testing-server/utils/expect-tests')
 
 workerTypes.forEach(type => {
   const browsersWithOrWithoutModuleSupport = typeToMatcher(type)

--- a/tests/functional/worker/xhr-jserror.test.js
+++ b/tests/functional/worker/xhr-jserror.test.js
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const testDriver = require('../../../tools/jil/index')
-const { fail, getErrorsFromResponse } = require('../err/assertion-helpers')
-const { getXhrFromResponse } = require('../xhr/helpers')
+const testDriver = require('../../tools/jil/index')
+const { fail, getErrorsFromResponse } = require('../functional/err/assertion-helpers')
+const { getXhrFromResponse } = require('../functional/xhr/helpers')
 const { workerTypes, typeToMatcher } = require('./helpers')
 
 const supportsFetch = testDriver.Matcher.withFeature('fetch')

--- a/tools/jil/runner/index.js
+++ b/tools/jil/runner/index.js
@@ -47,10 +47,12 @@ if (launchedFromCli) {
       if (testFiles.length === 0) {
         loadDefaultFiles(loadBrowsersAndRunTests)
       } else {
+        console.log(1)
         loadFiles(testFiles, loadBrowsersAndRunTests)
       }
     }))
   } else if (commandLineTestFiles.length) {
+    console.log(2)
     loadFiles(commandLineTestFiles, loadBrowsersAndRunTests)
   } else {
     loadDefaultFiles(loadBrowsersAndRunTests)
@@ -62,6 +64,7 @@ if (launchedFromCli) {
 }
 
 function loadDefaultFiles (cb) {
+  console.log("LOAD DEFAULT FILES!")
   let globOpts = { cwd: path.resolve(__dirname, '../../..') }
 
   let fileGlob = 'tests/@(browser|functional)/**/*.@(browser|test).js'
@@ -86,11 +89,19 @@ function loadFiles (testFiles, cb) {
       }
       loadBrowser(testDriver, file, undefined, spec) // queued for later (browserify)
     } else if (file.slice(-8) === '.test.js') {
+      try{
       require(file)
+      if (cb) cb()
+      } catch(err){
+        let globOpts = { cwd: path.resolve(__dirname, '../../..') }
+        glob(file, globOpts, (e, files = []) => {
+          if (e) throw new Error(e)
+          files.forEach(f => require(f))
+          if (cb) cb()
+        })
+      }
     }
   }
-
-  if (cb) cb()
 }
 
 function getBuildIdentifier () {

--- a/tools/jil/runner/index.js
+++ b/tools/jil/runner/index.js
@@ -47,12 +47,10 @@ if (launchedFromCli) {
       if (testFiles.length === 0) {
         loadDefaultFiles(loadBrowsersAndRunTests)
       } else {
-        console.log(1)
         loadFiles(testFiles, loadBrowsersAndRunTests)
       }
     }))
   } else if (commandLineTestFiles.length) {
-    console.log(2)
     loadFiles(commandLineTestFiles, loadBrowsersAndRunTests)
   } else {
     loadDefaultFiles(loadBrowsersAndRunTests)
@@ -64,7 +62,6 @@ if (launchedFromCli) {
 }
 
 function loadDefaultFiles (cb) {
-  console.log("LOAD DEFAULT FILES!")
   let globOpts = { cwd: path.resolve(__dirname, '../../..') }
 
   let fileGlob = 'tests/@(browser|functional)/**/*.@(browser|test).js'
@@ -145,11 +142,9 @@ function loadBrowsersAndRunTests () {
     } else {
       let sauceCreds = getSauceLabsCreds()
       connectionInfo = `http://${sauceCreds.username}:${sauceCreds.accessKey}@ondemand.saucelabs.com/wd/hub`
-
-      if (config.sauceExtendedDebugging && browser.allowsExtendedDebugging()) {
-        desired.extendedDebugging = true // turn on JS console logs & HAR files in SauceLabs
-      }
     }
+
+    if (browser.allowsExtendedDebugging()) desired.extendedDebugging = true // turn on JS console logs & HAR files in SauceLabs
 
     desired.build = buildIdentifier
     desired.name = `${buildIdentifier}-${browser.toString()}`


### PR DESCRIPTION
Move workers tests to run in a cron job overnight instead of blocking PR runs.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

This PR moves the worker tests out of the main test run path and into a cron job that runs nightly.  The reasoning is that our PR test suite runs are quite cumbersome and long, and much of that time is attributed to worker tests.  These tests are all built around a foundational piece of the agent that is not GA'd.

### Testing
All worker functional tests have been moved to a new directory and tied to a cron GHA.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

### Notes
* These changes are also represented in #532 .  If that is merged first, will close this PR.
