### PR TITLE
feat: Removing hash from chunk asset name

### DIFF
--- a/tools/webpack/configs/common.mjs
+++ b/tools/webpack/configs/common.mjs
@@ -47,7 +47,7 @@ export default (env, asyncChunkName) => {
 
         return env.SUBVERSION === 'PROD' ? `[name]${env.PATH_VERSION}.js` : '[name].js'
       },
-      chunkFilename: env.SUBVERSION === 'PROD' ? `[name].[chunkhash:8]${env.PATH_VERSION}.min.js` : `[name]${env.PATH_VERSION}.min.js`,
+      chunkFilename: `[name]${env.PATH_VERSION}.min.js`,
       path: env.paths.build,
       publicPath: env.PUBLIC_PATH,
       clean: false,


### PR DESCRIPTION
Removing the hash from the chunk asset file name. This will allow internal and external automation to predict the file name of each asset chunk as long as the loader type and version number is known.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Removing the hash from the chunk asset file name. This will allow internal and external automation to predict the file name of each asset chunk as long as the loader type and version number is known.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-160947

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
