### PR TITLE
fix: Fix illegal invocation error on final harvest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001505",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+      "version": "1.0.30001506",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001505",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+      "version": "1.0.30001506",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -244,13 +244,9 @@ export class Harvest extends SharedContext {
       }
       return Object.entries(input || {})
         .reduce((accumulator, [key, value]) => {
-          if (
-            value !== null &&
-            value !== undefined && (
-              (typeof value === 'number') ||
+          if ((typeof value === 'number') ||
               (typeof value === 'string' && value.length > 0) ||
-              (Object.entries(value).length > 0)
-            )
+              (typeof value === 'object' && Object.keys(value || {}).length > 0)
           ) {
             accumulator[key] = value
           }

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -244,7 +244,14 @@ export class Harvest extends SharedContext {
       }
       return Object.entries(input || {})
         .reduce((accumulator, [key, value]) => {
-          if (value !== null && value !== undefined && value.length) {
+          if (
+            value !== null &&
+            value !== undefined && (
+              (typeof value === 'number') ||
+              (typeof value === 'string' && value.length > 0) ||
+              (Object.entries(value).length > 0)
+            )
+          ) {
             accumulator[key] = value
           }
 

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -59,7 +59,7 @@ export class Harvest extends SharedContext {
   send (spec = {}) {
     const caller = this.obfuscator.shouldObfuscate() ? this.obfuscateAndSend.bind(this) : this._send.bind(this)
 
-    return caller({ ...spec, payload: this.cleanPayload(spec.payload) })
+    return caller(spec)
   }
 
   /**

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -244,7 +244,7 @@ export class Harvest extends SharedContext {
       }
       return Object.entries(input || {})
         .reduce((accumulator, [key, value]) => {
-          if (value !== null && value !== undefined && value.toString()?.length) {
+          if (value !== null && value !== undefined && value.length) {
             accumulator[key] = value
           }
 

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -304,9 +304,7 @@ describe('_send', () => {
 
   test('should set body to events when endpoint is events', () => {
     spec.endpoint = 'events'
-    spec.payload.body.e = {
-      [faker.datatype.uuid()]: faker.lorem.sentence()
-    }
+    spec.payload.body.e = faker.lorem.sentence()
 
     const result = harvestInstance._send(spec)
 

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -813,4 +813,20 @@ describe('cleanPayload', () => {
     expect(Object.keys(results.body)).not.toContain('foo')
     expect(Object.keys(results.qs)).not.toContain('foo')
   })
+
+  test.each([
+    { [faker.datatype.uuid()]: { [faker.datatype.uuid()]: faker.datatype.number({ min: 100, max: 1000 }) } },
+    { [faker.datatype.uuid()]: faker.datatype.number({ min: 100, max: 1000 }) },
+    { [faker.datatype.uuid()]: new Uint8Array(faker.datatype.number({ min: 100, max: 1000 })) }
+  ])('should retain %s properties in body and qs', (input) => {
+    const payload = {
+      body: input,
+      qs: input
+    }
+
+    const results = harvestInstance.cleanPayload(payload)
+
+    expect(results.body).toEqual(input)
+    expect(results.qs).toEqual(input)
+  })
 })

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -109,7 +109,7 @@ describe('send', () => {
 
     harvestInstance.send(spec)
 
-    expect(harvestInstance._send).toHaveBeenCalledWith(expect.objectContaining(spec))
+    expect(harvestInstance._send).toHaveBeenCalledWith(spec)
   })
 
   test('should not use obfuscateAndSend', async () => {
@@ -119,11 +119,7 @@ describe('send', () => {
     harvestInstance.send({ endpoint })
 
     expect(harvestInstance._send).toHaveBeenCalledWith({
-      endpoint,
-      payload: {
-        body: {},
-        qs: {}
-      }
+      endpoint
     })
     expect(harvestInstance.obfuscateAndSend).not.toHaveBeenCalled()
   })
@@ -135,11 +131,7 @@ describe('send', () => {
     harvestInstance.send({ endpoint })
 
     expect(harvestInstance.obfuscateAndSend).toHaveBeenCalledWith({
-      endpoint,
-      payload: {
-        body: {},
-        qs: {}
-      }
+      endpoint
     })
     expect(harvestInstance._send).not.toHaveBeenCalled()
   })
@@ -147,12 +139,7 @@ describe('send', () => {
   test.each([undefined, {}])('should still call _send when spec is %s', async (spec) => {
     harvestInstance.send(spec)
 
-    expect(harvestInstance._send).toHaveBeenCalledWith({
-      payload: {
-        body: {},
-        qs: {}
-      }
-    })
+    expect(harvestInstance._send).toHaveBeenCalledWith(spec || {})
   })
 })
 

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -4,7 +4,6 @@ import * as encodeModule from '../url/encode'
 import * as submitDataModule from '../util/submit-data'
 import * as configModule from '../config/config'
 import { applyFnToProps } from '../util/traverse'
-import * as runtimeModule from '../constants/runtime'
 
 import { Harvest } from './harvest'
 

--- a/tests/assets/api/addPageAction-unload.html
+++ b/tests/assets/api/addPageAction-unload.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>NEWRELIC-9370: addPageAction Unload Test</title>
+  {init}
+  {config}
+  {loader}
+
+</head>
+
+<body>
+  <div id="content">
+    This page is used to call `addPageAction` immediately followed by a navigation.
+  </div>
+  <a id="btn" href="#btn">Click Me</a>
+  <script>
+    window.triggerPageActionNavigation = function () {
+      newrelic.addPageAction('pageaction', window.location)
+      location = '/'
+    }
+  </script>
+</body>
+
+</html>

--- a/tests/specs/ins/harvesting.e2e.js
+++ b/tests/specs/ins/harvesting.e2e.js
@@ -1,0 +1,22 @@
+describe('ins harvesting', () => {
+  it('NEWRELIC-9370: should not throw an exception when calling addPageAction with window.location before navigating', async () => {
+    const testUrl = await browser.testHandle.assetURL('api/addPageAction-unload.html')
+    await browser.url(testUrl)
+      .then(() => browser.waitForAgentLoad())
+
+    const [pageActionsHarvest] = await Promise.all([
+      browser.testHandle.expectIns(),
+      browser.testHandle.expectErrors(10000, true),
+      browser.execute(function () {
+        window.triggerPageActionNavigation()
+      })
+    ])
+
+    expect((await pageActionsHarvest).request.body.ins).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        actionName: 'pageaction',
+        href: testUrl
+      })
+    ]))
+  })
+})

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "firefox",

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "108",
-      "browserVersion": "108"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "firefox",

--- a/tools/saucelabs/utils.mjs
+++ b/tools/saucelabs/utils.mjs
@@ -39,7 +39,7 @@ export function getSauceConnectTunnelName () {
  */
 export function buildSauceConnectOptions (cliArgs) {
   const opts = {
-    scVersion: '4.9.0',
+    scVersion: '4.9.1',
     tunnelName: getSauceConnectTunnelName(),
     noSslBumpDomains: 'all',
     logger: console.log,


### PR DESCRIPTION
An issue from 1.234.0 has been addressed in which an illegal invocation error could occur during a final harvest as a result of calling `addPageAction` and passing `window.location` as an argument before a navigation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Reverting a change from #521. Calling `addPageAction` and passing `window.location` as an argument before a navigation would result in calling `.toString` on the global `window.location`. Doing so during a page unload causes an `Illegal Invocation` error due to the global `window.location.toString()` losing it's context.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NEWRELIC-9370

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Test added to ensure this issue does not happen again.