### PR TITLE
chore: Fix inconsistent IE issues with err/attributes.e2e.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001505",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+      "version": "1.0.30001506",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001505",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+      "version": "1.0.30001506",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
       "dev": true
     },
     "capital-case": {

--- a/tests/specs/err/attributes.e2e.js
+++ b/tests/specs/err/attributes.e2e.js
@@ -11,7 +11,6 @@ describe('error attributes with spa loader', () => {
           await trigger.click()
           await trigger.click()
           await trigger.click()
-          return browser.refresh()
         })()
       ])
 

--- a/tests/specs/err/attributes.e2e.js
+++ b/tests/specs/err/attributes.e2e.js
@@ -6,12 +6,11 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        (async () => {
-          const trigger = await $('#trigger')
-          await trigger.click()
-          await trigger.click()
-          await trigger.click()
-        })()
+        browser.execute(function () {
+          triggerError()
+          triggerError()
+          triggerError()
+        })
       ])
 
       expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
@@ -76,13 +75,13 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        (async () => {
-          const trigger = await $('#trigger')
-          await trigger.click()
-          await trigger.click()
-          await trigger.click()
-          return browser.refresh()
-        })()
+        browser.execute(function () {
+          triggerError()
+          triggerError()
+          triggerError()
+        }).then(() => {
+          browser.refresh()
+        })
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload

--- a/tests/specs/err/attributes.e2e.js
+++ b/tests/specs/err/attributes.e2e.js
@@ -76,17 +76,19 @@ describe('error attributes with spa loader', () => {
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
         browser.execute(function () {
-          triggerError()
-          triggerError()
-          triggerError()
-        }).then(() => {
-          browser.refresh()
+          // Using setTimeout asks each command to wait for the event loop to pick it up from the message queue rather
+          // than executing direcly as a synchronous frame on the stack. This plays better with our api calls, which
+          // use an event emitter architecture.
+          setTimeout(triggerError, 0)
+          setTimeout(triggerError, 0)
+          setTimeout(triggerError, 0)
+          setTimeout(function () { location.reload() }, 0)
         })
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
       expect(errorResult.request.body.err[0].custom.customParamKey).toBe(2)
-      expect(errorResult.request.body.err[0].metrics.count).toBe(3)
+      expect(errorResult.request.body.err[0].metrics.count).toBe(3) // the one error has a count of 3
     })
 
     it('noticeError accepts custom attributes in an argument', async () => {
@@ -141,11 +143,10 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        (async () => {
-          const trigger = await $('#trigger')
-          await trigger.click()
-          return browser.refresh()
-        })()
+        browser.execute(function () {
+          document.getElementById('trigger').click()
+          setTimeout(function () { location.reload() }, 100) // IE needs a little time before the refresh.
+        })
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
@@ -158,11 +159,10 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        (async () => {
-          const trigger = await $('#trigger')
-          await trigger.click()
-          return browser.refresh()
-        })()
+        browser.execute(function () {
+          document.getElementById('trigger').click()
+          setTimeout(function () { location.reload() }, 100) // IE needs a little time before the refresh.
+        })
       ])
 
       expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
@@ -177,11 +177,10 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        (async () => {
-          const trigger = await $('#trigger')
-          await trigger.click()
-          return browser.refresh()
-        })()
+        browser.execute(function () {
+          document.getElementById('trigger').click()
+          setTimeout(function () { location.reload() }, 100) // IE needs a little time before the refresh.
+        })
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
@@ -238,11 +237,10 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        (async () => {
-          const trigger = await $('#trigger')
-          await trigger.click()
-          return browser.refresh()
-        })()
+        browser.execute(function () {
+          document.getElementById('trigger').click()
+          setTimeout(function () { location.reload() }, 100) // IE needs a little time before the refresh.
+        })
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload

--- a/tests/specs/err/attributes.e2e.js
+++ b/tests/specs/err/attributes.e2e.js
@@ -6,11 +6,13 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        await $('#trigger').then(async (trigger) => {
+        (async () => {
+          const trigger = await $('#trigger')
           await trigger.click()
           await trigger.click()
           await trigger.click()
-        })
+          return browser.refresh()
+        })()
       ])
 
       expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
@@ -75,12 +77,13 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        $('#trigger').then(async (trigger) => {
+        (async () => {
+          const trigger = await $('#trigger')
           await trigger.click()
           await trigger.click()
           await trigger.click()
-          browser.refresh()
-        })
+          return browser.refresh()
+        })()
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
@@ -140,10 +143,11 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        $('#trigger').then(async (trigger) => {
+        (async () => {
+          const trigger = await $('#trigger')
           await trigger.click()
-          browser.refresh()
-        })
+          return browser.refresh()
+        })()
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
@@ -156,10 +160,11 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        $('#trigger').then(async (trigger) => {
+        (async () => {
+          const trigger = await $('#trigger')
           await trigger.click()
-          browser.refresh()
-        })
+          return browser.refresh()
+        })()
       ])
 
       expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
@@ -174,10 +179,11 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        $('#trigger').then(async (trigger) => {
+        (async () => {
+          const trigger = await $('#trigger')
           await trigger.click()
-          browser.refresh()
-        })
+          return browser.refresh()
+        })()
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
@@ -234,10 +240,11 @@ describe('error attributes with spa loader', () => {
 
       const [errorResult] = await Promise.all([
         browser.testHandle.expectErrors(),
-        $('#trigger').then(async (trigger) => {
+        (async () => {
+          const trigger = await $('#trigger')
           await trigger.click()
-          browser.refresh() // forces harvest
-        })
+          return browser.refresh()
+        })()
       ])
 
       expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "firefox",


### PR DESCRIPTION
Intermittently WDIO was failing in IE to capture the ID of the selector used to trigger clicks.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

The error was `Error: Malformed type for "elementId" parameter of command elementClick` and it affected a number of the tests intermittently. The new logic mostly uses browser.execute to interact directly with the scripts and elements.

Some of the tests didn't actually need to use a click event because they weren't testing a SPA click interaction.

### Related Issue(s)

N/A

### Testing

`npm run wdio -- --retry=false tests/specs/err/attributes.e2e.js -P -b ie@11`
