### PR TITLE
chore: Remove eu db actions

### DIFF
--- a/.github/workflows/publish-apm.yml
+++ b/.github/workflows/publish-apm.yml
@@ -28,5 +28,4 @@ jobs:
           node tools/scripts/upload-to-nr.js \
             --staging-api-key=${{ secrets.NR_API_KEY_STAGING }} \
             --production-api-key=${{ secrets.NR_API_KEY_PRODUCTION }} \
-            --eu-api-key=${{ secrets.NR_API_KEY_EU }} \
             --v=${{ github.event.inputs.version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -125,7 +125,6 @@ jobs:
           node tools/scripts/upload-to-nr.js \
             --staging-api-key=${{ secrets.NR_API_KEY_STAGING }} \
             --production-api-key=${{ secrets.NR_API_KEY_PRODUCTION }} \
-            --eu-api-key=${{ secrets.NR_API_KEY_EU }} \
             --v=$(cat package.json | jq -r '.version')
       - name: validate file
         run: |

--- a/.github/workflows/publish-sudo-polyfills.yml
+++ b/.github/workflows/publish-sudo-polyfills.yml
@@ -23,5 +23,4 @@ jobs:
         run: |
           node tools/scripts/upload-polyfills-to-nr.js \
             --staging-api-key=${{ secrets.NR_API_KEY_STAGING }} \
-            --production-api-key=${{ secrets.NR_API_KEY_PRODUCTION }} \
-            --eu-api-key=${{ secrets.NR_API_KEY_EU }}
+            --production-api-key=${{ secrets.NR_API_KEY_PRODUCTION }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001505",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+      "version": "1.0.30001506",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001505",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
-      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
+      "version": "1.0.30001506",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
+      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
       "dev": true
     },
     "capital-case": {

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "firefox",

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "104",
+      "browserVersion": "104"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "108",
-      "browserVersion": "108"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "firefox",

--- a/tools/scripts/check-nrdb.js
+++ b/tools/scripts/check-nrdb.js
@@ -16,8 +16,8 @@ if (!version) {
 
 const urls = [
   'https://staging-api.newrelic.com/v2/js_agent_loaders/version.json',
-  'https://api.newrelic.com/v2/js_agent_loaders/version.json',
-  'https://api.eu.newrelic.com/v2/js_agent_loaders/version.json'
+  'https://api.newrelic.com/v2/js_agent_loaders/version.json'
+  // 'https://api.eu.newrelic.com/v2/js_agent_loaders/version.json'
 ]
 
 var opts = {

--- a/tools/scripts/upload-polyfills-to-nr.js
+++ b/tools/scripts/upload-polyfills-to-nr.js
@@ -14,7 +14,7 @@ const { deepmerge } = require('deepmerge-ts')
 var argv = yargs
   .string('environments')
   .describe('environments', 'Comma-separated list of environments to upload loaders to')
-  .default('environments', 'staging,production,eu')
+  .default('environments', 'staging,production')
 
   .string('production-api-key')
   .describe('production-api-key', 'API key to use for talking to production RPM site to upload loaders')

--- a/tools/scripts/upload-to-nr.js
+++ b/tools/scripts/upload-to-nr.js
@@ -11,7 +11,7 @@ var yargs = require('yargs')
 var argv = yargs
   .string('environments')
   .describe('environments', 'Comma-separated list of environments to upload loaders to')
-  .default('environments', 'staging,production,eu')
+  .default('environments', 'staging,production')
 
   .string('production-api-key')
   .describe('production-api-key', 'API key to use for talking to production RPM site to upload loaders')


### PR DESCRIPTION
Remove EU DB CI actions, as that table will no longer need populating as it switches to a replication view of the prod table.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR alters the CI actions that publish the loader code to the DB specifically for the `eu` target only.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NEWRELIC-9416
