### PR TITLE
chore: CI -- do not require wdio coverage success to publish

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -37,7 +37,7 @@ jobs:
 
   # Build and publish the latest code from the main branch
   publish-dev-to-s3:
-    needs: [jest-tests, wdio-coverage]
+    needs: [jest-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:


### PR DESCRIPTION
The Publish-Dev CI is failing to publish things to the dev env when wdio coverage fails to run.  This ignores that job's status
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
