### PR TITLE
chore: [Innovation] -  experiment with placing configs into features

### DIFF
--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -1,47 +1,14 @@
-import { isValidSelector } from '../../dom/query-selector'
 import { DEFAULT_EXPIRES_MS, DEFAULT_INACTIVE_MS } from '../../session/constants'
-import { warn } from '../../util/console'
 import { gosNREUMInitializedAgents } from '../../window/nreum'
 import { getModeledObject } from './configurable'
 
-const model = () => {
-  const hiddenState = {
-    mask_selector: '*',
-    block_selector: '[data-nr-block]',
-    mask_input_options: {
-      color: false,
-      date: false,
-      'datetime-local': false,
-      email: false,
-      month: false,
-      number: false,
-      range: false,
-      search: false,
-      tel: false,
-      text: false,
-      time: false,
-      url: false,
-      week: false,
-      // unify textarea and select element with text input
-      textarea: false,
-      select: false,
-      password: true // This will be enforced to always be true in the setter
-    }
-  }
+export const model = () => {
   return {
     proxy: {
       assets: undefined, // if this value is set, it will be used to overwrite the webpack asset path used to fetch assets
       beacon: undefined // likewise for the url to which we send analytics
     },
     privacy: { cookies_enabled: true }, // *cli - per discussion, default should be true
-    ajax: { deny_list: undefined, block_internal: true, enabled: true, harvestTimeSeconds: 10, autoStart: true },
-    distributed_tracing: {
-      enabled: undefined,
-      exclude_newrelic_header: undefined,
-      cors_use_newrelic_header: undefined,
-      cors_use_tracecontext_headers: undefined,
-      allowed_origins: undefined
-    },
     session: {
       domain: undefined, // used by first party cookies to set the top-level domain
       expiresMs: DEFAULT_EXPIRES_MS,
@@ -49,51 +16,7 @@ const model = () => {
     },
     ssl: undefined,
     obfuscate: undefined,
-    jserrors: { enabled: true, harvestTimeSeconds: 10, autoStart: true },
-    metrics: { enabled: true, autoStart: true },
-    page_action: { enabled: true, harvestTimeSeconds: 30, autoStart: true },
-    page_view_event: { enabled: true, autoStart: true },
-    page_view_timing: { enabled: true, harvestTimeSeconds: 30, long_task: false, autoStart: true },
-    session_trace: { enabled: true, harvestTimeSeconds: 10, autoStart: true },
-    harvest: { tooManyRequestsDelay: 60 },
-    session_replay: {
-      // feature settings
-      autoStart: true,
-      enabled: false,
-      harvestTimeSeconds: 60,
-      sampling_rate: 50, // float from 0 - 100
-      error_sampling_rate: 50, // float from 0 - 100
-      // recording config settings
-      mask_all_inputs: true,
-      // this has a getter/setter to facilitate validation of the selectors
-      get mask_text_selector () { return hiddenState.mask_selector },
-      set mask_text_selector (val) {
-        if (isValidSelector(val) || val === null) hiddenState.mask_selector = val // null is acceptable, which completely disables the behavior
-        else warn('An invalid session_replay.mask_selector was provided and will not be used', val)
-      },
-      // these properties only have getters because they are enforcable constants and should error if someone tries to override them
-      get block_class () { return 'nr-block' },
-      get ignore_class () { return 'nr-ignore' },
-      get mask_text_class () { return 'nr-mask' },
-      // props with a getter and setter are used to extend enforcable constants with customer input
-      // we must preserve data-nr-block no matter what else the customer sets
-      get block_selector () {
-        return hiddenState.block_selector
-      },
-      set block_selector (val) {
-        if (isValidSelector(val)) hiddenState.block_selector += `,${val}`
-        else if (val !== '') warn('An invalid session_replay.block_selector was provided and will not be used', val)
-      },
-      // password: must always be present and true no matter what customer sets
-      get mask_input_options () {
-        return hiddenState.mask_input_options
-      },
-      set mask_input_options (val) {
-        if (val && typeof val === 'object') hiddenState.mask_input_options = { ...val, password: true }
-        else warn('An invalid session_replay.mask_input_option was provided and will not be used', val)
-      }
-    },
-    spa: { enabled: true, harvestTimeSeconds: 10, autoStart: true }
+    harvest: { tooManyRequestsDelay: 60 }
   }
 }
 

--- a/src/common/context/shared-context.js
+++ b/src/common/context/shared-context.js
@@ -2,7 +2,8 @@ import { warn } from '../util/console'
 
 const model = {
   agentIdentifier: '',
-  ee: undefined
+  ee: undefined,
+  init: {}
 }
 
 export class SharedContext {

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -7,7 +7,7 @@ import { obj as encodeObj, param as encodeParam } from '../url/encode'
 import { stringify } from '../util/stringify'
 import * as submitData from '../util/submit-data'
 import { getLocation } from '../url/location'
-import { getInfo, getConfigurationValue, getRuntime, getConfiguration } from '../config/config'
+import { getInfo, getRuntime } from '../config/config'
 import { cleanURL } from '../url/clean-url'
 import { now } from '../timing/now'
 import { eventListenerOpts } from '../event-listener/event-listener-opts'
@@ -30,8 +30,7 @@ const warnings = {}
 export class Harvest extends SharedContext {
   constructor (parent) {
     super(parent) // gets any allowed properties from the parent and stores them in `sharedContext`
-
-    this.tooManyRequestsDelay = getConfigurationValue(this.sharedContext.agentIdentifier, 'harvest.tooManyRequestsDelay') || 60
+    this.tooManyRequestsDelay = this.sharedContext?.init.harvest.tooManyRequestsDelay || 60
     this.obfuscator = new Obfuscator(this.sharedContext)
 
     this._events = {}
@@ -95,7 +94,7 @@ export class Harvest extends SharedContext {
       return false
     }
 
-    const init = getConfiguration(this.sharedContext.agentIdentifier)
+    const init = this.sharedContext.init
     const protocol = init.ssl === false ? 'http' : 'https'
     const perceviedBeacon = init.proxy.beacon || info.errorBeacon
     const endpointURLPart = endpoint !== 'rum' ? `/${endpoint}` : ''

--- a/src/common/util/obfuscate.js
+++ b/src/common/util/obfuscate.js
@@ -1,4 +1,3 @@
-import { getConfigurationValue } from '../config/config'
 import { SharedContext } from '../context/shared-context'
 import { isFileProtocol } from '../url/protocol'
 import { warn } from './console'
@@ -9,7 +8,7 @@ var fileProtocolRule = {
 }
 export class Obfuscator extends SharedContext {
   shouldObfuscate () {
-    return getRules(this.sharedContext.agentIdentifier).length > 0
+    return getRules(this.sharedContext?.init?.obfuscate || [])
   }
 
   // applies all regex obfuscation rules to provided URL string and returns the result
@@ -31,9 +30,8 @@ export class Obfuscator extends SharedContext {
 }
 
 // TO DO: this function should be inside the Obfuscator class since its context relates to agentID
-export function getRules (agentIdentifier) {
+export function getRules (configRules) {
   var rules = []
-  var configRules = getConfigurationValue(agentIdentifier, 'obfuscate') || []
 
   rules = rules.concat(configRules)
 

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -6,7 +6,7 @@ import { registerHandler as register } from '../../../common/event-emitter/regis
 import { stringify } from '../../../common/util/stringify'
 import { nullable, numeric, getAddStringContext, addCustomAttributes } from '../../../common/serialize/bel-serializer'
 import { handle } from '../../../common/event-emitter/handle'
-import { getConfiguration, getInfo, getRuntime } from '../../../common/config/config'
+import { getInfo, getRuntime } from '../../../common/config/config'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { setDenyList, shouldCollectEvent } from '../../../common/deny-list/deny-list'
 import { FEATURE_NAME } from '../constants'
@@ -16,9 +16,9 @@ import { AggregateBase } from '../../utils/aggregate-base'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
-    const agentInit = getConfiguration(agentIdentifier)
+  constructor (agentIdentifier, aggregator, opts) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, opts)
+    const agentInit = this.init
     const allAjaxIsEnabled = agentInit.ajax.enabled !== false
 
     register('xhr', storeXhr, this.featureName, this.ee)

--- a/src/features/ajax/instrument/distributed-tracing.js
+++ b/src/features/ajax/instrument/distributed-tracing.js
@@ -2,23 +2,20 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { getConfiguration, getConfigurationValue, getLoaderConfig } from '../../../common/config/config'
+import { getLoaderConfig } from '../../../common/config/config'
 import { generateSpanId, generateTraceId } from '../../../common/ids/unique-id'
 import { parseUrl } from '../../../common/url/parse-url'
 import { globalScope } from '../../../common/constants/runtime'
 import { stringify } from '../../../common/util/stringify'
+import { SharedContext } from '../../../common/context/shared-context'
 
-export class DT {
-  constructor (agentIdentifier) {
-    this.agentIdentifier = agentIdentifier
-  }
-
+export class DT extends SharedContext {
   generateTracePayload (parsedOrigin) {
     if (!this.shouldGenerateTrace(parsedOrigin)) {
       return null
     }
 
-    var loaderConfig = getLoaderConfig(this.agentIdentifier)
+    var loaderConfig = getLoaderConfig(this.sharedContext.agentIdentifier)
     if (!loaderConfig) {
       return null
     }
@@ -105,10 +102,10 @@ export class DT {
   isAllowedOrigin (parsedOrigin) {
     var allowed = false
     var dtConfig = {}
-    var dt = getConfigurationValue(this.agentIdentifier, 'distributed_tracing')
+    var dt = this.sharedContext.init.distributed_tracing
 
     if (dt) {
-      dtConfig = getConfiguration(this.agentIdentifier).distributed_tracing
+      dtConfig = this.sharedContext.init.distributed_tracing
     }
 
     if (parsedOrigin.sameOrigin) {
@@ -128,35 +125,19 @@ export class DT {
   }
 
   isDtEnabled () {
-    var dt = getConfigurationValue(this.agentIdentifier, 'distributed_tracing')
-    if (dt) {
-      return !!dt.enabled
-    }
-    return false
+    return this.sharedContext?.init?.distributed_tracing?.enabled === true
   }
 
   // exclude the newrelic header for same-origin calls
   excludeNewrelicHeader () {
-    var dt = getConfigurationValue(this.agentIdentifier, 'distributed_tracing')
-    if (dt) {
-      return !!dt.exclude_newrelic_header
-    }
-    return false
+    return this.sharedContext?.init?.distributed_tracing?.exclude_newrelic_header === true
   }
 
   useNewrelicHeaderForCors () {
-    var dt = getConfigurationValue(this.agentIdentifier, 'distributed_tracing')
-    if (dt) {
-      return dt.cors_use_newrelic_header !== false
-    }
-    return false
+    return this.sharedContext?.init?.distributed_tracing?.cors_use_newrelic_header !== false
   }
 
   useTraceContextHeadersForCors () {
-    var dt = getConfigurationValue(this.agentIdentifier, 'distributed_tracing')
-    if (dt) {
-      return !!dt.cors_use_tracecontext_headers
-    }
-    return false
+    return this.sharedContext?.init?.distributed_tracing?.cors_use_tracecontext_headers === true
   }
 }

--- a/src/features/ajax/instrument/index.js
+++ b/src/features/ajax/instrument/index.js
@@ -16,6 +16,7 @@ import { responseSizeFromXhr } from './response-size'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { model } from '../model'
 
 var handlers = ['load', 'error', 'abort', 'timeout']
 var handlersLen = handlers.length
@@ -25,13 +26,13 @@ var origXHR = originals.XHR
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, { auto, init, model: model() })
 
     // Very unlikely, but in case the existing XMLHttpRequest.prototype object on the page couldn't be wrapped.
     if (!getRuntime(agentIdentifier).xhrWrappable) return
 
-    this.dt = new DT(agentIdentifier)
+    this.dt = new DT(this)
 
     this.handler = (type, args, ctx, group) => handle(type, args, ctx, group, this.ee)
 

--- a/src/features/ajax/model.js
+++ b/src/features/ajax/model.js
@@ -1,0 +1,11 @@
+
+export const model = () => ({
+  ajax: { deny_list: undefined, block_internal: true, enabled: true, harvestTimeSeconds: 10, autoStart: true },
+  distributed_tracing: {
+    enabled: undefined,
+    exclude_newrelic_header: undefined,
+    cors_use_newrelic_header: undefined,
+    cors_use_tracecontext_headers: undefined,
+    allowed_origins: undefined
+  }
+})

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -13,7 +13,7 @@ import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { stringify } from '../../../common/util/stringify'
 import { handle } from '../../../common/event-emitter/handle'
 import { mapOwn } from '../../../common/util/map-own'
-import { getInfo, getConfigurationValue, getRuntime } from '../../../common/config/config'
+import { getInfo, getRuntime } from '../../../common/config/config'
 import { now } from '../../../common/timing/now'
 import { globalScope } from '../../../common/constants/runtime'
 
@@ -27,8 +27,8 @@ import { AggregateBase } from '../../utils/aggregate-base'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
+  constructor (agentIdentifier, aggregator, opts) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, opts)
 
     this.stackReported = {}
     this.observedAt = {}
@@ -46,7 +46,7 @@ export class Aggregate extends AggregateBase {
     register('err', (...args) => this.storeError(...args), this.featureName, this.ee)
     register('ierr', (...args) => this.storeError(...args), this.featureName, this.ee)
 
-    const harvestTimeSeconds = getConfigurationValue(this.agentIdentifier, 'jserrors.harvestTimeSeconds') || 10
+    const harvestTimeSeconds = this.init.jserrors.harvestTimeSeconds || 10
 
     const scheduler = new HarvestScheduler('jserrors', { onFinished: (...args) => this.onHarvestFinished(...args) }, this)
     scheduler.harvest.on('jserrors', (...args) => this.onHarvestStarted(...args))

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -12,14 +12,15 @@ import { globalScope } from '../../../common/constants/runtime'
 import { eventListenerOpts } from '../../../common/event-listener/event-listener-opts'
 import { stringify } from '../../../common/util/stringify'
 import { UncaughtError } from './uncaught-error'
+import { model } from '../model'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
 
   #seenErrors = new Set()
 
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, { auto, init, model: model() })
 
     try {
       // this try-catch can be removed when IE11 is completely unsupported & gone

--- a/src/features/jserrors/model.js
+++ b/src/features/jserrors/model.js
@@ -1,0 +1,1 @@
+export const model = () => ({ jserrors: { enabled: true, harvestTimeSeconds: 10, autoStart: true } })

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -1,4 +1,4 @@
-import { getRuntime, getConfiguration } from '../../../common/config/config'
+import { getRuntime } from '../../../common/config/config'
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL } from '../constants'
@@ -12,8 +12,8 @@ import { AggregateBase } from '../../utils/aggregate-base'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
+  constructor (agentIdentifier, aggregator, opts) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, opts)
     let scheduler
 
     // If RUM-call's response determines that customer lacks entitlements for the /jserror ingest endpoint, don't harvest at all.
@@ -81,12 +81,12 @@ export class Aggregate extends AggregateBase {
     }
 
     // Capture SMs to assess customer engagement with the obfuscation config
-    const rules = getRules(this.agentIdentifier)
+    const rules = getRules(this.init?.obfuscate || [])
     if (rules.length > 0) this.storeSupportabilityMetrics('Generic/Obfuscate/Detected')
     if (rules.length > 0 && !validateRules(rules)) this.storeSupportabilityMetrics('Generic/Obfuscate/Invalid')
 
     // Check if proxy for either chunks or beacon is being used
-    const { proxy } = getConfiguration(this.agentIdentifier)
+    const { proxy } = this.init
     if (proxy.assets) this.storeSupportabilityMetrics('Config/AssetsUrl/Changed')
     if (proxy.beacon) this.storeSupportabilityMetrics('Config/BeaconUrl/Changed')
   }

--- a/src/features/metrics/instrument/index.js
+++ b/src/features/metrics/instrument/index.js
@@ -1,10 +1,11 @@
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
+import { model } from '../model'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, { auto, init, model: model() })
     this.importAggregator()
   }
 }

--- a/src/features/metrics/model.js
+++ b/src/features/metrics/model.js
@@ -1,0 +1,1 @@
+export const model = () => ({ metrics: { enabled: true, autoStart: true } })

--- a/src/features/page_action/aggregate/index.js
+++ b/src/features/page_action/aggregate/index.js
@@ -8,17 +8,17 @@ import { stringify } from '../../../common/util/stringify'
 import { registerHandler as register } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { cleanURL } from '../../../common/url/clean-url'
-import { getConfigurationValue, getInfo, getRuntime } from '../../../common/config/config'
+import { getInfo, getRuntime } from '../../../common/config/config'
 import { FEATURE_NAME } from '../constants'
 import { isBrowserScope } from '../../../common/constants/runtime'
 import { AggregateBase } from '../../utils/aggregate-base'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
+  constructor (agentIdentifier, aggregator, opts) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, opts)
     this.eventsPerMinute = 240
-    this.harvestTimeSeconds = getConfigurationValue(this.agentIdentifier, 'page_action.harvestTimeSeconds') || getConfigurationValue(this.agentIdentifier, 'ins.harvestTimeSeconds') || 30
+    this.harvestTimeSeconds = this.init.page_action.harvestTimeSeconds
     this.eventsPerHarvest = this.eventsPerMinute * this.harvestTimeSeconds / 60
     this.referrerUrl = undefined
     this.currentEvents = undefined

--- a/src/features/page_action/instrument/index.js
+++ b/src/features/page_action/instrument/index.js
@@ -5,11 +5,12 @@
 
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
+import { model } from '../model'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, { auto, init, model: model() })
     this.importAggregator()
   }
 }

--- a/src/features/page_action/model.js
+++ b/src/features/page_action/model.js
@@ -1,0 +1,1 @@
+export const model = () => ({ page_action: { enabled: true, harvestTimeSeconds: 30, autoStart: true } })

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -14,8 +14,8 @@ import { timeToFirstByte } from '../../../common/vitals/time-to-first-byte'
 
 export class Aggregate extends AggregateBase {
   static featureName = CONSTANTS.FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, CONSTANTS.FEATURE_NAME)
+  constructor (agentIdentifier, aggregator, opts) {
+    super(agentIdentifier, aggregator, CONSTANTS.FEATURE_NAME, opts)
 
     this.timeToFirstByte = 0
     this.firstByteToWindowLoad = 0 // our "frontend" duration

--- a/src/features/page_view_event/instrument/index.js
+++ b/src/features/page_view_event/instrument/index.js
@@ -1,10 +1,11 @@
 import { InstrumentBase } from '../../utils/instrument-base'
 import * as CONSTANTS from '../constants'
+import { model } from '../model'
 
 export class Instrument extends InstrumentBase {
   static featureName = CONSTANTS.FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, CONSTANTS.FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, CONSTANTS.FEATURE_NAME, { auto, init, model: model() })
 
     this.importAggregator()
   }

--- a/src/features/page_view_event/model.js
+++ b/src/features/page_view_event/model.js
@@ -1,0 +1,1 @@
+export const model = () => ({ page_view_event: { enabled: true, autoStart: true } })

--- a/src/features/page_view_timing/instrument/index.js
+++ b/src/features/page_view_timing/instrument/index.js
@@ -9,11 +9,12 @@ import { now } from '../../../common/timing/now'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
 import { isBrowserScope } from '../../../common/constants/runtime'
+import { model } from '../model'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, { auto, init, model: model() })
     if (!isBrowserScope) return // CWV is irrelevant outside web context
 
     // While we try to replicate web-vital's visibilitywatcher logic in an effort to defer that library to post-pageload, this isn't perfect and doesn't consider prerendering.

