### PR TITLE
chore: update settings to match API-E

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -134,6 +134,7 @@ module.exports = {
     'no-new': 'off',
     'prefer-const': 'off',
 
-    'sonarjs/cognitive-complexity': 'off'
+    'sonarjs/cognitive-complexity': 'off',
+    camelcase: 'off'
   }
 }

--- a/.github/actions/build-ab/template.js
+++ b/.github/actions/build-ab/template.js
@@ -14,8 +14,8 @@ window.NREUM={
     },
     session_replay: {
       enabled: true,
-      sampleRate: 0.5,
-      errorSampleRate: 1,
+      sampling_rate: 50,
+      error_sampling_rate: 100,
       autoStart: false
     }
   },

--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -4,8 +4,8 @@ import { getModeledObject } from './configurable'
 
 const model = () => {
   const hiddenState = {
-    blockSelector: '[data-nr-block]',
-    maskInputOptions: { password: true }
+    block_selector: '[data-nr-block]',
+    mask_input_options: { password: true }
   }
   return {
     proxy: {
@@ -40,29 +40,29 @@ const model = () => {
       autoStart: true,
       enabled: false,
       harvestTimeSeconds: 60,
-      sampleRate: 0.1,
-      errorSampleRate: 0.1,
+      sampling_rate: 50, // float from 0 - 100
+      error_sampling_rate: 50, // float from 0 - 100
       // recording config settings
-      maskTextSelector: '*',
-      maskAllInputs: true,
+      mask_text_selector: '*',
+      mask_all_inputs: true,
       // these properties only have getters because they are enforcable constants and should error if someone tries to override them
-      get blockClass () { return 'nr-block' },
-      get ignoreClass () { return 'nr-ignore' },
-      get maskTextClass () { return 'nr-mask' },
+      get block_class () { return 'nr-block' },
+      get ignore_class () { return 'nr-ignore' },
+      get mask_text_class () { return 'nr-mask' },
       // props with a getter and setter are used to extend enforcable constants with customer input
       // we must preserve data-nr-block no matter what else the customer sets
-      get blockSelector () {
-        return hiddenState.blockSelector
+      get block_selector () {
+        return hiddenState.block_selector
       },
-      set blockSelector (val) {
-        hiddenState.blockSelector += `,${val}`
+      set block_selector (val) {
+        hiddenState.block_selector += `,${val}`
       },
       // password: must always be present and true no matter what customer sets
-      get maskInputOptions () {
-        return hiddenState.maskInputOptions
+      get mask_input_options () {
+        return hiddenState.mask_input_options
       },
-      set maskInputOptions (val) {
-        hiddenState.maskInputOptions = { ...val, password: true }
+      set mask_input_options (val) {
+        hiddenState.mask_input_options = { ...val, password: true }
       }
     },
     spa: { enabled: true, harvestTimeSeconds: 10, autoStart: true }

--- a/src/features/session_replay/aggregate/index.component-test.js
+++ b/src/features/session_replay/aggregate/index.component-test.js
@@ -39,7 +39,7 @@ class LocalMemory {
 let sr, session
 const agentIdentifier = 'abcd'
 const info = { licenseKey: 1234, applicationID: 9876 }
-const init = { session_replay: { enabled: true, sampleRate: 1, errorSampleRate: 0 } }
+const init = { session_replay: { enabled: true, sampling_rate: 100, error_sampling_rate: 0 } }
 
 const anyQuery = {
   browser_monitoring_key: info.licenseKey,
@@ -99,14 +99,14 @@ describe('Session Replay', () => {
     })
 
     test('Session SR mode matches SR mode -- ERROR', async () => {
-      setConfiguration(agentIdentifier, { session_replay: { sampleRate: 0, errorSampleRate: 1 } })
+      setConfiguration(agentIdentifier, { session_replay: { sampling_rate: 0, error_sampling_rate: 100 } })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       expect(session.state.sessionReplay).toEqual(sr.mode)
     })
 
     test('Session SR mode matches SR mode -- OFF', async () => {
-      setConfiguration(agentIdentifier, { session_replay: { sampleRate: 0, errorSampleRate: 0 } })
+      setConfiguration(agentIdentifier, { session_replay: { sampling_rate: 0, error_sampling_rate: 0 } })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       expect(session.state.sessionReplay).toEqual(sr.mode)
@@ -149,28 +149,28 @@ describe('Session Replay', () => {
 
   describe('Session Replay Sample -> Mode Behaviors', () => {
     test('New Session -- Full 1 Error 1 === FULL', async () => {
-      setConfiguration(agentIdentifier, { session_replay: { errorSampleRate: 1, sampleRate: 1 } })
+      setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 100 } })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
     })
 
     test('New Session -- Full 1 Error 0 === FULL', async () => {
-      setConfiguration(agentIdentifier, { session_replay: { errorSampleRate: 0, sampleRate: 1 } })
+      setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 0, sampling_rate: 100 } })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
     })
 
     test('New Session -- Full 0 Error 1 === ERROR', async () => {
-      setConfiguration(agentIdentifier, { session_replay: { errorSampleRate: 1, sampleRate: 0 } })
+      setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       expect(sr.mode).toEqual(MODE.ERROR)
     })
 
     test('New Session -- Full 0 Error 0 === OFF', async () => {
-      setConfiguration(agentIdentifier, { session_replay: { errorSampleRate: 0, sampleRate: 0 } })
+      setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 0, sampling_rate: 0 } })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       expect(sr.mode).toEqual(MODE.OFF)
@@ -182,7 +182,7 @@ describe('Session Replay', () => {
       expect(session.isNew).toBeFalsy()
       primeSessionAndReplay(session)
       // configure to get "error" sample ---> but should inherit FULL from session manager
-      setConfiguration(agentIdentifier, { session_replay: { errorSampleRate: 1, sampleRate: 0 } })
+      setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
@@ -191,7 +191,7 @@ describe('Session Replay', () => {
 
   describe('Session Replay Error Mode Behaviors', () => {
     test('An error BEFORE rrweb import starts running in FULL from beginning', async () => {
-      setConfiguration(agentIdentifier, { session_replay: { errorSampleRate: 1, sampleRate: 0 } })
+      setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr.ee.emit('errorAgg')
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
@@ -200,7 +200,7 @@ describe('Session Replay', () => {
     })
 
     test('An error AFTER rrweb import changes mode and starts harvester', async () => {
-      setConfiguration(agentIdentifier, { session_replay: { errorSampleRate: 1, sampleRate: 0 } })
+      setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       expect(sr.mode).toEqual(MODE.ERROR)

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -123,8 +123,8 @@ export class Aggregate extends AggregateBase {
 
       this.waitForFlags(['sr']).then(([flagOn]) => this.initializeRecording(
         flagOn,
-        Math.random() < getConfigurationValue(this.agentIdentifier, 'session_replay.errorSampleRate'),
-        Math.random() < getConfigurationValue(this.agentIdentifier, 'session_replay.sampleRate')
+        (Math.random() * 100) < getConfigurationValue(this.agentIdentifier, 'session_replay.error_sampling_rate'),
+        (Math.random() * 100) < getConfigurationValue(this.agentIdentifier, 'session_replay.sampling_rate')
       )).then(() => sharedChannel.onReplayReady(this.mode)) // notify watchers that replay started with the mode
 
       this.drain()
@@ -263,18 +263,18 @@ export class Aggregate extends AggregateBase {
       return this.abort()
     }
     this.recording = true
-    const { blockClass, ignoreClass, maskTextClass, blockSelector, maskInputOptions, maskTextSelector, maskAllInputs } = getConfigurationValue(this.agentIdentifier, 'session_replay')
+    const { block_class, ignore_class, mask_text_class, block_selector, mask_input_options, mask_text_selector, mask_all_inputs } = getConfigurationValue(this.agentIdentifier, 'session_replay')
     // set up rrweb configurations for maximum privacy --
     // https://newrelic.atlassian.net/wiki/spaces/O11Y/pages/2792293280/2023+02+28+Browser+-+Session+Replay#Configuration-options
     const stop = recorder({
       emit: this.store.bind(this),
-      blockClass,
-      ignoreClass,
-      maskTextClass,
-      blockSelector,
-      maskInputOptions,
-      maskTextSelector,
-      maskAllInputs,
+      blockClass: block_class,
+      ignoreClass: ignore_class,
+      maskTextClass: mask_text_class,
+      blockSelector: block_selector,
+      maskInputOptions: mask_input_options,
+      maskTextSelector: mask_text_selector,
+      maskAllInputs: mask_all_inputs,
       checkoutEveryNms: CHECKOUT_MS[this.mode]
     })
 

--- a/tests/assets/rrweb-record.html
+++ b/tests/assets/rrweb-record.html
@@ -18,7 +18,7 @@
   {config}
   <script>
     localStorage.clear()
-    NREUM.init.session_replay = {enabled: true, harvestTimeSeconds: 5, errorSampleRate: 0, sampleRate: 1}
+    NREUM.init.session_replay = {enabled: true, harvestTimeSeconds: 5, error_sampling_rate: 0, sampling_rate: 100}
     NREUM.init.privacy.cookies_enabled = true
   </script>
   {loader}

--- a/tests/specs/session-replay/helpers.js
+++ b/tests/specs/session-replay/helpers.js
@@ -66,7 +66,7 @@ export function config (initOverrides = {}) {
       loader: 'experimental',
       init: {
         privacy: { cookies_enabled: true },
-        session_replay: { enabled: true, harvestTimeSeconds: 5, sampleRate: 1, errorSampleRate: 0 }
+        session_replay: { enabled: true, harvestTimeSeconds: 5, sampling_rate: 100, error_sampling_rate: 0 }
       }
     },
     {

--- a/tests/specs/session-replay/mode.e2e.js
+++ b/tests/specs/session-replay/mode.e2e.js
@@ -11,7 +11,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
   })
 
   it('Full 1 Error 1 === FULL', async () => {
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampleRate: 1, errorSampleRate: 1 } })))
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampling_rate: 100, error_sampling_rate: 100 } })))
       .then(() => browser.waitForSessionReplayRecording())
 
     await expect(getSR()).resolves.toEqual(expect.objectContaining({
@@ -23,7 +23,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
   })
 
   it('Full 1 Error 0 === FULL', async () => {
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampleRate: 1, errorSampleRate: 0 } })))
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampling_rate: 100, error_sampling_rate: 0 } })))
       .then(() => browser.waitForSessionReplayRecording())
 
     await expect(getSR()).resolves.toEqual(expect.objectContaining({
@@ -35,7 +35,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
   })
 
   it('Full 0 Error 1 === ERROR', async () => {
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 1 } })))
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 100 } })))
       .then(() => browser.waitForSessionReplayRecording())
 
     await expect(getSR()).resolves.toEqual(expect.objectContaining({
@@ -47,7 +47,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
   })
 
   it('Full 0 Error 0 === OFF', async () => {
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 0 } })))
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 0 } })))
       .then(() => browser.waitForFeatureAggregate('session_replay'))
 
     await expect(getSR()).resolves.toEqual(expect.objectContaining({
@@ -59,7 +59,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
   })
 
   it('ERROR (seen after init) => FULL', async () => {
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 1 } })))
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 100 } })))
       .then(() => browser.waitForSessionReplayRecording())
 
     await expect(getSR()).resolves.toEqual(expect.objectContaining({
@@ -82,7 +82,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
   })
 
   it('ERROR (seen before init) => FULL', async () => {
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 1 } })))
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 100 } })))
       .then(() => browser.execute(function () {
         newrelic.noticeError(new Error('test'))
       }))
