### PR TITLE
chore: exclude cdn loaders from code coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,8 @@ module.exports = {
   coverageDirectory: 'coverage',
   collectCoverageFrom: [
     'src/**/*.js',
-    '!src/**/*.test.js'
+    '!src/**/*.test.js',
+    '!src/cdn/**/*.js'
   ],
   modulePathIgnorePatterns: ['<rootDir>/temp'],
   testEnvironment: 'jsdom',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10749,9 +10749,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001489",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
-      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
+      "version": "1.0.30001491",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
+      "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
       "dev": true,
       "funding": [
         {
@@ -37923,9 +37923,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001489",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
-      "integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
+      "version": "1.0.30001491",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
+      "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
       "dev": true
     },
     "capital-case": {


### PR DESCRIPTION
Excluding the cdn loaders from jest code coverage reports.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Excluding the cdn loaders from the jest unit test coverage report. These files are only used as entrypoints for the cdn webpack builds and don't really need testing.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

N/A

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
