### PR TITLE
feat: Add API: setApplicationVersion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9765,9 +9765,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001519",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
+      "version": "1.0.30001520",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
+      "integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==",
       "dev": true,
       "funding": [
         {
@@ -34184,9 +34184,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001519",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001519.tgz",
-      "integrity": "sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==",
+      "version": "1.0.30001520",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
+      "integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==",
       "dev": true
     },
     "capital-case": {

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -52,9 +52,12 @@ export class AgentBase {
   }
 
   /**
-   * Adds a user-defined application version string to subsequent events on the page. This decorates all payloads with an attribute of `application.version` which is queryable in NR1.
+   * Adds a user-defined application version string to subsequent events on the page.
+   * This decorates all payloads with an attribute of `application.version` which is queryable in NR1.
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setapplicationversion/}
-   * @param {string|null} value A string identifier for the application version, useful for tying all browser events to a specific release tag. The value parameter does not have to be unique. Passing a null value unsets any existing value.
+   * @param {string|null} value A string identifier for the application version, useful for
+   * tying all browser events to a specific release tag. The value parameter does not
+   * have to be unique. Passing a null value unsets any existing value.
    */
   setApplicationVersion (value) {
     warn('Call to agent api setApplicationVersion failed. The agent is not currently initialized.')

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -52,6 +52,15 @@ export class AgentBase {
   }
 
   /**
+   * Adds a user-defined application version string to subsequent events on the page. This decorates all payloads with an attribute of `application.version` which is queryable in NR1.
+   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setapplicationversion/}
+   * @param {string|null} value A string identifier for the application version, useful for tying all browser events to a specific release tag. The value parameter does not have to be unique. Passing a null value unsets any existing value.
+   */
+  setApplicationVersion (value) {
+    warn('Call to agent api setApplicationVersion failed. The agent is not currently initialized.')
+  }
+
+  /**
    * Allows selective ignoring and grouping of known errors that the browser agent captures.
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/seterrorhandler/}
    * @param {(error: Error|string) => boolean | { group: string }} callback When an error occurs, the callback is called with the error object as a parameter. The callback will be called with each error, so it is not specific to one error.

--- a/src/loaders/api/api.component-test.js
+++ b/src/loaders/api/api.component-test.js
@@ -1,0 +1,37 @@
+import { setAPI } from './api'
+import { setInfo, getInfo, setConfiguration } from '../../common/config/config'
+
+setInfo('abcd', { licenseKey: '1234', applicationID: '1234' })
+setConfiguration('abcd', {})
+let apiInterface
+beforeEach(() => {
+  console.warn = jest.fn()
+  apiInterface = setAPI('abcd', true)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('api', () => {
+  describe('setApplicationVersion', () => {
+    test('setApplicationVersion sets and unsets ja with valid values', () => {
+      apiInterface.setApplicationVersion('1.2.3')
+      expect(getInfo('abcd').jsAttributes).toMatchObject({ 'application.version': '1.2.3' })
+
+      apiInterface.setApplicationVersion(null)
+      expect(getInfo('abcd').jsAttributes).toMatchObject({ })
+    })
+
+    test('setApplicationVersion warns if invalid data is supplied', () => {
+      apiInterface.setApplicationVersion(1)
+      expect(console.warn).toHaveBeenCalledWith('New Relic: Failed to execute setApplicationVersion. Expected <String | null>, but got <number>.')
+
+      apiInterface.setApplicationVersion(false)
+      expect(console.warn).toHaveBeenCalledWith('New Relic: Failed to execute setApplicationVersion. Expected <String | null>, but got <boolean>.')
+
+      apiInterface.setApplicationVersion({ version: '1.2.3' })
+      expect(console.warn).toHaveBeenCalledWith('New Relic: Failed to execute setApplicationVersion. Expected <String | null>, but got <object>.')
+    })
+  })
+})

--- a/src/loaders/api/api.component-test.js
+++ b/src/loaders/api/api.component-test.js
@@ -33,5 +33,13 @@ describe('api', () => {
       apiInterface.setApplicationVersion({ version: '1.2.3' })
       expect(console.warn).toHaveBeenCalledWith('New Relic: Failed to execute setApplicationVersion. Expected <String | null>, but got <object>.')
     })
+
+    test('setApplicationVersion replaces existing data if called twice', () => {
+      apiInterface.setApplicationVersion('1.2.3')
+      expect(getInfo('abcd').jsAttributes).toMatchObject({ 'application.version': '1.2.3' })
+
+      apiInterface.setApplicationVersion('4.5.6')
+      expect(getInfo('abcd').jsAttributes).toMatchObject({ 'application.version': '4.5.6' })
+    })
   })
 })

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -21,7 +21,7 @@ export function setTopLevelCallers () {
   const funcs = [
     'setErrorHandler', 'finished', 'addToTrace', 'inlineHit', 'addRelease',
     'addPageAction', 'setCurrentRouteName', 'setPageViewName', 'setCustomAttribute',
-    'interaction', 'noticeError', 'setUserId'
+    'interaction', 'noticeError', 'setUserId', 'setApplicationVersion'
   ]
   funcs.forEach(f => {
     nr[f] = (...args) => caller(f, ...args)
@@ -107,6 +107,19 @@ export function setAPI (agentIdentifier, forceDrain) {
       return
     }
     return appendJsAttribute('enduser.id', value, 'setUserId', true)
+  }
+
+  /**
+   * Attach the 'applcation.version' attribute onto agent payloads. This may be used in NR queries to group all browser events by a specific customer-defined release.
+   * @param {string|null} value - Application version -- if null, will "unset" the value
+   * @returns @see apiCall
+   */
+  apiInterface.setApplicationVersion = function (value) {
+    if (!(typeof value === 'string' || value === null)) {
+      warn(`Failed to execute setApplicationVersion. Expected <String | null>, but got <${typeof value}>.`)
+      return
+    }
+    return appendJsAttribute('application.version', value, 'setApplicationVersion', false)
   }
 
   apiInterface.interaction = function () {

--- a/tests/functional/uncat-internal-help.cjs
+++ b/tests/functional/uncat-internal-help.cjs
@@ -32,6 +32,7 @@ const asyncApiFns = [
   'setPageViewName',
   'setCustomAttribute',
   'setUserId',
+  'setApplicationVersion',
   'setErrorHandler',
   'finished',
   'addToTrace',

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -34,8 +34,8 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "105",
-      "browserVersion": "105"
+      "version": "106",
+      "browserVersion": "106"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -48,8 +48,8 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "110",
-      "browserVersion": "110"
+      "version": "111",
+      "browserVersion": "111"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "106",
-      "browserVersion": "106"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "108",
-      "browserVersion": "108"
+      "version": "109",
+      "browserVersion": "109"
     },
     {
       "browserName": "firefox",


### PR DESCRIPTION
Add api method to top-level interface to allow the setting of application version across all outgoing payloads
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds a method to add a standardized application version property to all outgoing payloads.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://issues.newrelic.com/browse/NR-150937
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new jest test has been added to validate this behavior.  Other browser tests checking existing API method behaviors should continue passing.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
