### PR TITLE
fix: SPA feature respects ajax deny_list for fetch

### DIFF
--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -415,7 +415,7 @@ export class Aggregate extends AggregateBase {
     register(FETCH_DONE, function (err, res) {
       var node = this[SPA_NODE]
       if (node) {
-        if (err) {
+        if (err || !shouldCollectEvent(this.params)) {
           node.cancel()
           return
         }

--- a/tests/assets/spa/ajax-deny-list.html
+++ b/tests/assets/spa/ajax-deny-list.html
@@ -19,6 +19,10 @@
         xhr.addEventListener('load', function () {}, true)
         xhr.send()
       }, true)
+
+      if (typeof fetch === 'function') {
+        fetch('/json').then(function () { fetch('/text') })
+      }
     </script>
   </head>
   <body>

--- a/tests/assets/spa/fetch-chunked.html
+++ b/tests/assets/spa/fetch-chunked.html
@@ -6,6 +6,7 @@
 <html>
   <head>
     <title>RUM Unit Test</title>
+    {init}
     {config}
     {loader}
   </head>

--- a/tests/assets/spa/fetch-simple.html
+++ b/tests/assets/spa/fetch-simple.html
@@ -6,6 +6,7 @@
 <html>
   <head>
     <title>RUM Unit Test</title>
+    {init}
     {config}
     {loader}
   </head>

--- a/tests/specs/xhr/deny-list.e2e.js
+++ b/tests/specs/xhr/deny-list.e2e.js
@@ -1,18 +1,79 @@
+import { supportsFetch } from '../../../tools/browser-matcher/common-matchers.mjs'
+
 describe('Ajax events to beacon endpoint', () => {
   it('not captured when blocked', async () => {
-    let url = await browser.testHandle.assetURL('spa/ajax-deny-list.html', { init: { ajax: { block_internal: true } } })
-    let nextAjaxReq = browser.testHandle.expectAjaxEvents(10000, true)
-    await browser.url(url)
+    const [ajaxEvents, interactionEvents] = await Promise.all([
+      browser.testHandle.expectAjaxEvents(10000, true),
+      browser.testHandle.expectInteractionEvents(),
+      browser.url(await browser.testHandle.assetURL('spa/ajax-deny-list.html', { init: { ajax: { block_internal: true } } }))
+    ])
 
-    await expect(nextAjaxReq).resolves.toBeUndefined()
+    expect(ajaxEvents).toBeUndefined()
+    expect(interactionEvents.request.body).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        domain: expect.stringContaining('bam-test-1.nr-local.net'),
+        path: '/json',
+        type: 'ajax',
+        requestedWith: 'XMLHttpRequest'
+      }),
+      expect.objectContaining({
+        domain: expect.stringContaining('bam-test-1.nr-local.net'),
+        path: '/text',
+        type: 'ajax',
+        requestedWith: 'XMLHttpRequest'
+      }),
+      expect.objectContaining({
+        domain: expect.stringContaining('bam-test-1.nr-local.net'),
+        path: '/json',
+        type: 'ajax',
+        requestedWith: 'fetch'
+      }),
+      expect.objectContaining({
+        domain: expect.stringContaining('bam-test-1.nr-local.net'),
+        path: '/text',
+        type: 'ajax',
+        requestedWith: 'fetch'
+      })
+    ]))
   })
 
-  it('captured when allowed', async () => {
-    let url = await browser.testHandle.assetURL('spa/ajax-deny-list.html', { init: { ajax: { block_internal: false } } })
-    let nextAjaxReq = browser.testHandle.expectAjaxEvents(10000)
-    await browser.url(url)
+  it('is captured when not blocked', async () => {
+    const [ajaxEvents, interactionEvents] = await Promise.all([
+      browser.testHandle.expectAjaxEvents(),
+      browser.testHandle.expectInteractionEvents(),
+      browser.url(await browser.testHandle.assetURL('spa/ajax-deny-list.html', { init: { ajax: { block_internal: false } } }))
+    ])
 
-    let correctXhrEvent = (await nextAjaxReq)?.request.body.some(ajaxNode => ajaxNode.domain.startsWith('bam-test-1.nr-local.net') && ajaxNode.path === '/json')
-    expect(correctXhrEvent).toEqual(true)
+    const events = [...ajaxEvents.request.body, ...interactionEvents.request.body]
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        domain: expect.stringContaining('bam-test-1.nr-local.net'),
+        path: '/json',
+        type: 'ajax',
+        requestedWith: 'XMLHttpRequest'
+      }),
+      expect.objectContaining({
+        domain: expect.stringContaining('bam-test-1.nr-local.net'),
+        path: '/text',
+        type: 'ajax',
+        requestedWith: 'XMLHttpRequest'
+      }),
+      ...(browserMatch(supportsFetch)
+        ? [
+            expect.objectContaining({
+              domain: expect.stringContaining('bam-test-1.nr-local.net'),
+              path: '/json',
+              type: 'ajax',
+              requestedWith: 'fetch'
+            }),
+            expect.objectContaining({
+              domain: expect.stringContaining('bam-test-1.nr-local.net'),
+              path: '/text',
+              type: 'ajax',
+              requestedWith: 'fetch'
+            })
+          ]
+        : [])
+    ]))
   })
 })

