### PR TITLE
chore: always upload code coverage

### DIFF
--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -88,12 +88,12 @@ jobs:
             ${{ inputs.additional-flags || '' }}
       - name: Find pull request
         id: pull-request-target
-        if: ${{ inputs.coverage }}
+        if: ${{ !cancelled() && inputs.coverage }}
         uses: ./.github/actions/find-pull-request
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload pr code coverage
-        if: ${{ inputs.coverage && steps.pull-request-target.outputs.results }}
+        if: ${{ !cancelled() && inputs.coverage && steps.pull-request-target.outputs.results }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -103,14 +103,14 @@ jobs:
           flags: integration-tests
           verbose: true
       - name: Upload branch code coverage
-        if: ${{ inputs.coverage && !steps.pull-request-target.outputs.results }}
+        if: ${{ !cancelled() && inputs.coverage && !steps.pull-request-target.outputs.results }}
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration-tests
           verbose: true
       - name: Archive code coverage results
-        if: ${{ inputs.coverage }}
+        if: ${{ !cancelled() && inputs.coverage }}
         uses: actions/upload-artifact@v3
         with:
           name: integration-code-coverage-report


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Even if wdio testing failes, when coverage is enabled, coverage will always be uploaded.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-157916

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
