### PR TITLE
chore: Add jest tests for common/util/get-or-set (NEWRELIC-7848)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10870,9 +10870,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001491",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
-      "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
+      "version": "1.0.30001492",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
       "dev": true,
       "funding": [
         {
@@ -37982,9 +37982,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001491",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001491.tgz",
-      "integrity": "sha512-17EYIi4TLnPiTzVKMveIxU5ETlxbSO3B6iPvMbprqnKh4qJsQGk5Nh1Lp4jIMAE0XfrujsJuWZAM3oJdMHaKBA==",
+      "version": "1.0.30001492",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
+      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/util/get-or-set.js
+++ b/src/common/util/get-or-set.js
@@ -5,7 +5,14 @@
 
 var has = Object.prototype.hasOwnProperty
 
-// Always returns the current value of obj[prop], even if it has to set it first
+/**
+ * Always returns the current value of obj[prop], even if it has to set it first. Sets properties as non-enumerable if possible.
+ *
+ * @param {Object} obj - The object to get or set the property on.
+ * @param {string} prop - The name of the property.
+ * @param {Function} getVal - A function that returns the value to be set if the property does not exist.
+ * @returns {*} The value of the property in the object.
+ */
 export function getOrSet (obj, prop, getVal) {
   // If the value exists return it.
   if (has.call(obj, prop)) return obj[prop]

--- a/src/common/util/get-or-set.test.js
+++ b/src/common/util/get-or-set.test.js
@@ -1,0 +1,54 @@
+import { getOrSet } from './get-or-set'
+
+describe('getOrSet', () => {
+  it('should return the current value of an existing property', () => {
+    const obj = { foo: 'bar' }
+    const prop = 'foo'
+    const getVal = jest.fn()
+
+    const result = getOrSet(obj, prop, getVal)
+
+    expect(result).toBe('bar')
+    expect(getVal).not.toHaveBeenCalled()
+  })
+
+  it('should set and return the value from getVal if the property does not exist', () => {
+    const obj = {}
+    const prop = 'foo'
+    const getVal = jest.fn(() => 'baz')
+
+    const result = getOrSet(obj, prop, getVal)
+
+    expect(result).toBe('baz')
+    expect(getVal).toHaveBeenCalled()
+    expect(obj.foo).toBe('baz')
+  })
+
+  it('should set the property as non-enumerable if Object.defineProperty is supported', () => {
+    const obj = {}
+    const prop = 'foo'
+    const getVal = jest.fn(() => 'baz')
+
+    jest.spyOn(Object, 'defineProperty')
+
+    const result = getOrSet(obj, prop, getVal)
+
+    expect(result).toBe('baz')
+    expect(Object.defineProperty).toHaveBeenCalledWith(obj, prop, {
+      value: 'baz',
+      writable: true,
+      enumerable: false
+    })
+  })
+
+  it('should set the property from getVal if Object.defineProperty and Object.keys are not supported', () => {
+    const obj = {}
+    const prop = 'foo'
+    const getVal = jest.fn(() => 'baz')
+
+    const result = getOrSet(obj, prop, getVal)
+
+    expect(result).toBe('baz')
+    expect(obj.foo).toBe('baz')
+  })
+})

--- a/src/common/util/get-or-set.test.js
+++ b/src/common/util/get-or-set.test.js
@@ -1,54 +1,58 @@
 import { getOrSet } from './get-or-set'
 
-describe('getOrSet', () => {
-  it('should return the current value of an existing property', () => {
-    const obj = { foo: 'bar' }
-    const prop = 'foo'
-    const getVal = jest.fn()
+test('should return the current value of an existing property', () => {
+  const obj = { foo: 'bar' }
+  const prop = 'foo'
+  const getVal = jest.fn()
 
-    const result = getOrSet(obj, prop, getVal)
+  const result = getOrSet(obj, prop, getVal)
 
-    expect(result).toBe('bar')
-    expect(getVal).not.toHaveBeenCalled()
+  expect(result).toBe('bar')
+  expect(getVal).not.toHaveBeenCalled()
+})
+
+test('should set and return the value from getVal if the property does not exist', () => {
+  const obj = {}
+  const prop = 'foo'
+  const getVal = jest.fn().mockReturnValue('baz')
+
+  const result = getOrSet(obj, prop, getVal)
+
+  expect(result).toBe('baz')
+  expect(getVal).toHaveBeenCalled()
+  expect(obj.foo).toBe('baz')
+})
+
+test('should set the property as non-enumerable if Object.defineProperty is supported', () => {
+  const obj = {}
+  const prop = 'foo'
+  const getVal = jest.fn().mockReturnValue('baz')
+
+  jest.spyOn(Object, 'defineProperty')
+
+  const result = getOrSet(obj, prop, getVal)
+
+  expect(result).toBe('baz')
+  expect(Object.defineProperty).toHaveBeenCalledWith(obj, prop, {
+    value: 'baz',
+    writable: true,
+    enumerable: false
   })
+})
 
-  it('should set and return the value from getVal if the property does not exist', () => {
-    const obj = {}
-    const prop = 'foo'
-    const getVal = jest.fn(() => 'baz')
+test('should set the property from getVal if Object.defineProperty and Object.keys are not supported', () => {
+  const obj = {}
+  const prop = 'foo'
+  const getVal = jest.fn(() => 'baz')
 
-    const result = getOrSet(obj, prop, getVal)
+  const originalFn = Object.defineProperty
+  Object.defineProperty = null
 
-    expect(result).toBe('baz')
-    expect(getVal).toHaveBeenCalled()
-    expect(obj.foo).toBe('baz')
-  })
+  const result = getOrSet(obj, prop, getVal)
 
-  it('should set the property as non-enumerable if Object.defineProperty is supported', () => {
-    const obj = {}
-    const prop = 'foo'
-    const getVal = jest.fn(() => 'baz')
+  expect(result).toBe('baz')
+  expect(obj.foo).toBe('baz')
+  expect(Object.prototype.propertyIsEnumerable.call(obj, 'foo')).toBe(true)
 
-    jest.spyOn(Object, 'defineProperty')
-
-    const result = getOrSet(obj, prop, getVal)
-
-    expect(result).toBe('baz')
-    expect(Object.defineProperty).toHaveBeenCalledWith(obj, prop, {
-      value: 'baz',
-      writable: true,
-      enumerable: false
-    })
-  })
-
-  it('should set the property from getVal if Object.defineProperty and Object.keys are not supported', () => {
-    const obj = {}
-    const prop = 'foo'
-    const getVal = jest.fn(() => 'baz')
-
-    const result = getOrSet(obj, prop, getVal)
-
-    expect(result).toBe('baz')
-    expect(obj.foo).toBe('baz')
-  })
+  Object.defineProperty = originalFn
 })

--- a/tools/browsers-lists/browsers-all.json
+++ b/tools/browsers-lists/browsers-all.json
@@ -608,6 +608,13 @@
       "platform": "Windows 11",
       "version": "113",
       "browserVersion": "113"
+    },
+    {
+      "browserName": "chrome",
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "114",
+      "browserVersion": "114"
     }
   ],
   "edge": [

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -23,10 +23,10 @@
     },
     {
       "browserName": "chrome",
-      "platformName": "Windows 11",
-      "platform": "Windows 11",
-      "version": "113",
-      "browserVersion": "113"
+      "platformName": "Windows 10",
+      "platform": "Windows 10",
+      "version": "114",
+      "browserVersion": "114"
     }
   ],
   "edge": [


### PR DESCRIPTION
Includes jest unit tests for the `common/util/get-or-set` module, and a new JSDoc block.
---

### Related Issue(s)

[NEWRELIC-7848](https://issues.newrelic.com/browse/NEWRELIC-7848)

### Testing

`npm test src/common/util/get-or-set.test.js`
