### PR TITLE
fix: prevent invalid error stack traces

### DIFF
--- a/src/features/jserrors/constants.js
+++ b/src/features/jserrors/constants.js
@@ -1,4 +1,3 @@
 import { FEATURE_NAMES } from '../../loaders/features/features'
 
 export const FEATURE_NAME = FEATURE_NAMES.jserrors
-export const NR_ERR_PROP = 'nr@seenError'

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -86,7 +86,7 @@ export class Instrument extends InstrumentBase {
      * The thrown value may contain a message property. If it does, try to treat the thrown
      * value as an Error-like object.
      */
-    if (typeof error.message !== 'undefined') {
+    if (typeof error?.message !== 'undefined') {
       return new UncaughtError(
         error.message,
         error.filename || error.sourceURL,
@@ -95,7 +95,7 @@ export class Instrument extends InstrumentBase {
       )
     }
 
-    return new UncaughtError(stringify(error))
+    return new UncaughtError(typeof error === 'string' ? error : stringify(error))
   }
 
   /**

--- a/tests/functional/err/unhandled-rejection-readable.test.js
+++ b/tests/functional/err/unhandled-rejection-readable.test.js
@@ -28,7 +28,7 @@ testDriver.test('unhandledPromiseRejections are caught and are readable', suppor
     assertErrorAttributes(t, request.query)
     const actualErrors = getErrorsFromResponse(request, browser)
     const expectedErrorMessages = [
-      { message: 'Unhandled Promise Rejection: "Test"', tested: false, meta: 'string' },
+      { message: 'Unhandled Promise Rejection: Test', tested: false, meta: 'string' },
       { message: 'Unhandled Promise Rejection: 1', tested: false, meta: 'number' },
       { message: 'Unhandled Promise Rejection: {"a":1,"b":{"a":1}}', tested: false, meta: 'nested obj' },
       { message: 'Unhandled Promise Rejection: [1,2,3]', tested: false, meta: 'array' },

--- a/tests/functional/spa/errors.test.js
+++ b/tests/functional/spa/errors.test.js
@@ -179,7 +179,6 @@ testDriver.test('string error in custom tracer', function (t, browser, router) {
       var nodeId = interactionTree.children[0].nodeId
 
       var error = errors[0]
-      console.log(JSON.stringify(error))
       t.equal(error.params.message, 'some error')
       t.equal(error.params.browserInteractionId, interactionId, 'should have the correct interaction id')
       t.equal(error.params.parentNodeId, nodeId, 'has the correct node id')


### PR DESCRIPTION
Removing the instantiation of the Error class in the jserrors feature for instances where a non-Error value is thrown from customer's code. In such cases, an Error instance would be created and the stack trace would point back to the agent code as the source. This causes confusion since it makes it seem like the agent code is throwing the error when that is not the case. Instead, the internal UncaughtError class will be used and no stack trace will exist.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Addressing PR comments from https://github.com/newrelic/newrelic-browser-agent/pull/614.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-138375

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
