### PR TITLE
chore: fix open handles warnings

### DIFF
--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -97,10 +97,10 @@ submitData.img = function img ({ url }) {
  * @returns {boolean}
  */
 submitData.beacon = function ({ url, body }) {
-  // Navigator has to be bound to ensure it does not error in some browsers
-  // https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch
-  const send = window.navigator.sendBeacon.bind(window.navigator)
   try {
+    // Navigator has to be bound to ensure it does not error in some browsers
+    // https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch
+    const send = window.navigator.sendBeacon.bind(window.navigator)
     return send(url, body)
   } catch (err) {
     // if sendBeacon still trys to throw an illegal invocation error,

--- a/src/common/util/submit-data.test.js
+++ b/src/common/util/submit-data.test.js
@@ -3,30 +3,31 @@
  * @jest-environment-options {"html": "<html><head><script></script></head><body></body></html>", "url": "https://example.com/"}
  */
 
+import { faker } from '@faker-js/faker'
 import { submitData } from './submit-data'
+import * as globalScope from './global-scope'
 
-const mockWorkerScope = jest.fn().mockImplementation(() => false)
 jest.mock('./global-scope', () => ({
   __esModule: true,
   get isWorkerScope () {
-    return mockWorkerScope()
+    return false
   }
 }))
 
 const url = 'https://example.com/api'
 
-beforeEach(() => {
+afterEach(() => {
   jest.restoreAllMocks()
-  mockWorkerScope.mockReturnValue(false)
 })
 
 describe('submitData.jsonp', () => {
+  afterEach(() => {
+    delete global.importScripts
+  })
+
   // This test requires a script tag to exist in the html set by this file's jest-environment-options header block.
   test('should return an HTMLScriptElement when called from a web window environment', () => {
-    mockWorkerScope.mockReturnValue(false)
-
-    const jsonp = 'callback'
-
+    const jsonp = faker.datatype.uuid()
     const result = submitData.jsonp({ url, jsonp })
 
     expect(result).toBeInstanceOf(HTMLScriptElement)
@@ -35,125 +36,141 @@ describe('submitData.jsonp', () => {
   })
 
   test('should try to use importScripts when called from a worker scope', () => {
-    mockWorkerScope.mockReturnValueOnce(true)
-
-    const jsonp = 'callback'
-
+    jest.spyOn(globalScope, 'isWorkerScope', 'get').mockReturnValue(true)
     global.importScripts = jest.fn()
 
+    const jsonp = faker.datatype.uuid()
     submitData.jsonp({ url, jsonp })
 
-    expect(importScripts).toHaveBeenCalledWith(url + '&jsonp=' + jsonp)
-
-    delete global.importScripts
+    expect(global.importScripts).toHaveBeenCalledWith(url + '&jsonp=' + jsonp)
   })
 
-  test('should fall back to an xhrGet call and return false when called from a worker scope', () => {
-    mockWorkerScope.mockReturnValueOnce(true)
-
-    const jsonp = 'callback'
-
+  test('should fall back to an xhrGet call and return false importScripts throws an error', () => {
+    jest.spyOn(globalScope, 'isWorkerScope', 'get').mockReturnValue(true)
     jest.spyOn(submitData, 'xhrGet').mockImplementation(jest.fn())
+    global.importScripts = jest.fn().mockImplementation(() => { throw new Error(faker.lorem.sentence()) })
 
+    const jsonp = faker.datatype.uuid()
     const result = submitData.jsonp({ url, jsonp })
 
     expect(result).toBe(false)
-    expect(submitData.xhrGet).toHaveBeenCalledTimes(1)
+    expect(global.importScripts).toHaveBeenCalledWith(url + '&jsonp=' + jsonp)
+    expect(submitData.xhrGet).toHaveBeenCalledWith({ url: url + '&jsonp=' + jsonp })
   })
 
-  test('should not throw an error if any error occurs during execution', () => {
-    jest.spyOn(document, 'createElement').mockImplementation(() => { throw new Error('message') })
+  test('should not throw an error when xhrGet throws an error', () => {
+    jest.spyOn(globalScope, 'isWorkerScope', 'get').mockReturnValue(true)
+    jest.spyOn(submitData, 'xhrGet').mockImplementation(() => { throw new Error(faker.lorem.sentence()) })
+    global.importScripts = jest.fn().mockImplementation(() => { throw new Error(faker.lorem.sentence()) })
 
-    const jsonp = 'callback'
+    const jsonp = faker.datatype.uuid()
 
-    expect(() => {
-      submitData.jsonp({ url, jsonp })
-    }).not.toThrow()
+    expect(() => submitData.jsonp({ url, jsonp })).not.toThrow()
+  })
+
+  test('should not throw an error when element insertion fails', () => {
+    jest.spyOn(document, 'createElement').mockImplementation(() => { throw new Error(faker.lorem.sentence()) })
+
+    const jsonp = faker.datatype.uuid()
+
+    expect(() => submitData.jsonp({ url, jsonp })).not.toThrow()
   })
 })
 
 describe('submitData.xhrGet', () => {
-  test('should return an XMLHttpRequest object', () => {
+  test('xhrGet should call xhr with GET as the method', () => {
+    jest.spyOn(submitData, 'xhr').mockReturnValue(new XMLHttpRequest())
+
     const result = submitData.xhrGet({ url })
+
     expect(result).toBeInstanceOf(XMLHttpRequest)
-  })
-
-  test('should not throw an error if URL is not provided', () => {
-    expect(() => {
-      submitData.xhrGet({})
-    }).not.toThrow()
-  })
-
-  test('should not throw an error if an invalid URL is provided', () => {
-    expect(() => {
-      submitData.xhrGet({ url: 'invalid url' })
-    }).not.toThrow()
+    expect(submitData.xhr).toHaveBeenCalledWith({ url, sync: false, method: 'GET' })
   })
 })
 
 describe('submitData.xhr', () => {
-  test('should return an XMLHttpRequest object', () => {
-    const result = submitData.xhrGet({ url })
-    expect(result).toBeInstanceOf(XMLHttpRequest)
-  })
+  beforeEach(() => {
+    jest.spyOn(global, 'XMLHttpRequest').mockImplementation(function () {
+      this.prototype = XMLHttpRequest.prototype
+      this.open = jest.fn()
+      this.send = jest.fn()
+      this.setRequestHeader = jest.fn()
 
-  test('should not throw an error if URL is not provided', () => {
-    expect(() => {
-      submitData.xhr({})
-    }).not.toThrow()
-  })
-
-  test('should not throw an error if an invalid URL is provided', () => {
-    expect(() => {
-      submitData.xhr({ url: 'invalid url' })
-    }).not.toThrow()
-  })
-
-  test('should send a POST request by default', () => {
-    jest.spyOn(XMLHttpRequest.prototype, 'open')
-
-    submitData.xhr({ url })
-
-    expect(XMLHttpRequest.prototype.open).toHaveBeenCalledWith('POST', url, true)
-  })
-
-  test('should send a GET request if specified', () => {
-    jest.spyOn(XMLHttpRequest.prototype, 'open')
-
-    submitData.xhr({ url, method: 'GET' })
-
-    expect(XMLHttpRequest.prototype.open).toHaveBeenCalledWith('GET', url, true)
-  })
-
-  // This test requires a same-origin url to be set by this file's jest-environment-options header block.
-  test('should send a request synchronously if specified', () => {
-    jest.spyOn(XMLHttpRequest.prototype, 'open')
-
-    submitData.xhr({ url, sync: true })
-
-    expect(XMLHttpRequest.prototype.open).toHaveBeenCalledWith('POST', url, false)
-  })
-
-  test('should set custom headers if provided', () => {
-    const headers = [{ key: 'Content-Type', value: 'application/json' }]
-
-    jest.spyOn(XMLHttpRequest.prototype, 'setRequestHeader')
-
-    submitData.xhr({ url, headers })
-
-    headers.forEach((header) => {
-      expect(XMLHttpRequest.prototype.setRequestHeader).toHaveBeenCalledWith(header.key, header.value)
+      this._withCredentials = false
+      Object.defineProperty(this, 'withCredentials', {
+        get: jest.fn(() => this._withCredentials),
+        set: jest.fn((val) => this._withCredentials = val)
+      })
     })
   })
 
-  test('should send a request with the specified body', () => {
-    const body = JSON.stringify({ key: 'value' })
+  test('should make and send an xhr with default values', () => {
+    const result = submitData.xhr({ url })
+    const xhr = jest.mocked(global.XMLHttpRequest).mock.instances[0]
 
-    jest.spyOn(XMLHttpRequest.prototype, 'send')
+    expect(result).toBeInstanceOf(XMLHttpRequest)
+    expect(result.withCredentials).toBe(true)
+    expect(xhr.open).toHaveBeenCalledWith('POST', url, true)
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith('content-type', 'text/plain')
+    expect(xhr.send).toHaveBeenCalledWith(null)
+  })
 
+  test('should send the body when provided', () => {
+    const body = faker.lorem.paragraph()
     submitData.xhr({ url, body })
+    const xhr = jest.mocked(global.XMLHttpRequest).mock.instances[0]
 
-    expect(XMLHttpRequest.prototype.send).toHaveBeenCalledWith(body)
+    expect(xhr.send).toHaveBeenCalledWith(body)
+  })
+
+  test('should set async to false', () => {
+    submitData.xhr({ url, sync: true })
+    const xhr = jest.mocked(global.XMLHttpRequest).mock.instances[0]
+
+    expect(xhr.open).toHaveBeenCalledWith('POST', url, false)
+  })
+
+  test('should use the provided method', () => {
+    submitData.xhr({ url, method: 'HEAD' })
+    const xhr = jest.mocked(global.XMLHttpRequest).mock.instances[0]
+
+    expect(xhr.open).toHaveBeenCalledWith('HEAD', url, true)
+  })
+
+  test('should use the provided headers', () => {
+    const headers = [{ key: faker.lorem.word(), value: faker.datatype.uuid() }]
+    submitData.xhr({ url, headers })
+    const xhr = jest.mocked(global.XMLHttpRequest).mock.instances[0]
+
+    expect(xhr.setRequestHeader).not.toHaveBeenCalledWith('content-type', 'text/plain')
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith(headers[0].key, headers[0].value)
+  })
+
+  test('should not throw an error if withCredentials is not supported', () => {
+    jest.spyOn(global, 'XMLHttpRequest').mockImplementation(function () {
+      this.prototype = XMLHttpRequest.prototype
+      this.open = jest.fn()
+      this.send = jest.fn()
+      this.setRequestHeader = jest.fn()
+    })
+
+    expect(() => submitData.xhr({ url })).not.toThrow()
+  })
+
+  test('should not throw an error if setRequestHeader throws an error', () => {
+    jest.spyOn(global, 'XMLHttpRequest').mockImplementation(function () {
+      this.prototype = XMLHttpRequest.prototype
+      this.open = jest.fn()
+      this.send = jest.fn()
+      this.setRequestHeader = jest.fn()
+
+      Object.defineProperty(this, 'withCredentials', {
+        get: jest.fn().mockImplementation(() => { throw new Error(faker.lorem.sentence()) }),
+        set: jest.fn().mockImplementation(() => { throw new Error(faker.lorem.sentence()) })
+      })
+    })
+
+    expect(() => submitData.xhr({ url })).not.toThrow()
   })
 })
 
@@ -164,55 +181,47 @@ describe('submitData.img', () => {
     const result = submitData.img({ url: imageUrl })
 
     expect(result).toBeInstanceOf(HTMLImageElement)
-  })
-
-  test('should not throw an error if URL is not provided', () => {
-    expect(() => {
-      submitData.img({})
-    }).not.toThrow()
-  })
-
-  test('should set the src attribute of the image element to the provided URL', () => {
-    const imageUrl = 'https://example.com/image.png'
-
-    const result = submitData.img({ url: imageUrl })
-
     expect(result.src).toBe(imageUrl)
   })
 })
 
 describe('submitData.beacon', () => {
+  afterEach(() => {
+    delete window.navigator.sendBeacon
+  })
+
   test('should return true when beacon request succeeds', () => {
-    const body = JSON.stringify({ key: 'value' })
+    window.navigator.sendBeacon = jest.fn().mockReturnValue(true)
 
-    window.navigator.sendBeacon = {
-      bind: jest.fn(() => () => true)
-    }
-
+    const body = faker.lorem.paragraph()
     const result = submitData.beacon({ url, body })
 
     expect(result).toBe(true)
+    expect(window.navigator.sendBeacon).toHaveBeenCalledWith(url, body)
   })
 
-  test('should return false when beacon request fails', () => {
-    const body = JSON.stringify({ key: 'value' })
+  test('should return false when beacon request returns false', () => {
+    window.navigator.sendBeacon = jest.fn().mockReturnValue(false)
 
-    window.navigator.sendBeacon = {
-      bind: jest.fn(() => () => { throw new Error('message') })
-    }
-
-    const result = submitData.beacon({ url, body })
+    const result = submitData.beacon({ url })
 
     expect(result).toBe(false)
   })
 
-  test('should error if sendBeacon is not supported', () => {
-    const body = JSON.stringify({ key: 'value' })
+  test('should return false when beacon request throws an error', () => {
+    window.navigator.sendBeacon = jest.fn(() => { throw new Error(faker.lorem.sentence()) })
 
-    window.navigator.sendBeacon = undefined
+    const result = submitData.beacon({ url })
 
-    expect(() => {
-      submitData.beacon({ url, body })
-    }).toThrow()
+    expect(result).toBe(false)
+  })
+
+  test('should always bind window.navigator to the sendBeacon function', () => {
+    window.navigator.sendBeacon = jest.fn().mockReturnValue(true)
+    window.navigator.sendBeacon.bind = jest.fn(() => {})
+
+    submitData.beacon({ url })
+
+    expect(window.navigator.sendBeacon.bind).toHaveBeenCalledWith(window.navigator)
   })
 })


### PR DESCRIPTION
Fixing jest warning about open handles remaining after test runs.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Fixing the warnings jest produces about open handles being left after running the submitData tests.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

N/A

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Run `npm test -- --detectOpenHandles ./src/common/util/submit-data` and verify there are no open handle warnings.