### PR TITLE
chore: Small fixes to release notes logic

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -28,7 +28,7 @@ jobs:
 
             head('TITLE')
             echo('----------------------------------------------------------------------')
-            const title = context.payload.pull_request.title
+            const title = context.payload.pull_request.title.replaceAll(/(?:[ \-(]*)(?:NR|NEWRELIC)-\d+(?:[, \-)]*)/gi, '')
             if (title.length > 70) echo(title.substring(0, 70) + highlight + title.substring(70))
             else echo(title)
 

--- a/tools/scripts/docs-website/create-docs-pr.mjs
+++ b/tools/scripts/docs-website/create-docs-pr.mjs
@@ -280,9 +280,9 @@ async function getBrowserTargetStatement (agentVersion, browsersFile) {
 
   return (
     'Consistent with our [browser support policy](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/compatibility-requirements-browser-monitoring/#browser-types), ' +
-    `version ${agentVersion} of the Browser agent was built for and tested against these browsers and version ranges: ` +
-    `Chrome ${min.chrome}-${max.chrome}, Edge ${min.edge}-${max.edge}, Safari ${min.safari}-${max.safari}, Firefox ${min.firefox}-${max.firefox}; ` +
-    `and for mobile devices, Android Chrome ${ANDROID_CHROME_VERSION} and iOS Safari ${min.ios}-${max.ios}.`
+    `${agentVersion} of the Browser agent was built for and tested against these browsers and version ranges: ` +
+    `Chrome ${min.chrome}-${max.chrome}, Edge ${min.edge}-${max.edge}, Safari ${min.safari}-${max.safari}, and Firefox ${min.firefox}-${max.firefox}. ` +
+    `For mobile devices, ${agentVersion} was built and tested for Android Chrome ${ANDROID_CHROME_VERSION} and iOS Safari ${min.ios}-${max.ios}.`
   )
 }
 


### PR DESCRIPTION
Makes two small non-agent changes related to release notes.
---

- No longer counts Jira issue when validating PR title length.
- Matches browser version support statement to what the docs team changes it to when the docs PR is raised.