### PR TITLE
chore: Add browserMatches method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9688,9 +9688,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001502",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
-      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
+      "version": "1.0.30001503",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
+      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==",
       "dev": true,
       "funding": [
         {
@@ -34049,9 +34049,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001502",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
-      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
+      "version": "1.0.30001503",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz",
+      "integrity": "sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==",
       "dev": true
     },
     "capital-case": {

--- a/tools/browsers-lists/browsers-polyfill.json
+++ b/tools/browsers-lists/browsers-polyfill.json
@@ -3,7 +3,8 @@
     {
       "browserName": "internet explorer",
       "platform": "Windows 10",
-      "version": "11"
+      "version": "11",
+      "browserVersion": "11"
     }
   ]
 }

--- a/tools/wdio/plugins/browser-matcher.mjs
+++ b/tools/wdio/plugins/browser-matcher.mjs
@@ -12,6 +12,7 @@ export default class BrowserMatcher {
     this.#browserName = getBrowserName(capabilities)
     this.#browserVersion = getBrowserVersion(capabilities)
     global.withBrowsersMatching = this.#browserMatchTest.bind(this)
+    global.browserMatches = this.#browserMatches.bind(this)
   }
 
   #browserMatchTest (matcher) {
@@ -42,5 +43,9 @@ export default class BrowserMatcher {
         global.it.apply(this, args)
       }
     }
+  }
+
+  #browserMatches (matcher) {
+    return matcher.test(this.#browserName, this.#browserVersion)
   }
 }


### PR DESCRIPTION
Adds a global browserMatches method available in WDIO tests
---

### Overview

I ended up not needing this code for one of my other PRs. I'm putting it here for discussion of if/how we want to enable specific-browser matching in our WDIO tests.

- Creates a new global method called `browserMatches` that takes a `SpecMatcher` object.
- Adds the `browserVersion` property to the `browsers-polyfills.json` so IE 11 can be matched to a version.

### Related Issue(s)

N/A

### Testing

TBD