@@ -97,7 +97,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
   })
 
   it('FULL => OFF', async () => {
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampleRate: 1, errorSampleRate: 0 } })))
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampling_rate: 100, error_sampling_rate: 0 } })))
       .then(() => browser.waitForSessionReplayRecording())
 
     await expect(getSR()).resolves.toEqual(expect.objectContaining({

--- a/tests/specs/session-replay/rrweb-configuration.e2e.js
+++ b/tests/specs/session-replay/rrweb-configuration.e2e.js
@@ -52,8 +52,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
     })
   })
 
-  describe('maskAllInputs', () => {
-    it('maskAllInputs: true should convert inputs to *', async () => {
+  describe('mask_all_inputs', () => {
+    it('mask_all_inputs: true should convert inputs to *', async () => {
       await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config()))
         .then(() => browser.waitForAgentLoad())
 
@@ -67,8 +67,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
       expect(JSON.stringify(body).includes('testing')).toBeFalsy()
     })
 
-    it('maskAllInputs: false should NOT convert inputs to *', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskAllInputs: false } })))
+    it('mask_all_inputs: false should NOT convert inputs to *', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_all_inputs: false } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -82,9 +82,9 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
     })
   })
 
-  describe('maskTextSelector', () => {
-    it('maskTextSelector: "*" should convert all text to *', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskAllInputs: false } })))
+  describe('mask_text_selector', () => {
+    it('mask_text_selector: "*" should convert all text to *', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_all_inputs: false } })))
         .then(() => browser.waitForAgentLoad())
 
       const { request: { body } } = await browser.testHandle.expectBlob()
