### PR TITLE
fix: Address early return preempting XHR harvest re-schedule

### DIFF
--- a/src/common/harvest/harvest-scheduler.js
+++ b/src/common/harvest/harvest-scheduler.js
@@ -89,7 +89,12 @@ export class HarvestScheduler extends SharedContext {
       const retry = submitMethod.method === submitData.xhr
       var payload = this.opts.getPayload({ retry: retry })
 
-      if (!payload) return
+      if (!payload) {
+        if (this.started) {
+          this.scheduleHarvest()
+        }
+        return
+      }
 
       payload = Object.prototype.toString.call(payload) === '[object Array]' ? payload : [payload]
       harvests.push(...payload)

--- a/src/common/harvest/harvest-scheduler.test.js
+++ b/src/common/harvest/harvest-scheduler.test.js
@@ -2,7 +2,7 @@ import { setConfiguration } from '../config/state/init'
 import { HarvestScheduler } from './harvest-scheduler'
 
 describe('runHarvest', () => {
-  it('should re-schedule Ajax harvest even if there is no accumulated data', () => {
+  it('should re-schedule harvest even if there is no accumulated data', () => {
     setConfiguration('asdf', {})
     const scheduler = new HarvestScheduler('events', { getPayload: jest.fn() }, { agentIdentifier: 'asdf', ee: { on: jest.fn() } })
     scheduler.started = true
@@ -12,7 +12,7 @@ describe('runHarvest', () => {
     expect(scheduler.scheduleHarvest).toHaveBeenCalledTimes(1)
   })
 
-  it('should re-schedule Ajax harvest if there is accumulated data', () => {
+  it('should also re-schedule harvest if there is accumulated data', () => {
     setConfiguration('asdf', {})
     const scheduler = new HarvestScheduler('events', { getPayload: jest.fn().mockImplementation(() => 'payload') }, { agentIdentifier: 'asdf', ee: { on: jest.fn() } })
     scheduler.started = true

--- a/src/common/harvest/harvest-scheduler.test.js
+++ b/src/common/harvest/harvest-scheduler.test.js
@@ -1,0 +1,25 @@
+import { setConfiguration } from '../config/state/init'
+import { HarvestScheduler } from './harvest-scheduler'
+
+describe('runHarvest', () => {
+  it('should re-schedule Ajax harvest even if there is no accumulated data', () => {
+    setConfiguration('asdf', {})
+    const scheduler = new HarvestScheduler('events', { getPayload: jest.fn() }, { agentIdentifier: 'asdf', ee: { on: jest.fn() } })
+    scheduler.started = true
+    jest.spyOn(scheduler, 'scheduleHarvest')
+    scheduler.runHarvest()
+    expect(scheduler.opts.getPayload()).toBeFalsy()
+    expect(scheduler.scheduleHarvest).toHaveBeenCalledTimes(1)
+  })
+
+  it('should re-schedule Ajax harvest if there is accumulated data', () => {
+    setConfiguration('asdf', {})
+    const scheduler = new HarvestScheduler('events', { getPayload: jest.fn().mockImplementation(() => 'payload') }, { agentIdentifier: 'asdf', ee: { on: jest.fn() } })
+    scheduler.started = true
+    scheduler.harvest._send = () => {}
+    jest.spyOn(scheduler, 'scheduleHarvest')
+    scheduler.runHarvest()
+    expect(scheduler.opts.getPayload()).toBeTruthy()
+    expect(scheduler.scheduleHarvest).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
A early return condition in the harvest rescheduling logic in version 1.233.0 was preventing Ajax event harvest from being rescheduled in cases where no data had accumulated.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

This PR addresses a problem where, once the harvest scheduler runs for the Ajax feature and the Ajax feature has no accumulated data, the Ajax feature no longer performs future harvests. The issue appears to be [line 92](https://github.com/newrelic/newrelic-browser-agent/blob/main/src/common/harvest/harvest-scheduler.js#L92) in the harvest scheduler where it early-returns when there is no data to send, but does not schedule the next harvest.

### Related Issue(s)

[NEWRELIC-8876](https://issues.newrelic.com/browse/NEWRELIC-8876)

### Testing

- All tests should run.
- `npm test src/common/harvest/harvest-scheduler.test.js`
- Manual verification of event harvest behavior should be confirmed.
