### PR TITLE
chore: Session Replay - checkout every 5 minutes in full mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001516",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
+      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001516",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
+      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
       "dev": true
     },
     "capital-case": {

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -32,8 +32,8 @@ let recorder, gzipper, u8
 export const MAX_PAYLOAD_SIZE = 1000000
 /** Unloading caps around 64kb */
 export const IDEAL_PAYLOAD_SIZE = 64000
-/** Interval between forcing new full snapshots in "error" mode */
-const CHECKOUT_MS = 30000
+/** Interval between forcing new full snapshots -- 30 seconds in error mode, 5 minutes in full mode */
+const CHECKOUT_MS = { [MODE.ERROR]: 30000, [MODE.FULL]: 300000, [MODE.OFF]: 0 }
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -273,7 +273,7 @@ export class Aggregate extends AggregateBase {
       maskInputOptions,
       maskTextSelector,
       maskAllInputs,
-      ...(this.mode === MODE.ERROR && { checkoutEveryNms: CHECKOUT_MS })
+      checkoutEveryNms: CHECKOUT_MS[this.mode]
     })
 
     this.stopRecording = () => {


### PR DESCRIPTION
To aid with UI searching, Session Replay will need to periodically checkout snapshots, which for now has been decided to be every 5 minutes.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR updates the Session Replay feature to checkout a snapshot every 5 minutes in "full" mode.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://issues.newrelic.com/browse/NR-142816
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
All existing tests should continue to pass.  If desired, to reproduce locally, run in experimental mode and ensure that a snapshot (type 2) is generated at least every x minutes
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