--- a/tools/wdio/plugins/browser-matcher.mjs
+++ b/tools/wdio/plugins/browser-matcher.mjs
@@ -14,10 +14,6 @@ export default class BrowserMatcher {
     this.#browserName = getBrowserName(capabilities)
     this.#browserVersion = getBrowserVersion(capabilities)
     this.#setupMochaGlobals()
-    global.withBrowsersMatching = (matcher) => {
-      log.warn('withBrowsersMatching() global deprecated, use it.withBrowsersMatching() or describe.withBrowsersMatching()')
-      return this.#browserMatchTest(matcher, global.it)
-    }
   }
 
   #setupMochaGlobals () {
@@ -44,29 +40,22 @@ export default class BrowserMatcher {
         globalIt = value
       }
     })
+
+    global.browserMatch = (matcher) => {
+      return !this.#wrapFnWithBrowserMatcher(matcher)
+    }
   }
 
   #extendMochaGlobal (originalGlobal) {
     Object.defineProperty(originalGlobal, 'withBrowsersMatching', {
       value: (matcher) => {
-        return this.#browserMatchTest(matcher, originalGlobal)
+        return this.#wrapFnWithBrowserMatcher(matcher, originalGlobal)
       }
     })
   }
 
-  #browserMatchTest (matcher, originalGlobal) {
-    let skip = false
-
-    if (Array.isArray(matcher) && matcher.length > 0) {
-      for (const indexedMatcher of matcher) {
-        if (!indexedMatcher.test(this.#browserName, this.#browserVersion)) {
-          skip = true
-          break
-        }
-      }
-    } else if (matcher && typeof matcher.test === 'function') {
-      skip = !matcher.test(this.#browserName, this.#browserVersion)
-    }
+  #wrapFnWithBrowserMatcher (matcher, originalGlobal) {
+    const skip = this.#browserMatchTest(matcher)
 
     return function (...args) {
       /*
@@ -82,5 +71,22 @@ export default class BrowserMatcher {
         originalGlobal.apply(this, args)
       }
     }
+  }
+
+  #browserMatchTest (matcher) {
+    let skip = false
+
+    if (Array.isArray(matcher) && matcher.length > 0) {
+      for (const indexedMatcher of matcher) {
+        if (!indexedMatcher.test(this.#browserName, this.#browserVersion)) {
+          skip = true
+          break
+        }
+      }
+    } else if (matcher && typeof matcher.test === 'function') {
+      skip = !matcher.test(this.#browserName, this.#browserVersion)
+    }
+
+    return skip
   }
 }


### PR DESCRIPTION
The SPA feature will now properly respect the ajax deny list and block internal settings for fetch calls. In prior versions, the SPA feature only consulted the ajax deny list for XMLHttpRequest calls.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

The SPA feature will now properly respect the ajax deny list and block internal settings for fetch calls. In prior versions, the SPA feature only consulted the ajax deny list for XMLHttpRequest calls.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-146248

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Build the agent and run the local server. The below links can be used to test the functionality.

[Block Internal Disabled](http://bam-test-1.nr-local.net:3333/tests/assets/spa/ajax-deny-list.html?loader=spa&config=eyJsaWNlbnNlS2V5IjoiMjM2YWZhNzQtZDM2NS00MWFmLWE0YjctMzUyMDY1M2YwYmQ2In0%3D&init=eyJhamF4Ijp7ImJsb2NrX2ludGVybmFsIjpmYWxzZSwiZGVueV9saXN0IjpbXX19)
[Block Internal Enabled](http://bam-test-1.nr-local.net:3333/tests/assets/spa/ajax-deny-list.html?loader=spa&config=eyJsaWNlbnNlS2V5IjoiMjM2YWZhNzQtZDM2NS00MWFmLWE0YjctMzUyMDY1M2YwYmQ2In0%3D&init=eyJhamF4Ijp7ImJsb2NrX2ludGVybmFsIjp0cnVlLCJkZW55X2xpc3QiOltdfX0=)