--- a/src/features/page_view_timing/model.js
+++ b/src/features/page_view_timing/model.js
@@ -1,0 +1,1 @@
+export const model = () => ({ page_view_timing: { enabled: true, harvestTimeSeconds: 30, long_task: false, autoStart: true } })

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -11,11 +11,11 @@
  */
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
-
+import { model } from '../model'
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, { auto, init, model: model() })
     this.importAggregator()
   }
 }

--- a/src/features/session_replay/model.js
+++ b/src/features/session_replay/model.js
@@ -1,0 +1,68 @@
+const { isValidSelector } = require('../../common/dom/query-selector')
+const { warn } = require('../../common/util/console')
+
+export const model = () => {
+  const hiddenState = {
+    mask_selector: '*',
+    block_selector: '[data-nr-block]',
+    mask_input_options: {
+      color: false,
+      date: false,
+      'datetime-local': false,
+      email: false,
+      month: false,
+      number: false,
+      range: false,
+      search: false,
+      tel: false,
+      text: false,
+      time: false,
+      url: false,
+      week: false,
+      // unify textarea and select element with text input
+      textarea: false,
+      select: false,
+      password: true // This will be enforced to always be true in the setter
+    }
+  }
+  return {
+    session_replay: {
+      // feature settings
+      autoStart: true,
+      enabled: false,
+      harvestTimeSeconds: 60,
+      sampling_rate: 50, // float from 0 - 100
+      error_sampling_rate: 50, // float from 0 - 100
+      // recording config settings
+      mask_all_inputs: true,
+      // this has a getter/setter to facilitate validation of the selectors
+      get mask_text_selector () { return hiddenState.mask_selector },
+      set mask_text_selector (val) {
+        if (isValidSelector(val) || val === null) hiddenState.mask_selector = val // null is acceptable, which completely disables the behavior
+        else warn('An invalid session_replay.mask_selector was provided and will not be used', val)
+      },
+      // these properties only have getters because they are enforcable constants and should error if someone tries to override them
+      get block_class () { return 'nr-block' },
+      get ignore_class () { return 'nr-ignore' },
+      get mask_text_class () { return 'nr-mask' },
+      // props with a getter and setter are used to extend enforcable constants with customer input
+      // we must preserve data-nr-block no matter what else the customer sets
+      get block_selector () {
+        return hiddenState.block_selector
+      },
+      set block_selector (val) {
+        if (isValidSelector(val)) hiddenState.block_selector += `,${val}`
+        else if (val !== '') warn('An invalid session_replay.block_selector was provided and will not be used', val)
+      },
+      // password: must always be present and true no matter what customer sets
+      get mask_input_options () {
+        return hiddenState.mask_input_options
+      },
+      set mask_input_options (val) {
+        if (val && typeof val === 'object') hiddenState.mask_input_options = { ...val, password: true }
+        else warn('An invalid session_replay.mask_input_option was provided and will not be used', val)
+      }
+    },
+    session_trace: { enabled: true }
+  }
+}

