### PR TITLE
chore: Add jest tests for common/util/stringify (NEWRELIC-7854)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10870,9 +10870,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001491",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
-      "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
+      "version": "1.0.30001492",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
       "dev": true,
       "funding": [
         {
@@ -37982,9 +37982,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001491",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
-      "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
+      "version": "1.0.30001492",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/util/stringify.test.js
+++ b/src/common/util/stringify.test.js
@@ -8,44 +8,42 @@ jest.mock('../event-emitter/contextual-ee', () => ({
   }
 }))
 
-describe('stringify', () => {
-  it('should return a JSON string representation of the value', () => {
-    const obj = { a: 1, b: { nested: true } }
-    const expected = '{"a":1,"b":{"nested":true}}'
+test('should return a JSON string representation of the value', () => {
+  const obj = { a: 1, b: { nested: true } }
+  const expected = '{"a":1,"b":{"nested":true}}'
 
-    const result = stringify(obj)
+  const result = stringify(obj)
 
-    expect(result).toBe(expected)
+  expect(result).toBe(expected)
+})
+
+test('should handle circular references and exclude them from the JSON output', () => {
+  const obj = { a: 1 }
+  obj.b = obj // Create a circular reference
+  const expected = '{"a":1}'
+
+  const result = stringify(obj)
+
+  expect(result).toBe(expected)
+})
+
+test('should handle non-object values and return their string representation', () => {
+  const value = 42
+  const expected = '42'
+
+  const result = stringify(value)
+
+  expect(result).toBe(expected)
+})
+
+test('should emit an "internal-error" event if an error occurs during JSON.stringify', () => {
+  const obj = { a: 1 }
+
+  jest.spyOn(JSON, 'stringify').mockImplementation(() => {
+    throw new Error('message')
   })
 
-  it('should handle circular references and exclude them from the JSON output', () => {
-    const obj = { a: 1 }
-    obj.b = obj // Create a circular reference
-    const expected = '{"a":1}'
+  stringify(obj)
 
-    const result = stringify(obj)
-
-    expect(result).toBe(expected)
-  })
-
-  it('should handle non-object values and return their string representation', () => {
-    const value = 42
-    const expected = '42'
-
-    const result = stringify(value)
-
-    expect(result).toBe(expected)
-  })
-
-  it('should emit an "internal-error" event if an error occurs during JSON.stringify', () => {
-    const obj = { a: 1 }
-
-    jest.spyOn(JSON, 'stringify').mockImplementation(() => {
-      throw new Error('message')
-    })
-
-    stringify(obj)
-
-    expect(mockEmit).toHaveBeenCalledWith('internal-error', expect.any(Array))
-  })
+  expect(mockEmit).toHaveBeenCalledWith('internal-error', expect.any(Array))
 })

--- a/src/common/util/stringify.test.js
+++ b/src/common/util/stringify.test.js
@@ -1,0 +1,51 @@
+import { stringify } from './stringify'
+
+var mockEmit = jest.fn()
+jest.mock('../event-emitter/contextual-ee', () => ({
+  __esModule: true,
+  get ee () {
+    return { emit: mockEmit }
+  }
+}))
+
+describe('stringify', () => {
+  it('should return a JSON string representation of the value', () => {
+    const obj = { a: 1, b: { nested: true } }
+    const expected = '{"a":1,"b":{"nested":true}}'
+
+    const result = stringify(obj)
+
+    expect(result).toBe(expected)
+  })
+
+  it('should handle circular references and exclude them from the JSON output', () => {
+    const obj = { a: 1 }
+    obj.b = obj // Create a circular reference
+    const expected = '{"a":1}'
+
+    const result = stringify(obj)
+
+    expect(result).toBe(expected)
+  })
+
+  it('should handle non-object values and return their string representation', () => {
+    const value = 42
+    const expected = '42'
+
+    const result = stringify(value)
+
+    expect(result).toBe(expected)
+  })
+
+  it('should emit an "internal-error" event if an error occurs during JSON.stringify', () => {
+    const obj = { a: 1 }
+
+    jest.spyOn(JSON, 'stringify').mockImplementation(() => {
+      throw new Error('message')
+    })
+
+    stringify(obj)
+
+    expect(mockEmit).toHaveBeenCalledWith('internal-error', expect.any(Array))
+  })
+})

--- a/tools/browsers-lists/browsers-all.json
+++ b/tools/browsers-lists/browsers-all.json
@@ -608,6 +608,13 @@
       "platform": "Windows 11",
       "version": "113",
       "browserVersion": "113"
+    },
+    {
+      "browserName": "chrome",
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "114",
+      "browserVersion": "114"
     }
   ],
   "edge": [

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -23,10 +23,10 @@
     },
     {
       "browserName": "chrome",
-      "platformName": "Windows 11",
-      "platform": "Windows 11",
-      "version": "113",
-      "browserVersion": "113"
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "114",
+      "browserVersion": "114"
     }
   ],
   "edge": [


### PR DESCRIPTION
Includes jest unit tests for the `common/util/stringify` module.
---

### Related Issue(s)

[NEWRELIC-7854](https://issues.newrelic.com/browse/NEWRELIC-7854)

### Testing

`npm test src/common/util/stringify.test.js`
