### PR TITLE
feat: Add messaging about Session Replay abort behavior

### DIFF
--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -35,6 +35,10 @@ on:
         description: 'Github branch ref to checkout and run tests on'
         required: false
         type: string
+      concurrency:
+        description: 'Github branch ref to checkout and run tests on'
+        required: false
+        type: string
     secrets:
       SAUCE_USERNAME:
         required: true

--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -35,10 +35,6 @@ on:
         description: 'Github branch ref to checkout and run tests on'
         required: false
         type: string
-      concurrency:
-        description: 'Github branch ref to checkout and run tests on'
-        required: false
-        type: string
     secrets:
       SAUCE_USERNAME:
         required: true

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -93,7 +93,7 @@ export class Aggregate extends AggregateBase {
     if (shouldSetup) {
       // The SessionEntity class can emit a message indicating the session was cleared and reset (expiry, inactivity). This feature must abort and never resume if that occurs.
       this.ee.on(SESSION_EVENTS.RESET, () => {
-        this.abort()
+        this.abort('Session Reset')
       })
 
       // The SessionEntity class can emit a message indicating the session was paused (visibility change). This feature must stop recording if that occurs.
@@ -178,7 +178,7 @@ export class Aggregate extends AggregateBase {
       // Do not change the webpackChunkName or it will break the webpack nrba-chunking plugin
       recorder = (await import(/* webpackChunkName: "recorder" */'rrweb')).record
     } catch (err) {
-      return this.abort()
+      return this.abort('Recorder failed to import')
     }
 
     // FULL mode records AND reports from the beginning, while ERROR mode only records (but does not report).
@@ -253,7 +253,7 @@ export class Aggregate extends AggregateBase {
   onHarvestFinished (result) {
     // The mutual decision for now is to stop recording and clear buffers if ingest is experiencing 429 rate limiting
     if (result.status === 429) {
-      this.abort()
+      this.abort('429')
     }
 
     if (this.blocked) this.scheduler.stopTimer(true)
@@ -274,7 +274,7 @@ export class Aggregate extends AggregateBase {
   startRecording () {
     if (!recorder) {
       warn('Recording library was never imported')
-      return this.abort()
+      return this.abort('Recorder was never imported')
     }
     this.clearTimestamps()
     // set the fallbacks as early as possible
@@ -312,7 +312,7 @@ export class Aggregate extends AggregateBase {
     if (payloadSize > MAX_PAYLOAD_SIZE) {
       this.clearBuffer()
       this.ee.emit(SUPPORTABILITY_METRIC_CHANNEL, ['SessionReplay/Too-Big/Seen'], undefined, FEATURE_NAMES.metrics, this.ee)
-      return this.abort()
+      return this.abort('Payload too big')
     }
     // Checkout events are flags by the recording lib that indicate a fullsnapshot was taken every n ms. These are important
     // to help reconstruct the replay later and must be included.  While waiting and buffering for errors to come through,
@@ -376,7 +376,8 @@ export class Aggregate extends AggregateBase {
   }
 
   /** Abort the feature, once aborted it will not resume */
-  abort () {
+  abort (reason) {
+    warn(`SR aborted -- ${reason}`)
     this.blocked = true
     this.mode = MODE.OFF
     this.stopRecording()

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -253,7 +253,7 @@ export class Aggregate extends AggregateBase {
   onHarvestFinished (result) {
     // The mutual decision for now is to stop recording and clear buffers if ingest is experiencing 429 rate limiting
     if (result.status === 429) {
-      this.abort('429')
+      this.abort('429: Too many requests')
     }
 
     if (this.blocked) this.scheduler.stopTimer(true)


### PR DESCRIPTION
Add messaging to signal why a replay aborted, which could happen for a number of reasons.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds messaging to signal why a replay aborted
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests should be unaffected
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
