### PR TITLE
fix: Set Session Replay first chunk flags more reliably

### DIFF
--- a/src/common/session/session-entity.component-test.js
+++ b/src/common/session/session-entity.component-test.js
@@ -81,6 +81,7 @@ describe('constructor', () => {
         expiresAt: expect.any(Number),
         inactiveAt: expect.any(Number),
         sessionReplay: expect.any(Number),
+        sessionReplaySentFirstChunk: expect.any(Boolean),
         sessionTraceMode: expect.any(Number)
       })
     })
@@ -94,6 +95,7 @@ describe('constructor', () => {
       inactiveAt: expect.any(Number),
       updatedAt: expect.any(Number),
       sessionReplay: expect.any(Number),
+      sessionReplaySentFirstChunk: expect.any(Boolean),
       sessionTraceMode: expect.any(Number)
     }))
   })
@@ -108,7 +110,7 @@ describe('constructor', () => {
   test('expiresAt is the correct future timestamp - existing session', () => {
     const now = Date.now()
     jest.setSystemTime(now)
-    const existingData = new LocalMemory({ [`${PREFIX}_${key}`]: { value, expiresAt: now + 5000, inactiveAt: Infinity, updatedAt: now, sessionReplay: 0, sessionTraceMode: 0, custom: {} } })
+    const existingData = new LocalMemory({ [`${PREFIX}_${key}`]: { value, expiresAt: now + 5000, inactiveAt: Infinity, updatedAt: now, sessionReplay: 0, sessionReplaySentFirstChunk: false, sessionTraceMode: 0, custom: {} } })
     const session = new SessionEntity({ agentIdentifier, key, expiresMs: 100, storage: existingData })
     expect(session.state.expiresAt).toEqual(now + 5000)
   })
@@ -128,7 +130,7 @@ describe('constructor', () => {
   test('inactiveAt is the correct future timestamp - existing session', () => {
     const now = Date.now()
     jest.setSystemTime(now)
-    const existingData = new LocalMemory({ [`${PREFIX}_${key}`]: { value, inactiveAt: now + 5000, expiresAt: Infinity, updatedAt: now, sessionReplay: 0, sessionTraceMode: 0, custom: {} } })
+    const existingData = new LocalMemory({ [`${PREFIX}_${key}`]: { value, inactiveAt: now + 5000, expiresAt: Infinity, updatedAt: now, sessionReplay: 0, sessionReplaySentFirstChunk: false, sessionTraceMode: 0, custom: {} } })
     const session = new SessionEntity({ agentIdentifier, key, inactiveMs: 100, storage: existingData })
     expect(session.state.inactiveAt).toEqual(now + 5000)
   })
@@ -142,7 +144,7 @@ describe('constructor', () => {
     const newSession = new SessionEntity({ agentIdentifier, key, storage, expiresMs: 10 })
     expect(newSession.isNew).toBeTruthy()
 
-    const newStorage = new LocalMemory({ [`${PREFIX}_${key}`]: { value, expiresAt: Infinity, inactiveAt: Infinity, updatedAt: Date.now(), sessionReplay: 0, sessionTraceMode: 0, custom: {} } })
+    const newStorage = new LocalMemory({ [`${PREFIX}_${key}`]: { value, expiresAt: Infinity, inactiveAt: Infinity, updatedAt: Date.now(), sessionReplay: 0, sessionReplaySentFirstChunk: false, sessionTraceMode: 0, custom: {} } })
     const existingSession = new SessionEntity({ agentIdentifier, key, expiresMs: 10, storage: newStorage })
     expect(existingSession.isNew).toBeFalsy()
   })
@@ -157,6 +159,7 @@ describe('constructor', () => {
       inactiveAt: expect.any(Number),
       updatedAt: expect.any(Number),
       sessionReplay: expect.any(Number),
+      sessionReplaySentFirstChunk: expect.any(Boolean),
       sessionTraceMode: expect.any(Number)
     }))
   })
@@ -172,6 +175,7 @@ describe('constructor', () => {
       inactiveAt: expect.any(Number),
       updatedAt: expect.any(Number),
       sessionReplay: expect.any(Number),
+      sessionReplaySentFirstChunk: expect.any(Boolean),
       sessionTraceMode: expect.any(Number)
     }))
   })
@@ -187,6 +191,7 @@ describe('constructor', () => {
       inactiveAt: expect.any(Number),
       updatedAt: expect.any(Number),
       sessionReplay: expect.any(Number),
+      sessionReplaySentFirstChunk: expect.any(Boolean),
       sessionTraceMode: expect.any(Number)
     }))
   })
