### PR TITLE
chore: fix size diff action script

### DIFF
--- a/.github/actions/size-diff/report-settings.js
+++ b/.github/actions/size-diff/report-settings.js
@@ -1,51 +1,67 @@
+function createRegExpFn (agentType, assetType) {
+  if (typeof assetType !== 'string' || assetType.trim() === '') {
+    assetType = ''
+  } else {
+    assetType = `-${assetType}`
+  }
+
+  return (version) => {
+    if (typeof version !== 'string' || version.trim() === '') {
+      return new RegExp(`nr${assetType}-${agentType}.min.js`)
+    } else {
+      return new RegExp(`nr${assetType}-${agentType}(?:\\.[\\w\\d]{8})?-${version}.min.js`)
+    }
+  }
+}
+
 export const reportSettings = {
   lite: {
     statsFileNameTemplate: 'nr-rum-standard{{version}}.stats.json',
     assetFileNameTemplates: [
-      { name: 'loader', fileNameTemplate: 'nr-loader-rum{{version}}.min.js' },
-      { name: 'async-chunk', fileNameTemplate: 'nr-rum{{version}}.min.js' }
+      { name: 'loader', fileNameRegex: createRegExpFn('rum', 'loader')  },
+      { name: 'async-chunk', fileNameRegex: createRegExpFn('rum') }
     ]
   },
   pro: {
     statsFileNameTemplate: 'nr-full-standard{{version}}.stats.json',
     assetFileNameTemplates: [
-      { name: 'loader', fileNameTemplate: 'nr-loader-full{{version}}.min.js' },
-      { name: 'async-chunk', fileNameTemplate: 'nr-full{{version}}.min.js' }
+      { name: 'loader', fileNameRegex: createRegExpFn('full', 'loader') },
+      { name: 'async-chunk', fileNameRegex: createRegExpFn('full') }
     ]
   },
   spa: {
     statsFileNameTemplate: 'nr-spa-standard{{version}}.stats.json',
     assetFileNameTemplates: [
-      { name: 'loader', fileNameTemplate: 'nr-loader-spa{{version}}.min.js' },
-      { name: 'async-chunk', fileNameTemplate: 'nr-spa{{version}}.min.js' }
+      { name: 'loader', fileNameRegex: createRegExpFn('spa', 'loader') },
+      { name: 'async-chunk', fileNameRegex: createRegExpFn('spa') }
     ]
   },
   'lite-polyfills': {
     statsFileNameTemplate: 'nr-rum-polyfills{{version}}.stats.json',
     assetFileNameTemplates: [
-      { name: 'loader', fileNameTemplate: 'nr-loader-rum-polyfills{{version}}.min.js' },
-      { name: 'async-chunk', fileNameTemplate: 'nr-rum-polyfills{{version}}.min.js' }
+      { name: 'loader', fileNameRegex: createRegExpFn('rum-polyfills', 'loader') },
+      { name: 'async-chunk', fileNameRegex: createRegExpFn('rum-polyfills') }
     ]
   },
   'pro-polyfills': {
     statsFileNameTemplate: 'nr-full-polyfills{{version}}.stats.json',
     assetFileNameTemplates: [
-      { name: 'loader', fileNameTemplate: 'nr-loader-full-polyfills{{version}}.min.js' },
-      { name: 'async-chunk', fileNameTemplate: 'nr-full-polyfills{{version}}.min.js' }
+      { name: 'loader', fileNameRegex: createRegExpFn('full-polyfills', 'loader') },
+      { name: 'async-chunk', fileNameRegex: createRegExpFn('full-polyfills') }
     ]
   },
   'spa-polyfills': {
     statsFileNameTemplate: 'nr-spa-polyfills{{version}}.stats.json',
     assetFileNameTemplates: [
-      { name: 'loader', fileNameTemplate: 'nr-loader-spa-polyfills{{version}}.min.js' },
-      { name: 'async-chunk', fileNameTemplate: 'nr-spa-polyfills{{version}}.min.js' }
+      { name: 'loader', fileNameRegex: createRegExpFn('spa-polyfills', 'loader') },
+      { name: 'async-chunk', fileNameRegex: createRegExpFn('spa-polyfills') }
     ]
   },
   worker: {
     statsFileNameTemplate: 'nr-worker{{version}}.stats.json',
     assetFileNameTemplates: [
-      { name: 'loader', fileNameTemplate: 'nr-loader-worker{{version}}.min.js' },
-      { name: 'async-chunk', fileNameTemplate: 'nr-worker{{version}}.min.js' }
+      { name: 'loader', fileNameRegex: createRegExpFn('worker', 'loader') },
+      { name: 'async-chunk', fileNameRegex: createRegExpFn('worker') }
     ]
   }
 }


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Since release 1.240.0 where the SR feature was included in the PRO and SPA builds, the size diff table on PRs has been incorrectly using the wrong asset size when calculating the async chunk diff. Since the recorder chunk appears in the JSON stats file first, it was being used in the calculation due to poor string replacement logic in the size diff script.

The updated script uses a regular expression and takes into account the version of the agent stats are being retrieved for to ensure the correct asset stats are used in the diff. The regular expression also contains support for the hash that was removed from the file names in version 1.241.0 allowing us to compare our asset sizes back to version 1.238.0.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

N/A

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