@@ -92,8 +92,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
       expect(JSON.stringify(body).includes('this is a page')).toBeFalsy()
     })
 
-    it('maskTextSelector: "null" should convert NO text to "*"', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskAllInputs: false } })))
+    it('mask_text_selector: "null" should convert NO text to "*"', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false } })))
         .then(() => browser.waitForAgentLoad())
 
       const { request: { body } } = await browser.testHandle.expectBlob()
@@ -102,9 +102,9 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
     })
   })
 
-  describe('ignoreClass', () => {
-    it('ignoreClass: nr-ignore should ignore elem', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskAllInputs: false } })))
+  describe('ignore_class', () => {
+    it('ignore_class: nr-ignore should ignore elem', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -117,8 +117,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
       expect(JSON.stringify(body).includes('testing')).toBeFalsy()
     })
 
-    it('ignoreClass: cannot be overridden', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskAllInputs: false, ignoreClass: null } })))
+    it('ignore_class: cannot be overridden', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false, ignore_class: null } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -132,9 +132,9 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
     })
   })
 
-  describe('blockClass', () => {
-    it('blockClass: nr-block should block elem', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskAllInputs: false } })))
+  describe('block_class', () => {
+    it('block_class: nr-block should block elem', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -147,8 +147,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
       expect(JSON.stringify(body).includes('testing')).toBeFalsy()
     })
 
-    it('blockClass: cannot be overridden', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskAllInputs: false, blockClass: null } })))
+    it('block_class: cannot be overridden', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false, block_class: null } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -162,9 +162,9 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
     })
   })
 
