### PR TITLE
fix: Drain event emitter even when feature fails to initialize

### DIFF
--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -108,6 +108,7 @@ export class InstrumentBase extends FeatureBase {
         warn(`Downloading and initializing ${this.featureName} failed...`, e)
         this.abortHandler?.() // undo any important alterations made to the page
         // not supported yet but nice to do: "abort" this agent's EE for this feature specifically
+        drain(this.agentIdentifier, this.featureName)
         loadedSuccessfully(false)
       }
     }


### PR DESCRIPTION
A failure to import and initialize a feature could block the agent from draining data out of the event emitter, which prevents the agent from making any successful calls.  This fix allows the event emitter to drain even when an individual feature fails to initialize.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
A failure to import and initialize a feature could block the agent from draining data out of the event emitter, which prevents the agent from making any successful calls.  This fix allows the event emitter to drain even when an individual feature fails to initialize.  This is also tangentially related to the Session Replay feature failing to import and blocking the agent on polyfill builds. 
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
This PR would replace the need for #729 if deemed appropriate

### Testing
All tests should continue passing
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
