### PR TITLE
fix: Remove fetch keep-alive unhandled rejection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9687,9 +9687,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001516",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
-      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
+      "version": "1.0.30001517",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
       "dev": true,
       "funding": [
         {
@@ -34042,9 +34042,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001516",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001516.tgz",
-      "integrity": "sha512-Wmec9pCBY8CWbmI4HsjBeQLqDTqV91nFVR83DnZpYyRnPI1wePDsTg0bGLPC5VU/3OIZV1fmxEea1b+tFKe86g==",
+      "version": "1.0.30001517",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -156,19 +156,6 @@ export class Harvest extends SharedContext {
       }, eventListenerOpts(false))
     }
 
-    // if beacon request failed, retry with an alternative method -- will not happen for workers
-    if (!result && submitMethod === submitData.beacon) {
-      // browsers that support sendBeacon also support fetch with keepalive - IE will not retry unload calls
-      submitMethod = submitData.fetchKeepAlive
-      try {
-        submitMethod({ url: fullUrl, body, headers })
-      } catch (e) {
-        // Ignore error in final harvest
-      } finally {
-        result = true
-      }
-    }
-
     return result
   }
 

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -440,41 +440,6 @@ describe('_send', () => {
       sent: true
     })
   })
-
-  test('should fallback to fetchKeepAlive when beacon returns false', async () => {
-    jest.mocked(submitDataModule.getSubmitMethod).mockReturnValue(submitDataModule.beacon)
-    jest.mocked(submitDataModule.beacon).mockReturnValue(false)
-    spec.opts.unload = true
-
-    const results = harvestInstance._send(spec)
-    await new Promise(process.nextTick)
-
-    expect(results).toEqual(true)
-    expect(submitDataModule.fetchKeepAlive).toHaveBeenCalledWith({
-      body: JSON.stringify(spec.payload.body),
-      headers: [{ key: 'content-type', value: 'text/plain' }],
-      url: expect.stringContaining(`https://${errorBeacon}/${spec.endpoint}/1/${licenseKey}?`)
-    })
-  })
-
-  test('should not throw an exception if fetchKeepAlive throws error', async () => {
-    jest.mocked(submitDataModule.getSubmitMethod).mockReturnValue(submitDataModule.beacon)
-    jest.mocked(submitDataModule.beacon).mockReturnValue(false)
-    jest.mocked(submitDataModule.fetchKeepAlive).mockImplementation(() => {
-      throw new Error(faker.lorem.sentence())
-    })
-    spec.opts.unload = true
-
-    const results = harvestInstance._send(spec)
-    await new Promise(process.nextTick)
-
-    expect(results).toEqual(true)
-    expect(submitDataModule.fetchKeepAlive).toHaveBeenCalledWith({
-      body: JSON.stringify(spec.payload.body),
-      headers: [{ key: 'content-type', value: 'text/plain' }],
-      url: expect.stringContaining(`https://${errorBeacon}/${spec.endpoint}/1/${licenseKey}?`)
-    })
-  })
 })
 
 describe('obfuscateAndSend', () => {

--- a/src/common/util/__mocks__/submit-data.js
+++ b/src/common/util/__mocks__/submit-data.js
@@ -2,5 +2,4 @@ export const getSubmitMethod = jest.fn(() => jest.fn())
 export const xhr = jest.fn(() => ({
   addEventListener: jest.fn()
 }))
-export const fetchKeepAlive = jest.fn().mockResolvedValue({})
 export const beacon = jest.fn(() => true)

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -7,7 +7,7 @@
 import { isBrowserScope, supportsSendBeacon } from '../constants/runtime'
 
 /**
- * @typedef {xhr|fetchKeepAlive|beacon} NetworkMethods
+ * @typedef {xhr|beacon} NetworkMethods
  */
 
 /**
@@ -55,27 +55,6 @@ export function xhr ({ url, body = null, sync, method = 'POST', headers = [{ key
 }
 
 /**
- * Send via fetch with keepalive true
- * @param {Object} args - The args.
- * @param {string} args.url - The URL to send to.
- * @param {string=} args.body - The Stringified body.
- * @param {string=} [args.method=POST] - The XHR method to use.
- * @param {{key: string, value: string}[]} [args.headers] - The headers to attach.
- * @returns {XMLHttpRequest}
- */
-export function fetchKeepAlive ({ url, body = null, method = 'POST', headers = [{ key: 'content-type', value: 'text/plain' }] }) {
-  return fetch(url, {
-    method,
-    headers: headers.reduce((aggregator, header) => {
-      aggregator.push([header.key, header.value])
-      return aggregator
-    }, []),
-    body,
-    keepalive: true
-  })
-}
-
-/**
  * Send via sendBeacon. Do NOT call this function outside of a guaranteed web window environment.
  * @param {Object} args - The args
  * @param {string} args.url - The URL to send to
@@ -90,8 +69,7 @@ export function beacon ({ url, body }) {
     return send(url, body)
   } catch (err) {
     // if sendBeacon still trys to throw an illegal invocation error,
-    // we can catch here and return.  The harvest module will fallback to use
-    // fetchKeepAlive to try to send
+    // we can catch here and return
     return false
   }
 }

--- a/src/common/util/submit-data.test.js
+++ b/src/common/util/submit-data.test.js
@@ -141,62 +141,6 @@ describe('xhr', () => {
   })
 })
 
-describe('fetchKeepAlive', () => {
-  beforeEach(() => {
-    global.fetch = jest.fn().mockReturnValue(Promise.resolve())
-  })
-
-  afterEach(() => {
-    delete global.fetch
-  })
-
-  test('should make a fetch with default values', () => {
-    submitData.fetchKeepAlive({ url })
-
-    expect(global.fetch).toHaveBeenCalledWith(url, {
-      method: 'POST',
-      body: null,
-      keepalive: true,
-      headers: [['content-type', 'text/plain']]
-    })
-  })
-
-  test('should send the body when provided', () => {
-    const body = faker.lorem.paragraph()
-    submitData.fetchKeepAlive({ url, body })
-
-    expect(global.fetch).toHaveBeenCalledWith(url, {
-      method: 'POST',
-      body,
-      keepalive: true,
-      headers: [['content-type', 'text/plain']]
-    })
-  })
-
-  test('should use the provided method', () => {
-    submitData.fetchKeepAlive({ url, method: 'HEAD' })
-
-    expect(global.fetch).toHaveBeenCalledWith(url, {
-      method: 'HEAD',
-      body: null,
-      keepalive: true,
-      headers: [['content-type', 'text/plain']]
-    })
-  })
-
-  test('should use the provided headers', () => {
-    const headers = [{ key: faker.lorem.word(), value: faker.datatype.uuid() }]
-    submitData.fetchKeepAlive({ url, headers })
-
-    expect(global.fetch).toHaveBeenCalledWith(url, {
-      method: 'POST',
-      body: null,
-      keepalive: true,
-      headers: [[headers[0].key, headers[0].value]]
-    })
-  })
-})
-
 describe('beacon', () => {
   afterEach(() => {
     delete window.navigator.sendBeacon

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -4,15 +4,15 @@
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "108",
-      "browserVersion": "108"
+      "version": "109",
+      "browserVersion": "109"
     },
     {
       "browserName": "chrome",


### PR DESCRIPTION
Eliminate an unhandled promise rejection error caused by fetch failure in agent EoL logic.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

In #576 released as part of v1.236.0, the fetch keep-alive was introduced as a fallback to sendBeacon failure when agent is sending final analytics. It wasn't caught when it failed--whenever sendBeacon itself would fail, resulting in an unhandled rejection exception to be thrown. That fallback is deemed as redundant and extraneous, so the fetch is being removed completely, which should resolve the exception issue too.

### Related Issue(s)

NR-142507
NR-144070 / #622 
NR-129244 / #599 

### Testing

When `sendBeacon` fails, e.g. due to size limitation exceeded, on unloading, there should be no further error from fetch keep-alive, as that's gone.