-  describe('maskTextClass', () => {
-    it('maskTextClass: should mask elem', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null } })))
+  describe('mask_text_class', () => {
+    it('mask_text_class: should mask elem', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -177,8 +177,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
       expect(JSON.stringify(body).includes('testing')).toBeFalsy()
     })
 
-    it('maskTextClass: cannot be overridden', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskTextClass: null } })))
+    it('mask_text_class: cannot be overridden', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_text_class: null } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -192,9 +192,9 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
     })
   })
 
-  describe('blockSelector', () => {
-    it('blockSelector: nr-data-block should block elem', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskAllInputs: false } })))
+  describe('block_selector', () => {
+    it('block_selector: nr-data-block should block elem', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -207,8 +207,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
       expect(JSON.stringify(body).includes('testing')).toBeFalsy()
     })
 
-    it('blockSelector: only applies to specified elem', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskAllInputs: false } })))
+    it('block_selector: only applies to specified elem', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -222,8 +222,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
       expect(JSON.stringify(body).includes('testing')).toBeTruthy()
     })
 
-    it('blockSelector: can be extended but not overridden', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskAllInputs: false, blockSelector: '[data-other-block]' } })))
+    it('block_selector: can be extended but not overridden', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false, block_selector: '[data-other-block]' } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -238,9 +238,9 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
     })
   })
 
