### PR TITLE
feat: Isolate spa event observation context

### DIFF
--- a/src/common/context/observation-context.js
+++ b/src/common/context/observation-context.js
@@ -1,0 +1,20 @@
+import { gosNREUM } from '../window/nreum'
+
+export class ObservationContext {
+  static getObservationContextByAgentIdentifier (agentIdentifier) {
+    const nr = gosNREUM()
+    return Object.keys(nr?.initializedAgents || {}).indexOf(agentIdentifier) > -1
+      ? nr.initializedAgents[agentIdentifier].observationContext
+      : undefined
+  }
+
+  #observationContext = new WeakMap()
+
+  getContext (key) {
+    return this.#observationContext.get(key)
+  }
+
+  setContext (key, value) {
+    this.#observationContext.set(key, value)
+  }
+}

--- a/src/common/context/observation-context.test.js
+++ b/src/common/context/observation-context.test.js
@@ -1,0 +1,48 @@
+import { faker } from '@faker-js/faker'
+import { ObservationContext } from './observation-context'
+import * as NREUMModule from '../window/nreum'
+
+jest.enableAutomock()
+jest.unmock('./observation-context')
+
+let agentIdentifier
+let observationContext
+beforeEach(() => {
+  agentIdentifier = faker.datatype.uuid()
+  observationContext = new ObservationContext()
+
+  jest.spyOn(NREUMModule, 'gosNREUM').mockReturnValue({
+    initializedAgents: {
+      [agentIdentifier]: {
+        observationContext
+      }
+    }
+  })
+})
+
+test('should return undefined when the observation context instance cannot be found', () => {
+  const context = ObservationContext.getObservationContextByAgentIdentifier(faker.datatype.uuid())
+
+  expect(context).toBeUndefined()
+})
+
+test('should return the observation context instance when it exists on a found agent', () => {
+  const context = ObservationContext.getObservationContextByAgentIdentifier(agentIdentifier)
+
+  expect(context).toEqual(observationContext)
+})
+
+test('should return undefined when a context cannot be found', () => {
+  const scope = {}
+
+  expect(observationContext.getContext(scope)).toBeUndefined()
+})
+
+test('should return the context for the given scope when it exists', () => {
+  const scope = {}
+  const context = {}
+
+  observationContext.setContext(scope, context)
+
+  expect(observationContext.getContext(scope)).toEqual(context)
+})

--- a/src/features/session_replay/aggregate/index.component-test.js
+++ b/src/features/session_replay/aggregate/index.component-test.js
@@ -3,6 +3,7 @@ import { Aggregator } from '../../../common/aggregate/aggregator'
 import { SESSION_EVENTS, SessionEntity, MODE } from '../../../common/session/session-entity'
 import { setConfiguration } from '../../../common/config/config'
 import { configure } from '../../../loaders/configure/configure'
