### PR TITLE
chore: fix endless metrics call

### DIFF
--- a/src/common/harvest/harvest-scheduler.js
+++ b/src/common/harvest/harvest-scheduler.js
@@ -48,7 +48,7 @@ export class HarvestScheduler extends SharedContext {
    * to send payloads while the page is still active, due to limitations on how much data can be buffered in the API at any one time.
    */
   unload () {
-    if (this.aborted || !this.started) return
+    if (this.aborted) return
     // If opts.onUnload is defined, these are special actions to execute before attempting to send the final payload.
     if (this.opts.onUnload) this.opts.onUnload()
     this.runHarvest({ unload: true })

--- a/src/common/harvest/harvest-scheduler.test.js
+++ b/src/common/harvest/harvest-scheduler.test.js
@@ -37,7 +37,6 @@ describe('unload', () => {
   })
 
   test('should run onUnload callback when started', () => {
-    harvestSchedulerInstance.started = true
     harvestSchedulerInstance.opts.onUnload = jest.fn()
 
     eolSubscribeFn()
@@ -46,21 +45,11 @@ describe('unload', () => {
   })
 
   test('should run harvest when started and not aborted', () => {
-    harvestSchedulerInstance.started = true
     harvestSchedulerInstance.aborted = false
 
     eolSubscribeFn()
 
     expect(harvestSchedulerInstance.runHarvest).toHaveBeenCalledWith({ unload: true })
-  })
-
-  test('should not run harvest when not started', () => {
-    harvestSchedulerInstance.started = false
-    jest.spyOn(harvestSchedulerInstance, 'runHarvest').mockImplementation(jest.fn())
-
-    eolSubscribeFn()
-
-    expect(harvestSchedulerInstance.runHarvest).not.toHaveBeenCalled()
   })
 
   test('should not run harvest when aborted', () => {

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -29,10 +29,11 @@ export class Aggregate extends AggregateBase {
     this.singleChecks() // checks that are run only one time, at script load
     this.eachSessionChecks() // the start of every time user engages with page
 
-    // *cli, Mar 23 - Per NR-94597, this feature should only harvest ONCE at the (potential) EoL time of the page.
-    scheduler = new HarvestScheduler('jserrors', { onUnload: () => this.unload() }, this)
-    scheduler.harvest.on('jserrors', () => ({ body: this.aggregator.take(['cm', 'sm']) }))
-    this.ee.on(`drain-${this.featureName}`, () => { scheduler.started = true }) // this is needed to ensure EoL is "on" and sent
+    this.ee.on(`drain-${this.featureName}`, () => {
+      // *cli, Mar 23 - Per NR-94597, this feature should only harvest ONCE at the (potential) EoL time of the page.
+      scheduler = new HarvestScheduler('jserrors', { onUnload: () => this.unload() }, this)
+      scheduler.harvest.on('jserrors', () => ({ body: this.aggregator.take(['cm', 'sm']) }))
+    }) // this is needed to ensure EoL is "on" and sent
 
     this.drain()
   }


### PR DESCRIPTION
Fix an issue where metrics unloading would create an endless loop
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
Fixes endless loop related to #702
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
