### PR TITLE
fix: Re-update assets proxy to accept host URL strings

### DIFF
--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -33,7 +33,7 @@ export function configure (agentIdentifier, opts = {}, loaderType, forceDrain) {
   if (!alreadySetOnce) {
     alreadySetOnce = true
     if (updatedInit.proxy.assets) {
-      redefinePublicPath(updatedInit.proxy.assets + '/') // much like the info.beacon & init.proxy.beacon, this input should not end in a slash, but one is needed for webpack concat
+      redefinePublicPath(updatedInit.proxy.assets)
       internalTrafficList.push(updatedInit.proxy.assets)
     }
     if (updatedInit.proxy.beacon) internalTrafficList.push(updatedInit.proxy.beacon)

--- a/src/loaders/configure/public-path.js
+++ b/src/loaders/configure/public-path.js
@@ -1,6 +1,9 @@
 // Set the default CDN or remote for fetching the assets; NPM shouldn't change this var.
 
-export const redefinePublicPath = (url) => {
-  // There's no URL validation here, so caller should check arg if need be.
-  __webpack_public_path__ = url // eslint-disable-line
+export const redefinePublicPath = (urlString) => {
+  const isOrigin = urlString.startsWith('http')
+  // Input is not expected to end in a slash, but webpack concats as-is, so one is inserted.
+  urlString += '/'
+  // If there's no existing HTTP scheme, the secure protocol is prepended by default.
+  __webpack_public_path__ = isOrigin ? urlString : 'https://' + urlString // eslint-disable-line
 }


### PR DESCRIPTION
Tweaks the feature added in v1.240.0 wherein the agent code became proxy-able. It worked correctly in expecting that the protocol (i.e. `https://`) is included in the configuration input, but we have since decided that it can be excluded in conformity with the proxy beacon field that only accepts a host string.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Both proxy.beacon and proxy.assets should follow the format `<hostname>[:<port>]` now, without protocol specified (will default to https).

### Related Issue(s)

#659 

### Testing

Existing proxy.e2e.js suffices.
