### PR TITLE
fix: Validation of SR configurations

### DIFF
--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -8,7 +8,25 @@ const model = () => {
   const hiddenState = {
     mask_selector: '*',
     block_selector: '[data-nr-block]',
-    mask_input_options: { password: true }
+    mask_input_options: {
+      color: false,
+      date: false,
+      'datetime-local': false,
+      email: false,
+      month: false,
+      number: false,
+      range: false,
+      search: false,
+      tel: false,
+      text: false,
+      time: false,
+      url: false,
+      week: false,
+      // unify textarea and select element with text input
+      textarea: false,
+      select: false,
+      password: true // This will be enforced to always be true in the setter
+    }
   }
   return {
     proxy: {

--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -55,14 +55,14 @@ const model = () => {
         return hiddenState.block_selector
       },
       set block_selector (val) {
-        hiddenState.block_selector += `,${val}`
+        if (val) hiddenState.block_selector += `,${val}`
       },
       // password: must always be present and true no matter what customer sets
       get mask_input_options () {
         return hiddenState.mask_input_options
       },
       set mask_input_options (val) {
-        hiddenState.mask_input_options = { ...val, password: true }
+        if (val && typeof val === 'object') hiddenState.mask_input_options = { ...val, password: true }
       }
     },
     spa: { enabled: true, harvestTimeSeconds: 10, autoStart: true }

--- a/src/common/config/state/init.test.js
+++ b/src/common/config/state/init.test.js
@@ -26,3 +26,33 @@ test('getConfigurationValue parses path correctly', () => {
   expect(getConfigurationValue('ab', 'page_action')).toEqual({ enabled: true, harvestTimeSeconds: 1000, autoStart: true })
   expect(getConfigurationValue('ab', 'page_action.harvestTimeSeconds')).toEqual(1000)
 })
+
+describe('property getters/setters used for validation', () => {
+  test('invalid values do not pass through', () => {
+    setConfiguration('12345', {
+      session_replay: {
+        block_selector: '[invalid selector]',
+        mask_text_selector: '[invalid selector]',
+        mask_input_options: 'select:true'
+      }
+    })
+
+    expect(getConfigurationValue('12345', 'session_replay.block_selector')).toEqual('[data-nr-block]')
+    expect(getConfigurationValue('12345', 'session_replay.mask_text_selector')).toEqual('*')
+    expect(getConfigurationValue('12345', 'session_replay.mask_input_options')).toMatchObject({ password: true, select: false })
+  })
+
+  test('valid values do pass through', () => {
+    setConfiguration('23456', {
+      session_replay: {
+        block_selector: '[block-text-test]',
+        mask_text_selector: '[mask-text-test]',
+        mask_input_options: { select: true }
+      }
+    })
+
+    expect(getConfigurationValue('23456', 'session_replay.block_selector')).toEqual('[data-nr-block],[block-text-test]')
+    expect(getConfigurationValue('23456', 'session_replay.mask_text_selector')).toEqual('[mask-text-test]')
+    expect(getConfigurationValue('23456', 'session_replay.mask_input_options')).toMatchObject({ password: true, select: true })
+  })
+})

--- a/src/common/dom/query-selector.js
+++ b/src/common/dom/query-selector.js
@@ -1,0 +1,9 @@
+export const isValidSelector = (selector) => {
+  if (!selector || typeof selector !== 'string') return false
+  try {
+    document.createDocumentFragment().querySelector(selector)
+  } catch {
+    return false
+  }
+  return true
+}

--- a/src/common/dom/query-selector.test.js
+++ b/src/common/dom/query-selector.test.js
@@ -1,0 +1,24 @@
+import { isValidSelector } from './query-selector'
+describe('query selector tests', () => {
+  test('handles nullish values', () => {
+    expect(isValidSelector(null)).toEqual(false)
+    expect(isValidSelector('')).toEqual(false)
+    expect(isValidSelector(0)).toEqual(false)
+    expect(isValidSelector(false)).toEqual(false)
+  })
+
+  test('handles truthy but invalid values', () => {
+    expect(isValidSelector({ test: 1 })).toEqual(false)
+    expect(isValidSelector([1, 2, 3])).toEqual(false)
+    expect(isValidSelector(1)).toEqual(false)
+    expect(isValidSelector(',')).toEqual(false)
+    expect(isValidSelector('[invalid space]')).toEqual(false)
+  })
+
+  test('handles valid selectors', () => {
+    expect(isValidSelector('#id')).toEqual(true)
+    expect(isValidSelector('.class')).toEqual(true)
+    expect(isValidSelector('.multiple,#selectors')).toEqual(true)
+    expect(isValidSelector('[attr-selector]')).toEqual(true)
+  })
+})

--- a/tests/specs/session-replay/rrweb-configuration.e2e.js
+++ b/tests/specs/session-replay/rrweb-configuration.e2e.js
@@ -236,6 +236,19 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
 
       expect(JSON.stringify(body).includes('testing')).toBeFalsy()
     })
+
+    it('block_selector: should not extend on empty string argument', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { mask_text_selector: null, mask_all_inputs: false, block_selector: '' } })))
+        .then(() => browser.waitForAgentLoad())
+
+      const blockSelectorOutput = await browser.execute(function () {
+        return Object.values(newrelic.initializedAgents)[0].config.session_replay.block_selector
+      })
+
+      expect(blockSelectorOutput.endsWith(',')).toEqual(false)
+      expect(blockSelectorOutput.split(',').length).toEqual(1)
+      expect(blockSelectorOutput.includes('[data-nr-block]')).toEqual(true)
+    })
   })
 
   describe('mask_input_options', () => {


### PR DESCRIPTION
Update the block selector, mask selector, and mask input setters to handle empty strings
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
block_selector should always return [data-nr-block] as well as any customer-supplied configs in a comma delimited string.  This failed when `''` was passed as an argument, as the agent would append `,''` to the string, breaking the agent.

other configs could also benefit from being validated, so those were added here as well.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-162325
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been added.  Can be confirmed manually by supplying `''` as the block_selector argument to init.session_replay in a test-server page and inspecting the `initalizedAgents` config property.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
