### PR TITLE
chore: Fix workers test job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,13 +71,12 @@ jobs:
         run: npm run build:all
       - name: Run JIL Tests
         run: |
-          node --max-old-space-size=8192 ./tools/jil/bin/cli.js \
+          find ./tests/worker -regex ".*.test.js" | xargs node --max-old-space-size=8192 ./tools/jil/bin/cli.js \
             -f merged \
             -s \
             -b '*@*' \
             --concurrent 30 \
             -t 85000 \
-            ${{ runner.debug && '-v -L -D -d' || '' }} \
-            tests/worker/**/*.test.js
+            ${{ runner.debug && '-v -L -D -d' || '' }}
 
   # TODO: Need to add a job for cleaning up experiments to run nightly


### PR DESCRIPTION
The workers test job does not currently run because it doesnt support the syntax of the command being passed in.  This change just finds the worker test files and passes them in as args to the command.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
