### PR TITLE
chore: SR validation - only warn if not empty string

### DIFF
--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -82,7 +82,7 @@ const model = () => {
       },
       set block_selector (val) {
         if (isValidSelector(val)) hiddenState.block_selector += `,${val}`
-        else warn('An invalid session_replay.block_selector was provided and will not be used', val)
+        else if (val !== '') warn('An invalid session_replay.block_selector was provided and will not be used', val)
       },
       // password: must always be present and true no matter what customer sets
       get mask_input_options () {


### PR DESCRIPTION
Only warn if the block config is not an empty string, which is the default supplied by the API if not set
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