+import { ObservationContext } from '../../../common/context/observation-context'
 
 class LocalMemory {
   constructor (initialState = {}) {
@@ -313,7 +314,8 @@ function wait (ms = 0) {
 }
 
 function primeSessionAndReplay (sess = new SessionEntity({ agentIdentifier, key: 'SESSION', storage: new LocalMemory() })) {
+  const observationContext = new ObservationContext()
   session = sess
-  configure(agentIdentifier, { info, runtime: { session }, init: {} }, 'test', true)
+  configure(agentIdentifier, { info, runtime: { session }, init: {} }, 'test', observationContext, true)
   sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
 }

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -1,8 +1,17 @@
 /* eslint-disable n/handle-callback-err */
 
 import { warn } from '../common/util/console'
+import { generateRandomHexString } from '../common/ids/unique-id'
+import { ObservationContext } from '../common/context/observation-context'
 
 export class AgentBase {
+  agentIdentifier
+  observationContext = new ObservationContext()
+
+  constructor (agentIdentifier = generateRandomHexString(16)) {
+    this.agentIdentifier = agentIdentifier
+  }
+
   /**
    * Reports a browser PageAction event along with a name and optional attributes.
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/addpageaction/}

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -11,7 +11,6 @@ import { Instrument as PageViewEvent } from '../features/page_view_event/instrum
 // common files
 import { Aggregator } from '../common/aggregate/aggregator'
 import { gosNREUM, gosNREUMInitializedAgents } from '../common/window/nreum'
-import { generateRandomHexString } from '../common/ids/unique-id'
 import { getConfiguration, getInfo, getLoaderConfig, getRuntime } from '../common/config/config'
 import { warn } from '../common/util/console'
 import { stringify } from '../common/util/stringify'
@@ -26,8 +25,8 @@ import { globalScope } from '../common/constants/runtime'
  * sensitive to network load, this may result in smaller builds with slightly lower performance impact.
  */
 export class Agent extends AgentBase {
-  constructor (options, agentIdentifier = generateRandomHexString(16)) {
-    super()
+  constructor (options, agentIdentifier) {
+    super(agentIdentifier)
 
     if (!globalScope) {
       // We could not determine the runtime environment. Short-circuite the agent here
@@ -36,7 +35,6 @@ export class Agent extends AgentBase {
       return
     }
 
-    this.agentIdentifier = agentIdentifier
     this.sharedAggregator = new Aggregator({ agentIdentifier: this.agentIdentifier })
     this.features = {}
 
@@ -46,7 +44,7 @@ export class Agent extends AgentBase {
     // Future work is being planned to evaluate removing this behavior from the backend, but for now we must ensure this call is made
     this.desiredFeatures.add(PageViewEvent)
 
-    Object.assign(this, configure(this.agentIdentifier, options, options.loaderType || 'agent'))
+    Object.assign(this, configure(this.agentIdentifier, options, options.loaderType || 'agent', this.observationContext))
 
     this.run()
   }

--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -7,7 +7,7 @@ import { redefinePublicPath } from './public-path'
 
 let alreadySetOnce = false // the configure() function can run multiple times in agent lifecycle
 
-export function configure (agentIdentifier, opts = {}, loaderType, forceDrain) {
+export function configure (agentIdentifier, opts = {}, loaderType, observationContext, forceDrain) {
   // eslint-disable-next-line camelcase
   let { init, info, loader_config, runtime = { loaderType }, exposed = true } = opts
   const nr = gosCDN()
@@ -50,6 +50,8 @@ export function configure (agentIdentifier, opts = {}, loaderType, forceDrain) {
   gosNREUMInitializedAgents(agentIdentifier, api, 'api')
   gosNREUMInitializedAgents(agentIdentifier, exposed, 'exposed')
   addToNREUM('activatedFeatures', activatedFeatures)
+
+  if (observationContext) gosNREUMInitializedAgents(agentIdentifier, observationContext, 'observationContext')
 
   return api
 }

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -5,7 +5,6 @@ import { configure } from './configure/configure'
 // core files
 import { Aggregator } from '../common/aggregate/aggregator'
 import { gosNREUMInitializedAgents } from '../common/window/nreum'
-import { generateRandomHexString } from '../common/ids/unique-id'
 import { getConfiguration, getConfigurationValue, getInfo, getLoaderConfig, getRuntime } from '../common/config/config'
 import { FEATURE_NAMES } from './features/features'
 import { warn } from '../common/util/console'
@@ -28,14 +27,13 @@ export class MicroAgent extends AgentBase {
    * @param {Object} options - Specifies features and runtime configuration,
    * @param {string=} agentIdentifier - The optional unique ID of the agent.
    */
-  constructor (options, agentIdentifier = generateRandomHexString(16)) {
-    super()
+  constructor (options, agentIdentifier) {
+    super(agentIdentifier)
 
-    this.agentIdentifier = agentIdentifier
     this.sharedAggregator = new Aggregator({ agentIdentifier: this.agentIdentifier })
     this.features = {}
 
-    Object.assign(this, configure(this.agentIdentifier, { ...options, runtime: { isolatedBacklog: true } }, options.loaderType || 'micro-agent'))
+    Object.assign(this, configure(this.agentIdentifier, { ...options, runtime: { isolatedBacklog: true } }, options.loaderType || 'micro-agent', this.observationContext))
 
     /**
      * Starts a set of agent features if not running in "autoStart" mode
@@ -43,7 +41,7 @@ export class MicroAgent extends AgentBase {
      * @param {string|string[]|undefined} name The feature name(s) to start.  If no name(s) are passed, all features will be started
      */
     this.start = features => this.run(features)
-    this.run(nonAutoFeatures.filter(featureName => getConfigurationValue(agentIdentifier, `${featureName}.autoStart`)))
+    this.run(nonAutoFeatures.filter(featureName => getConfigurationValue(this.agentIdentifier, `${featureName}.autoStart`)))
   }
 
   get config () {

--- a/tests/browser/utils/setup.js
+++ b/tests/browser/utils/setup.js
@@ -1,9 +1,11 @@
 const { ee } = require('../../../src/common/event-emitter/contextual-ee')
 const { gosNREUM } = require('../../../src/common/window/nreum')
 const { Aggregator } = require('../../../src/common/aggregate/aggregator')
+const { ObservationContext } = require('../../../src/common/context/observation-context')
 const { configure } = require('../../../src/loaders/configure/configure')
 export function setup (agentIdentifier = (Math.random() + 1).toString(36).substring(7)) {
-  const api = configure(agentIdentifier, {}, 'browser-test', true)
+  const observationContext = new ObservationContext()
+  const api = configure(agentIdentifier, {}, 'browser-test', observationContext, true)
   const nr = gosNREUM()
   const aggregator = new Aggregator({ agentIdentifier, ee })
   const baseEE = ee.get(agentIdentifier)


### PR DESCRIPTION
Introducing a new agent instance private observation context store and implementing it for the isolation of observation contexts for SPA events. This makes it possible to run multiple agents from the same code bundle without interference causing one agent to not report observation data. The observation context also removes the need to alter the event objects. The private observation context store will be extended into other parts of the agent over time.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Creating a new ObservationContext class that utilizes a WeakMap to allow agent instances to associate context data with observed scopes like objects, callback functions, promises, etc.

The first POC use-case included here is a rewrite of #758 using the observation context instance instead of modifying the event object directly.

The ticket has been updated with screenshots show the WeakMap properly allowing garbage collection and browser interactions still being reported correctly.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://issues.newrelic.com/browse/NR-168327
https://issues.newrelic.com/browse/NR-168326

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
