### PR TITLE
feat: Add warning for large payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001516",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
+      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001516",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
+      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
       "dev": true
     },
     "capital-case": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001516",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
-      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
+      "version": "1.0.30001517",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001516",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
-      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
+      "version": "1.0.30001517",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -18,7 +18,7 @@ import { VERSION } from '../constants/env'
 import { isWorkerScope, isIE } from '../constants/runtime'
 import { warn } from '../util/console'
 
-let warnings = 0
+const warnings = {}
 
 /**
  * @typedef {import('./types.js').NetworkSendSpec} NetworkSendSpec
@@ -117,8 +117,8 @@ export class Harvest extends SharedContext {
       } else {
         body = stringify(body)
       }
-      /** Warn --once-- if the agent tries to send large payloads */
-      if (body.length > 750000 && warnings++ < 1) warn('The Browser Agent is attempting to send a very large payload. This is usually tied to large amounts of custom attributes. Please check your configurations.')
+      /** Warn --once per endpoint-- if the agent tries to send large payloads */
+      if (body.length > 750000 && (warnings[endpoint] = (warnings?.[endpoint] || 0) + 1) === 1) warn(`The Browser Agent is attempting to send a very large payload to /${endpoint}. This is usually tied to large amounts of custom attributes. Please check your configurations.`)
     }
 
     if (!body || body.length === 0 || body === '{}' || body === '[]') {

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -18,6 +18,8 @@ import { VERSION } from '../constants/env'
 import { isWorkerScope, isIE } from '../constants/runtime'
 import { warn } from '../util/console'
 
+let warnings = 0
+
 /**
  * @typedef {import('./types.js').NetworkSendSpec} NetworkSendSpec
  * @typedef {import('./types.js').HarvestEndpointIdentifier} HarvestEndpointIdentifier
@@ -25,7 +27,6 @@ import { warn } from '../util/console'
  * @typedef {import('./types.js').FeatureHarvestCallback} FeatureHarvestCallback
  * @typedef {import('./types.js').FeatureHarvestCallbackOptions} FeatureHarvestCallbackOptions
  */
-
 export class Harvest extends SharedContext {
   constructor (parent) {
     super(parent) // gets any allowed properties from the parent and stores them in `sharedContext`
@@ -116,7 +117,8 @@ export class Harvest extends SharedContext {
       } else {
         body = stringify(body)
       }
-      if (body.length > 750000) warn('The Browser Agent is attempting to send a very large payload. This is usually tied to large amounts of custom attributes. Please check your configurations.')
+      /** Warn --once-- if the agent tries to send large payloads */
+      if (body.length > 750000 && warnings++ < 1) warn('The Browser Agent is attempting to send a very large payload. This is usually tied to large amounts of custom attributes. Please check your configurations.')
     }
 
     if (!body || body.length === 0 || body === '{}' || body === '[]') {

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -16,6 +16,7 @@ import { applyFnToProps } from '../util/traverse'
 import { SharedContext } from '../context/shared-context'
 import { VERSION } from '../constants/env'
 import { isWorkerScope, isIE } from '../constants/runtime'
+import { warn } from '../util/console'
 
 /**
  * @typedef {import('./types.js').NetworkSendSpec} NetworkSendSpec
@@ -115,6 +116,7 @@ export class Harvest extends SharedContext {
       } else {
         body = stringify(body)
       }
+      if (body.length > 750000) warn('The Browser Agent is attempting to send a very large payload. This is usually tied to large amounts of custom attributes. Please check your configurations.')
     }
 
     if (!body || body.length === 0 || body === '{}' || body === '[]') {

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -289,13 +289,18 @@ describe('_send', () => {
     })
   })
 
-  test('should warn if payload is large', () => {
+  test('should warn (once) if payload is large', () => {
     spec.payload.body = 'x'.repeat(1024 * 1024) // ~1mb string
 
     const result = harvestInstance._send(spec)
 
     expect(result).toEqual(true)
     expect(warn).toHaveBeenCalledWith('The Browser Agent is attempting to send a very large payload. This is usually tied to large amounts of custom attributes. Please check your configurations.')
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    const result2 = harvestInstance._send(spec)
+    expect(result2).toEqual(true)
+    expect(warn).toHaveBeenCalledTimes(1)
   })
 
   test('should set body to events when endpoint is events', () => {

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -295,7 +295,7 @@ describe('_send', () => {
     const result = harvestInstance._send(spec)
 
     expect(result).toEqual(true)
-    expect(warn).toHaveBeenCalledWith('The Browser Agent is attempting to send a very large payload. This is usually tied to large amounts of custom attributes. Please check your configurations.')
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('The Browser Agent is attempting to send a very large payload'))
     expect(warn).toHaveBeenCalledTimes(1)
 
     const result2 = harvestInstance._send(spec)

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker'
 import * as encodeModule from '../url/encode'
 import * as submitDataModule from '../util/submit-data'
 import * as configModule from '../config/config'
+import { warn } from '../util/console'
 import { applyFnToProps } from '../util/traverse'
 
 import { Harvest } from './harvest'
@@ -286,6 +287,15 @@ describe('_send', () => {
       sync: undefined,
       url: expect.stringContaining(`https://${errorBeacon}/${spec.endpoint}/1/${licenseKey}?`)
     })
+  })
+
+  test('should warn if payload is large', () => {
+    spec.payload.body = 'x'.repeat(1024 * 1024) // ~1mb string
+
+    const result = harvestInstance._send(spec)
+
+    expect(result).toEqual(true)
+    expect(warn).toHaveBeenCalledWith('The Browser Agent is attempting to send a very large payload. This is usually tied to large amounts of custom attributes. Please check your configurations.')
   })
 
   test('should set body to events when endpoint is events', () => {

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -4,15 +4,15 @@
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "108",
-      "browserVersion": "108"
+      "version": "109",
+      "browserVersion": "109"
     },
     {
       "browserName": "chrome",


### PR DESCRIPTION
Add warning for large payloads, which is typically caused by excessive custom attribute sizes.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds a check to the harvest cycle to check the body size.  If the body is large (>750kb), it will log a warning to the console noting that customers should check their custom attributes.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
[NR-137463](https://issues.newrelic.com/browse/NR-137463)
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new jest test representing this case has been added to `harvest.test.js`
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
