### PR TITLE
fix: Tap session entity into storage api for changes across tabs

### DIFF
--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -33,7 +33,12 @@ export const SESSION_EVENTS = {
   PAUSE: 'session-pause',
   RESET: 'session-reset',
   RESUME: 'session-resume',
-  CROSS_TAB_UPDATE: 'session-cross-tab-update'
+  UPDATE: 'session-update'
+}
+
+export const SESSION_EVENT_TYPES = {
+  SAME_TAB: 'same-tab',
+  CROSS_TAB: 'cross-tab'
 }
 
 export class SessionEntity {
@@ -65,7 +70,7 @@ export class SessionEntity {
         if (event.key === this.lookupKey) {
           const obj = typeof event.newValue === 'string' ? JSON.parse(event.newValue) : event.newValue
           this.sync(obj)
-          this.ee.emit(SESSION_EVENTS.CROSS_TAB_UPDATE, [this.state])
+          this.ee.emit(SESSION_EVENTS.UPDATE, [SESSION_EVENT_TYPES.CROSS_TAB, this.state])
         }
       })
     }
@@ -201,6 +206,7 @@ export class SessionEntity {
       //
       // TODO - compression would need happen here if we decide to do it
       this.storage.set(this.lookupKey, stringify(this.state))
+      this.ee.emit(SESSION_EVENTS.UPDATE, [SESSION_EVENT_TYPES.SAME_TAB, this.state])
       return data
     } catch (e) {
       // storage is inaccessible

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -15,7 +15,7 @@ import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { FEATURE_NAME } from '../constants'
 import { stringify } from '../../../common/util/stringify'
 import { getConfigurationValue, getInfo, getRuntime } from '../../../common/config/config'
-import { SESSION_EVENTS, MODE } from '../../../common/session/session-entity'
+import { SESSION_EVENTS, MODE, SESSION_EVENT_TYPES } from '../../../common/session/session-entity'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { sharedChannel } from '../../../common/constants/shared-channel'
 import { obj as encodeObj } from '../../../common/url/encode'
@@ -104,16 +104,10 @@ export class Aggregate extends AggregateBase {
         this.startRecording()
       })
 
-      this.ee.on(SESSION_EVENTS.CROSS_TAB_UPDATE, (data) => {
-        if (!this.initialized) return
-        if (this.mode !== MODE.OFF && data.sessionReplay === MODE.OFF) this.abort('Session Entity was set to OFF')
-        else if (this.mode === MODE.ERROR && data.sessionReplay === MODE.FULL) {
-          this.scheduler.startTimer(this.harvestTimeSeconds)
-          if (recorder && globalScope?.document.visibilityState === 'visible') {
-            this.stopRecording()
-            this.startRecording()
-          }
-        } else this.mode = data.sessionReplay
+      this.ee.on(SESSION_EVENTS.UPDATE, (type, data) => {
+        if (!this.initialized || this.mode === MODE.OFF || type !== SESSION_EVENT_TYPES.CROSS_TAB) return
+        if (this.mode !== MODE.OFF && data.sessionReplay === MODE.OFF) this.abort('Session Entity was set to OFF on another tab')
+        this.mode = data.sessionReplay
       })
 
       // Bespoke logic for new endpoint.  This will change as downstream dependencies become solidified.

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -106,15 +106,14 @@ export class Aggregate extends AggregateBase {
 
       this.ee.on(SESSION_EVENTS.CROSS_TAB_UPDATE, (data) => {
         if (!this.initialized) return
-        if (data.sessionReplay === MODE.OFF) this.abort()
-        if (this.mode === MODE.ERROR && data.sessionReplay === MODE.FULL) {
+        if (this.mode !== MODE.OFF && data.sessionReplay === MODE.OFF) this.abort()
+        else if (this.mode === MODE.ERROR && data.sessionReplay === MODE.FULL) {
           this.scheduler.startTimer(this.harvestTimeSeconds)
-          if (recorder && this.initialized && globalScope?.document.visibilityState === 'visible') {
+          if (recorder && globalScope?.document.visibilityState === 'visible') {
             this.stopRecording()
             this.startRecording()
           }
-        }
-        this.mode = data.sessionReplay
+        } else this.mode = data.sessionReplay
       })
 
       // Bespoke logic for new endpoint.  This will change as downstream dependencies become solidified.

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -106,7 +106,7 @@ export class Aggregate extends AggregateBase {
 
       this.ee.on(SESSION_EVENTS.CROSS_TAB_UPDATE, (data) => {
         if (!this.initialized) return
-        if (this.mode !== MODE.OFF && data.sessionReplay === MODE.OFF) this.abort()
+        if (this.mode !== MODE.OFF && data.sessionReplay === MODE.OFF) this.abort('Session Entity was set to OFF')
         else if (this.mode === MODE.ERROR && data.sessionReplay === MODE.FULL) {
           this.scheduler.startTimer(this.harvestTimeSeconds)
           if (recorder && globalScope?.document.visibilityState === 'visible') {

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -105,7 +105,7 @@ export class Aggregate extends AggregateBase {
       })
 
       this.ee.on(SESSION_EVENTS.UPDATE, (type, data) => {
-        if (!this.initialized || this.mode === MODE.OFF || type !== SESSION_EVENT_TYPES.CROSS_TAB) return
+        if (!this.initialized || type !== SESSION_EVENT_TYPES.CROSS_TAB) return
         if (this.mode !== MODE.OFF && data.sessionReplay === MODE.OFF) this.abort('Session Entity was set to OFF on another tab')
         this.mode = data.sessionReplay
       })
@@ -124,14 +124,13 @@ export class Aggregate extends AggregateBase {
         this.hasError = true
         this.errorNoticed = true
         // run once
-        if (this.mode === MODE.ERROR) {
+        if (this.mode === MODE.ERROR && globalScope?.document.visibilityState === 'visible') {
           this.mode = MODE.FULL
           // if the error was noticed AFTER the recorder was already imported....
           if (recorder && this.initialized) {
-            if (globalScope?.document.visibilityState === 'visible') {
-              this.stopRecording()
-              this.startRecording()
-            }
+            this.stopRecording()
+            this.startRecording()
+
             this.scheduler.startTimer(this.harvestTimeSeconds)
 
             this.syncWithSessionManager({ sessionReplay: this.mode })

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -105,7 +105,7 @@ export class Aggregate extends AggregateBase {
       })
 
       this.ee.on(SESSION_EVENTS.UPDATE, (type, data) => {
-        if (!this.initialized || type !== SESSION_EVENT_TYPES.CROSS_TAB) return
+        if (!this.initialized || this.blocked || type !== SESSION_EVENT_TYPES.CROSS_TAB) return
         if (this.mode !== MODE.OFF && data.sessionReplay === MODE.OFF) this.abort('Session Entity was set to OFF on another tab')
         this.mode = data.sessionReplay
       })


### PR DESCRIPTION
Tap session entity into storage event listener for stateful changes across tabs.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
There are certain cases where the agent needs to update when changes happen in backgrounded tabs. Utilizing the storage API allows for updates from other tabs.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A test has been added to ensure that a backgrounded tab could terminate an existing session replay
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
