### PR TITLE
feat: Reducing the agent chunk count

### DIFF
--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -173,12 +173,14 @@ export class Aggregate extends AggregateBase {
     }
 
     try {
+      // Do not change the webpackChunkName or it will break the webpack nrba-chunking plugin
       recorder = (await import(/* webpackChunkName: "recorder" */'rrweb')).record
     } catch (err) {
       return this.abort()
     }
 
     try {
+      // Do not change the webpackChunkName or it will break the webpack nrba-chunking plugin
       const { gzipSync, strToU8 } = await import(/* webpackChunkName: "compressor" */'fflate')
       gzipper = gzipSync
       u8 = strToU8

--- a/tools/webpack/configs/common.mjs
+++ b/tools/webpack/configs/common.mjs
@@ -1,5 +1,6 @@
 import webpack from 'webpack'
 import TerserPlugin from 'terser-webpack-plugin'
+import NRBAChunkingPlugin from '../plugins/nrba-chunking/index.mjs'
 
 /**
  * @typedef {import('../index.mjs').WebpackBuildOptions} WebpackBuildOptions
@@ -10,8 +11,9 @@ import TerserPlugin from 'terser-webpack-plugin'
  * builds.
  * @param {WebpackBuildOptions} env Build variables passed into the webpack cli
  * using --env foo=bar --env biz=baz
+ * @param {string} asyncChunkName Partial name to use for the loader's async chunk
  */
-export default (env) => {
+export default (env, asyncChunkName) => {
   return {
     devtool: false,
     mode: env.SUBVERSION === 'PROD' ? 'production' : 'development',
@@ -28,7 +30,14 @@ export default (env) => {
         }
       })],
       flagIncludedChunks: true,
-      mergeDuplicateChunks: true
+      mergeDuplicateChunks: true,
+      splitChunks: {
+        chunks: 'async',
+        cacheGroups: {
+          defaultVendors: false,
+          default: false
+        }
+      }
     },
     output: {
       filename: (pathData) => {
@@ -51,6 +60,9 @@ export default (env) => {
         filename: '[file].map[query]',
         moduleFilenameTemplate: 'nr-browser-agent://[namespace]/[resource-path]?[loaders]',
         publicPath: env.PUBLIC_PATH
+      }),
+      new NRBAChunkingPlugin({
+        asyncChunkName
       })
     ]
   }

