### PR TITLE
fix: Isolate browser interaction node

### DIFF
--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -20,6 +20,7 @@ import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { firstContentfulPaint } from '../../../common/vitals/first-contentful-paint'
 import { firstPaint } from '../../../common/vitals/first-paint'
+import { bundleId } from '../../../common/ids/bundle-id'
 
 const {
   FEATURE_NAME, INTERACTION_EVENTS, MAX_TIMER_BUDGET, FN_START, FN_END, CB_START, INTERACTION_API, REMAINING,
@@ -166,7 +167,7 @@ export class Aggregate extends AggregateBase {
     register(FN_START, function (args, eventSource) {
       var ev = args[0]
       var evName = ev.type
-      var eventNode = ev.__nrNode
+      var eventNode = ev[`__nrNode:${bundleId}`]
 
       if (!state.pageLoaded && evName === 'load' && eventSource === window) {
         state.pageLoaded = true
@@ -216,7 +217,7 @@ export class Aggregate extends AggregateBase {
         }
       }
 
-      ev.__nrNode = state.currentNode
+      ev[`__nrNode:${bundleId}`] = state.currentNode
     }, this.featureName, eventsEE)
 
     /**


### PR DESCRIPTION
Improving context isolation for events the SPA feature tracks to allow for multiple agent bundles to live on the same page. This is only intended for internal New Relic usage at this time and should not affect customers.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

When running multiple agent bundles on the same page, we get two initial page load interactions but only one interaction for all soft navigations. This was caused by the SPA feature not scoping the scope object it was adding to the events. Adding scoping now results in both agent bundles sending their own interactions for soft navigations.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-152262

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
