### PR TITLE
chore: SR - handle meta nodes more gracefully

### DIFF
--- a/tests/specs/session-replay/helpers.js
+++ b/tests/specs/session-replay/helpers.js
@@ -14,7 +14,7 @@ export const RRWEB_EVENT_TYPES = {
   Custom: 5
 }
 
-export function testExpectedReplay ({ data, session, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes }) {
+export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes }) {
   expect(data.query).toMatchObject({
     browser_monitoring_key: expect.any(String),
     type: 'SessionReplay',
@@ -31,6 +31,7 @@ export function testExpectedReplay ({ data, session, hasSnapshot, hasError, isFi
     'replay.lastTimestamp': expect.any(Number),
     'replay.durationMs': expect.any(Number),
     session: session || expect.any(String),
+    hasMeta: hasMeta || expect.any(Boolean),
     hasSnapshot: hasSnapshot || expect.any(Boolean),
     hasError: hasError || expect.any(Boolean),
     agentVersion: expect.any(String),

--- a/tests/specs/session-replay/payload.e2e.js
+++ b/tests/specs/session-replay/payload.e2e.js
@@ -58,7 +58,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Payload Validation', () => 
     const { request: harvestContents } = await browser.testHandle.expectBlob()
     const { localStorage } = await browser.getAgentSessionInfo()
 
-    testExpectedReplay({ data: harvestContents, session: localStorage.value, hasError: false, hasSnapshot: true, isFirstChunk: true })
+    testExpectedReplay({ data: harvestContents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
   })
 
   it('should match expected payload - error', async () => {
@@ -73,6 +73,29 @@ describe.withBrowsersMatching(notIE)('Session Replay Payload Validation', () => 
     ])
     const { localStorage } = await browser.getAgentSessionInfo()
 
-    testExpectedReplay({ data: harvestContents, session: localStorage.value, hasError: true, hasSnapshot: true, isFirstChunk: true })
+    testExpectedReplay({ data: harvestContents, session: localStorage.value, hasError: true, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
+  })
+
+  it('should handle meta if separated', async () => {
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config()))
+      .then(() => browser.waitForAgentLoad())
+
+    const events = await browser.execute(function () {
+      var instance = Object.values(newrelic.initializedAgents)[0]
+      instance.features.session_replay.featAggregate.events = instance.features.session_replay.featAggregate.events.filter(x => x.type !== 4)
+      return instance.features.session_replay.featAggregate.events
+    })
+
+    expect(events.find(x => x.type === 4)).toEqual(undefined)
+
+    const [{ request: harvestContents }] = await Promise.all([
+      browser.testHandle.expectBlob(),
+      browser.execute(function () {
+        newrelic.noticeError(new Error('test'))
+      })
+    ])
+    const { localStorage } = await browser.getAgentSessionInfo()
+
+    testExpectedReplay({ data: harvestContents, session: localStorage.value, hasError: true, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
   })
 })

--- a/tests/specs/session-replay/session-pages.e2e.js
+++ b/tests/specs/session-replay/session-pages.e2e.js
@@ -18,7 +18,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
     const { request: page1Contents } = await browser.testHandle.expectBlob(10000)
     const { localStorage } = await browser.getAgentSessionInfo()
 
-    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasSnapshot: true, isFirstChunk: true })
+    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
 
     await browser.enableSessionReplay()
     await browser.refresh()
@@ -26,7 +26,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
 
     const { request: page2Contents } = await browser.testHandle.expectBlob()
 
-    testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasSnapshot: true, isFirstChunk: false })
+    testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
   })
 
   it('should record across same-tab page navigation', async () => {
@@ -35,7 +35,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
 
     const { localStorage } = await browser.getAgentSessionInfo()
     const { request: page1Contents } = await browser.testHandle.expectBlob(10000)
-    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasSnapshot: true, isFirstChunk: true })
+    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
 
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
@@ -56,7 +56,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
       .then(() => browser.waitForAgentLoad())
 
     const { request: page2Contents } = await browser.testHandle.expectBlob(10000)
-    testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasSnapshot: true, isFirstChunk: false })
+    testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
   })
 
   // As of 06/26/2023 test fails in Safari, though tested behavior works in a live browser (revisit in NR-138940).
@@ -67,7 +67,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
     const { request: page1Contents } = await browser.testHandle.expectBlob(10000)
     const { localStorage } = await browser.getAgentSessionInfo()
 
-    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasSnapshot: true, isFirstChunk: true })
+    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
 
     const newTab = await browser.createWindow('tab')
     await browser.switchToWindow(newTab.handle)
@@ -77,7 +77,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
 
     const { request: page2Contents } = await browser.testHandle.expectBlob(10000)
 
-    testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasSnapshot: true, isFirstChunk: false })
+    testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
 
     await browser.closeWindow()
     await browser.switchToWindow((await browser.getWindowHandles())[0])
@@ -90,7 +90,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
     const { request: page1Contents } = await browser.testHandle.expectBlob(10000)
     const { localStorage } = await browser.getAgentSessionInfo()
 
-    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasSnapshot: true, isFirstChunk: true })
+    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
 
     await browser.execute(function () {
       Object.values(NREUM.initializedAgents)[0].runtime.session.state.sessionReplay = 0


### PR DESCRIPTION
 handle meta nodes more gracefully
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
A new discovery found that the replayer actually needs BOTH the meta node, and subsequent snapshot node in order to render properly.  This is an effort to keep those events together.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Existing tests should continue to pass.  A new test will be added to check for meta flag
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
