### PR TITLE
fix: Final harvest does not happen when initial RUM call fails

### DIFF
--- a/src/common/harvest/harvest-scheduler.js
+++ b/src/common/harvest/harvest-scheduler.js
@@ -48,7 +48,7 @@ export class HarvestScheduler extends SharedContext {
    * to send payloads while the page is still active, due to limitations on how much data can be buffered in the API at any one time.
    */
   unload () {
-    if (this.aborted) return
+    if (this.aborted || !this.started) return
     // If opts.onUnload is defined, these are special actions to execute before attempting to send the final payload.
     if (this.opts.onUnload) this.opts.onUnload()
     this.runHarvest({ unload: true })

--- a/src/common/harvest/harvest-scheduler.test.js
+++ b/src/common/harvest/harvest-scheduler.test.js
@@ -36,7 +36,8 @@ describe('unload', () => {
     expect(subscribeToEOL).toHaveBeenCalledWith(expect.any(Function))
   })
 
-  test('should run onUnload callback', () => {
+  test('should run onUnload callback when started', () => {
+    harvestSchedulerInstance.started = true
     harvestSchedulerInstance.opts.onUnload = jest.fn()
 
     eolSubscribeFn()
@@ -44,12 +45,22 @@ describe('unload', () => {
     expect(harvestSchedulerInstance.opts.onUnload).toHaveBeenCalledTimes(1)
   })
 
-  test('should run harvest when not aborted', () => {
+  test('should run harvest when started and not aborted', () => {
+    harvestSchedulerInstance.started = true
     harvestSchedulerInstance.aborted = false
 
     eolSubscribeFn()
 
     expect(harvestSchedulerInstance.runHarvest).toHaveBeenCalledWith({ unload: true })
+  })
+
+  test('should not run harvest when not started', () => {
+    harvestSchedulerInstance.started = false
+    jest.spyOn(harvestSchedulerInstance, 'runHarvest').mockImplementation(jest.fn())
+
+    eolSubscribeFn()
+
+    expect(harvestSchedulerInstance.runHarvest).not.toHaveBeenCalled()
   })
 
   test('should not run harvest when aborted', () => {

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -32,6 +32,7 @@ export class Aggregate extends AggregateBase {
     // *cli, Mar 23 - Per NR-94597, this feature should only harvest ONCE at the (potential) EoL time of the page.
     scheduler = new HarvestScheduler('jserrors', { onUnload: () => this.unload() }, this)
     scheduler.harvest.on('jserrors', () => ({ body: this.aggregator.take(['cm', 'sm']) }))
+    this.ee.on(`drain-${this.featureName}`, () => { scheduler.started = true }) // this is needed to ensure EoL is "on" and sent
 
     this.drain()
   }

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -53,7 +53,6 @@ export class Aggregate extends AggregateBase {
       getPayload: (...args) => this.prepareHarvest(...args)
     }, this)
 
-    registerHandler('timing', (name, value, attrs) => this.addTiming(name, value, attrs), this.featureName, this.ee) // notice CLS is added to all timings via 4th param
     registerHandler('docHidden', msTimestamp => this.endCurrentSession(msTimestamp), this.featureName, this.ee)
     registerHandler('winPagehide', msTimestamp => this.recordPageUnload(msTimestamp), this.featureName, this.ee)
 


### PR DESCRIPTION
Fixes the final harvest behavior in cases when the RUM request fails. The initial request is meant to act as a gateway for the agent to start reporting data, and its failure should result in the agent not sending anything. As of previous version, the metrics and page view timing features do not follow this rule, and that has been corrected.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

This cuts down on disassociated data from user page "sessions" wherein their agent never sent any RUM or interval analytics yet does sent disjoint metrics and timings that cannot be tied to anything else of said page session.

### Related Issue(s)

NR-138551

### Testing

Tests added but can also manually verify that following a failed RUM request, nothing else gets send either on interval or on refresh (sendBeacon).
