### PR TITLE
chore: Redirect non-next ab loader data

### DIFF
--- a/.github/actions/build-ab/action.yml
+++ b/.github/actions/build-ab/action.yml
@@ -18,10 +18,16 @@ inputs:
     required: false
     default: https://js-agent.newrelic.com/dev/nr-loader-spa.min.js
   nrba_app_id:
-    description: 'App id to insert into the NRBA configuration.'
+    description: 'App id to insert into the NRBA configuration for next loader.'
     required: true
   nrba_license_key:
-    description: 'License key to insert into the NRBA configuration.'
+    description: 'License key to insert into the NRBA configuration for next loader.'
+    required: true
+  nrba_ab_app_id:
+    description: 'App id to insert into the NRBA configuration for non-next loaders.'
+    required: true
+  nrba_ab_license_key:
+    description: 'License key to insert into the NRBA configuration for non-next loaders.'
     required: true
   aws_access_key_id:
     description: 'AWS access key id used for authentication.'
@@ -58,6 +64,8 @@ runs:
           --next ${{ inputs.nrba_next_script_url }} \
           --app-id ${{ inputs.nrba_app_id }} \
           --license-key ${{ inputs.nrba_license_key }} \
+          --ab-app-id ${{ inputs.nrba_ab_app_id }} \
+          --ab-license-key ${{ inputs.nrba_ab_license_key }} \
           --region ${{ inputs.aws_region }} \
           --bucket ${{ inputs.aws_bucket_name || '' }} \
           --role ${{ inputs.aws_role || '' }} \

--- a/.github/actions/build-ab/args.js
+++ b/.github/actions/build-ab/args.js
@@ -17,10 +17,16 @@ export const args = yargs(hideBin(process.argv))
   .default('next', 'https://js-agent.newrelic.com/dev/nr-loader-spa.min.js')
 
   .string('app-id')
-  .describe('Application ID to use in the environment NRBA configuration.')
+  .describe('Application ID to use in the environment NRBA configuration for the next loader.')
 
   .string('license-key')
-  .describe('License key to use in the environment NRBA configuration.')
+  .describe('License key to use in the environment NRBA configuration for the next loader.')
+
+  .string('ab-app-id')
+  .describe('Application ID to use in the environment NRBA configuration for non-next loaders.')
+
+  .string('ab-license-key')
+  .describe('License key to use in the environment NRBA configuration for non-next loaders.')
 
   .string('role')
   .describe('role', 'S3 role ARN; used when including experiments in the ab script.')

--- a/.github/actions/build-ab/template.js
+++ b/.github/actions/build-ab/template.js
@@ -34,11 +34,22 @@ window.NREUM={
     sa: 1
   }
 }
+
 // scripts
-{{#each scripts}}
-    // {{{this.name}}}
-    {{{this.contents}}}
+{{{nextScript}}}
+
+{{#if abScripts}}
+window.NREUM.loader_config.agentID = '{{{args.abAppId}}}'
+window.NREUM.loader_config.applicationID = '{{{args.abAppId}}}'
+window.NREUM.loader_config.licenseKey = '{{{args.abLicenseKey}}}'
+window.NREUM.info.applicationID = '{{{args.abAppId}}}'
+window.NREUM.info.licenseKey = '{{{args.abLicenseKey}}}'
+{{/if}}
+
+{{#each abScripts}}
+{{{this.contents}}}
 {{/each}}
+
 // post-script checks
 try {
   var xhr = new XMLHttpRequest()
@@ -50,15 +61,15 @@ try {
   xhr.setRequestHeader('pragma','no-cache')
 
   xhr.send(
-      JSON.stringify({
-          'query': 'query PlatformEntitlementsQuery($names: [String]!) { currentUser { id authorizedAccounts { id entitlements(filter: {names: $names}) { name __typename } __typename } __typename } }',
-          'variables': {
-              'names': [
-                  'hipaa',
-                  'fedramp'
-              ]
-          }
-      })
+    JSON.stringify({
+      'query': 'query PlatformEntitlementsQuery($names: [String]!) { currentUser { id authorizedAccounts { id entitlements(filter: {names: $names}) { name __typename } __typename } __typename } }',
+      'variables': {
+        'names': [
+          'hipaa',
+          'fedramp'
+        ]
+      }
+    })
   )
 
   xhr.addEventListener('load', function(evt){
@@ -73,7 +84,7 @@ try {
           for (var j = 0; j < ent.entitlements.length; j++){
             if (ent.entitlements[j].name === 'fedramp' || ent.entitlements[j].name === 'hipaa') canRunSr = false
           }
-        } 
+        }
       }
       if (canRunSr && newrelic && !!newrelic.start) newrelic.start('session_replay')
     } catch(e){

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -101,6 +101,8 @@ jobs:
           nr_environment: dev
           nrba_app_id: ${{ secrets.INTERNAL_DEV_APPLICATION_ID }}
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
+          nrba_ab_app_id: ${{ secrets.INTERNAL_AB_DEV_APPLICATION_ID }}
+          nrba_ab_license_key: ${{ secrets.INTERNAL_AB_LICENSE_KEY }}
           nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
           nrba_next_script_url: https://js-agent.newrelic.com/dev/nr-loader-spa.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -130,6 +132,8 @@ jobs:
           nr_environment: staging
           nrba_app_id: ${{ secrets.INTERNAL_STAGING_APPLICATION_ID }}
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
+          nrba_ab_app_id: ${{ secrets.INTERNAL_AB_STAGING_APPLICATION_ID }}
+          nrba_ab_license_key: ${{ secrets.INTERNAL_AB_LICENSE_KEY }}
           nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
           nrba_next_script_url: https://js-agent.newrelic.com/dev/nr-loader-spa.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -69,6 +69,8 @@ jobs:
           nr_environment: dev
           nrba_app_id: ${{ secrets.INTERNAL_DEV_APPLICATION_ID }}
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
+          nrba_ab_app_id: ${{ secrets.INTERNAL_AB_DEV_APPLICATION_ID }}
+          nrba_ab_license_key: ${{ secrets.INTERNAL_AB_LICENSE_KEY }}
           nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
           nrba_next_script_url: https://js-agent.newrelic.com/dev/nr-loader-experimental.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -98,6 +100,8 @@ jobs:
           nr_environment: staging
           nrba_app_id: ${{ secrets.INTERNAL_STAGING_APPLICATION_ID }}
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
+          nrba_ab_app_id: ${{ secrets.INTERNAL_AB_STAGING_APPLICATION_ID }}
+          nrba_ab_license_key: ${{ secrets.INTERNAL_AB_LICENSE_KEY }}
           nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
           nrba_next_script_url: https://js-agent.newrelic.com/dev/nr-loader-experimental.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9108,9 +9108,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001532",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001532.tgz",
-      "integrity": "sha512-FbDFnNat3nMnrROzqrsg314zhqN5LGQ1kyyMk2opcrwGbVGpHRhgCWtAgD5YJUqNAiQ+dklreil/c3Qf1dfCTw==",
+      "version": "1.0.30001533",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001533.tgz",
+      "integrity": "sha512-9aY/b05NKU4Yl2sbcJhn4A7MsGwR1EPfW/nrqsnqVA0Oq50wpmPaGI+R1Z0UKlUl96oxUkGEOILWtOHck0eCWw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Non-next A/B loaders will now direct their data to a separate browser entity found in the browser NR account.

[staging](https://staging.onenr.io/0z7wky0anjL)
[dev](https://staging.onenr.io/0a7j94lKlRO)

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-152262

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

New A/B scripts have been manually generated and uploaded for dev and staging.