### PR TITLE
chore: Adjust expected long task count for Istanbul

### DIFF
--- a/tests/functional/pvt/timings.test.js
+++ b/tests/functional/pvt/timings.test.js
@@ -536,7 +536,8 @@ function runLongTasksTest (loader) {
         const timings = body && body.length ? body : querypack.decode(query.e)
 
         const ltEvents = timings.filter(t => t.name === 'lt')
-        t.ok(ltEvents.length == 2, 'expected number of long tasks (2) observed')
+        // This should be changed from 3 to 2 once Istanbul is no longer included by default in the test agent build.
+        t.ok(ltEvents.length == 3, 'expected number of long tasks (3) observed')
 
         ltEvents.forEach((lt) => {
           t.ok(lt.value >= 59, 'task duration is roughly as expected') // defined in some-long-task.js -- duration should be at least that value +/- 1ms


### PR DESCRIPTION
Adjusts the number of long tasks expected in timings.test.js from 2 to 3 following the addition of Istanbul to test agent builds.
---

### Overview

Istanbul adds long tasks to the agent build used with tests, following https://github.com/newrelic/newrelic-browser-agent/pull/567. The long term solution is actually to change the WDIO coverage mechanism so it doesn't include Istanbul except when collecting coverage.

### Related Issue(s)

https://issues.newrelic.com/browse/NR-124935

### Testing

Automated tests should all pass.