--- a/src/features/session_replay/replay-mode.js
+++ b/src/features/session_replay/replay-mode.js
@@ -1,4 +1,3 @@
-import { getConfigurationValue } from '../../common/config/config'
 import { MODE } from '../../common/session/session-entity'
 import { gosNREUM } from '../../common/window/nreum'
 import { sharedChannel } from '../../common/constants/shared-channel'
@@ -10,11 +9,11 @@ import { sharedChannel } from '../../common/constants/shared-channel'
  * @param {String} agentId
  * @returns Promise that resolves to one of the values in MODE enum
  */
-export async function getSessionReplayMode (agentId) {
+export async function getSessionReplayMode (agentId, init) {
   try {
     const newrelic = gosNREUM()
     // Should be enabled by configuration and using an agent build that includes it (via checking that the instrument class was initialized).
-    if (getConfigurationValue(agentId, 'session_replay.enabled') && typeof newrelic.initializedAgents[agentId].features.session_replay === 'object') {
+    if (init?.session_replay?.enabled && typeof newrelic.initializedAgents[agentId].features.session_replay === 'object') {
       const srInitialized = await newrelic.initializedAgents[agentId].features.session_replay.onAggregateImported
       if (srInitialized) return await sharedChannel.sessionReplayInitialized // wait for replay to determine which mode it's after running its sampling logic
     }

--- a/src/features/session_trace/instrument/index.js
+++ b/src/features/session_trace/instrument/index.js
@@ -9,6 +9,7 @@ import { InstrumentBase } from '../../utils/instrument-base'
 import * as CONSTANTS from '../constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { isBrowserScope } from '../../../common/constants/runtime'
+import { model } from '../model'
 
 const {
   BST_RESOURCE, RESOURCE, START, END, FEATURE_NAME, FN_END, FN_START, PUSH_STATE
@@ -16,8 +17,8 @@ const {
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, { auto, init, model: model() })
     if (!isBrowserScope) return // session traces not supported outside web env
 
     const thisInstrumentEE = this.ee

--- a/src/features/session_trace/model.js
+++ b/src/features/session_trace/model.js
@@ -1,0 +1,4 @@
+export const model = () => ({
+  session_trace: { enabled: true, harvestTimeSeconds: 10, autoStart: true },
+  session_replay: { enabled: false }
+})

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -11,6 +11,7 @@ import { getRuntime } from '../../../common/config/config'
 import { now } from '../../../common/timing/now'
 import * as CONSTANTS from '../constants'
 import { isBrowserScope } from '../../../common/constants/runtime'
+import { model } from '../model'
 
 const {
   FEATURE_NAME, START, END, BODY, CB_END, JS_TIME, FETCH, FN_START, CB_START, FN_END
@@ -18,8 +19,8 @@ const {
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (agentIdentifier, aggregator, auto = true, init) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, { auto, init, model: model() })
     if (!isBrowserScope) return // SPA not supported outside web env
 
     if (!getRuntime(agentIdentifier).xhrWrappable) return

--- a/src/features/spa/model.js
+++ b/src/features/spa/model.js
@@ -1,0 +1,1 @@
+export const model = () => ({ spa: { enabled: true, harvestTimeSeconds: 10, autoStart: true } })

--- a/src/features/utils/agent-session.js
+++ b/src/features/utils/agent-session.js
@@ -1,4 +1,4 @@
-import { getConfiguration, getInfo, getRuntime } from '../../common/config/config'
+import { getInfo, getRuntime } from '../../common/config/config'
 import { drain } from '../../common/drain/drain'
 import { ee } from '../../common/event-emitter/contextual-ee'
 import { registerHandler } from '../../common/event-emitter/register-handler'
@@ -7,11 +7,10 @@ import { LocalStorage } from '../../common/storage/local-storage.js'
 import { FirstPartyCookies } from '../../common/storage/first-party-cookies'
 
 let ranOnce = 0
-export function setupAgentSession (agentIdentifier) {
+export function setupAgentSession (agentIdentifier, sessionInit) {
   const agentRuntime = getRuntime(agentIdentifier)
   if (ranOnce++) return agentRuntime.session
 
-  const sessionInit = getConfiguration(agentIdentifier).session
   /* Domain is a string that can be specified by customer. The only way to keep the session object across subdomains is using first party cookies.
     This determines which storage wrapper the session manager will use to keep state. */
   const storageTypeInst = sessionInit?.domain

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -6,8 +6,8 @@ import { gosCDN } from '../../common/window/nreum'
 import { drain } from '../../common/drain/drain'
 
 export class AggregateBase extends FeatureBase {
-  constructor (...args) {
-    super(...args)
+  constructor (agentIdentifier, aggregator, FEATURE_NAME, opts = {}) {
+    super(agentIdentifier, aggregator, FEATURE_NAME, opts.init)
     this.checkConfiguration()
   }
 

--- a/src/features/utils/feature-base.js
+++ b/src/features/utils/feature-base.js
@@ -2,7 +2,7 @@ import { getRuntime } from '../../common/config/config'
 import { ee } from '../../common/event-emitter/contextual-ee'
 
 export class FeatureBase {
-  constructor (agentIdentifier, aggregator, featureName) {
+  constructor (agentIdentifier, aggregator, featureName, init = {}) {
     /** @type {string} */
     this.agentIdentifier = agentIdentifier
     /** @type {Aggregator} */
@@ -17,5 +17,7 @@ export class FeatureBase {
      * @type {boolean}
      */
     this.blocked = false
+
+    this.init = init
   }
 }

--- a/src/loaders/features/enabled-features.js
+++ b/src/loaders/features/enabled-features.js
@@ -1,16 +1,15 @@
 import { FEATURE_NAMES } from './features'
-import { getConfigurationValue } from '../../common/config/config'
 
 const featureNames = Object.values(FEATURE_NAMES)
 
-function isEnabled (name, agentIdentifier) {
-  return getConfigurationValue(agentIdentifier, `${name}.enabled`) !== false
+function isEnabled (name, init) {
+  return init?.[name]?.enabled !== false
 }
 
-export function getEnabledFeatures (agentIdentifier) {
+export function getEnabledFeatures (init) {
   const enabledFeatures = {}
   featureNames.forEach(featureName => {
-    enabledFeatures[featureName] = isEnabled(featureName, agentIdentifier)
+    enabledFeatures[featureName] = isEnabled(featureName, init)
   })
   return enabledFeatures
 }

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -44,6 +44,7 @@ export class MicroAgent extends AgentBase {
      */
     this.start = features => this.run(features)
     this.run(nonAutoFeatures.filter(featureName => getConfigurationValue(agentIdentifier, `${featureName}.autoStart`)))
+    // TODO - pipe init through micro agent
   }
 
   get config () {


### PR DESCRIPTION
Please ignore any test failures.  This is a concept POC only.  Seeking feedback on whether this is a path we want to go down before making further changes such as test fixes, moving other config values, etc.  See overview for general concept picture
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Right now, the agent uses a centralized file that is name-spaced per agent instance ID to retrieve config values.  This creates a few challenges worth thinking about:
1. The full config objects must be loaded on all agent builds, even those that barely use any of them such as the lite agent, which is essentially pure bloat
2. In order to read from the config object, you must have the agent ID present, which sometimes is a little odd to manage.

#### The concept(s) proposed in this PR:
* (addressing (1) above) -- Each feature in the agent could define the configs (with defaults) that it needs, and then the agent only imports those configs when the build includes the feature
* (addressing (2) above) -- Each feature instrument and aggregate file would get the relevant `.init` values appended to the feature class, which (maybe? needs feedback) simplifies interacting with the concept of the init values.

#### Key Concepts:
* Each feature has a `model.js` file that defines only what init values are expected to append to the feature base
* Since each feature has `.init` set at the feature-base level, the configs will be intrinsically exposed to both the inst and agg classes
* There will very likely need to be a `common` type model, which is those init values that apply to all features or other files that are not features.  Right now in this POC this still exists as `init.js` for now. 
* This POC leans on the already-implemented `SharedContext` class concept more, simply passing the context from parent to child as new classes are spin up. 

#### Pros (add your own if you'd like):
* Its more obvious what configs are required for each feature
* Configs only add to the bundle size when actually used
* First steps to slowly starting to eliminate the concept of name-spacing via agentIdentifier (if desired)
* Removes the "magic" layer of getting/setting configs, as they will be set at feature instantiation time and be static properties of the feature itself

#### Cons (add your own if you'd like):
* A little more complicated to check the totality of init values since they are broken apart instead of in one place
* You have to be more explicit about what configs are needed by each feature, esp. if crossing across features (ie. session replay needs session_replay inits AND session_trace inits, so both must be defined in the model)

#### Other steps if this is a path we wish to further explore:
* clean up/remove the central set/get config file
* consider passing info and loader_config through the features as well in the same way
* possibly follow suit with the API methods (assigning them as features are included in the build, otherwise they exist as an empty no-op fn)
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
