### PR TITLE
chore: Fix IE problems in tests/specs/session-manager.e2e.js 

### DIFF
--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "104",
-      "browserVersion": "104"
+      "version": "105",
+      "browserVersion": "105"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "firefox",


### PR DESCRIPTION
The default session.state.custom value (an empty object) was being converted to null when passed from IE in browser.execute return values.
---

### Overview

Preserves empty objects in session state passed from IE via browser.execute using JSON.stringify.

### Related Issue(s)

N/A

### Testing

`npm run wdio -- --retry=false tests/specs/session-manager.e2e.js -P -b ie@11`
