### PR TITLE
chore: Post release repo updates

### DIFF
--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Aug 23 2023 07:36:28 GMT-0500 (Central Daylight Time)",
+  "lastUpdated": "Tue Sep 12 2023 21:47:25 GMT+0000 (Coordinated Universal Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.238.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.240.0.tgz"
   }
 }

--- a/tools/test-builds/browser-tests/package.json
+++ b/tools/test-builds/browser-tests/package.json
@@ -9,6 +9,6 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.238.0.tgz"
+        "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.240.0.tgz"
     }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.238.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.240.0.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.238.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.240.0.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
When this PR is merged, caniuse-lite database is updated, latest browserslist for SauceLabs is retrieved, and third-party dependencies docs are updates.
---

This PR was generated with post-release-updates GitHub action.