### PR TITLE
chore: Recapture IE final harvest (dev bug) NR-139090

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001507",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
-      "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
+      "version": "1.0.30001508",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
+      "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001507",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001507.tgz",
-      "integrity": "sha512-SFpUDoSLCaE5XYL2jfqe9ova/pbQHEmbheDf5r4diNwbAgR3qxM9NQtfsiSscjqoya5K7kFcHPUQ+VsUkIJR4A==",
+      "version": "1.0.30001508",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
+      "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/constants/runtime.js
+++ b/src/common/constants/runtime.js
@@ -66,4 +66,6 @@ export const ffVersion = (() => {
   return 0
 })()
 
+export const isIE = Boolean(isBrowserScope && window.document.documentMode) // deprecated property that only works in IE
+
 export const supportsSendBeacon = !!navigator.sendBeacon

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -15,7 +15,7 @@ import { Obfuscator } from '../util/obfuscate'
 import { applyFnToProps } from '../util/traverse'
 import { SharedContext } from '../context/shared-context'
 import { VERSION } from '../constants/env'
-import { isWorkerScope } from '../constants/runtime'
+import { isWorkerScope, isIE } from '../constants/runtime'
 
 /**
  * @typedef {import('./types.js').NetworkSendSpec} NetworkSendSpec
@@ -131,11 +131,11 @@ export class Harvest extends SharedContext {
 
     headers.push({ key: 'content-type', value: 'text/plain' })
 
-    /* Since workers don't support sendBeacon right now, or Image(), they can only use XHR method.
+    /* Since workers don't support sendBeacon right now, they can only use XHR method.
         Because they still do permit synch XHR, the idea is that at final harvest time (worker is closing),
-        we just make a BLOCKING request--trivial impact--with the remaining data as a temp fill-in for sendBeacon. */
-
-    let result = submitMethod({ url: fullUrl, body, sync: opts.unload && isWorkerScope, headers })
+        we just make a BLOCKING request--trivial impact--with the remaining data as a temp fill-in for sendBeacon.
+       Following the removal of img-element method, IE will also use sync XHR on page dismissal to ensure final analytics are sent. */
+    let result = submitMethod({ url: fullUrl, body, sync: opts.unload && (isWorkerScope || isIE), headers })
 
     if (!opts.unload && cbFinished && submitMethod === submitData.xhr) {
       const harvestScope = this


### PR DESCRIPTION
This is a same-version patch to #576 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

#576 made the final harvest on page unload unreliable for IE11. This reintroduces reliability to that browser, while keeping usage of img out, 414 too-long-url at bay, and existing behavior for other browsers.

### Related Issue(s)

NR-139090

### Testing

Existing tests are sufficient -- this fixes failing IE functional on pvt/timings.
Verify that for IE, final analytics are sent when page is dismissed like for the other browser versions.
