### PR TITLE
chore: New experiments publishing process

### DIFF
--- a/.github/actions/build-ab/action.yml
+++ b/.github/actions/build-ab/action.yml
@@ -9,12 +9,12 @@ inputs:
   nr_environment:
     description: 'Target New Relic environment for the A/B script.'
     required: true
-  nrba_current_script_url:
-    description: 'URL for the script to use as the "current" version NRBA loader.'
+  nrba_released_script_url:
+    description: 'URL for the script to use as the latest released version NRBA loader.'
     required: false
     default: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
-  nrba_next_script_url:
-    description: 'URL for the script to use as the "next" version NRBA loader.'
+  nrba_latest_script_url:
+    description: 'URL for the script to use as the latest unreleased version NRBA loader.'
     required: false
     default: https://js-agent.newrelic.com/dev/nr-loader-spa.min.js
   nrba_app_id:
@@ -60,8 +60,8 @@ runs:
       run: |
         node $GITHUB_ACTION_PATH/index.js \
           --environment ${{ inputs.nr_environment }} \
-          --current ${{ inputs.nrba_current_script_url }} \
-          --next ${{ inputs.nrba_next_script_url }} \
+          --released ${{ inputs.nrba_released_script_url }} \
+          --latest ${{ inputs.nrba_latest_script_url }} \
           --app-id ${{ inputs.nrba_app_id }} \
           --license-key ${{ inputs.nrba_license_key }} \
           --ab-app-id ${{ inputs.nrba_ab_app_id }} \

--- a/.github/actions/build-ab/action.yml
+++ b/.github/actions/build-ab/action.yml
@@ -50,7 +50,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/build-ab/args.js
+++ b/.github/actions/build-ab/args.js
@@ -8,13 +8,13 @@ export const args = yargs(hideBin(process.argv))
   .choices('environment', ['dev', 'staging', 'prod', 'eu-prod'])
   .describe('environment', 'Which environment are we building the a/b script for?')
 
-  .string('current')
-  .describe('current', 'current/stable build (defaults to -current)')
-  .default('current', 'https://js-agent.newrelic.com/nr-loader-spa-current.min.js')
+  .string('released')
+  .describe('released', 'current/stable build (defaults to -current)')
+  .default('released', 'https://js-agent.newrelic.com/nr-loader-spa-current.min.js')
 
-  .string('next')
-  .describe('next', 'next version to compare to stable version (defaults to /dev)')
-  .default('next', 'https://js-agent.newrelic.com/dev/nr-loader-spa.min.js')
+  .string('latest')
+  .describe('latest', 'next version to compare to stable version (defaults to /dev)')
+  .default('latest', 'https://js-agent.newrelic.com/dev/nr-loader-spa.min.js')
 
   .string('app-id')
   .describe('Application ID to use in the environment NRBA configuration for the next loader.')
@@ -39,4 +39,11 @@ export const args = yargs(hideBin(process.argv))
   .default('region', 'us-east-1')
 
   .demandOption(['environment', 'app-id', 'license-key'])
+  .check((argv) => {
+    if (['dev', 'staging'].includes(argv.environment) && (!argv.abAppId || !argv.abLicenseKey)) {
+      throw new Error(`Cannot create ${argv.environment} script without A/B app ID and license key.`)
+    }
+
+    return true
+  })
   .argv

--- a/.github/actions/build-ab/index.js
+++ b/.github/actions/build-ab/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import url from 'url'
+import process from 'process'
 import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts'
 import { S3Client, ListObjectsCommand } from '@aws-sdk/client-s3'
 import { v4 as uuidv4 } from 'uuid'
@@ -9,84 +10,116 @@ import { fetchRetry } from '../shared-utils/fetch-retry.js'
 import Handlebars from 'handlebars'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
-const template = Handlebars.compile(await fs.promises.readFile(path.resolve(__dirname, './template.js'), 'utf-8'))
-
-let nextScript
-const abScripts = []
+const outputDir = path.resolve(__dirname, '../../../temp')
+const fileList = []
 
 // 0. Ensure the output directory is available and the target file does not exist
+await fs.promises.mkdir(outputDir, { recursive: true })
 
