### PR TITLE
chore: Change Mootools test to not rely on payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001506",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+      "version": "1.0.30001507",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
+      "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001506",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+      "version": "1.0.30001507",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
+      "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
       "dev": true
     },
     "capital-case": {

--- a/tests/assets/third-party-compatibility/mootools/1.6.0-nocompat.html
+++ b/tests/assets/third-party-compatibility/mootools/1.6.0-nocompat.html
@@ -17,17 +17,15 @@
       This is a generic page that is instrumented by the JS agent and includes mootools to ensure compatibility.
     </div>
     <script>
-      document.addEventListener('click', function () {
+      window.run = function () {
         window.location.hash = Math.random()
         var myJSONP = new Request.JSONP({
           url: '/jsonp',
           onComplete: function (data) {
-            setTimeout(newrelic.interaction().createTracer('tacoTimer', function () {
-              window.location.hash = Math.random()
-            }), 500)
+            window.success = true
           }
         }).send();
-      }, false)
+      }
     </script>
     <p>Click me!</p>
   </body>

--- a/tests/specs/third-party-compatibility/mootools.e2e.js
+++ b/tests/specs/third-party-compatibility/mootools.e2e.js
@@ -7,21 +7,16 @@ describe.withBrowsersMatching(reliableUnload)('mootools compatibility', () => {
       browser,
       testAsset: 'third-party-compatibility/mootools/1.6.0-nocompat.html',
       afterLoadCallback: async () => {
-        await browser.testHandle.expectEvents() // Wait for the next harvest to continue the test
-
-        const [eventsResults] = await Promise.all([
-          browser.testHandle.expectInteractionEvents(),
-          $('body').click() // Setup expects before interacting with page
-        ])
-
-        const jsonpRequest = eventsResults.request.body
-          .find(interaction =>
-            Array.isArray(interaction.children) && interaction.children.findIndex(childNode =>
-              childNode.type === 'ajax' && childNode.path === '/jsonp'
-            ) > -1
-          )
-        expect(jsonpRequest).toBeDefined()
-        expect(Array.isArray(jsonpRequest.children)).toEqual(true)
+        await browser.execute(function () { window.run() })
+        await browser.waitUntil(
+          () => browser.execute(function () {
+            return !!window.success
+          }),
+          {
+            timeout: 10000,
+            timeoutMsg: 'Request never resolved'
+          }
+        )
       }
     })
   })


### PR DESCRIPTION
Update Mootools test to just check for success flag after running a Mootools method
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR updates the Mootools test to just check for success status in an attempt to fix flakiness issues with WDIO.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
`npm run wdio -- --no-retry tests/specs/third-party-compatibility/mootools.e2e.js`
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
