### PR TITLE
chore: Fix err/error-payload.e2e.js for IE 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001505",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+      "version": "1.0.30001506",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001505",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+      "version": "1.0.30001506",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
       "dev": true
     },
     "capital-case": {

--- a/tests/assets/duplicate-errors.html
+++ b/tests/assets/duplicate-errors.html
@@ -18,7 +18,7 @@ this is a generic page that is instrumented by the JS agent
   function errorFn(){
     setTimeout(function(){
       var a
-      window[`error-${count++}`] = Date.now()
+      window['error-' + (count++)] = Date.now()
       a.click = true
     })
   }

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "firefox",


### PR DESCRIPTION
The asset had string literals in it.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Apparently we weren't running tests with `duplicate-errors.html` against IE before.

### Related Issue(s)

N/A

### Testing

`npm run wdio -- --retry=false tests/specs/err/error-payload.e2e.js -P -b ie@11`
