### PR TITLE
chore: Remove allow_bfcache flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9709,9 +9709,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001521",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
-      "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
+      "version": "1.0.30001522",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
+      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
       "dev": true,
       "funding": [
         {
@@ -34674,9 +34674,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001521",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001521.tgz",
-      "integrity": "sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==",
+      "version": "1.0.30001522",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
+      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
       "dev": true
     },
     "capital-case": {

--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -8,7 +8,6 @@ const model = () => {
     maskInputOptions: { password: true }
   }
   return {
-    allow_bfcache: true, // *cli - temporary feature flag for BFCache work
     privacy: { cookies_enabled: true }, // *cli - per discussion, default should be true
     ajax: { deny_list: undefined, block_internal: true, enabled: true, harvestTimeSeconds: 10 },
     distributed_tracing: {

--- a/src/common/harvest/harvest-scheduler.js
+++ b/src/common/harvest/harvest-scheduler.js
@@ -7,7 +7,6 @@ import * as submitData from '../util/submit-data'
 import { SharedContext } from '../context/shared-context'
 import { Harvest } from './harvest'
 import { subscribeToEOL } from '../unload/eol'
-import { getConfigurationValue } from '../config/config'
 import { SESSION_EVENTS } from '../session/session-entity'
 
 /**
@@ -36,7 +35,7 @@ export class HarvestScheduler extends SharedContext {
     this.harvest = new Harvest(this.sharedContext)
 
     // unload if EOL mechanism fires
-    subscribeToEOL(this.unload.bind(this), getConfigurationValue(this.sharedContext.agentIdentifier, 'allow_bfcache')) // TO DO: remove feature flag after rls stable
+    subscribeToEOL(this.unload.bind(this))
 
     /* Flush all buffered data if session resets and give up retries. This should be synchronous to ensure that the correct `session` value is sent.
       Since session-reset generates a new session ID and the ID is grabbed at send-time, any delays or retries would cause the payload to be sent under

--- a/src/common/harvest/harvest-scheduler.test.js
+++ b/src/common/harvest/harvest-scheduler.test.js
@@ -2,7 +2,6 @@ import { faker } from '@faker-js/faker'
 
 import * as submitData from '../util/submit-data'
 import { subscribeToEOL } from '../unload/eol'
-import { getConfigurationValue } from '../config/config'
 import { Harvest } from './harvest'
 
 import { HarvestScheduler } from './harvest-scheduler'
@@ -31,13 +30,10 @@ describe('unload', () => {
     jest.spyOn(harvestSchedulerInstance, 'runHarvest').mockImplementation(jest.fn())
   })
 
-  test('should subscribe to eol with allow_bfcache setting', () => {
-    const mockedBFCacheSetting = faker.datatype.uuid()
-    jest.mocked(getConfigurationValue).mockReturnValue(mockedBFCacheSetting)
-
+  test('should subscribe to eol', () => {
     new HarvestScheduler()
 
-    expect(subscribeToEOL).toHaveBeenCalledWith(expect.any(Function), mockedBFCacheSetting)
+    expect(subscribeToEOL).toHaveBeenCalledWith(expect.any(Function))
   })
 
   test('should run onUnload callback', () => {

--- a/src/common/unload/eol.js
+++ b/src/common/unload/eol.js
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { windowAddEventListener } from '../event-listener/event-listener-opts'
-import { single } from '../util/invoke'
-import { ffVersion, globalScope, isWorkerScope, isBrowserScope } from '../constants/runtime'
+import { globalScope, isWorkerScope, isBrowserScope } from '../constants/runtime'
 import { subscribeToVisibilityChange } from '../window/page-visibility'
 
 if (isWorkerScope) {
@@ -23,37 +22,12 @@ if (isWorkerScope) {
  * Subscribes a provided callback to the time/event when the agent should treat it as end-of-life.
  * This is used, for example, to submit a final harvest and send all remaining data on best-effort.
  * @param {function} cb - func to run before or during the last reliable event or time of an env's life span
- * @param {boolean} allowBFCache - (temp) feature flag to gate new v1222 BFC support
  */
-export function subscribeToEOL (cb, allowBFCache) {
+export function subscribeToEOL (cb) {
   if (isBrowserScope) {
-    if (allowBFCache) {
-      subscribeToVisibilityChange(cb, true) // when user switches tab or hides window, esp. mobile scenario
-      windowAddEventListener('pagehide', cb) // when user navigates away, and because safari iOS v14.4- doesn't fully support vis change
-      // --this ought to be removed once support for version below 14.5 phases out
-    } else {
-      var oneCall = single(cb)
-
-      // Firefox has a bug wherein a slow-loading resource loaded from the 'pagehide'
-      // or 'unload' event will delay the 'load' event firing on the next page load.
-      // In Firefox versions that support sendBeacon, this doesn't matter, because
-      // we'll use it instead of an image load for our final harvest.
-      //
-      // Some Safari versions never fire the 'unload' event for pages that are being
-      // put into the WebKit page cache, so we *need* to use the pagehide event for
-      // the final submission from Safari.
-      //
-      // Generally speaking, we will try to submit our final harvest from either
-      // pagehide or unload, whichever comes first, but in Firefox, we need to avoid
-      // attempting to submit from pagehide to ensure that we don't slow down loading
-      // of the next page.
-      if (!ffVersion || navigator.sendBeacon) {
-        windowAddEventListener('pagehide', oneCall)
-      } else {
-        windowAddEventListener('beforeunload', oneCall)
-      }
-      windowAddEventListener('unload', oneCall)
-    }
+    subscribeToVisibilityChange(cb, true) // when user switches tab or hides window, esp. mobile scenario
+    windowAddEventListener('pagehide', cb) // when user navigates away, and because safari iOS v14.4- doesn't fully support vis change
+    // --this ought to be removed once support for version below 14.5 phases out
   } else if (isWorkerScope) {
     globalScope.cleanupTasks.push(cb) // close() should run these tasks before quitting thread
   }

--- a/tests/functional/pvt/bfcache.test.js
+++ b/tests/functional/pvt/bfcache.test.js
@@ -11,12 +11,9 @@ function fail (t) {
 }
 
 testDriver.test("Agent doesn't block page from back/fwd cache", bfCacheSupport, function (t, browser, router) {
-  const init = {
-    allow_bfcache: true
-  }
   const scriptString = `window.addEventListener('pagehide', (evt) => { navigator.sendBeacon('/echo?testId=${router.testId}&persisted='+evt.persisted) });`
   const rumPromise = router.expectRum()
-  const assetURL = router.assetURL('instrumented.html', { loader: 'spa', init, scriptString })
+  const assetURL = router.assetURL('instrumented.html', { loader: 'spa', scriptString })
   const loadPromise = browser.get(assetURL)
 
   Promise.all([rumPromise, loadPromise]).then(() => {
@@ -35,11 +32,9 @@ testDriver.test("Agent doesn't block page from back/fwd cache", bfCacheSupport, 
 })
 
 testDriver.test('EOL events are sent appropriately', excludeIE, function (t, browser, router) {
-  const init = {
-    allow_bfcache: true	// with this, all timings except "unload" event are expected to be harvested after the first time the page becomes hidden
-  }
+  // all timings except "unload" event are expected to be harvested after the first time the page becomes hidden
 
-  const assetURL = router.assetURL('pagehide.html', { loader: 'rum', init })
+  const assetURL = router.assetURL('pagehide.html', { loader: 'rum' })
   const loadPromise = browser.get(assetURL)
 
   Promise.all([loadPromise, router.expectRum()]).then(() => {

--- a/tools/wdio/plugins/testing-server/default-asset-query.mjs
+++ b/tools/wdio/plugins/testing-server/default-asset-query.mjs
@@ -6,7 +6,6 @@
 const query = {
   loader: 'spa',
   init: {
-    allow_bfcache: true,
     privacy: { cookies_enabled: false },
     ajax: { deny_list: [], block_internal: false, enabled: true, harvestTimeSeconds: 5 },
     distributed_tracing: {},


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

PR cleans up unused (old) code associated with the bf cache support change in the past. This flag has been on for multiple agent versions with no report of issues, hence by consensus is due to be removed at this time.

### Related Issue(s)

NR-137640

### Testing

Code deletion only. No change in default behavior of the agent.