### PR TITLE
feat: Applying new cache headers to assets

### DIFF
--- a/.github/actions/internal-ab/action.yml
+++ b/.github/actions/internal-ab/action.yml
@@ -46,7 +46,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: echo '===========================\n= Building A/B Script     =\n===========================\n'
+    - run: echo '=========================== Building A/B Script     ==========================='
       shell: bash
     - name: Build a/b script
       id: ab-build
@@ -64,7 +64,7 @@ runs:
         nrba_released_script_url: ${{ inputs.nrba_released_script_url }}
         nrba_latest_script_url: ${{ inputs.nrba_latest_script_url }}
 
-    - run: echo '===========================\n= Uploading A/B Script    =\n===========================\n'
+    - run: echo '=========================== Uploading A/B Script    ==========================='
       shell: bash
     - name: Upload a/b script
       id: ab-s3-upload
@@ -77,7 +77,7 @@ runs:
         local_dir: $GITHUB_WORKSPACE/temp
         bucket_dir: internal/
 
-    - run: echo '===========================\n= Purging Fastly Cache    =\n===========================\n'
+    - run: echo '=========================== Purging Fastly Cache    ==========================='
       shell: bash
     - name: Gather a/b purge paths
       id: ab-purge-paths
@@ -90,7 +90,7 @@ runs:
         fastly_service: js-agent.newrelic.com
         purge_path: ${{ steps.ab-purge-paths.outputs.results }}
 
-    - run: echo '===========================\n= Verifying A/B Scripts   =\n===========================\n'
+    - run: echo '=========================== Verifying A/B Scripts   ==========================='
       shell: bash
     - name: Verify a/b assets
       uses: ./.github/actions/fastly-verify

--- a/.github/actions/s3-upload/action.yml
+++ b/.github/actions/s3-upload/action.yml
@@ -28,9 +28,6 @@ inputs:
   bucket_dir:
     description: 'A sub directory to put the files within the S3 bucket.'
     required: false
-  asset_cache_duration:
-    description: 'Value to be set for the asset cache header.'
-    default: 3600
 
 outputs:
   results:
@@ -54,7 +51,6 @@ runs:
           --bucket ${{ inputs.aws_bucket_name }} \
           --role ${{ inputs.aws_role }} \
           --input ${{ inputs.local_dir }} \
-          --asset-cache-duration ${{ inputs.asset_cache_duration }} \
           ${{ inputs.dry_run && '--dry' || '' }} \
           ${{ inputs.bucket_dir && format('--dir {0}', inputs.bucket_dir) || '' }}
       shell: bash

--- a/.github/actions/s3-upload/args.js
+++ b/.github/actions/s3-upload/args.js
@@ -25,9 +25,5 @@ export const args = yargs(hideBin(process.argv))
   .string('dir')
   .describe('dir', 'Bucket sub-directory name. Leave empty to upload to the root of the bucket.')
 
-  .number('asset-cache-duration')
-  .describe('asset-cache-duration', 'Set the amount of time used for the cache control header of each asset. Defaults to 2 hours.')
-  .default('asset-cache-duration', 3600)
-
   .demandOption(['bucket', 'role', 'input'])
   .argv

--- a/.github/actions/s3-upload/asset-cache.js
+++ b/.github/actions/s3-upload/asset-cache.js
@@ -1,0 +1,22 @@
+export function getAssetCacheHeader (bucketDir, assetName) {
+  if (
+    // Set cache time for non-released assets to 2 hours
+    ((bucketDir && bucketDir !== '/') || !bucketDir) ||
+    // Set cache time for wildcard version assets to 2 hours
+    (assetName.indexOf('.x') > -1) ||
+    // Set cache time for "current" loader to 2 hours
+    (assetName.indexOf('-current') > -1)
+  ) {
+    // Set 'public' to allow intermediaries like CDNs to cache
+    // Set 'max-age=7200' to cache for 2 hours
+    // Set 'stale-while-revalidate=600' to allow cached responses to be used for 10 additional minutes while revalidating ETag
+    // Set 'stale-if-error=600' to allow cached responses to be used for 10 additional minutes when upstream server reports an error
+    return 'public, max-age=7200, stale-while-revalidate=600, stale-if-error=600'
+  }
+
+  // Set 'public' to allow intermediaries like CDNs to cache
+  // Set 'max-age=31536000' to cache for 1 year
+  // Set 'stale-while-revalidate=86400' to allow cached responses to be used for 1 additional day while revalidating ETag
+  // Set 'stale-if-error=86400' to allow cached responses to be used for 1 additional day when upstream server reports an error
+  return 'public, max-age=31536000, stale-while-revalidate=86400, stale-if-error=86400'
+}

--- a/.github/actions/s3-upload/index.js
+++ b/.github/actions/s3-upload/index.js
@@ -6,6 +6,7 @@ import { S3Client } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 import mime from 'mime-types'
 import { args } from './args.js'
+import { getAssetCacheHeader } from './asset-cache.js'
 
 const stsClient = new STSClient({ region: args.region })
 const s3Credentials = await stsClient.send(new AssumeRoleCommand({
@@ -39,7 +40,7 @@ const uploads = await Promise.all(filesToUpload
         encoding: 'utf-8'
       }),
       ContentType: mime.lookup(file.path) || 'application/javascript',
-      CacheControl: `public, max-age=${args.assetCacheDuration}`,
+      CacheControl: getAssetCacheHeader(args.dir, file.name),
     }
 
     if (typeof args.dir === 'string' && args.dir.trim() !== '') {


### PR DESCRIPTION
Released browser agent assets will now be delivered with a 1 year cache header. This will allow user's browsers to cache the async chunks the agent loads for much longer and eliminate performance recommendations found in synthetic performance tools like Lighthouse. This will be applied retroactively to all released versions of the agent.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Updating the s3-upload action to apply a 1 year cache header to versioned released asset files uploaded to the root of our s3 bucket.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-149717

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
