### PR TITLE
feat: remove unused data from stn requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10870,9 +10870,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001492",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
-      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
+      "version": "1.0.30001495",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
+      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
       "dev": true,
       "funding": [
         {
@@ -37982,9 +37982,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001492",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz",
-      "integrity": "sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==",
+      "version": "1.0.30001495",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
+      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
       "dev": true
     },
     "capital-case": {

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -4,7 +4,6 @@
  */
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
-import { stringify } from '../../../common/util/stringify'
 import { parseUrl } from '../../../common/url/parse-url'
 import { getConfigurationValue, getInfo, getRuntime } from '../../../common/config/config'
 import { now } from '../../../common/timing/now'
@@ -325,18 +324,10 @@ export class Aggregate extends AggregateBase {
     this.trace = {}
     this.nodeCount = 0
 
-    const stnInfo = {
+    return {
       qs: { st: String(getRuntime(this.agentIdentifier).offset) },
       body: { res: stns }
     }
-    if (!this.ptid) { // send custom and user attributes on the very first ST harvest only
-      const { userAttributes, atts, jsAttributes } = getInfo(this.agentIdentifier)
-      stnInfo.qs.ua = userAttributes
-      stnInfo.qs.at = atts
-      const ja = stringify(jsAttributes)
-      stnInfo.qs.ja = ja === '{}' ? null : ja
-    }
-    return stnInfo
   }
 
   smearEvtsByOrigin (name) {

--- a/tests/functional/stn/index.test.js
+++ b/tests/functional/stn/index.test.js
@@ -17,10 +17,8 @@ testDriver.test('posts session traces', supported, function (t, browser, router)
   Promise.all([resourcePromise, rumPromise, loadPromise]).then(([{ request: { query } }]) => {
     t.ok(+query.st > 1408126770885, `Got start time ${query.st}`)
     t.notok(query.ptid, 'No ptid on first harvest')
-    t.equal(query.ja, '{"aargh":"somanytimers"}', 'custom javascript attributes (on stn first post)')
     return router.expectResources().then(({ request: { query } }) => {
       t.ok(query.ptid, `ptid on second harvest ${query.ptid}`)
-      t.equal(query.ja, undefined, 'no javascript attributes (on stn second post)')
       t.end()
     })
   }).catch(fail)

--- a/tests/functional/stn/index.test.js
+++ b/tests/functional/stn/index.test.js
@@ -8,8 +8,6 @@ const testDriver = require('../../../tools/jil/index')
 let supported = testDriver.Matcher.withFeature('stn')
 
 testDriver.test('posts session traces', supported, function (t, browser, router) {
-  t.plan(5)
-
   let rumPromise = router.expectRum()
   let resourcePromise = router.expectResources()
   let loadPromise = browser.get(router.assetURL('lotsatimers.html')).waitForFeature('loaded')

--- a/tests/functional/xhr/ajax-events.test.js
+++ b/tests/functional/xhr/ajax-events.test.js
@@ -30,13 +30,13 @@ testDriver.test('Disabled ajax events', function (t, browser, router) {
 })
 
 testDriver.test('capturing XHR ajax events', function (t, browser, router) {
-  const ajaxPromise = router.expectAjaxEvents(5000)
+  const ajaxPromise = router.expectAjaxEvents(10000)
   const rumPromise = router.expectRum()
   const loadPromise = browser.safeGet(router.assetURL('xhr-outside-interaction.html', {
     loader: 'spa',
     init: {
       ajax: {
-        harvestTimeSeconds: 2,
+        harvestTimeSeconds: 5,
         enabled: true
       }
     }
@@ -53,8 +53,8 @@ testDriver.test('capturing XHR ajax events', function (t, browser, router) {
 
 testDriver.test('capturing large payload of XHR ajax events', function (t, browser, router) {
   const ajaxPromises = Promise.all([
-    router.expectAjaxEvents(8000),
-    router.expectAjaxEvents(16000)
+    router.expectAjaxEvents(10000),
+    router.expectAjaxEvents(20000)
   ])
   const rumPromise = router.expectRum()
   const loadPromise = browser.safeGet(router.assetURL('xhr-large-payload.html', {

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -4,15 +4,15 @@
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "chrome",
@@ -34,15 +34,15 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "MicrosoftEdge",


### PR DESCRIPTION
Removing customer and apm defined data from the session trace requests since the data is not consumed downstream and can result in 414 errors for network requests where the custom data could cause the URL to exceed the max length of 8192 bytes.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Removed the `ja`, `ua`, and `at` query parameters from the session trace network requests. These parameters, especially `ja`, could grow so large that it would cause the resulting URL to exceed the 8192 bytes limit. This data was never actually consumed downstream and doesn't need to be sent on any session trace request.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NEWRELIC-7997

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

The integration tests have been updated to remove reliance on these properties. To test locally, build the agent and inject it into a test project. Verify in NR that session traces are still getting created.