### PR TITLE
chore: single loader in prod

### DIFF
--- a/.github/actions/build-ab/index.js
+++ b/.github/actions/build-ab/index.js
@@ -63,17 +63,19 @@ await fs.promises.writeFile(
   { encoding: 'utf-8' }
 )
 
-// 2. Write the current loader script
-console.log(`Writing current loader ${args.current} in A/B script.`)
-const currentScript = await fetchRetry(`${args.current}?_nocache=${uuidv4()}`, { retry: 3 })
-await fs.promises.appendFile(
-  outputFile,
-  await currentScript.text() + '\n\n',
-  { encoding: 'utf-8' }
-)
+// 2. Write the current loader script if env is not prod or eu-prod
+if (['dev', 'staging'].includes(args.environment)) {
+  console.log(`Writing current loader ${args.current} in A/B script.`)
+  const currentScript = await fetchRetry(`${args.current}?_nocache=${uuidv4()}`, { retry: 3 })
+  await fs.promises.appendFile(
+    outputFile,
+    await currentScript.text() + '\n\n',
+    { encoding: 'utf-8' }
+  )
+}
 
 // 3. Write the next loader script
-console.log(`Writing current loader ${args.next} in A/B script.`)
+console.log(`Writing next loader ${args.next} in A/B script.`)
 const nextScript = await fetchRetry(`${args.next}?_nocache=${uuidv4()}`, { retry: 3 })
 await fs.promises.appendFile(
   outputFile,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9108,9 +9108,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001524",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
       "dev": true,
       "funding": [
         {
@@ -32924,9 +32924,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001524",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001524.tgz",
-      "integrity": "sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==",
+      "version": "1.0.30001525",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001525.tgz",
+      "integrity": "sha512-/3z+wB4icFt3r0USMwxujAqRvaD/B7rvGTsKhbhSQErVrJvkZCLhgNLJxU8MevahQVH6hCU9FsHdNUFbiwmE7Q==",
       "dev": true
     },
     "capital-case": {

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -34,15 +34,15 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "106",
-      "browserVersion": "106"
+      "version": "107",
+      "browserVersion": "107"
     },
     {
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "109",
-      "browserVersion": "109"
+      "version": "110",
+      "browserVersion": "110"
     },
     {
       "browserName": "MicrosoftEdge",
@@ -64,15 +64,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "107",
-      "browserVersion": "107"
+      "version": "108",
+      "browserVersion": "108"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "110",
-      "browserVersion": "110"
+      "version": "111",
+      "browserVersion": "111"
     },
     {
       "browserName": "firefox",


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Removing the `current` loader from prod and eu-prod a/b scripts. We will only run the newly released loader in those environments.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

N/A

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
