### PR TITLE
chore: Fix experimental build in staging

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -22,8 +22,6 @@ jobs:
       - name: Setup container
         run: apt update && apt install -y git
       - uses: actions/checkout@v3
-        with:
-          ref: 'main'
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001508",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
-      "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
+      "version": "1.0.30001509",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
+      "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001508",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
-      "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
+      "version": "1.0.30001509",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
+      "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
       "dev": true
     },
     "capital-case": {

--- a/tools/scripts/upload-ab-to-s3.js
+++ b/tools/scripts/upload-ab-to-s3.js
@@ -68,6 +68,11 @@ const config = {
         'staging-bam.nr-data.net',
         'bam-cell.nr-data.net'
       ]
+    },
+    session_replay: {
+      enabled: true,
+      sampleRate: 0.5,
+      errorSampleRate: 1
     }
   },
 
@@ -125,6 +130,9 @@ function getIdFromUrl (url) {
       expires.setMonth(expires.getMonth() + 1)
 
       const uploads = await uploadToS3(filename, output, bucket, dry, 300, expires.toISOString())
+
+      console.log(output)
+      console.log('---------------------------------------')
       console.log(`Successfully uploaded ${filename} to S3`)
       process.exit(0)
     }).catch(err => {
@@ -210,5 +218,5 @@ function getOpenPrNums () {
 
 async function getExperiments () {
   const objects = await getListOfObjects(bucket, 'experiments/')
-  return objects.filter(({ Key }) => Key.includes('nr-loader-spa.min.js')).map(({ Key }) => Key)
+  return objects.filter(({ Key }) => Key.includes('nr-loader-spa.min.js') && Key.endsWith('.js')).map(({ Key }) => Key)
 }


### PR DESCRIPTION
Fix the experimental build and ship CI, which was causing errors in Staging NR1 when trying include .txt files as loaders.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR updates the a-b publish script to only include files that end with `.js` as a loader.  It was previously finding `.txt` files occasionally and including them as loaders, after running the experiment build.  This caused `newrelic does not exist` errors in staging, as the txt file does not work as a loader.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://newrelic.slack.com/archives/C0193KAHHAS/p1687958325562219
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Validate that running `Build and Publish Experiment` action on this branch does not include `.txt` loader(s) in the output.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
