### PR TITLE
chore: Use serialize-any on url config and command body

### DIFF
--- a/tools/jil/webpack.modular.js
+++ b/tools/jil/webpack.modular.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const Dotenv = require('dotenv-webpack')
 const webpack = require('webpack')
 const pkg = require('../../package.json')
 

--- a/tools/shared/serializer.js
+++ b/tools/shared/serializer.js
@@ -1,0 +1,6 @@
+const { serialize, deserialize } = require('serialize-anything')
+
+module.exports = {
+  serialize,
+  deserialize
+}

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -26,8 +26,6 @@ module.exports.loaderConfigKeys = [
 
 module.exports.loaderOnlyConfigKeys = ['accountID', 'agentID', 'trustKey']
 
-module.exports.regexReplacementRegex = /"new RegExp\('(.*?)','(.*?)'\)"/g
-
 module.exports.rumFlags = {
   stn: 1,
   err: 1,

--- a/tools/testing-server/index.js
+++ b/tools/testing-server/index.js
@@ -283,6 +283,7 @@ class TestServer {
     this.#commandServer.register(require('./routes/command-apis'), this)
     this.#commandServer.register(require('./plugins/no-cache'))
     this.#commandServer.register(require('./plugins/request-logger'))
+    this.#commandServer.register(require('./plugins/deserialize-body'))
   }
 
   /**

--- a/tools/testing-server/plugins/agent-injector/config-transform.js
+++ b/tools/testing-server/plugins/agent-injector/config-transform.js
@@ -6,6 +6,7 @@ const {
   loaderConfigKeys,
   loaderOnlyConfigKeys
 } = require('../../constants')
+const { deserialize } = require('../../../shared/serializer.js')
 
 /**
  * Constructs the agent config script block based on the config query and default
@@ -16,19 +17,20 @@ const {
  * @return {string}
  */
 function getConfigContent (request, reply, testServer) {
-  const queryConfig = (() => {
-    try {
-      return JSON.parse(
-        Buffer.from(request.query.config || 'e30=', 'base64').toString()
+  let queryConfig
+  try {
+    if (request.query.config) {
+      queryConfig = deserialize(
+        Buffer.from(request.query.config, 'base64').toString()
       )
-    } catch (error) {
-      testServer.config.logger.error(
-        `Invalid config query parameter for request ${request.url}`
-      )
-      testServer.config.logger.error(error)
-      return {}
     }
-  })()
+  } catch (error) {
+    testServer.config.logger.error(
+      `Invalid config query parameter for request ${request.url}`
+    )
+    testServer.config.logger.error(error)
+  }
+
   const config = {
     agent: `${testServer.assetServer.host}:${testServer.assetServer.port}/build/nr.js`,
     beacon: `${testServer.bamServer.host}:${testServer.bamServer.port}`,

--- a/tools/testing-server/plugins/agent-injector/init-transform.js
+++ b/tools/testing-server/plugins/agent-injector/init-transform.js
@@ -25,7 +25,15 @@ function getInitContent (request, reply, testServer) {
     testServer.config.logger.error(error)
   }
 
-  let initJSON = JSON.stringify(deepmerge(defaultInitBlock, queryInit))
+  let initJSON = JSON.stringify(deepmerge(defaultInitBlock, queryInit || {}), (k, v) => {
+    if (v instanceof RegExp) {
+      // de-serialize RegExp obj from router
+      return `new RegExp(${v.toString()})`
+    }
+    return v
+  })
+
+  initJSON = initJSON.replace(/"new RegExp\((.*?)\)"/g, 'new RegExp($1)')
 
   return `window.NREUM||(NREUM={});NREUM.init=${initJSON};NREUM.init.ssl=false;`
 }

--- a/tools/testing-server/plugins/agent-injector/init-transform.js
+++ b/tools/testing-server/plugins/agent-injector/init-transform.js
@@ -1,6 +1,7 @@
 const { Transform } = require('stream')
-const { regexReplacementRegex, defaultInitBlock } = require('../../constants')
+const { defaultInitBlock } = require('../../constants')
 const { deepmerge } = require('deepmerge-ts')
+const { deserialize } = require('../../../shared/serializer.js')
 
 /**
  * Constructs the agent init script block based on the init query.
@@ -10,25 +11,21 @@ const { deepmerge } = require('deepmerge-ts')
  * @return {string}
  */
 function getInitContent (request, reply, testServer) {
-  const queryInit = (() => {
-    try {
-      return JSON.parse(
-        Buffer.from(request.query.init || 'e30=', 'base64').toString()
+  let queryInit
+  try {
+    if (request.query.init) {
+      queryInit = deserialize(
+        Buffer.from(request.query.init, 'base64').toString()
       )
-    } catch (error) {
-      testServer.config.logger.error(
-        `Invalid init query parameter for request ${request.url}`
-      )
-      testServer.config.logger.error(error)
-      return {}
     }
-  })()
+  } catch (error) {
+    testServer.config.logger.error(
+      `Invalid init query parameter for request ${request.url}`
+    )
+    testServer.config.logger.error(error)
+  }
 
   let initJSON = JSON.stringify(deepmerge(defaultInitBlock, queryInit))
-  if (initJSON.includes('new RegExp')) {
-    // de-serialize RegExp obj from router
-    initJSON = initJSON.replace(regexReplacementRegex, '/$1/$2')
-  }
 
   return `window.NREUM||(NREUM={});NREUM.init=${initJSON};NREUM.init.ssl=false;`
 }

--- a/tools/testing-server/plugins/bam-parser/index.js
+++ b/tools/testing-server/plugins/bam-parser/index.js
@@ -1,7 +1,7 @@
 const fp = require('fastify-plugin')
 const querypack = require('@newrelic/nr-querypack')
 
-const beaconRequestsRegex = /^\/1\/|\/events\/1\/|\/jserrors\/1\/|\/ins\/1\/|\/resources\/1\/|\/browser\/blobs/i
+const beaconRequestsRegex = /^((\/((events)|(jserrors)|(ins)|(resources)))?\/1\/)|(\/browser\/blobs)/i
 
 /**
  * Fastify plugin to add a custom text/plain content parser that uses querypack.

--- a/tools/testing-server/plugins/deserialize-body/index.js
+++ b/tools/testing-server/plugins/deserialize-body/index.js
@@ -1,0 +1,17 @@
+const fp = require('fastify-plugin')
+const { deserialize } = require('../../../shared/serializer.js')
+
+/**
+ * Fastify plugin to deserialize the body of requests with specific content-type.
+ * @param {module:fastify.FastifyInstance} fastify the fastify server instance
+ */
+module.exports = fp(async function (fastify) {
+  fastify.addContentTypeParser('application/serialized+json', { parseAs: 'string' },
+    function (req, body, done) {
+      try {
+        done(null, deserialize(body))
+      } catch (error) {
+        done(error, body)
+      }
+    })
+})

--- a/tools/testing-server/routes/command-apis.js
+++ b/tools/testing-server/routes/command-apis.js
@@ -1,6 +1,5 @@
 const fp = require('fastify-plugin')
 const { v4: uuidV4 } = require('uuid')
-const { deserialize } = require('../../shared/serializer.js')
 
 /**
  * Fastify plugin to apply routes to the command server.
@@ -26,7 +25,7 @@ module.exports = fp(async function (fastify, testServer) {
     const testHandle = testServer.getTestHandle(request.params.testId)
 
     try {
-      const result = await testHandle.assetURL(request.body.assetFile, deserialize(request.body.query))
+      const result = await testHandle.assetURL(request.body.assetFile, request.body.query)
       reply.code(200).send({
         assetURL: result
       })

--- a/tools/testing-server/routes/command-apis.js
+++ b/tools/testing-server/routes/command-apis.js
@@ -1,6 +1,6 @@
 const fp = require('fastify-plugin')
 const { v4: uuidV4 } = require('uuid')
-const SerAny = require('serialize-anything')
+const { deserialize } = require('../../shared/serializer.js')
 
 /**
  * Fastify plugin to apply routes to the command server.
@@ -26,7 +26,7 @@ module.exports = fp(async function (fastify, testServer) {
     const testHandle = testServer.getTestHandle(request.params.testId)
 
     try {
-      const result = await testHandle.assetURL(request.body.assetFile, SerAny.deserialize(request.body.query))
+      const result = await testHandle.assetURL(request.body.assetFile, deserialize(request.body.query))
       reply.code(200).send({
         assetURL: result
       })

--- a/tools/testing-server/routes/tests-index.js
+++ b/tools/testing-server/routes/tests-index.js
@@ -47,12 +47,10 @@ module.exports = fp(async function (fastify, testServer) {
     return urlFor(
       '/tests/assets/browser.html',
       {
-        config: Buffer.from(
-          JSON.stringify({
-            assetServerPort: testServer.assetServer.port,
-            corsServerPort: testServer.corsServer.port
-          })
-        ).toString('base64'),
+        config: {
+          assetServerPort: testServer.assetServer.port,
+          corsServerPort: testServer.corsServer.port
+        },
         script: `/${filePath}?browserify=true`
       },
       testServer

--- a/tools/testing-server/test-handle.js
+++ b/tools/testing-server/test-handle.js
@@ -18,7 +18,6 @@ const {
   testInteractionEventsRequest,
   testBlobRequest
 } = require('./utils/expect-tests')
-const { deserialize } = require('../shared/serializer.js')
 
 /**
  * Scheduled reply options
@@ -115,11 +114,6 @@ module.exports = class TestHandle {
         try {
           let test = scheduledReply.test
 
-          if (typeof test === 'string') {
-            // eslint-disable-next-line no-new-func
-            test = deserialize(test)
-          }
-
           if (test.call(this, request)) {
             request.scheduledReply = scheduledReply
 
@@ -143,11 +137,6 @@ module.exports = class TestHandle {
       for (const pendingExpect of pendingExpects) {
         try {
           let test = pendingExpect.test
-
-          if (typeof test === 'string') {
-            // eslint-disable-next-line no-new-func
-            test = deserialize(test)
-          }
 
           if (test.call(this, request)) {
             request.resolvingExpect = pendingExpect
@@ -208,10 +197,6 @@ module.exports = class TestHandle {
     if (testServerExpect.timeout !== false) {
       deferred.timeout = setTimeout(() => {
         let testName = testServerExpect.test.name
-
-        if (typeof testServerExpect.test === 'string') {
-          testName = deserialize(testServerExpect.test).name
-        }
 
         if (deferred.expectTimeout) {
           deferred.resolve()

--- a/tools/testing-server/test-handle.js
+++ b/tools/testing-server/test-handle.js
@@ -18,7 +18,7 @@ const {
   testInteractionEventsRequest,
   testBlobRequest
 } = require('./utils/expect-tests')
-const SerAny = require('serialize-anything')
+const { deserialize } = require('../shared/serializer.js')
 
 /**
  * Scheduled reply options
@@ -117,7 +117,7 @@ module.exports = class TestHandle {
 
           if (typeof test === 'string') {
             // eslint-disable-next-line no-new-func
-            test = SerAny.deserialize(test)
+            test = deserialize(test)
           }
 
           if (test.call(this, request)) {
@@ -146,7 +146,7 @@ module.exports = class TestHandle {
 
           if (typeof test === 'string') {
             // eslint-disable-next-line no-new-func
-            test = SerAny.deserialize(test)
+            test = deserialize(test)
           }
 
           if (test.call(this, request)) {
@@ -210,7 +210,7 @@ module.exports = class TestHandle {
         let testName = testServerExpect.test.name
 
         if (typeof testServerExpect.test === 'string') {
-          testName = SerAny.deserialize(testServerExpect.test).name
+          testName = deserialize(testServerExpect.test).name
         }
 
         if (deferred.expectTimeout) {

--- a/tools/testing-server/utils/url.js
+++ b/tools/testing-server/utils/url.js
@@ -1,4 +1,5 @@
 const { URL } = require('url')
+const { serialize } = require('../../shared/serializer.js')
 
 /**
  * Resolves the path of a file and provides a URL that can be used to load that
@@ -21,28 +22,15 @@ module.exports.urlFor = function urlFor (relativePath, query, testServer) {
   }
 
   if (Object.prototype.hasOwnProperty.call(query || {}, 'config') && typeof query.config !== 'string') {
-    query.config = Buffer.from(JSON.stringify(query.config)).toString('base64')
+    query.config = Buffer.from(serialize(query.config)).toString('base64')
   }
 
   if (Object.prototype.hasOwnProperty.call(query || {}, 'init') && typeof query.init !== 'string') {
-    query.init = Buffer.from(
-      JSON.stringify(query.init, (k, v) => {
-        if (typeof v === 'object' && v instanceof RegExp) {
-          let m = v.toString().match(/\/(.*)\/(\w*)/)
-          return `new RegExp('${m[1]}','${m[2] || ''}')` // serialize regex in a way our test server can receive it
-        }
-        return v
-      })
-    ).toString('base64')
+    query.init = Buffer.from(serialize(query.init)).toString('base64')
   }
 
-  if (
-    Object.prototype.hasOwnProperty.call(query || {}, 'workerCommands') &&
-    typeof query.workerCommands !== 'string'
-  ) {
-    query.workerCommands = Buffer.from(
-      JSON.stringify(query.workerCommands)
-    ).toString('base64')
+  if (Object.prototype.hasOwnProperty.call(query || {}, 'workerCommands') && typeof query.workerCommands !== 'string') {
+    query.workerCommands = Buffer.from(serialize(query.workerCommands)).toString('base64')
   }
 
   return new URL(

--- a/tools/wdio/plugins/testing-server/index.mjs
+++ b/tools/wdio/plugins/testing-server/index.mjs
@@ -1,5 +1,6 @@
 import TestingServerLauncher from './launcher.mjs'
 import { TestHandleConnector } from './test-handle-connector.mjs'
+import { deserialize } from '../../../shared/serializer.js'
 
 /**
  * This is a WDIO worker plugin that provides access to the testing server via
@@ -12,10 +13,10 @@ export default class TestingServerWorker {
   #commandServerConfig
 
   beforeSession (_, capabilities) {
-    this.#assetServerConfig = JSON.parse(capabilities.assetServer)
-    this.#corsServerConfig = JSON.parse(capabilities.corsServer)
-    this.#bamServerConfig = JSON.parse(capabilities.bamServer)
-    this.#commandServerConfig = JSON.parse(capabilities.commandServer)
+    this.#assetServerConfig = deserialize(capabilities.assetServer)
+    this.#corsServerConfig = deserialize(capabilities.corsServer)
+    this.#bamServerConfig = deserialize(capabilities.bamServer)
+    this.#commandServerConfig = deserialize(capabilities.commandServer)
 
     delete capabilities.assetServer
     delete capabilities.corsServer

--- a/tools/wdio/plugins/testing-server/launcher.mjs
+++ b/tools/wdio/plugins/testing-server/launcher.mjs
@@ -1,5 +1,6 @@
 import logger from '@wdio/logger'
 import TestServer from '../../../testing-server/index.js'
+import { serialize } from '../../../shared/serializer.js'
 
 const log = logger('testing-server')
 
@@ -25,10 +26,10 @@ export default class TestingServerLauncher {
     log.info(`Command server started on http://${this.#testingServer.commandServer.host}:${this.#testingServer.commandServer.port}`)
 
     capabilities.forEach((capability) => {
-      capability.assetServer = JSON.stringify({ host: this.#testingServer.assetServer.host, port: this.#testingServer.assetServer.port })
-      capability.corsServer = JSON.stringify({ host: this.#testingServer.corsServer.host, port: this.#testingServer.corsServer.port })
-      capability.bamServer = JSON.stringify({ host: this.#testingServer.bamServer.host, port: this.#testingServer.bamServer.port })
-      capability.commandServer = JSON.stringify({ host: this.#testingServer.commandServer.host, port: this.#testingServer.commandServer.port })
+      capability.assetServer = serialize({ host: this.#testingServer.assetServer.host, port: this.#testingServer.assetServer.port })
+      capability.corsServer = serialize({ host: this.#testingServer.corsServer.host, port: this.#testingServer.corsServer.port })
+      capability.bamServer = serialize({ host: this.#testingServer.bamServer.host, port: this.#testingServer.bamServer.port })
+      capability.commandServer = serialize({ host: this.#testingServer.commandServer.host, port: this.#testingServer.commandServer.port })
     })
   }
 

--- a/tools/wdio/plugins/testing-server/test-handle-connector.mjs
+++ b/tools/wdio/plugins/testing-server/test-handle-connector.mjs
@@ -1,6 +1,6 @@
 import logger from '@wdio/logger'
 import fetch from 'node-fetch'
-import * as SerAny from 'serialize-anything'
+import { serialize } from '../../../shared/serializer.js'
 import { deepmerge } from 'deepmerge-ts'
 import {
   testAjaxEventsRequest, testAjaxTimeSlicesRequest, testCustomMetricsRequest, testErrorsRequest,
@@ -97,11 +97,11 @@ export class TestHandleConnector {
   async scheduleReply (serverId, scheduledReply) {
     await fetch(`${this.#commandServerBase}/test-handle/${this.#testId}/scheduleReply`, {
       method: 'POST',
-      body: JSON.stringify({
+      body: serialize({
         serverId,
-        scheduledReply: { ...scheduledReply, test: SerAny.serialize(scheduledReply.test) }
+        scheduledReply: { ...scheduledReply, test: scheduledReply.test }
       }),
-      headers: { 'content-type': 'application/json' }
+      headers: { 'content-type': 'application/serialized+json' }
     })
   }
 
@@ -112,10 +112,10 @@ export class TestHandleConnector {
   async clearScheduledReplies (serverId) {
     await fetch(`${this.#commandServerBase}/test-handle/${this.#testId}/clearScheduledReplies`, {
       method: 'POST',
-      body: JSON.stringify({
+      body: serialize({
         serverId
       }),
-      headers: { 'content-type': 'application/json' }
+      headers: { 'content-type': 'application/serialized+json' }
     })
   }
 
@@ -133,15 +133,15 @@ export class TestHandleConnector {
     const abortController = new AbortController()
     const expectRequest = fetch(`${this.#commandServerBase}/test-handle/${this.#testId}/expect`, {
       method: 'POST',
-      body: JSON.stringify({
+      body: serialize({
         serverId,
         expectOpts: {
           timeout: testServerExpect.timeout,
-          test: SerAny.serialize(testServerExpect.test),
+          test: testServerExpect.test,
           expectTimeout: testServerExpect.expectTimeout
         }
       }),
-      headers: { 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/serialized+json' },
       signal: abortController.signal
     })
 
@@ -186,11 +186,11 @@ export class TestHandleConnector {
     query.testId = this.#testId
     const result = await fetch(`${this.#commandServerBase}/test-handle/${this.#testId}/asset-url`, {
       method: 'POST',
-      body: JSON.stringify({
+      body: serialize({
         assetFile,
-        query: SerAny.serialize(deepmerge(defaultAssetQuery, query))
+        query: deepmerge(defaultAssetQuery, query)
       }),
-      headers: { 'content-type': 'application/json' }
+      headers: { 'content-type': 'application/serialized+json' }
     })
 
     if (result.status !== 200) {

--- a/tools/wdio/runner.mjs
+++ b/tools/wdio/runner.mjs
@@ -5,7 +5,7 @@ import url from 'url'
 import crypto from 'crypto'
 import { deepmerge } from 'deepmerge-ts'
 import { Launcher } from '@wdio/cli'
-import { serialize } from 'serialize-anything'
+import { serialize } from '../shared/serializer.js'
 import baseConfig from './config/base.conf.mjs'
 import specsConfig from './config/specs.conf.mjs'
 import sauceConfig from './config/sauce.conf.mjs'
@@ -35,7 +35,7 @@ fs.ensureDirSync(path.dirname(configFilePath))
 process.argv.splice(2)
 fs.writeFile(
   configFilePath,
-  `import { deserialize } from 'serialize-anything'\nexport const config = deserialize('${serialize(wdioConfig)}')`,
+  `import { deserialize } from '../../../tools/shared/serializer.js'\nexport const config = deserialize('${serialize(wdioConfig)}')`,
   (error) => {
     if (error) {
       console.error(error)


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Pre-existing use of serialize-anything was refactor into a central module agnostic of the underlying serializer used. Url configruation passing via query param switched to using this module. The body of requests to the command server for the few api's also switched to using serializer.

### Related Issue(s)

[NR-136508](https://issues.newrelic.com/browse/NR-136508)

### Testing

That all existing test works, both jil and wdio.