-const outputFile = path.join(
-  path.resolve(__dirname, '../../../temp'),
-  `${args.environment}.js`
-)
-await fs.promises.mkdir(path.dirname(outputFile), { recursive: true })
-if (fs.existsSync(outputFile)) {
-  await fs.promises.rm(outputFile)
-}
-
-const nextScriptRequest = await fetchRetry(`${args.next}?_nocache=${uuidv4()}`, { retry: 3 })
-nextScript = await nextScriptRequest.text()
-
-if (['dev', 'staging'].includes(args.environment)) {
-  if (!args.abAppId || !args.abLicenseKey) {
-    throw new Error('Cannot deploy current loader or experiments without A/B app id and license key.')
-  }
-
-  const currentScript = await fetchRetry(`${args.current}?_nocache=${uuidv4()}`, { retry: 3 })
-  abScripts.push({ name: 'current', contents: await currentScript.text() })
-
-  const stsClient = new STSClient({ region: args.region })
-  const s3Credentials = await stsClient.send(new AssumeRoleCommand({
-    RoleArn: args.role,
-    RoleSessionName: 'downloadFromS3Session',
-    DurationSeconds: 900
-  }))
-
-  const s3Client = new S3Client({
-    region: args.region,
-    credentials: {
-      accessKeyId: s3Credentials.Credentials.AccessKeyId,
-      secretAccessKey: s3Credentials.Credentials.SecretAccessKey,
-      sessionToken: s3Credentials.Credentials.SessionToken
-    }
-  })
-
-  let isTruncated = true
-  const listCommand = new ListObjectsCommand({
-    Bucket: args.bucket,
-    Prefix: 'experiments/',
-    Delimiter: '/'
-  });
-  let experimentsList = new Set()
-
-  while (isTruncated) {
-    const { IsTruncated, NextMarker, CommonPrefixes } = await s3Client.send(listCommand)
-    if (CommonPrefixes) CommonPrefixes.forEach(prefix => experimentsList.add(prefix.Prefix))
-
-    if (IsTruncated) {
-      listCommand.input.Marker = NextMarker
-    } else {
-      isTruncated = false
-    }
-  }
-
-  if (experimentsList.size === 0) {
-    console.log('No experiments to include in A/B script.')
-  } else {
-    for (const experiment of experimentsList) {
-      const experimentLoader = `https://js-agent.newrelic.com/${experiment}nr-loader-experimental.min.js`
-      const experimentScript = await fetchRetry(`${experimentLoader}?_nocache=${uuidv4()}`, { retry: 3 })
-      abScripts.push({ name: experiment, contents: await experimentScript.text() })
-    }
-  }
-}
-console.log('writing', abScripts.length + 1,'scripts:', [{ name: 'next' }, ...abScripts].map(x => x.name).join(', '))
-
+// 1. Create the released environment script
+const releasedScriptRequest = await fetchRetry(`${args.released}?_nocache=${uuidv4()}`, { retry: 3 })
+const releasedScript = (await releasedScriptRequest.text()).replace(/\/\/# sourceMappingURL=.*?\.map/, '')
+const releasedScriptOutput = path.join(outputDir, `${args.environment}-released.js`)
+const releasedScriptTemplate = Handlebars.compile(await fs.promises.readFile(path.resolve(__dirname, './templates/released.js'), 'utf-8'))
 await fs.promises.writeFile(
-  outputFile,
-  template({
-    args, nextScript, abScripts, env: args.environment
+  releasedScriptOutput,
+  releasedScriptTemplate({
+    args, releasedScript
   }),
   { encoding: 'utf-8' }
 )
+fileList.push(releasedScriptOutput)
+
+if (['dev', 'staging'].includes(args.environment)) {
+  // 2. Create latest environment script
+  const latestScriptRequest = await fetchRetry(`${args.latest}?_nocache=${uuidv4()}`, { retry: 3 })
+  const latestScript = (await latestScriptRequest.text()).replace(/\/\/# sourceMappingURL=.*?\.map/, '')
+  const latestScriptOutput = path.join(outputDir, `${args.environment}-latest.js`)
+  const releasedScriptTemplate = Handlebars.compile(await fs.promises.readFile(path.resolve(__dirname, './templates/latest.js'), 'utf-8'))
+  await fs.promises.writeFile(
+    latestScriptOutput,
+    releasedScriptTemplate({
+      args, latestScript
+    }),
+    { encoding: 'utf-8' }
+  )
+  fileList.push(latestScriptOutput)
+
+  // 3. Creating experiments script
+  if (!args.role || !args.bucket || !args.region) {
+    console.warn('Skipping experiments; AWS role, bucket, and region must be defined.')
+  } else if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+    console.warn('Skipping experiments; AWS credentials missing in environment variables.')
+  } else {
+    const stsClient = new STSClient({ region: args.region })
+    const s3Credentials = await stsClient.send(new AssumeRoleCommand({
+      RoleArn: args.role,
+      RoleSessionName: 'downloadFromS3Session',
+      DurationSeconds: 900
+    }))
+
+    const s3Client = new S3Client({
+      region: args.region,
+      credentials: {
+        accessKeyId: s3Credentials.Credentials.AccessKeyId,
+        secretAccessKey: s3Credentials.Credentials.SecretAccessKey,
+        sessionToken: s3Credentials.Credentials.SessionToken
+      }
+    })
+
+    let isTruncated = true
+    const listCommand = new ListObjectsCommand({
+      Bucket: args.bucket,
+      Prefix: `experiments/${args.environment}/`,
+      Delimiter: '/'
+    });
+    let experimentsList = new Set()
+
+    while (isTruncated) {
+      const { IsTruncated, NextMarker, CommonPrefixes } = await s3Client.send(listCommand)
+      if (CommonPrefixes) CommonPrefixes.forEach(prefix => experimentsList.add(prefix.Prefix))
+
+      if (IsTruncated) {
+        listCommand.input.Marker = NextMarker
+      } else {
+        isTruncated = false
+      }
+    }
+
+    const experimentScripts = []
+    for (const experiment of experimentsList) {
+      const experimentLoader = `https://js-agent.newrelic.com/${experiment}nr-loader-experimental.min.js`
+      const experimentScript = await fetchRetry(`${experimentLoader}?_nocache=${uuidv4()}`, { retry: 3 })
+      experimentScripts.push((await experimentScript.text()).replace(/\/\/# sourceMappingURL=.*?\.map/, ''))
+    }
+
+    if (experimentScripts.length === 0) {
+      console.log(`No experiments found for ${args.environment} environment.`)
+    }
+
+    const experimentsScriptOutput = path.join(outputDir, `${args.environment}-experiments.js`)
+    const experimentsScriptTemplate = Handlebars.compile(await fs.promises.readFile(path.resolve(__dirname, './templates/experiments.js'), 'utf-8'))
+    await fs.promises.writeFile(
+      experimentsScriptOutput,
+      experimentsScriptTemplate({
+        args, experimentScripts
+      }),
+      { encoding: 'utf-8' }
+    )
+    fileList.push(experimentsScriptOutput)
+  }
+}
+
+// 4. Write the postamble script
+const postambleScriptOutput = path.join(outputDir, `${args.environment}-postamble.js`)
+const postambleScriptTemplate = Handlebars.compile(await fs.promises.readFile(path.resolve(__dirname, './templates/postamble.js'), 'utf-8'))
+await fs.promises.writeFile(
+  postambleScriptOutput,
+  postambleScriptTemplate({
+    args
+  }),
+  { encoding: 'utf-8' }
+)
+fileList.push(postambleScriptOutput)
+
+console.log(`Successfully created ${fileList.length} A/B files for ${args.environment} environment.`)

--- a/.github/actions/build-ab/index.js
+++ b/.github/actions/build-ab/index.js
@@ -19,7 +19,7 @@ await fs.promises.mkdir(outputDir, { recursive: true })
 // 1. Create the released environment script
 const releasedScriptRequest = await fetchRetry(`${args.released}?_nocache=${uuidv4()}`, { retry: 3 })
 
-if (!releasedScriptRequest.ok() || typeof releasedScriptRequest.text !== 'function') {
+if (!releasedScriptRequest.ok || typeof releasedScriptRequest.text !== 'function') {
   throw new Error('Could not retrieve the latest published loader script.')
 }
 
@@ -39,7 +39,7 @@ if (['dev', 'staging'].includes(args.environment)) {
   // 2. Create latest environment script
   const latestScriptRequest = await fetchRetry(`${args.latest}?_nocache=${uuidv4()}`, { retry: 3 })
 
-  if (!latestScriptRequest.ok() || typeof latestScriptRequest.text !== 'function') {
+  if (!latestScriptRequest.ok || typeof latestScriptRequest.text !== 'function') {
     throw new Error('Could not retrieve the latest unpublished loader script.')
   }
 

--- a/.github/actions/build-ab/templates/experiments.js
+++ b/.github/actions/build-ab/templates/experiments.js
@@ -1,0 +1,13 @@
+window.NREUM.loader_config.agentID = '{{{args.abAppId}}}'
+window.NREUM.loader_config.applicationID = '{{{args.abAppId}}}'
+window.NREUM.loader_config.licenseKey = '{{{args.abLicenseKey}}}'
+window.NREUM.info.applicationID = '{{{args.abAppId}}}'
+window.NREUM.info.licenseKey = '{{{args.abLicenseKey}}}'
+
+{{#if experimentScripts}}
+{{#each experimentScripts}}
+{{{this}}}
+{{/each}}
+{{else}}
+console.log('NRBA: No experimental loaders found for this environment.')
+{{/if}}

--- a/.github/actions/build-ab/templates/latest.js
+++ b/.github/actions/build-ab/templates/latest.js
@@ -1,0 +1,7 @@
+window.NREUM.loader_config.agentID = '{{{args.abAppId}}}'
+window.NREUM.loader_config.applicationID = '{{{args.abAppId}}}'
+window.NREUM.loader_config.licenseKey = '{{{args.abLicenseKey}}}'
+window.NREUM.info.applicationID = '{{{args.abAppId}}}'
+window.NREUM.info.licenseKey = '{{{args.abLicenseKey}}}'
+
+{{{latestScript}}}

--- a/.github/actions/build-ab/templates/postamble.js
+++ b/.github/actions/build-ab/templates/postamble.js
@@ -1,56 +1,4 @@
-// config
-window.NREUM={
-  init: {
-    distributed_tracing: {
-      enabled: true
-    },
-    ajax: {
-      deny_list: [
-        'nr-data.net',
-        'bam.nr-data.net',
-        'staging-bam.nr-data.net',
-        'bam-cell.nr-data.net'
-      ]
-    },
-    session_replay: {
-      enabled: true,
-      sampling_rate: 50,
-      error_sampling_rate: 100,
-      autoStart: false
-    }
-  },
-  loader_config: {
-    accountID: '1',
-    trustKey: '1',
-    agentID: '{{{args.appId}}}',
-    licenseKey: '{{{args.licenseKey}}}',
-    applicationID: '{{{args.appId}}}'
-  },
-  info: {
-    beacon: 'staging-bam.nr-data.net',
-    errorBeacon: 'staging-bam.nr-data.net',
-    licenseKey: '{{{args.licenseKey}}}',
-    applicationID: '{{{args.appId}}}',
-    sa: 1
-  }
-}
-
-// scripts
-{{{nextScript}}}
-
-{{#if abScripts}}
-window.NREUM.loader_config.agentID = '{{{args.abAppId}}}'
-window.NREUM.loader_config.applicationID = '{{{args.abAppId}}}'
-window.NREUM.loader_config.licenseKey = '{{{args.abLicenseKey}}}'
-window.NREUM.info.applicationID = '{{{args.abAppId}}}'
-window.NREUM.info.licenseKey = '{{{args.abLicenseKey}}}'
-{{/if}}
-
-{{#each abScripts}}
-{{{this.contents}}}
-{{/each}}
-
-// post-script checks
+// Session replay entitlements check
 try {
   var xhr = new XMLHttpRequest()
   xhr.open('POST', '/graphql')
@@ -97,4 +45,4 @@ try {
   if (!!newrelic && !!newrelic.noticeError) newrelic.noticeError(err)
 }
 
-if (!!newrelic && !!newrelic.setApplicationVersion && '{{{env}}}' === 'staging') newrelic.setApplicationVersion( '' + Math.floor(Math.random() * 10) + '.' + Math.floor(Math.random() * 10) + '.' + Math.floor(Math.random() * 10) )
+if (!!newrelic && !!newrelic.setApplicationVersion && '{{{args.environment}}}' === 'staging') newrelic.setApplicationVersion( '' + Math.floor(Math.random() * 10) + '.' + Math.floor(Math.random() * 10) + '.' + Math.floor(Math.random() * 10) )

--- a/.github/actions/build-ab/templates/postamble.js
+++ b/.github/actions/build-ab/templates/postamble.js
@@ -1,3 +1,10 @@
+// Reset config values back to released
+window.NREUM.loader_config.agentID = '{{{args.appId}}}'
+window.NREUM.loader_config.applicationID = '{{{args.appId}}}'
+window.NREUM.loader_config.licenseKey = '{{{args.licenseKey}}}'
+window.NREUM.info.applicationID = '{{{args.appId}}}'
+window.NREUM.info.licenseKey = '{{{args.licenseKey}}}'
+
 // Session replay entitlements check
 try {
   var xhr = new XMLHttpRequest()

--- a/.github/actions/build-ab/templates/released.js
+++ b/.github/actions/build-ab/templates/released.js
@@ -1,0 +1,38 @@
+// config
+window.NREUM={
+  init: {
+    distributed_tracing: {
+      enabled: true
+    },
+    ajax: {
+      deny_list: [
+        'nr-data.net',
+        'bam.nr-data.net',
+        'staging-bam.nr-data.net',
+        'bam-cell.nr-data.net'
+      ]
+    },
+    session_replay: {
+      enabled: true,
+      sampling_rate: 50,
+      error_sampling_rate: 100,
+      autoStart: false
+    }
+  },
+  loader_config: {
+    accountID: '1',
+    trustKey: '1',
+    agentID: '{{{args.appId}}}',
+    licenseKey: '{{{args.licenseKey}}}',
+    applicationID: '{{{args.appId}}}'
+  },
+  info: {
+    beacon: 'staging-bam.nr-data.net',
+    errorBeacon: 'staging-bam.nr-data.net',
+    licenseKey: '{{{args.licenseKey}}}',
+    applicationID: '{{{args.appId}}}',
+    sa: 1
+  }
+}
+
+{{{releasedScript}}}

--- a/.github/actions/comment-pull-request/action.yml
+++ b/.github/actions/comment-pull-request/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/docs-pr/action.yml
+++ b/.github/actions/docs-pr/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/fastly-purge/action.yml
+++ b/.github/actions/fastly-purge/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/fastly-verify/action.yml
+++ b/.github/actions/fastly-verify/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/find-pull-request/action.yml
+++ b/.github/actions/find-pull-request/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/internal-ab/action.yml
+++ b/.github/actions/internal-ab/action.yml
@@ -17,11 +17,11 @@ inputs:
   nrba_ab_license_key:
     description: 'License key to insert into the NRBA configuration for non-next loaders.'
     required: false
-  nrba_current_script_url:
-    description: 'URL for the script to use as the "current" version NRBA loader.'
+  nrba_released_script_url:
+    description: 'URL for the script to use as the latest released version NRBA loader.'
     required: false
-  nrba_next_script_url:
-    description: 'URL for the script to use as the "next" version NRBA loader.'
+  nrba_latest_script_url:
+    description: 'URL for the script to use as the latest unreleased version NRBA loader.'
     required: false
   aws_access_key_id:
     description: 'AWS access key id used for authentication.'
@@ -47,6 +47,7 @@ runs:
   using: "composite"
   steps:
     - name: Build a/b script
+      id: ab-build
       uses: ./.github/actions/build-ab
       with:
         aws_access_key_id: ${{ inputs.aws_access_key_id }}
@@ -58,8 +59,8 @@ runs:
         nrba_license_key: ${{ inputs.nrba_license_key }}
         nrba_ab_app_id: ${{ inputs.nrba_ab_app_id }}
         nrba_ab_license_key: ${{ inputs.nrba_ab_license_key }}
-        nrba_current_script_url: ${{ inputs.nrba_current_script_url }}
-        nrba_next_script_url: ${{ inputs.nrba_next_script_url }}
+        nrba_released_script_url: ${{ inputs.nrba_released_script_url }}
+        nrba_latest_script_url: ${{ inputs.nrba_latest_script_url }}
     - name: Upload a/b script
       id: ab-s3-upload
       uses: ./.github/actions/s3-upload

--- a/.github/actions/internal-ab/action.yml
+++ b/.github/actions/internal-ab/action.yml
@@ -46,6 +46,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - run: echo '===========================\n= Building A/B Script     =\n===========================\n'
+      shell: bash
     - name: Build a/b script
       id: ab-build
       uses: ./.github/actions/build-ab
@@ -61,6 +63,9 @@ runs:
         nrba_ab_license_key: ${{ inputs.nrba_ab_license_key }}
         nrba_released_script_url: ${{ inputs.nrba_released_script_url }}
         nrba_latest_script_url: ${{ inputs.nrba_latest_script_url }}
+
+    - run: echo '===========================\n= Uploading A/B Script    =\n===========================\n'
+      shell: bash
     - name: Upload a/b script
       id: ab-s3-upload
       uses: ./.github/actions/s3-upload
@@ -71,6 +76,9 @@ runs:
         aws_bucket_name: ${{ inputs.aws_bucket_name }}
         local_dir: $GITHUB_WORKSPACE/temp
         bucket_dir: internal/
+
+    - run: echo '===========================\n= Purging Fastly Cache    =\n===========================\n'
+      shell: bash
     - name: Gather a/b purge paths
       id: ab-purge-paths
       run: echo "results=$(echo '${{ steps.ab-s3-upload.outputs.results }}' | jq -j '.[].Key | select(. | test(".*?\\.js$")) + " "')" >> $GITHUB_OUTPUT
@@ -81,6 +89,9 @@ runs:
         fastly_key: ${{ inputs.fastly_key }}
         fastly_service: js-agent.newrelic.com
         purge_path: ${{ steps.ab-purge-paths.outputs.results }}
+
+    - run: echo '===========================\n= Verifying A/B Scripts   =\n===========================\n'
+      shell: bash
     - name: Verify a/b assets
       uses: ./.github/actions/fastly-verify
       with:

--- a/.github/actions/nr-upload-dev/action.yml
+++ b/.github/actions/nr-upload-dev/action.yml
@@ -1,0 +1,22 @@
+# This composite action is used to upload a dev loader
+# to the staging environment only.
+
+name: 'NR Upload - Dev'
+
+inputs:
+  nr_stage_api_key:
+    description: 'API key to use for talking to staging RPM site to upload loaders'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
+      shell: bash
+    - name: Run action script
+      id: action-script
+      run: |
+        node $GITHUB_ACTION_PATH/index.js \
+          ${{ inputs.nr_stage_api_key && format('--stage-api-key {0}', inputs.nr_stage_api_key) || '' }}
+      shell: bash

--- a/.github/actions/nr-upload-dev/args.js
+++ b/.github/actions/nr-upload-dev/args.js
@@ -1,0 +1,12 @@
+import process from 'process'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+export const args = yargs(hideBin(process.argv))
+  .usage('$0 [options]')
+
+  .string('stage-api-key')
+  .describe('stage-api-key', 'API key to use for talking to staging RPM site to upload loaders')
+
+  .demandOption(['stage-api-key'])
+  .argv

--- a/.github/actions/nr-upload-dev/index.js
+++ b/.github/actions/nr-upload-dev/index.js
@@ -1,0 +1,44 @@
+import { v4 as uuidv4 } from 'uuid'
+import { args } from './args.js'
+import { fetchRetry } from '../shared-utils/fetch-retry.js'
+import { loaderTypes } from '../shared-utils/loaders.js'
+
+const envOptions = {
+  url: 'https://staging-api.newrelic.com/v2/js_agent_loaders/create.json',
+  headers: {
+    'X-Api-Key': args.stageApiKey,
+    'Content-Type': 'application/json'
+  }
+}
+
+for (const loader of loaderTypes) {
+  console.log(`Downloading ${loader} dev loader`)
+  const loaderContentsRequest = await fetchRetry(`https://js-agent.newrelic.com/dev/nr-loader-spa.min.js?_nocache=${uuidv4()}`, { retry: 3 })
+
+  if (!loaderContentsRequest.ok) {
+    throw new Error(`Download for ${loader} dev loader failed`)
+  }
+
+  const loaderContents = await loaderContentsRequest.text()
+
+  console.log(`Uploading ${loader} dev loader to NRDB`)
+  const uploadRequest = await fetchRetry(envOptions.url, {
+    retry: 3,
+    method: 'PUT',
+    redirect: 'follow',
+    headers: envOptions.headers,
+    body: JSON.stringify({
+      js_agent_loader: {
+        version: `nr-loader-${loader}-0.x.x-dev.min.js`,
+        loader: loaderContents
+      },
+      set_current: false
+    })
+  })
+
+  if (!uploadRequest?.ok) {
+    throw new Error(`Upload failed with status code ${uploadRequest?.status}. ${uploadRequest?.statusText}`)
+  } else {
+    console.log(`Completed upload of ${loader} dev loader`)
+  }
+}

--- a/.github/actions/nr-upload/action.yml
+++ b/.github/actions/nr-upload/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/nr-verify/action.yml
+++ b/.github/actions/nr-verify/action.yml
@@ -15,7 +15,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/post-release-updates/action.yml
+++ b/.github/actions/post-release-updates/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/s3-upload/action.yml
+++ b/.github/actions/s3-upload/action.yml
@@ -41,7 +41,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/shared-utils/fetch-retry.js
+++ b/.github/actions/shared-utils/fetch-retry.js
@@ -1,8 +1,15 @@
 import fetch from 'node-fetch'
 
+/**
+ * Wraps fetch with retry capabilities.
+ * @param {string} url
+ * @param {import('node-fetch').RequestInit & { retry?: number }} options
+ * @returns {Promise<import('node-fetch').Response>}
+ */
 export async function fetchRetry (url, options) {
   let retryLimit
-  let status, statusText
+  let request
+
   if (typeof options.retry !== 'number' || options.retry <= 1) {
     retryLimit = 1
   } else {
@@ -11,21 +18,17 @@ export async function fetchRetry (url, options) {
 
   while (retryLimit >= 1) {
     try {
-      const result = await fetch(url, {
+      request = await fetch(url, {
         ...options,
         retry: undefined
       })
 
-      status = result?.status, 
-      statusText = result?.statusText
-
-      if (result?.ok) {
-        return result
+      if (request?.ok) {
+        return request
       } else {
         retryLimit--
       }
     } catch (error) {
-      errMsg = err
       if (retryLimit <= 1) {
         throw error
       }
@@ -34,5 +37,5 @@ export async function fetchRetry (url, options) {
     }
   }
 
-  return {status, statusText}
+  return request
 }

--- a/.github/actions/size-diff/action.yml
+++ b/.github/actions/size-diff/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/actions/update-current/action.yml
+++ b/.github/actions/update-current/action.yml
@@ -35,7 +35,7 @@ runs:
   using: "composite"
   steps:
     - name: Install dependencies
-      run: npm install --prefix $GITHUB_ACTION_PATH/..
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
       shell: bash
     - name: Run action script
       id: action-script

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -102,8 +102,6 @@ jobs:
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
           nrba_ab_app_id: ${{ secrets.INTERNAL_AB_DEV_APPLICATION_ID }}
           nrba_ab_license_key: ${{ secrets.INTERNAL_AB_LICENSE_KEY }}
-          nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
-          nrba_next_script_url: https://js-agent.newrelic.com/dev/nr-loader-spa.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_role: ${{ secrets.AWS_ROLE_ARN }}
@@ -133,8 +131,6 @@ jobs:
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
           nrba_ab_app_id: ${{ secrets.INTERNAL_AB_STAGING_APPLICATION_ID }}
           nrba_ab_license_key: ${{ secrets.INTERNAL_AB_LICENSE_KEY }}
-          nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
-          nrba_next_script_url: https://js-agent.newrelic.com/dev/nr-loader-spa.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_role: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -79,6 +79,26 @@ jobs:
           fastly_service: js-agent.newrelic.com
           asset_path: ${{ join(fromJson(steps.dev-s3-upload.outputs.results).*.Key, ' ') }}
 
+  # Publish dev to staging NRDB
+  publish-dev-ab:
+    needs: [publish-dev-to-s3]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - name: Publish dev loader to nr
+        uses: ./.github/actions/nr-upload-dev
+        with:
+          nr_stage_api_key: ${{ secrets.NR_API_KEY_STAGING }}
+
   # Rebuild and publish the dev environment A/B script
   publish-dev-ab:
     needs: [publish-dev-to-s3]

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*
-      - name: Publish dev a/b script
+      - name: Publish a/b script
         uses: ./.github/actions/internal-ab
         with:
           nr_environment: ${{ inputs.nr_environment }}

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -7,6 +7,14 @@ name: Publish Experiment
 
 on:
   workflow_dispatch:
+    inputs:
+      nr_environment:
+        description: 'Target New Relic environment'
+        required: true
+        type: choice
+        options:
+          - dev
+          - staging
 
 jobs:
   # Build and publish the branch to S3 experiments folder
@@ -37,7 +45,7 @@ jobs:
           aws_role: ${{ secrets.AWS_ROLE_ARN }}
           aws_bucket_name: ${{ secrets.AWS_BUCKET }}
           local_dir: $GITHUB_WORKSPACE/build
-          bucket_dir: experiments/${{ steps.clean-branch-name.outputs.results }}
+          bucket_dir: experiments/${{ inputs.nr_environment }}/${{ steps.clean-branch-name.outputs.results }}
       - name: Gather purge paths
         id: purge-paths
         run: echo "results=$(echo '${{ steps.s3-upload.outputs.results }}' | jq -j '.[].Key | select(. | test("nr-loader-.*?\\.js$") or test(".*stats\\.json$")) + " "')" >> $GITHUB_OUTPUT
@@ -48,8 +56,8 @@ jobs:
           fastly_service: js-agent.newrelic.com
           purge_path: ${{ steps.purge-paths.outputs.results }}
 
-  # Rebuild and publish the dev environment A/B script
-  publish-dev-ab:
+  # Rebuild and publish the environment A/B script
+  publish-ab:
     needs: [publish-experiment-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -66,44 +74,11 @@ jobs:
       - name: Publish dev a/b script
         uses: ./.github/actions/internal-ab
         with:
-          nr_environment: dev
-          nrba_app_id: ${{ secrets.INTERNAL_DEV_APPLICATION_ID }}
+          nr_environment: ${{ inputs.nr_environment }}
+          nrba_app_id: ${{ inputs.nr_environment == 'dev' && secrets.INTERNAL_DEV_APPLICATION_ID || secrets.INTERNAL_STAGING_APPLICATION_ID }}
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
-          nrba_ab_app_id: ${{ secrets.INTERNAL_AB_DEV_APPLICATION_ID }}
+          nrba_ab_app_id: ${{ inputs.nr_environment == 'dev' && secrets.INTERNAL_AB_DEV_APPLICATION_ID || secrets.INTERNAL_AB_STAGING_APPLICATION_ID }}
           nrba_ab_license_key: ${{ secrets.INTERNAL_AB_LICENSE_KEY }}
-          nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
-          nrba_next_script_url: https://js-agent.newrelic.com/dev/nr-loader-experimental.min.js
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_role: ${{ secrets.AWS_ROLE_ARN }}
-          aws_bucket_name: ${{ secrets.AWS_BUCKET }}
-          fastly_key: ${{ secrets.FASTLY_PURGE_KEY }}
-
-  # Rebuild and publish the staging environment A/B script
-  publish-staging-ab:
-    needs: [publish-experiment-to-s3]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: main
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-      - name: Deploy staging a/b script
-        uses: ./.github/actions/internal-ab
-        with:
-          nr_environment: staging
-          nrba_app_id: ${{ secrets.INTERNAL_STAGING_APPLICATION_ID }}
-          nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
-          nrba_ab_app_id: ${{ secrets.INTERNAL_AB_STAGING_APPLICATION_ID }}
-          nrba_ab_license_key: ${{ secrets.INTERNAL_AB_LICENSE_KEY }}
-          nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
-          nrba_next_script_url: https://js-agent.newrelic.com/dev/nr-loader-experimental.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_role: ${{ secrets.AWS_ROLE_ARN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,9 +50,50 @@ jobs:
           fastly_service: js-agent.newrelic.com
           asset_path: ${{ join(fromJson(steps.prod-s3-upload.outputs.results).*.Key, ' ') }}
 
+  # Publish the new "current" version to s3 before the prod a/b scripts have been built
+  publish-current-to-s3:
+    needs: [publish-prod-to-s3]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - name: Get version number
+        id: agent-loader-version
+        run: echo "results=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+      - name: Copy loaders to current
+        id: current-s3-update
+        uses: ./.github/actions/update-current
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_role: ${{ secrets.AWS_ROLE_ARN }}
+          aws_bucket_name: ${{ secrets.AWS_BUCKET }}
+          loader_version: ${{ steps.agent-loader-version.outputs.results }}
+      - name: Gather current purge paths
+        id: current-purge-paths
+        run: echo "results=$(echo '${{ steps.current-s3-update.outputs.results }}' | jq -j '.[].Key + " "')" >> $GITHUB_OUTPUT
+      - name: Purge current fastly cache
+        uses: ./.github/actions/fastly-purge
+        with:
+          fastly_key: ${{ secrets.FASTLY_PURGE_KEY }}
+          fastly_service: js-agent.newrelic.com
+          purge_path: ${{ steps.current-purge-paths.outputs.results }}
+      - name: Verify current assets
+        uses: ./.github/actions/fastly-verify
+        with:
+          fastly_key: ${{ secrets.FASTLY_PURGE_KEY }}
+          fastly_service: js-agent.newrelic.com
+          asset_path: ${{ join(fromJson(steps.current-s3-update.outputs.results).*.Key, ' ') }}
+
   # Rebuild and publish the prod environment A/B script
   publish-prod-ab:
-    needs: [publish-prod-to-s3]
+    needs: [publish-current-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -72,8 +113,6 @@ jobs:
           nr_environment: prod
           nrba_app_id: ${{ secrets.INTERNAL_PRODUCTION_APPLICATION_ID }}
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
-          nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
-          nrba_next_script_url: https://js-agent.newrelic.com/nr-loader-spa-${{ steps.agent-loader-version.outputs.results }}.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_role: ${{ secrets.AWS_ROLE_ARN }}
@@ -82,7 +121,7 @@ jobs:
 
   # Rebuild and publish the eu-prod environment A/B script
   publish-eu-prod-ab:
-    needs: [publish-prod-to-s3]
+    needs: [publish-current-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -102,8 +141,6 @@ jobs:
           nr_environment: eu-prod
           nrba_app_id: ${{ secrets.INTERNAL_EU_PRODUCTION_APPLICATION_ID }}
           nrba_license_key: ${{ secrets.INTERNAL_LICENSE_KEY }}
-          nrba_current_script_url: https://js-agent.newrelic.com/nr-loader-spa-current.min.js
-          nrba_next_script_url: https://js-agent.newrelic.com/nr-loader-spa-${{ steps.agent-loader-version.outputs.results }}.min.js
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_role: ${{ secrets.AWS_ROLE_ARN }}
@@ -185,44 +222,3 @@ jobs:
           github_login: ${{ secrets.BROWSER_GITHUB_BOT_NAME }}
           github_token: ${{ secrets.BROWSER_GITHUB_BOT_PAT }}
           github_email: ${{ secrets.BROWSER_GITHUB_BOT_EMAIL }}
-
-  # Publish the new "current" version to s3 after the prod a/b scripts have been built
-  publish-current-to-s3:
-    needs: [publish-prod-ab, publish-eu-prod-ab]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-      - name: Get version number
-        id: agent-loader-version
-        run: echo "results=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
-      - name: Copy loaders to current
-        id: current-s3-update
-        uses: ./.github/actions/update-current
-        with:
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_role: ${{ secrets.AWS_ROLE_ARN }}
-          aws_bucket_name: ${{ secrets.AWS_BUCKET }}
-          loader_version: ${{ steps.agent-loader-version.outputs.results }}
-      - name: Gather current purge paths
-        id: current-purge-paths
-        run: echo "results=$(echo '${{ steps.current-s3-update.outputs.results }}' | jq -j '.[].Key + " "')" >> $GITHUB_OUTPUT
-      - name: Purge current fastly cache
-        uses: ./.github/actions/fastly-purge
-        with:
-          fastly_key: ${{ secrets.FASTLY_PURGE_KEY }}
-          fastly_service: js-agent.newrelic.com
-          purge_path: ${{ steps.current-purge-paths.outputs.results }}
-      - name: Verify current assets
-        uses: ./.github/actions/fastly-verify
-        with:
-          fastly_key: ${{ secrets.FASTLY_PURGE_KEY }}
-          fastly_service: js-agent.newrelic.com
-          asset_path: ${{ join(fromJson(steps.current-s3-update.outputs.results).*.Key, ' ') }}


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

New experiments and A/B script publishing process:
- Experiments workflow will now ask which environment to publish the experiment to. Only that environment's A/B scripts will be rebuilt after the experiment is published into a sub-directory of `/experiments/{{environment}}/` in the S3 bucket.
  - Experiments can still be published to both `dev` and `staging` but it must be done by running the workflow twice, once for each environment.
- The publish-release and publish-dev workflow will no longer pass different values for the currently released and next versions of the loader.
- The publish-release workflow will no longer gate the publishing of the `current` loader on the publishing of the A/B environment scripts.
- Loader version loading order has been changed:
  - The latest released loader version will be the first loader to execute on internal environments and will report data to the internal NR1 account.
  - The latest loader built from the main branch will be the second loader to execute on internal environments and will report to internal Browser account.
  - Experiments will be the third loader(s) to execute on internal environments and will report to internal Browser account.
  - A final postamble script will be loaded for any post loader code that we need to run in the environment after the loader has started but before the page load event fires.
- The latest released, latest main, experiments, and postamble scripts all load independently to ensure a bug in one script does not keep the other loaders from running.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-160203

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
