### PR TITLE
chore: Modify mask_text_selector setter

### DIFF
--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -68,7 +68,8 @@ const model = () => {
       // this has a getter/setter to facilitate validation of the selectors
       get mask_text_selector () { return hiddenState.mask_selector },
       set mask_text_selector (val) {
-        if (isValidSelector(val) || val === null) hiddenState.mask_selector = val // null is acceptable, which completely disables the behavior
+        if (isValidSelector(val)) hiddenState.mask_selector = val + ',[data-nr-mask]'
+        else if (val === null) hiddenState.mask_selector = val // null is acceptable, which completely disables the behavior
         else warn('An invalid session_replay.mask_selector was provided and will not be used', val)
       },
       // these properties only have getters because they are enforcable constants and should error if someone tries to override them

--- a/src/common/config/state/init.test.js
+++ b/src/common/config/state/init.test.js
@@ -52,7 +52,7 @@ describe('property getters/setters used for validation', () => {
     })
 
     expect(getConfigurationValue('23456', 'session_replay.block_selector')).toEqual('[data-nr-block],[block-text-test]')
-    expect(getConfigurationValue('23456', 'session_replay.mask_text_selector')).toEqual('[mask-text-test]')
+    expect(getConfigurationValue('23456', 'session_replay.mask_text_selector')).toEqual('[mask-text-test],[data-nr-mask]')
     expect(getConfigurationValue('23456', 'session_replay.mask_input_options')).toMatchObject({ password: true, select: true })
   })
 


### PR DESCRIPTION
Modify mask_text_selector setter
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
A result of bug testing led to decision that the `mask_text_selector` config should now do the following:
* if no config (undefined) is provided --> `*`
* if any value is provided (including null)--> use that value, but append `[nr-data-mask]`
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been updated to match and other pre-existing SR tests should continue to pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
