### PR TITLE
fix: Fix potential property of undefined errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001509",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
-      "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
+      "version": "1.0.30001512",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001509",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001509.tgz",
-      "integrity": "sha512-2uDDk+TRiTX5hMcUYT/7CSyzMZxjfGu0vAUjS2g0LSD8UoXOv0LtpH4LxGMemsiPq6LCVIUjNwVM0erkOkGCDA==",
+      "version": "1.0.30001512",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/wrap/wrap-jsonp.js
+++ b/src/common/wrap/wrap-jsonp.js
@@ -98,13 +98,18 @@ export function wrapJsonP (sharedEE) {
     return matches ? matches[1] : null
   }
 
+  /**
+   * Traverse a nested object using a '.'-delimited string wherein each substring piece maps to each subsequent object property layer.
+   * @param {string} longKey
+   * @param {object} obj
+   * @returns The final nested object referred to by initial longKey.
+   */
   function discoverValue (longKey, obj) {
-    var matches = longKey.match(VALUE_REGEX)
-    var key = matches[1]
-    var remaining = matches[3]
-    if (!remaining) {
-      return obj[key]
-    }
+    if (!longKey) return obj // end of object recursion depth when no more key levels
+    const matches = longKey.match(VALUE_REGEX)
+    // if 'longKey' was not undefined, that is it at least had 1 level left, then the regexp would've at least matched 1st group
+    const key = matches[1]
+    const remaining = matches[3]
     return discoverValue(remaining, obj[key])
   }
 

--- a/src/features/page_view_event/aggregate/initialized-features.js
+++ b/src/features/page_view_event/aggregate/initialized-features.js
@@ -1,4 +1,5 @@
 import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { gosNREUM } from '../../../common/window/nreum'
 
 /**
  * Get an array of flags required by downstream (NR UI) based on the features initialized in this agent
@@ -8,21 +9,24 @@ import { FEATURE_NAMES } from '../../../loaders/features/features'
  */
 export function getActivatedFeaturesFlags (agentId) {
   const flagArr = []
+  const newrelic = gosNREUM()
 
-  Object.keys(newrelic.initializedAgents[agentId].features).forEach(featName => {
-    switch (featName) {
-      case FEATURE_NAMES.ajax:
-        flagArr.push('xhr'); break
-      case FEATURE_NAMES.jserrors:
-        flagArr.push('err'); break
-      case FEATURE_NAMES.pageAction:
-        flagArr.push('ins'); break
-      case FEATURE_NAMES.sessionTrace:
-        flagArr.push('stn'); break
-      case FEATURE_NAMES.spa:
-        flagArr.push('spa'); break
-    }
-  })
+  try {
+    Object.keys(newrelic.initializedAgents[agentId].features).forEach(featName => {
+      switch (featName) {
+        case FEATURE_NAMES.ajax:
+          flagArr.push('xhr'); break
+        case FEATURE_NAMES.jserrors:
+          flagArr.push('err'); break
+        case FEATURE_NAMES.pageAction:
+          flagArr.push('ins'); break
+        case FEATURE_NAMES.sessionTrace:
+          flagArr.push('stn'); break
+        case FEATURE_NAMES.spa:
+          flagArr.push('spa'); break
+      }
+    })
+  } catch (e) {}
 
   return flagArr
 }


### PR DESCRIPTION
Patch a couple of areas that can yield reading property of undefined or null errors in the RUM call and jsonp wrapper.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

See summary

### Related Issue(s)

NR-122092
NR-138554

### Testing

All regression