--- a/tools/webpack/configs/polyfills.mjs
+++ b/tools/webpack/configs/polyfills.mjs
@@ -19,8 +19,8 @@ export default (env) => {
     {
       asyncChunkName: 'nr-rum-polyfills',
       entry: {
-        'nr-loader-rum-polyfills': path.join(env.paths.src, 'cdn/lite.js'),
-        'nr-loader-rum-polyfills.min': path.join(env.paths.src, 'cdn/lite.js')
+        'nr-loader-rum-polyfills': path.join(env.paths.src, 'cdn/polyfills/lite.js'),
+        'nr-loader-rum-polyfills.min': path.join(env.paths.src, 'cdn/polyfills/lite.js')
       },
       plugins: [
         new webpack.IgnorePlugin({
@@ -38,8 +38,8 @@ export default (env) => {
     {
       asyncChunkName: 'nr-full-polyfills',
       entry: {
-        'nr-loader-full-polyfills': path.join(env.paths.src, 'cdn/pro.js'),
-        'nr-loader-full-polyfills.min': path.join(env.paths.src, 'cdn/pro.js')
+        'nr-loader-full-polyfills': path.join(env.paths.src, 'cdn/polyfills/pro.js'),
+        'nr-loader-full-polyfills.min': path.join(env.paths.src, 'cdn/polyfills/pro.js')
       },
       plugins: [
         new webpack.IgnorePlugin({
@@ -57,8 +57,8 @@ export default (env) => {
     {
       asyncChunkName: 'nr-spa-polyfills',
       entry: {
-        'nr-loader-spa-polyfills': path.join(env.paths.src, 'cdn/spa.js'),
-        'nr-loader-spa-polyfills.min': path.join(env.paths.src, 'cdn/spa.js')
+        'nr-loader-spa-polyfills': path.join(env.paths.src, 'cdn/polyfills/spa.js'),
+        'nr-loader-spa-polyfills.min': path.join(env.paths.src, 'cdn/polyfills/spa.js')
       },
       plugins: [
         new webpack.IgnorePlugin({

--- a/tools/webpack/configs/standard.mjs
+++ b/tools/webpack/configs/standard.mjs
@@ -1,4 +1,5 @@
 import path from 'path'
+import webpack from 'webpack'
 import { merge } from 'webpack-merge'
 import commonConfig from './common.mjs'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
@@ -14,57 +15,122 @@ import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
  * using --env foo=bar --env biz=baz
  */
 export default (env) => {
-  return merge(commonConfig(env), {
-    target: 'web',
-    entry: {
-      'nr-loader-rum': path.join(env.paths.src, 'cdn/lite.js'),
-      'nr-loader-rum.min': path.join(env.paths.src, 'cdn/lite.js'),
-      'nr-loader-full': path.join(env.paths.src, 'cdn/pro.js'),
-      'nr-loader-full.min': path.join(env.paths.src, 'cdn/pro.js'),
-      'nr-loader-spa': path.join(env.paths.src, 'cdn/spa.js'),
-      'nr-loader-spa.min': path.join(env.paths.src, 'cdn/spa.js'),
-      ...(env.SUBVERSION !== 'PROD' && { 'nr-loader-experimental': path.resolve(env.paths.src, 'cdn/experimental.js') }),
-      ...(env.SUBVERSION !== 'PROD' && { 'nr-loader-experimental.min': path.resolve(env.paths.src, 'cdn/experimental.js') })
-    },
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          exclude: /(node_modules)/,
-          use: (env.coverage || 'false').toLowerCase() === 'true'
-            ? [
-                { loader: './tools/webpack/loaders/istanbul/index.mjs' },
-                {
-                  loader: 'babel-loader',
-                  options: {
-                    envName: 'webpack'
-                  }
-                }
-              ]
-            : [
-                {
-                  loader: 'babel-loader',
-                  options: {
-                    envName: 'webpack'
-                  }
-                }
-              ]
-        }
+  const entryGroups = [
+    {
+      asyncChunkName: 'nr-rum',
+      entry: {
+        'nr-loader-rum': path.join(env.paths.src, 'cdn/lite.js'),
+        'nr-loader-rum.min': path.join(env.paths.src, 'cdn/lite.js')
+      },
+      plugins: [
+        new webpack.IgnorePlugin({
+          checkResource: (resource, context) => {
+            if (context.match(/features\/utils/) && resource.indexOf('aggregate') > -1) {
+              // Only allow page_view_event, page_view_timing, and metrics features
+              return !resource.match(/page_view_event\/aggregate|page_view_timing\/aggregate|metrics\/aggregate/)
+            }
+
+            return false
+          }
+        })
       ]
     },
-    plugins: [
-      new BundleAnalyzerPlugin({
-        analyzerMode: 'static',
-        openAnalyzer: false,
-        defaultSizes: 'stat',
-        reportFilename: `standard${env.PATH_VERSION}.stats.html`
-      }),
-      new BundleAnalyzerPlugin({
-        analyzerMode: 'json',
-        openAnalyzer: false,
-        defaultSizes: 'stat',
-        reportFilename: `standard${env.PATH_VERSION}.stats.json`
-      })
-    ]
+    {
+      asyncChunkName: 'nr-full',
+      entry: {
+        'nr-loader-full': path.join(env.paths.src, 'cdn/pro.js'),
+        'nr-loader-full.min': path.join(env.paths.src, 'cdn/pro.js')
+      },
+      plugins: [
+        new webpack.IgnorePlugin({
+          checkResource: (resource, context) => {
+            if (context.match(/features\/utils/) && resource.indexOf('aggregate') > -1) {
+              // Allow all features except spa and session_replay
+              return resource.match(/spa\/aggregate|session_replay\/aggregate/)
+            }
+
+            return false
+          }
+        })
+      ]
+    },
+    {
+      asyncChunkName: 'nr-spa',
+      entry: {
+        'nr-loader-spa': path.join(env.paths.src, 'cdn/spa.js'),
+        'nr-loader-spa.min': path.join(env.paths.src, 'cdn/spa.js')
+      },
+      plugins: [
+        new webpack.IgnorePlugin({
+          checkResource: (resource, context) => {
+            if (context.match(/features\/utils/) && resource.indexOf('aggregate') > -1) {
+              // Do not allow session_replay feature
+              return resource.match(/session_replay\/aggregate/)
+            }
+
+            return false
+          }
+        })
+      ]
+    }
+  ]
+
+  if (env.SUBVERSION !== 'PROD') {
+    entryGroups.push({
+      asyncChunkName: 'nr-experimental',
+      entry: {
+        'nr-loader-experimental': path.join(env.paths.src, 'cdn/experimental.js'),
+        'nr-loader-experimental.min': path.join(env.paths.src, 'cdn/experimental.js')
+      },
+      plugins: []
+    })
+  }
+
+  return entryGroups.map(entryGroup => {
+    return merge(commonConfig(env, entryGroup.asyncChunkName), {
+      target: 'web',
+      entry: entryGroup.entry,
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            exclude: /(node_modules)/,
+            use: (env.coverage || 'false').toLowerCase() === 'true'
+              ? [
+                  { loader: './tools/webpack/loaders/istanbul/index.mjs' },
+                  {
+                    loader: 'babel-loader',
+                    options: {
+                      envName: 'webpack'
+                    }
+                  }
+                ]
+              : [
+                  {
+                    loader: 'babel-loader',
+                    options: {
+                      envName: 'webpack'
+                    }
+                  }
+                ]
+          }
+        ]
+      },
+      plugins: [
+        ...entryGroup.plugins,
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'static',
+          openAnalyzer: false,
+          defaultSizes: 'stat',
+          reportFilename: `${entryGroup.asyncChunkName}-standard${env.PATH_VERSION}.stats.html`
+        }),
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'json',
+          openAnalyzer: false,
+          defaultSizes: 'stat',
+          reportFilename: `${entryGroup.asyncChunkName}-standard${env.PATH_VERSION}.stats.json`
+        })
+      ]
+    })
   })
 }

--- a/tools/webpack/configs/workers.mjs
+++ b/tools/webpack/configs/workers.mjs
@@ -14,34 +14,44 @@ import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
  * using --env foo=bar --env biz=baz
  */
 export default (env) => {
-  return merge(commonConfig(env), {
-    target: 'webworker',
-    entry: {
-      'nr-loader-worker': {
-        import: path.resolve(env.paths.src, 'cdn/worker.js'),
-        chunkLoading: 'import-scripts'
+  const entryGroups = [
+    {
+      asyncChunkName: 'nr-worker',
+      entry: {
+        'nr-loader-worker': {
+          import: path.resolve(env.paths.src, 'cdn/worker.js'),
+          chunkLoading: 'import-scripts'
+        },
+        'nr-loader-worker.min': {
+          import: path.resolve(env.paths.src, 'cdn/worker.js'),
+          chunkLoading: 'import-scripts'
+        }
       },
-      'nr-loader-worker.min': {
-        import: path.resolve(env.paths.src, 'cdn/worker.js'),
-        chunkLoading: 'import-scripts'
-      }
-    },
-    output: {
-      chunkFilename: env.SUBVERSION === 'PROD' ? `[name].[chunkhash:8]-worker${env.PATH_VERSION}.min.js` : `[name]-worker${env.PATH_VERSION}.js`
-    },
-    plugins: [
-      new BundleAnalyzerPlugin({
-        analyzerMode: 'static',
-        openAnalyzer: false,
-        defaultSizes: 'stat',
-        reportFilename: `workers${env.PATH_VERSION}.stats.html`
-      }),
-      new BundleAnalyzerPlugin({
-        analyzerMode: 'json',
-        openAnalyzer: false,
-        defaultSizes: 'stat',
-        reportFilename: `workers${env.PATH_VERSION}.stats.json`
-      })
-    ]
+      plugins: []
+    }
+  ]
+
+  return entryGroups.map(entryGroup => {
+    return merge(commonConfig(env, entryGroup.asyncChunkName), {
+      target: 'webworker',
+      entry: entryGroup.entry,
+      output: {
+        chunkFilename: env.SUBVERSION === 'PROD' ? `[name].[chunkhash:8]-worker${env.PATH_VERSION}.min.js` : `[name]-worker${env.PATH_VERSION}.js`
+      },
+      plugins: [
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'static',
+          openAnalyzer: false,
+          defaultSizes: 'stat',
+          reportFilename: `${entryGroup.asyncChunkName}${env.PATH_VERSION}.stats.html`
+        }),
+        new BundleAnalyzerPlugin({
+          analyzerMode: 'json',
+          openAnalyzer: false,
+          defaultSizes: 'stat',
+          reportFilename: `${entryGroup.asyncChunkName}${env.PATH_VERSION}.stats.json`
+        })
+      ]
+    })
   })
 }

--- a/tools/webpack/index.mjs
+++ b/tools/webpack/index.mjs
@@ -61,8 +61,8 @@ export default async (env) => {
   await fs.emptyDir(env.paths.build)
 
   return [
-    standardConfig(env),
-    polyfillsConfig(env),
-    workersConfig(env)
+    ...standardConfig(env),
+    ...polyfillsConfig(env),
+    ...workersConfig(env)
   ]
 }

--- a/tools/webpack/plugins/nrba-chunking/index.mjs
+++ b/tools/webpack/plugins/nrba-chunking/index.mjs
@@ -1,0 +1,35 @@
+export default class NRBAChunkingPlugin {
+  #options
+
+  constructor (options) {
+    this.#options = options
+  }
+
+  /**
+   * @param {import('webpack/lib/Compiler')} compiler the webpack compiler
+   * @returns {void}
+   */
+  apply (compiler) {
+    compiler.hooks.compilation.tap('NRBAChunkingPlugin', compilation => {
+      compilation.hooks.afterChunks.tap('NRBAChunkingPlugin', (chunks) => {
+        const chunkGraph = compilation.chunkGraph
+        const asyncChunks = Array.from(chunks)
+          .filter(chunk => !chunk.isOnlyInitial())
+
+        if (asyncChunks.length === 0) {
+          return
+        }
+
+        for (const chunk of asyncChunks) {
+          if (chunkGraph.canChunksBeIntegrated(asyncChunks[0], chunk) && !['recorder', 'compressor'].includes(chunk.name)) {
+            chunkGraph.integrateChunks(asyncChunks[0], chunk)
+          } else if (['recorder', 'compressor'].includes(chunk.name)) {
+            chunk.name = `${this.#options.asyncChunkName}-${chunk.name}`
+          }
+        }
+
+        asyncChunks[0].name = this.#options.asyncChunkName
+      })
+    })
+  }
+}


### PR DESCRIPTION
Reducing the number JavaScript files the agent loads asynchronously down to a single file. This means customer's users will now only need to load one additional JavaScript file for the New Relic Browser Agent to operate. This additional JavaScript file will continue to only be loaded upon the document "load" event. This change not only reduces the number of additional requests the agent must make but also reduces the amount of code that must be loaded by eliminating duplication.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Header pretty much says it all. Below are the code size statistics and the CDN cost statistics are attached in the JIRA.

#### Current Loader Statistics

|Loader|# of Assets|Raw Size|GZip Size|
|---|---|---|---|
|lite|8|106 KB|29 KB|
|pro|12|172 KB|46 KB|
|spa|13|205 KB|53 KB|
|experimental|15|381 KB|110 KB|

#### New Loader Statistics

|Loader|# of Assets|Raw Size|GZip Size|
|---|---|---|--|
|lite|1|74 KB|24 KB|
|pro|1|111 KB|35 KB|
|spa|1|135 KB|41 KB|
|experimental|3|315 KB|99 KB|

> Sizes also include the loader.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-149736

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Load the 1mb test page to verify the async chunk is still being loaded on page load. Otherwise, the existing wdio and jil tests should continue passing.