@@ -229,12 +234,13 @@ describe('read()', () => {
       expiresAt: expect.any(Number),
       inactiveAt: expect.any(Number),
       sessionReplay: expect.any(Number),
+      sessionReplaySentFirstChunk: expect.any(Boolean),
       sessionTraceMode: expect.any(Number)
     }))
   })
 
   test('"pre-existing" sessions get data from read()', () => {
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { value, expiresAt: Infinity, inactiveAt: Infinity, updatedAt: Date.now(), sessionReplay: 0, sessionTraceMode: 0, custom: {} } })
+    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { value, expiresAt: Infinity, inactiveAt: Infinity, updatedAt: Date.now(), sessionReplay: 0, sessionReplaySentFirstChunk: false, sessionTraceMode: 0, custom: {} } })
     const session = new SessionEntity({ agentIdentifier, key, storage })
     expect(session.isNew).toBeFalsy()
     expect(session.read()).toEqual(expect.objectContaining({

--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -25,6 +25,7 @@ const model = {
   expiresAt: 0,
   updatedAt: Date.now(),
   sessionReplay: MODE.OFF,
+  sessionReplaySentFirstChunk: false,
   sessionTraceMode: MODE.OFF,
   custom: {}
 }

--- a/src/features/session_replay/aggregate/index.component-test.js
+++ b/src/features/session_replay/aggregate/index.component-test.js
@@ -177,7 +177,7 @@ describe('Session Replay', () => {
     })
 
     test('Existing Session -- Should inherit mode from session entity and ignore samples', async () => {
-      const storage = new LocalMemory({ NRBA_SESSION: { value: 'abcdefghijklmnop', expiresAt: Date.now() + 10000, inactiveAt: Date.now() + 10000, updatedAt: Date.now(), sessionReplay: MODE.FULL, sessionTraceMode: MODE.FULL, custom: {} } })
+      const storage = new LocalMemory({ NRBA_SESSION: { value: 'abcdefghijklmnop', expiresAt: Date.now() + 10000, inactiveAt: Date.now() + 10000, updatedAt: Date.now(), sessionReplay: MODE.FULL, sessionReplaySentFirstChunk: true, sessionTraceMode: MODE.FULL, custom: {} } })
       session = new SessionEntity({ agentIdentifier, key: 'SESSION', storage })
       expect(session.isNew).toBeFalsy()
       primeSessionAndReplay(session)
@@ -235,6 +235,7 @@ describe('Session Replay', () => {
       const [harvestContents] = sr.prepareHarvest()
       expect(harvestContents.qs).toMatchObject(anyQuery)
       expect(harvestContents.qs.attributes.includes('content_encoding=gzip')).toEqual(true)
+      expect(harvestContents.qs.attributes.includes('isFirstChunk=true')).toEqual(true)
       expect(harvestContents.body).toEqual(expect.any(Uint8Array))
       expect(JSON.parse(strFromU8(gunzipSync(harvestContents.body)))).toMatchObject(expect.any(Array))
     })
@@ -256,6 +257,7 @@ describe('Session Replay', () => {
         browser_monitoring_key: info.licenseKey
       })
       expect(harvestContents.qs.attributes.includes('content_encoding')).toEqual(false)
+      expect(harvestContents.qs.attributes.includes('isFirstChunk')).toEqual(true)
       expect(harvestContents.body).toEqual(expect.any(Array))
     })
 

--- a/src/features/session_replay/aggregate/index.component-test.js
+++ b/src/features/session_replay/aggregate/index.component-test.js
@@ -54,7 +54,7 @@ describe('Session Replay', () => {
     primeSessionAndReplay()
   })
   afterEach(async () => {
-    sr.abort()
+    sr.abort('jest test manually aborted')
     jest.clearAllMocks()
   })
 

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -100,7 +100,11 @@ export class Aggregate extends AggregateBase {
       this.ee.on(SESSION_EVENTS.PAUSE, () => { this.stopRecording() })
       // The SessionEntity class can emit a message indicating the session was resumed (visibility change). This feature must start running again (if already running) if that occurs.
       this.ee.on(SESSION_EVENTS.RESUME, () => {
+        // if the mode changed on a different tab, it needs to update this instance to match
+        const { session } = getRuntime(this.agentIdentifier)
+        this.mode = session.state.sessionReplay
         if (!this.initialized || this.mode === MODE.OFF) return
+        if (this.mode === MODE.ERROR) this.isFirstChunk = true
         this.startRecording()
       })
 

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -242,7 +242,7 @@ export class Aggregate extends AggregateBase {
           hasMeta: this.hasMeta,
           hasSnapshot: this.hasSnapshot,
           hasError: this.hasError,
-          isFirstChunk: !agentRuntime.session.state.sessionReplaySentFirstChunk,
+          isFirstChunk: agentRuntime.session.state.sessionReplaySentFirstChunk === false,
           decompressedBytes: this.payloadBytesEstimation,
           'nr.rrweb.version': RRWEB_VERSION
         }, MAX_PAYLOAD_SIZE - this.payloadBytesEstimation).substring(1) // remove the leading '&'

--- a/tests/specs/session-manager.e2e.js
+++ b/tests/specs/session-manager.e2e.js
@@ -13,6 +13,7 @@ describe('newrelic session ID', () => {
     inactiveAt: expect.any(Number),
     updatedAt: expect.any(Number),
     sessionReplay: expect.any(Number),
+    sessionReplaySentFirstChunk: expect.any(Boolean),
     sessionTraceMode: expect.any(Number),
     custom: expect.any(Object)
   })

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -73,6 +73,7 @@ export default class CustomCommands {
               expiresAt: agentEntry[1].runtime.session.state.expiresAt,
               updatedAt: agentEntry[1].runtime.session.state.updatedAt,
               sessionReplay: agentEntry[1].runtime.session.state.sessionReplay,
+              sessionReplaySentFirstChunk: agentEntry[1].runtime.session.state.sessionReplaySentFirstChunk,
               sessionTraceMode: agentEntry[1].runtime.session.state.sessionTraceMode,
               custom: agentEntry[1].runtime.session.state.custom
             }


### PR DESCRIPTION
Add logic to set firstChunk flag and replay mode on new replays more reliably.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR increases reliability of SR payload decoration in two ways:
* it adds logic to decorate firstChunk flags better while running in error mode
* it adds logic to ensure replay mode syncs across tab changes
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://newrelic.slack.com/archives/C04QZSS6XPV/p1695774682575609?thread_ts=1695766285.826099&cid=C04QZSS6XPV
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Existing tests should continue to pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
