### PR TITLE
chore: Add jest tests for common/util/submit-data (NEWRELIC-7855)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10870,9 +10870,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001491",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
-      "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
+      "version": "1.0.30001492",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
       "dev": true,
       "funding": [
         {
@@ -37982,9 +37982,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001491",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
-      "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
+      "version": "1.0.30001492",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -33,22 +33,29 @@ submitData.jsonp = function jsonp ({ url, jsonp }) {
       return element
     }
   } catch (err) {
-  // do nothing
+    // do nothing
   }
 }
 
+/**
+ * Performs an asynchronous GET request using XMLHttpRequest.
+ *
+ * @param {Object} args - An object containing a `url` property.
+ * @param {string} args.url - The URL to send the GET request to.
+ * @returns {XMLHttpRequest} - An XMLHttpRequest object.
+ */
 submitData.xhrGet = function xhrGet ({ url }) {
   return submitData.xhr({ url, sync: false, method: 'GET' })
 }
 
 /**
  * Send via XHR
- * @param {Object} args - The args
- * @param {string} args.url - The URL to send to
- * @param {string=} args.body - The Stringified body
- * @param {boolean=} args.sync - Run XHR as Synchronous
- * @param {string=} [args.method=POST] - The XHR method to use
- * @param {{key: string, value: string}[]} [args.headers] - The headers to attach
+ * @param {Object} args - The args.
+ * @param {string} args.url - The URL to send to.
+ * @param {string=} args.body - The Stringified body.
+ * @param {boolean=} args.sync - Run XHR synchronously.
+ * @param {string=} [args.method=POST] - The XHR method to use.
+ * @param {{key: string, value: string}[]} [args.headers] - The headers to attach.
  * @returns {XMLHttpRequest}
  */
 submitData.xhr = function xhr ({ url, body, sync, method = 'POST', headers = [{ key: 'content-type', value: 'text/plain' }] }) {
@@ -69,13 +76,6 @@ submitData.xhr = function xhr ({ url, body, sync, method = 'POST', headers = [{ 
   request.send(body)
   return request
 }
-
-/**
- * Unused at the moment -- DEPRECATED
- */
-// submitData.xhrSync = function xhrSync (url, body) {
-//   return submitData.xhr(url, body, true)
-// }
 
 /**
  * Send by appending an <img> element to the page. Do NOT call this function outside of a guaranteed web window environment.

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -84,7 +84,6 @@ submitData.xhr = function xhr ({ url, body, sync, method = 'POST', headers = [{ 
  * @returns {HTMLImageElement}
  */
 submitData.img = function img ({ url }) {
-  console.log('img url', url)
   var element = new Image()
   element.src = url
   return element

--- a/src/common/util/submit-data.test.js
+++ b/src/common/util/submit-data.test.js
@@ -1,0 +1,170 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"html": "<html><head><script></script></head><body></body></html>"}
+ */
+
+import { submitData } from './submit-data'
+
+const mockWorkerScope = jest.fn().mockImplementation(() => false)
+jest.mock('../util/global-scope', () => ({
+  __esModule: true,
+  get isWorkerScope () {
+    return mockWorkerScope()
+  }
+}))
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+  mockWorkerScope.mockReturnValue(false)
+})
+
+describe('submitData.jsonp', () => {
+  // This test requires a script tag to exist in the html set by this file's jest-environment-options header block.
+  it('should return an HTMLScriptElement when called from a web window environment', () => {
+    mockWorkerScope.mockReturnValue(false)
+
+    const url = 'https://example.com/'
+    const jsonp = 'callback'
+
+    const result = submitData.jsonp({ url, jsonp })
+
+    expect(result).toBeInstanceOf(HTMLScriptElement)
+    expect(result.type).toBe('text/javascript')
+    expect(result.src).toBe('https://example.com/&jsonp=callback')
+  })
+
+  it('should try to use importScripts when called from a worker scope', () => {
+    mockWorkerScope.mockReturnValueOnce(true)
+
+    const url = 'https://example.com/'
+    const jsonp = 'callback'
+
+    global.importScripts = jest.fn()
+
+    submitData.jsonp({ url, jsonp })
+
+    expect(importScripts).toHaveBeenCalledWith('https://example.com/&jsonp=callback')
+
+    delete global.importScripts
+  })
+
+  it('should fall back to an xhrGet call and return false when called from a worker scope', () => {
+    mockWorkerScope.mockReturnValueOnce(true)
+
+    const url = 'https://example.com/'
+    const jsonp = 'callback'
+
+    jest.spyOn(submitData, 'xhrGet').mockImplementation(jest.fn())
+
+    const result = submitData.jsonp({ url, jsonp })
+
+    expect(result).toBe(false)
+    expect(submitData.xhrGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not throw an error if any error occurs during execution', () => {
+    jest.spyOn(document, 'createElement').mockImplementation(() => { throw new Error('message') })
+
+    const url = 'https://example.com/'
+    const jsonp = 'callback'
+
+    expect(() => {
+      submitData.jsonp({ url, jsonp })
+    }).not.toThrow()
+  })
+})
+
+describe('submitData.xhrGet', () => {
+  it('should return an XMLHttpRequest object', () => {
+    const url = 'https://example.com/'
+
+    const result = submitData.xhrGet({ url })
+
+    expect(result).toBeInstanceOf(XMLHttpRequest)
+  })
+
+  it('should not throw an error if URL is not provided', () => {
+    expect(() => {
+      submitData.xhrGet({})
+    }).not.toThrow()
+  })
+
+  it('should not throw an error if an invalid URL is provided', () => {
+    const url = 'invalid-url'
+
+    expect(() => {
+      submitData.xhrGet({ url })
+    }).not.toThrow()
+  })
+})
+
+describe('submitData.xhr', () => {
+  it('should return an XMLHttpRequest object', () => {
+    const result = submitData.xhrGet({ url: 'https://example.com/' })
+
+    expect(result).toBeInstanceOf(XMLHttpRequest)
+  })
+
+  it('should not throw an error if URL is not provided', () => {
+    expect(() => {
+      submitData.xhr({})
+    }).not.toThrow()
+  })
+
+  it('should not throw an error if an invalid URL is provided', () => {
+    const url = 'invalid-url'
+
+    expect(() => {
+      submitData.xhr({ url })
+    }).not.toThrow()
+  })
+
+  // it('should send a POST request by default', () => {
+  //   const url = 'https://example.com/'
+
+  //   const result = submitData.xhr({ url })
+  //   jest.spyOn(result, 'open')
+
+  //   expect(result.open).toHaveBeenCalledWith('POST', url, true)
+  // })
+
+  // it('should send a GET request if specified', () => {
+  //   const url = 'https://example.com/'
+
+  //   const result = submitData.xhr({ url, method: 'GET' })
+  //   jest.spyOn(result, 'open')
+
+  //   expect(result.open).toHaveBeenCalledWith('GET', url, true)
+  // })
+
+  // it('should send a request synchronously if specified', () => {
+  //   const url = 'https://example.com/'
+
+  //   const result = submitData.xhr({ url, sync: true })
+  //   jest.spyOn(result, 'open')
+
+  //   expect(result.open).toHaveBeenCalledWith('POST', url, false)
+  // })
+
+  // it('should set custom headers if provided', () => {
+  //   const url = 'https://example.com/'
+  //   const headers = [{ key: 'Content-Type', value: 'application/json' }]
+
+  //   const result = submitData.xhr({ url, headers })
+  //   jest.spyOn(result, 'setRequestHeader')
+
+  //   headers.forEach((header) => {
+  //     expect(result.setRequestHeader).toHaveBeenCalledWith(header.key, header.value)
+  //   })
+  // })
+
+  // it('should send a request with the specified body', () => {
+  //   const url = 'https://example.com/'
+  //   const body = JSON.stringify({ key: 'value' })
+
+  //   const result = submitData.xhr({ url, body })
+  //   jest.spyOn(result, 'send')
+
+  //   expect(result.send).toHaveBeenCalledWith(body)
+  // })
+})

--- a/src/common/util/submit-data.test.js
+++ b/src/common/util/submit-data.test.js
@@ -22,7 +22,7 @@ beforeEach(() => {
 
 describe('submitData.jsonp', () => {
   // This test requires a script tag to exist in the html set by this file's jest-environment-options header block.
-  it('should return an HTMLScriptElement when called from a web window environment', () => {
+  test('should return an HTMLScriptElement when called from a web window environment', () => {
     mockWorkerScope.mockReturnValue(false)
 
     const jsonp = 'callback'
@@ -34,7 +34,7 @@ describe('submitData.jsonp', () => {
     expect(result.src).toBe(url + '&jsonp=' + jsonp)
   })
 
-  it('should try to use importScripts when called from a worker scope', () => {
+  test('should try to use importScripts when called from a worker scope', () => {
     mockWorkerScope.mockReturnValueOnce(true)
 
     const jsonp = 'callback'
@@ -48,7 +48,7 @@ describe('submitData.jsonp', () => {
     delete global.importScripts
   })
 
-  it('should fall back to an xhrGet call and return false when called from a worker scope', () => {
+  test('should fall back to an xhrGet call and return false when called from a worker scope', () => {
     mockWorkerScope.mockReturnValueOnce(true)
 
     const jsonp = 'callback'
@@ -61,7 +61,7 @@ describe('submitData.jsonp', () => {
     expect(submitData.xhrGet).toHaveBeenCalledTimes(1)
   })
 
-  it('should not throw an error if any error occurs during execution', () => {
+  test('should not throw an error if any error occurs during execution', () => {
     jest.spyOn(document, 'createElement').mockImplementation(() => { throw new Error('message') })
 
     const jsonp = 'callback'
@@ -73,18 +73,18 @@ describe('submitData.jsonp', () => {
 })
 
 describe('submitData.xhrGet', () => {
-  it('should return an XMLHttpRequest object', () => {
+  test('should return an XMLHttpRequest object', () => {
     const result = submitData.xhrGet({ url })
     expect(result).toBeInstanceOf(XMLHttpRequest)
   })
 
-  it('should not throw an error if URL is not provided', () => {
+  test('should not throw an error if URL is not provided', () => {
     expect(() => {
       submitData.xhrGet({})
     }).not.toThrow()
   })
 
-  it('should not throw an error if an invalid URL is provided', () => {
+  test('should not throw an error if an invalid URL is provided', () => {
     expect(() => {
       submitData.xhrGet({ url: 'invalid url' })
     }).not.toThrow()
@@ -92,24 +92,24 @@ describe('submitData.xhrGet', () => {
 })
 
 describe('submitData.xhr', () => {
-  it('should return an XMLHttpRequest object', () => {
+  test('should return an XMLHttpRequest object', () => {
     const result = submitData.xhrGet({ url })
     expect(result).toBeInstanceOf(XMLHttpRequest)
   })
 
-  it('should not throw an error if URL is not provided', () => {
+  test('should not throw an error if URL is not provided', () => {
     expect(() => {
       submitData.xhr({})
     }).not.toThrow()
   })
 
-  it('should not throw an error if an invalid URL is provided', () => {
+  test('should not throw an error if an invalid URL is provided', () => {
     expect(() => {
       submitData.xhr({ url: 'invalid url' })
     }).not.toThrow()
   })
 
-  it('should send a POST request by default', () => {
+  test('should send a POST request by default', () => {
     jest.spyOn(XMLHttpRequest.prototype, 'open')
 
     submitData.xhr({ url })
@@ -117,7 +117,7 @@ describe('submitData.xhr', () => {
     expect(XMLHttpRequest.prototype.open).toHaveBeenCalledWith('POST', url, true)
   })
 
-  it('should send a GET request if specified', () => {
+  test('should send a GET request if specified', () => {
     jest.spyOn(XMLHttpRequest.prototype, 'open')
 
     submitData.xhr({ url, method: 'GET' })
@@ -126,7 +126,7 @@ describe('submitData.xhr', () => {
   })
 
   // This test requires a same-origin url to be set by this file's jest-environment-options header block.
-  it('should send a request synchronously if specified', () => {
+  test('should send a request synchronously if specified', () => {
     jest.spyOn(XMLHttpRequest.prototype, 'open')
 
     submitData.xhr({ url, sync: true })
@@ -134,7 +134,7 @@ describe('submitData.xhr', () => {
     expect(XMLHttpRequest.prototype.open).toHaveBeenCalledWith('POST', url, false)
   })
 
-  it('should set custom headers if provided', () => {
+  test('should set custom headers if provided', () => {
     const headers = [{ key: 'Content-Type', value: 'application/json' }]
 
     jest.spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
@@ -146,7 +146,7 @@ describe('submitData.xhr', () => {
     })
   })
 
-  it('should send a request with the specified body', () => {
+  test('should send a request with the specified body', () => {
     const body = JSON.stringify({ key: 'value' })
 
     jest.spyOn(XMLHttpRequest.prototype, 'send')
@@ -158,7 +158,7 @@ describe('submitData.xhr', () => {
 })
 
 describe('submitData.img', () => {
-  it('should return an HTMLImageElement', () => {
+  test('should return an HTMLImageElement', () => {
     const imageUrl = 'https://example.com/image.png'
 
     const result = submitData.img({ url: imageUrl })
@@ -166,13 +166,13 @@ describe('submitData.img', () => {
     expect(result).toBeInstanceOf(HTMLImageElement)
   })
 
-  it('should not throw an error if URL is not provided', () => {
+  test('should not throw an error if URL is not provided', () => {
     expect(() => {
       submitData.img({})
     }).not.toThrow()
   })
 
-  it('should set the src attribute of the image element to the provided URL', () => {
+  test('should set the src attribute of the image element to the provided URL', () => {
     const imageUrl = 'https://example.com/image.png'
 
     const result = submitData.img({ url: imageUrl })
@@ -182,7 +182,7 @@ describe('submitData.img', () => {
 })
 
 describe('submitData.beacon', () => {
-  it('should return true when beacon request succeeds', () => {
+  test('should return true when beacon request succeeds', () => {
     const body = JSON.stringify({ key: 'value' })
 
     window.navigator.sendBeacon = {
@@ -194,7 +194,7 @@ describe('submitData.beacon', () => {
     expect(result).toBe(true)
   })
 
-  it('should return false when beacon request fails', () => {
+  test('should return false when beacon request fails', () => {
     const body = JSON.stringify({ key: 'value' })
 
     window.navigator.sendBeacon = {
@@ -206,7 +206,7 @@ describe('submitData.beacon', () => {
     expect(result).toBe(false)
   })
 
-  it('should error if sendBeacon is not supported', () => {
+  test('should error if sendBeacon is not supported', () => {
     const body = JSON.stringify({ key: 'value' })
 
     window.navigator.sendBeacon = undefined

--- a/tools/browsers-lists/browsers-all.json
+++ b/tools/browsers-lists/browsers-all.json
@@ -608,6 +608,13 @@
       "platform": "Windows 11",
       "version": "113",
       "browserVersion": "113"
+    },
+    {
+      "browserName": "chrome",
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "114",
+      "browserVersion": "114"
     }
   ],
   "edge": [

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -23,10 +23,10 @@
     },
     {
       "browserName": "chrome",
-      "platformName": "Windows 11",
-      "platform": "Windows 11",
-      "version": "113",
-      "browserVersion": "113"
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "114",
+      "browserVersion": "114"
     }
   ],
   "edge": [


### PR DESCRIPTION
Includes jest tests for the `common/util/submit-data` module and adds some JSDoc comments.
---

### Related Issue(s)

[NEWRELIC-7855](https://issues.newrelic.com/browse/NEWRELIC-7855)

### Testing

`npm test src/common/util/submit-data.test.js`