### PR TITLE
fix: Undefined deny list ignores block internal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9765,9 +9765,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001518",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
+      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
       "dev": true,
       "funding": [
         {
@@ -34184,9 +34184,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001518",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001518.tgz",
+      "integrity": "sha512-rup09/e3I0BKjncL+FesTayKtPrdwKhUufQFd3riFw1hHg8JmIFoInYfB102cFcY/pPgGmdyl/iy+jgiDi2vdA==",
       "dev": true
     },
     "capital-case": {

--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -23,13 +23,15 @@ export function configure (agentIdentifier, opts = {}, loaderType, forceDrain) {
   setInfo(agentIdentifier, info)
 
   const updatedInit = getConfiguration(agentIdentifier)
-  if (updatedInit.ajax?.block_internal) {
-    runtime.denyList = [
-      ...(updatedInit.ajax.denyList || []),
-      info.beacon,
-      info.errorBeacon
-    ]
-  }
+  runtime.denyList = [
+    ...(updatedInit.ajax?.deny_list || []),
+    ...(updatedInit.ajax?.block_internal
+      ? [
+          info.beacon,
+          info.errorBeacon
+        ]
+      : [])
+  ]
   setRuntime(agentIdentifier, runtime)
 
   setTopLevelCallers()

--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -1,6 +1,6 @@
 import { setAPI, setTopLevelCallers } from '../api/api'
 import { addToNREUM, gosCDN, gosNREUMInitializedAgents } from '../../common/window/nreum'
-import { setConfiguration, setInfo, setLoaderConfig, setRuntime } from '../../common/config/config'
+import { getConfiguration, setConfiguration, setInfo, setLoaderConfig, setRuntime } from '../../common/config/config'
 import { activatedFeatures } from '../../common/util/feature-flags'
 import { isWorkerScope } from '../../common/constants/runtime'
 
@@ -22,7 +22,14 @@ export function configure (agentIdentifier, opts = {}, loaderType, forceDrain) {
   }
   setInfo(agentIdentifier, info)
 
-  runtime.denyList = init.ajax?.block_internal ? (init.ajax.deny_list || []).concat(info.beacon, info.errorBeacon) : init.ajax?.deny_list
+  const updatedInit = getConfiguration(agentIdentifier)
+  if (updatedInit.ajax?.block_internal) {
+    runtime.denyList = [
+      ...(updatedInit.ajax.denyList || []),
+      info.beacon,
+      info.errorBeacon
+    ]
+  }
   setRuntime(agentIdentifier, runtime)
 
   setTopLevelCallers()

--- a/tests/assets/spa/multiple-custom-interactions.html
+++ b/tests/assets/spa/multiple-custom-interactions.html
@@ -9,6 +9,14 @@
     {init}
     {config}
     {loader}
+    <style>
+      .left{
+        position: absolute; left: 50px; top: 200px;
+      }
+      .right {
+        position: absolute; right: 50px; top: 200px;
+      }
+    </style>
   </head>
   <body>
     <div>Multiple load handlers</div>

--- a/tests/assets/spa/multiple-custom-interactions.html
+++ b/tests/assets/spa/multiple-custom-interactions.html
@@ -9,14 +9,6 @@
     {init}
     {config}
     {loader}
-    <style>
-      .left{
-        position: absolute; left: 50px; top: 200px;
-      }
-      .right {
-        position: absolute; right: 50px; top: 200px;
-      }
-    </style>
   </head>
   <body>
     <div>Multiple load handlers</div>

--- a/tests/specs/spa/harvesting.e2e.js
+++ b/tests/specs/spa/harvesting.e2e.js
@@ -1,27 +1,49 @@
 describe('spa harvesting', () => {
   it('should set correct customEnd value on multiple custom interactions', async () => {
-    const [interactionResults] = await Promise.all([
+    // interaction3 will eventually be harvested so we need to capture two harvests here
+
+    const [interactionResults1, interactionResults2] = await Promise.all([
+      browser.testHandle.expectInteractionEvents(),
       browser.testHandle.expectInteractionEvents(),
       browser.url(await browser.testHandle.assetURL('spa/multiple-custom-interactions.html'))
-        .then(() => browser.waitForAgentLoad())
     ])
 
-    const interactions = interactionResults.request.body
-    expect(interactions.length).toEqual(3)
+    const interactions = [
+      ...interactionResults1.request.body,
+      ...interactionResults2.request.body
+    ]
+    expect(interactions.length).toEqual(4)
     expect(interactions).toEqual(expect.arrayContaining([
       expect.objectContaining({
-        customName: 'interaction1'
+        customName: 'interaction1',
+        children: expect.arrayContaining([expect.objectContaining({
+          type: 'customEnd'
+        })])
       }),
       expect.objectContaining({
-        customName: 'interaction2'
+        customName: 'interaction2',
+        children: expect.arrayContaining([expect.objectContaining({
+          type: 'customEnd'
+        })])
       }),
       expect.objectContaining({
-        customName: 'interaction4'
+        customName: 'interaction3',
+        children: expect.not.arrayContaining([expect.objectContaining({
+          type: 'customEnd'
+        })])
+      }),
+      expect.objectContaining({
+        customName: 'interaction4',
+        children: expect.arrayContaining([expect.objectContaining({
+          type: 'customEnd'
+        })])
       })
     ]))
-    interactions.forEach(interaction => {
-      const customEndTime = interaction.children.find(child => child.type === 'customEnd')
-      expect(customEndTime.time).toBeGreaterThanOrEqual(interaction.end)
-    })
+    interactions
+      .filter(interaction => ['interaction1', 'interaction2', 'interaction4'].includes(interaction.customName))
+      .forEach(interaction => {
+        const customEndTime = interaction.children.find(child => child.type === 'customEnd')
+        expect(customEndTime.time).toBeGreaterThanOrEqual(interaction.end)
+      })
   })
 })

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -34,8 +34,8 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -48,8 +48,8 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "110",
-      "browserVersion": "110"
+      "version": "111",
+      "browserVersion": "111"
     },
     {
       "browserName": "MicrosoftEdge",

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.236.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.237.0.tgz"
   }
 }

--- a/tools/test-builds/browser-tests/package.json
+++ b/tools/test-builds/browser-tests/package.json
@@ -9,6 +9,6 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.236.0.tgz"
+        "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.237.0.tgz"
     }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.236.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.237.0.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.236.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.237.0.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
In cases where the customer's configuration does not include the `init.ajax.deny_list` property, the agent would not properly account for the `init.ajax.block_internal` setting and would not block ajax events for internal agent network calls.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

In cases where the customer's configuration does not include the `init.ajax.deny_list` property, the agent would not properly account for the `init.ajax.block_internal` setting and would not block ajax events for internal agent network calls.

This may be an edge case for most of customers since most have at least the BAM endpoint in their deny list. For customers with an empty deny list in their browser entity settings, this fix will now apply the `block_internal` setting properly.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

These are just related tickets. This issue was found while troubleshooting these tickets.
https://issues.newrelic.com/browse/NR-146248
https://issues.newrelic.com/browse/NR-147189

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Running the local server with no changes to settings should now block ajax events for the local server. You can use the fetch test page to verify.