### PR TITLE
fix: Issues with types resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9108,9 +9108,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001524",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
       "dev": true,
       "funding": [
         {
@@ -32924,9 +32924,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001524",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
       "dev": true
     },
     "capital-case": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,45 @@
     ">=4.2": {
       "*": [
         "dist/types/*"
+      ],
+      "src/*": [
+        "dist/types/*"
+      ],
+      "loaders/agent": [
+        "dist/types/loaders/agent.d.ts"
+      ],
+      "loaders/browser-agent": [
+        "dist/types/loaders/browser-agent.d.ts"
+      ],
+      "loaders/micro-agent": [
+        "dist/types/loaders/micro-agent.d.ts"
+      ],
+      "loaders/worker-agent": [
+        "dist/types/loaders/worker-agent.d.ts"
+      ],
+      "features/ajax": [
+        "dist/types/features/ajax/index.d.ts"
+      ],
+      "features/jserrors": [
+        "dist/types/features/jserrors/index.d.ts"
+      ],
+      "features/metrics": [
+        "dist/types/features/metrics/index.d.ts"
+      ],
+      "features/page_action": [
+        "dist/types/features/page_action/index.d.ts"
+      ],
+      "features/page_view_event": [
+        "dist/types/features/page_view_event/index.d.ts"
+      ],
+      "features/page_view_timing": [
+        "dist/types/features/page_view_timing/index.d.ts"
+      ],
+      "features/session_trace": [
+        "dist/types/features/session_trace/index.d.ts"
+      ],
+      "features/spa": [
+        "dist/types/features/spa/index.d.ts"
       ]
     }
   },

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -34,15 +34,15 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "106",
-      "browserVersion": "106"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "109",
-      "browserVersion": "109"
+      "version": "110",
+      "browserVersion": "110"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "110",
-      "browserVersion": "110"
+      "version": "111",
+      "browserVersion": "111"
     },
     {
       "browserName": "firefox",

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -10,6 +10,8 @@
   },
   "scripts": {
     "start": "vite",
+    "test:types-resolver": "tsc --project tsconfig.types-resolver.json",
+    "prebuild": "npm run test:types-resolver",
     "build": "tsc && vite build"
   },
   "devDependencies": {

--- a/tools/test-builds/vite-react-wrapper/tsconfig.types-resolver.json
+++ b/tools/test-builds/vite-react-wrapper/tsconfig.types-resolver.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "outDir": "./node_module/.type-check"
+  },
+  "include": [
+    "./types-resolver/**/*.ts"
+  ]
+}

--- a/tools/test-builds/vite-react-wrapper/types-resolver/browser-agent.ts
+++ b/tools/test-builds/vite-react-wrapper/types-resolver/browser-agent.ts
@@ -1,0 +1,1 @@
+import { BrowserAgent } from "@newrelic/browser-agent/loaders/browser-agent"

--- a/tools/test-builds/vite-react-wrapper/types-resolver/custom-agent.ts
+++ b/tools/test-builds/vite-react-wrapper/types-resolver/custom-agent.ts
@@ -1,0 +1,9 @@
+import { Agent } from "@newrelic/browser-agent/loaders/agent"
+import { Ajax } from '@newrelic/browser-agent/features/ajax'
+import { JSErrors } from '@newrelic/browser-agent/features/jserrors'
+import { Metrics } from '@newrelic/browser-agent/features/metrics'
+import { PageAction } from '@newrelic/browser-agent/features/page_action'
+import { PageViewEvent } from '@newrelic/browser-agent/features/page_view_event'
+import { PageViewTiming } from '@newrelic/browser-agent/features/page_view_timing'
+import { SessionTrace } from '@newrelic/browser-agent/features/session_trace'
+import { Spa } from '@newrelic/browser-agent/features/spa'

--- a/tools/test-builds/vite-react-wrapper/types-resolver/micro-agent.ts
+++ b/tools/test-builds/vite-react-wrapper/types-resolver/micro-agent.ts
@@ -1,0 +1,1 @@
+import { MicroAgent } from "@newrelic/browser-agent/loaders/micro-agent"

--- a/tools/test-builds/vite-react-wrapper/types-resolver/worker-agent.ts
+++ b/tools/test-builds/vite-react-wrapper/types-resolver/worker-agent.ts
@@ -1,0 +1,1 @@
+import { WorkerAgent } from "@newrelic/browser-agent/loaders/worker-agent"


### PR DESCRIPTION
Fixing issues with typescript throwing errors when trying to resolve the typings for individual features with `"moduleResolution": "node"` set in the `tsconfig.json`. `"moduleResolution": "nodenext"` and `"moduleResolution": "node16"` will enable typescript use of the `exports` field of our `package.json` but could also break other libraries and forces developers to change all local imports to include file extensions.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Our `package.json` contains `exports` for types but typescript only uses the `exports` field when `"moduleResolution": "nodenext"` is set in the `tsconfig.json`. This setting has other ramifications that may make it impossible for customers to use. To resolve the issue for customers that cannot use `"moduleResolution": "nodenext"`, the `typesVersions` settings have been updated to include type declarations for all the items exported in the `exports` settings.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-155273
closes: #666

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

I added some ts module resolution testing in the vite test wrapper.