### PR TITLE
fix: Ensure runtime is preserved for late-configuration cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10573,9 +10573,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001488",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
-      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
+      "version": "1.0.30001489",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
+      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
       "dev": true,
       "funding": [
         {
@@ -36984,9 +36984,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001488",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001488.tgz",
-      "integrity": "sha512-NORIQuuL4xGpIy6iCCQGN4iFjlBXtfKWIenlUuyZJumLRIindLb7wXM+GO8erEhb7vXfcnf4BAg2PrSDN5TNLQ==",
+      "version": "1.0.30001489",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
+      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
       "dev": true
     },
     "capital-case": {

--- a/src/features/utils/feature-base.js
+++ b/src/features/utils/feature-base.js
@@ -44,7 +44,8 @@ export class FeatureBase {
         info: {
           ...gosCDN().info,
           jsAttributes
-        }
+        },
+        runtime: getRuntime(this.agentIdentifier)
       })
     }
   }

--- a/tests/functional/session/config-race-condition.test.js
+++ b/tests/functional/session/config-race-condition.test.js
@@ -1,0 +1,27 @@
+
+const testDriver = require('../../../tools/jil/index')
+let notSafariWithSeleniumBug = testDriver.Matcher.withFeature('notSafariWithSeleniumBug')
+
+testDriver.test(`Session object exists when config is set after loader`, notSafariWithSeleniumBug, function (t, browser, router) {
+    let url = router.assetURL('custom-attribute-race-condition.html', {init: {jserrors: {enabled: true, harvestTimeSeconds: 5}}})
+
+    let loadPromise = browser.get(url)
+    let rumPromise = router.expectRum()
+    var errorsPromise = router.expectErrors()
+
+    Promise.all([rumPromise, loadPromise])
+      .then(() => {
+        var domPromise = browser.get(url) // forces harvest
+        return Promise.all([errorsPromise, domPromise])
+      })
+      .then(([{ request: {query} }]) => {
+        t.ok(query.s !== '0', 'Session ID exists')
+        t.end()
+      })
+      .catch(fail)
+
+    function fail (e) {
+      t.error(e)
+      t.end()
+    }
+  })

--- a/tests/functional/session/config-race-condition.test.js
+++ b/tests/functional/session/config-race-condition.test.js
@@ -3,25 +3,25 @@ const testDriver = require('../../../tools/jil/index')
 let notSafariWithSeleniumBug = testDriver.Matcher.withFeature('notSafariWithSeleniumBug')
 
 testDriver.test(`Session object exists when config is set after loader`, notSafariWithSeleniumBug, function (t, browser, router) {
-    let url = router.assetURL('custom-attribute-race-condition.html', {init: {jserrors: {enabled: true, harvestTimeSeconds: 5}}})
+  let url = router.assetURL('custom-attribute-race-condition.html', {init: {jserrors: {enabled: true, harvestTimeSeconds: 5}}})
 
-    let loadPromise = browser.get(url)
-    let rumPromise = router.expectRum()
-    var errorsPromise = router.expectErrors()
+  let loadPromise = browser.get(url)
+  let rumPromise = router.expectRum()
+  var errorsPromise = router.expectErrors()
 
-    Promise.all([rumPromise, loadPromise])
-      .then(() => {
-        var domPromise = browser.get(url) // forces harvest
-        return Promise.all([errorsPromise, domPromise])
-      })
-      .then(([{ request: {query} }]) => {
-        t.ok(query.s !== '0', 'Session ID exists')
-        t.end()
-      })
-      .catch(fail)
-
-    function fail (e) {
-      t.error(e)
+  Promise.all([rumPromise, loadPromise])
+    .then(() => {
+      var domPromise = browser.get(url) // forces harvest
+      return Promise.all([errorsPromise, domPromise])
+    })
+    .then(([{ request: {query} }]) => {
+      t.ok(query.s !== '0', 'Session ID exists')
       t.end()
-    }
-  })
+    })
+    .catch(fail)
+
+  function fail (e) {
+    t.error(e)
+    t.end()
+  }
+})

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -127,20 +127,6 @@
       "browserName": "Safari",
       "platformName": "iOS",
       "platform": "iOS",
-      "version": "15.0",
-      "device": "iPhone 7 Plus",
-      "appium:deviceName": "iPhone 7 Plus Simulator",
-      "appium:platformVersion": "15.0",
-      "appium:automationName": "XCUITest",
-      "sauce:options": {
-        "appiumVersion": "1.22.3"
-      },
-      "acceptInsecureCerts": false
-    },
-    {
-      "browserName": "Safari",
-      "platformName": "iOS",
-      "platform": "iOS",
       "version": "15.2",
       "device": "iPhone 11 Pro",
       "appium:deviceName": "iPhone 11 Pro Simulator",


### PR DESCRIPTION
Fix an issue where the internal runtime state of the agent was not preserved when the agent configurations were supplied after the loader had finished initializing, which caused the session to be cleared.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR ensures that the runtime object is passed through the configuration step for late-configuration cases. Although this was initially surfaced by a voided session manager instance, the runtime object holds lots of state which was likely also affected.  This will ensure that state gets preserved if we have to pass the configurations later than the runtime setters.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NEWRELIC-8733
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new JIL functional test has been added to check the state of the session query param after a late load.  This was confirmed to fail on main, and pass on this new branch.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
