### PR TITLE
chore: Fix inconsistency in 3rd-party-compat WDIO tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001506",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+      "version": "1.0.30001507",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
+      "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001506",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-      "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+      "version": "1.0.30001507",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
+      "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
       "dev": true
     },
     "capital-case": {

--- a/tests/assets/third-party-compatibility/requirejs/2.3.6.html
+++ b/tests/assets/third-party-compatibility/requirejs/2.3.6.html
@@ -10,7 +10,6 @@
           The data-main attribute tells require.js to load JQuery after
           RequireJS loads. For other typical usages, see the docs:
           https://requirejs.org/docs/start.html  -->
-    <!-- <script data-main="js/vendor/jquery-3.2.1" src="js/vendor/require-2.3.6.js"></script> -->
     <script data-main="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.js" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.js" integrity="sha512-vRqhAr2wsn+/cSsyz80psBbCcqzz2GTuhGk3bq3dAyytz4J/8XwFqMjiAGFBj+WM95lHBJ9cDf87T3P8yMrY7A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     {init}
     {loader}

--- a/tests/specs/third-party-compatibility/run-test.js
+++ b/tests/specs/third-party-compatibility/run-test.js
@@ -33,20 +33,20 @@ export default async function runTest ({
   await afterLoadCallback({ rumResults, resourcesResults, eventsResults, ajaxResults })
   await browser.collectCoverage()
 
-  const [unloadEventsResults, unloadMetricsResults] = await Promise.all([
-    browser.testHandle.expectEvents(),
+  const [unloadTimingsResults, unloadMetricsResults] = await Promise.all([
+    browser.testHandle.expectTimings(),
     browser.testHandle.expectMetrics(),
     browser.url(
       await browser.testHandle.assetURL('/')
     ) // Setup expects before navigating
   ])
 
-  expect(Array.isArray(unloadEventsResults.request.body)).toEqual(true)
-  expect(unloadEventsResults.request.body.findIndex(e => e.name === 'unload')).toBeGreaterThan(-1)
-  expect(unloadEventsResults.request.body.findIndex(e => e.name === 'pageHide')).toBeGreaterThan(-1)
+  expect(Array.isArray(unloadTimingsResults.request.body)).toEqual(true)
+  expect(unloadTimingsResults.request.body.findIndex(e => e.name === 'unload')).toBeGreaterThan(-1)
+  expect(unloadTimingsResults.request.body.findIndex(e => e.name === 'pageHide')).toBeGreaterThan(-1)
 
   expect(Array.isArray(unloadMetricsResults.request.body.sm)).toEqual(true)
   expect(unloadMetricsResults.request.body.sm.length).toBeGreaterThan(0)
 
-  await afterUnloadCallback({ unloadEventsResults, unloadMetricsResults })
+  await afterUnloadCallback({ unloadTimingsResults, unloadMetricsResults })
 }


### PR DESCRIPTION
The unload checks were looking specifically for timing values but the BAM expect was for generic events, so sometimes it would pick up an XHR call instead of the timings call.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Changed `expectEvents` to `expectTimings`.

### Related Issue(s)

N/A

### Testing

- `npm run wdio -- --retry=false tests/specs/third-party-compatibility/requirejs.e2e.js`
- `npm run wdio -- --retry=false tests/specs/third-party-compatibility/requirejs.e2e.js -b ios@15.2`