-  describe('maskInputOptions', () => {
-    it('maskInputOptions: nr-data-block should block elem', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null } })))
+  describe('mask_input_options', () => {
+    it('mask_input_options: nr-data-block should block elem', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([
@@ -253,8 +253,8 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
       expect(JSON.stringify(body).includes('testing')).toBeFalsy()
     })
 
-    it('maskInputOptions: can be extended but not overridden', async () => {
-      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { maskTextSelector: null, maskInputOptions: { text: true } } })))
+    it('mask_input_options: can be extended but not overridden', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_input_options: { text: true } } })))
         .then(() => browser.waitForAgentLoad())
 
       const [{ request: { body } }] = await Promise.all([

--- a/tests/specs/session-replay/session-state.e2e.js
+++ b/tests/specs/session-replay/session-state.e2e.js
@@ -22,7 +22,7 @@ describe.withBrowsersMatching(notIE)('session manager state behavior', () => {
     })
 
     it('should match in error mode', async () => {
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 1 } })))
+      await browser.url(await browser.testHandle.assetURL('instrumented.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 100 } })))
         .then(() => browser.waitForFeatureAggregate('session_replay'))
 
       await browser.pause(1000)
@@ -32,7 +32,7 @@ describe.withBrowsersMatching(notIE)('session manager state behavior', () => {
     })
 
     it('should match in off mode', async () => {
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 0 } })))
+      await browser.url(await browser.testHandle.assetURL('instrumented.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 0 } })))
         .then(() => browser.waitForFeatureAggregate('session_replay'))
 
       await browser.pause(1000)

--- a/tests/specs/stn/with-replay-error-mode.e2e.js
+++ b/tests/specs/stn/with-replay-error-mode.e2e.js
@@ -24,7 +24,7 @@ describe.withBrowsersMatching(notIE)('Trace error mode', () => {
       body: JSON.stringify({ stn: 0, err: 1, ins: 1, spa: 1, sr: 1, loaded: 1 })
     })
 
-    getReplayOnErrorUrl = browser.testHandle.assetURL('stn/instrumented.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 1 }, session_trace: { harvestTimeSeconds: 3 } }))
+    getReplayOnErrorUrl = browser.testHandle.assetURL('stn/instrumented.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 100 }, session_trace: { harvestTimeSeconds: 3 } }))
   })
 
   function simulateErrorInBrowser () { // this is a way to throw error in WdIO / Selenium without killing the test itself
@@ -55,7 +55,7 @@ describe.withBrowsersMatching(notIE)('Trace error mode', () => {
 
   it('starts in full mode when an error happens before page load', async () => {
     let getFirstSTPayload = browser.testHandle.expectResources(5010)
-    await browser.url(await browser.testHandle.assetURL('js-error-with-error-before-page-load.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 1 }, session_trace: { harvestTimeSeconds: 3 } })))
+    await browser.url(await browser.testHandle.assetURL('js-error-with-error-before-page-load.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 100 }, session_trace: { harvestTimeSeconds: 3 } })))
     await browser.waitForAgentLoad()
     await expect(getFirstSTPayload).resolves.toBeTruthy()
     await expect(getTraceMode()).resolves.toEqual([MODE.FULL, false])
@@ -122,8 +122,8 @@ describe.withBrowsersMatching(notIE)('Trace when replay runs then is aborted', (
   const triggerReplayAbort = () => browser.execute(function () { Object.values(NREUM.initializedAgents)[0].runtime.session.reset() })
 
   ;[
-    ['does a last harvest then stops, in full mode', MODE.FULL, { sampleRate: 1, errorSampleRate: 0 }],
-    ['does not harvest anything, in error mode', MODE.ERROR, { sampleRate: 0, errorSampleRate: 1 }]
+    ['does a last harvest then stops, in full mode', MODE.FULL, { sampling_rate: 100, error_sampling_rate: 0 }],
+    ['does not harvest anything, in error mode', MODE.ERROR, { sampling_rate: 0, error_sampling_rate: 100 }]
   ].forEach(([description, supposedMode, replayConfig]) => {
     it(description, async () => {
       let url = await browser.testHandle.assetURL('stn/instrumented.html', config({ session_replay: replayConfig, session_trace: { harvestTimeSeconds: 2 } }))

--- a/tests/specs/stn/with-session-replay.e2e.js
+++ b/tests/specs/stn/with-session-replay.e2e.js
@@ -100,9 +100,9 @@ describe('Trace when replay entitlement is 1 and stn is 1', () => {
   })
 
   ;[
-    ['OFF', { sampleRate: 0, errorSampleRate: 0 }],
-    ['FULL', { sampleRate: 1, errorSampleRate: 0 }],
-    ['ERR', { sampleRate: 0, errorSampleRate: 1 }]
+    ['OFF', { sampling_rate: 0, error_sampling_rate: 0 }],
+    ['FULL', { sampling_rate: 100, error_sampling_rate: 0 }],
+    ['ERR', { sampling_rate: 0, error_sampling_rate: 100 }]
   ].forEach(([replayMode, replayConfig]) => {
     it.withBrowsersMatching(notIE)(`runs in full when replay feature is present and in ${replayMode} mode`, async () => {
       const getRuntimeValues = () => browser.execute(function () {
@@ -160,14 +160,14 @@ describe.withBrowsersMatching(notIE)('Trace when replay entitlement is 1 and stn
   })
 
   it('does not run when replay is OFF', async () => {
-    await browser.url(await browser.testHandle.assetURL('stn/instrumented.html', config({ session_replay: { sampleRate: 0, errorSampleRate: 0 } })))
+    await browser.url(await browser.testHandle.assetURL('stn/instrumented.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 0 } })))
     await browser.waitForAgentLoad()
     expect(initSTReceived).toBeUndefined()
   })
 
   ;[
-    ['FULL', { sampleRate: 1, errorSampleRate: 0 }],
-    ['ERR', { sampleRate: 0, errorSampleRate: 1 }]
+    ['FULL', { sampling_rate: 100, error_sampling_rate: 0 }],
+    ['ERR', { sampling_rate: 0, error_sampling_rate: 100 }]
   ].forEach(([replayMode, replayConfig]) => {
     it(`still runs and in the same ${replayMode} mode as replay feature that's on`, async () => {
       const urlReplayOn = await browser.testHandle.assetURL('stn/instrumented.html', config({ session_replay: replayConfig, session_trace: { harvestTimeSeconds: 2 } }))

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -53,5 +53,5 @@ module.exports.defaultInitBlock = {
   session_trace: { enabled: true, harvestTimeSeconds: 5, autoStart: true },
   spa: { enabled: true, harvestTimeSeconds: 5, autoStart: true },
   harvest: { tooManyRequestsDelay: 5 },
-  session_replay: { enabled: false, harvestTimeSeconds: 5, sampleRate: 0, errorSampleRate: 0, autoStart: true }
+  session_replay: { enabled: false, harvestTimeSeconds: 5, sampling_rate: 0, error_sampling_rate: 0, autoStart: true }
 }


### PR DESCRIPTION
Update the init settings for Session Replay to match changes in the API/DB.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR updates the init settings for SR to match the output object generated by API.  The settings previously implemented in the agent were a "best guess" until the API actually finished their work to output a config blob for session replay settings.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
All existing SR and STN tests should be updated to use the new settings names and continue to pass.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
