### PR TITLE
feat: Add network info to all page view timing events

### DIFF
--- a/src/common/vitals/first-input-delay.js
+++ b/src/common/vitals/first-input-delay.js
@@ -13,8 +13,7 @@ if (isBrowserScope) {
     firstInputDelay.update({
       value: entries[0].startTime,
       entries,
-      attrs: { type: entries[0].name, fid: Math.round(value) },
-      shouldAddConnectionAttributes: true
+      attrs: { type: entries[0].name, fid: Math.round(value) }
     })
   })
 }

--- a/src/common/vitals/largest-contentful-paint.js
+++ b/src/common/vitals/largest-contentful-paint.js
@@ -22,8 +22,7 @@ if (isBrowserScope) {
           ...(!!lcpEntry.url && { elUrl: cleanURL(lcpEntry.url) }),
           ...(!!lcpEntry.element?.tagName && { elTag: lcpEntry.element.tagName })
         }
-      }),
-      shouldAddConnectionAttributes: true
+      })
     })
   })
 }

--- a/src/common/vitals/vital-metric.js
+++ b/src/common/vitals/vital-metric.js
@@ -8,7 +8,7 @@ export class VitalMetric {
     this.roundingMethod = typeof roundingMethod === 'function' ? roundingMethod : Math.floor
   }
 
-  update ({ value, entries = [], attrs = {}, shouldAddConnectionAttributes = false }) {
+  update ({ value, entries = [], attrs = {} }) {
     if (value < 0) return
     const state = {
       value: this.roundingMethod(value),
@@ -16,7 +16,7 @@ export class VitalMetric {
       entries,
       attrs
     }
-    if (shouldAddConnectionAttributes) addConnectionAttributes(state.attrs)
+
     this.history.push(state)
     this.#subscribers.forEach(cb => {
       try {
@@ -47,14 +47,4 @@ export class VitalMetric {
     if (this.isValid && !!buffered) this.history.forEach(state => { callback(state) })
     return () => { this.#subscribers.delete(callback) }
   }
-}
-
-function addConnectionAttributes (obj) {
-  var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection // to date, both window & worker shares the same support for connection
-  if (!connection) return
-
-  if (connection.type) obj['net-type'] = connection.type
-  if (connection.effectiveType) obj['net-etype'] = connection.effectiveType
-  if (connection.rtt) obj['net-rtt'] = connection.rtt
-  if (connection.downlink) obj['net-dlink'] = connection.downlink
 }

--- a/src/common/vitals/vital-metric.test.js
+++ b/src/common/vitals/vital-metric.test.js
@@ -26,7 +26,7 @@ describe('vital-metric', () => {
 
   test('update', () => {
     let i = 0
-    vitalMetric.update({ value: i, entries: [{ test: i + 1 }], attrs: { test: i + 2 }, shouldAddConnectionAttributes: true })
+    vitalMetric.update({ value: i, entries: [{ test: i + 1 }], attrs: { test: i + 2 } })
     expect(vitalMetric.current).toMatchObject({
       value: i,
       entries: [{ test: i + 1 }],
@@ -34,7 +34,7 @@ describe('vital-metric', () => {
     })
 
     i++
-    vitalMetric.update({ value: i, entries: [{ test: i + 1 }], attrs: { test: i + 2 }, shouldAddConnectionAttributes: true })
+    vitalMetric.update({ value: i, entries: [{ test: i + 1 }], attrs: { test: i + 2 } })
     expect(vitalMetric.current).toMatchObject({
       value: i,
       entries: [{ test: i + 1 }],
@@ -115,57 +115,5 @@ describe('vital-metric', () => {
     unsubscribe()
     vitalMetric.update({ value: 1 })
     setTimeout(done, 1000)
-  })
-
-  test('addConnectionAttributes', () => {
-    global.navigator.connection = {}
-    vitalMetric.update({ value: 1, shouldAddConnectionAttributes: true })
-    expect(vitalMetric.current.attrs).toEqual(expect.objectContaining({}))
-
-    global.navigator.connection.type = 'type'
-    vitalMetric.update({ value: 1, shouldAddConnectionAttributes: true })
-    expect(vitalMetric.current.attrs).toEqual(expect.objectContaining({
-      'net-type': 'type'
-    }))
-
-    global.navigator.connection.effectiveType = 'effectiveType'
-    vitalMetric.update({ value: 1, shouldAddConnectionAttributes: true })
-    expect(vitalMetric.current.attrs).toEqual(expect.objectContaining({
-      'net-type': 'type',
-      'net-etype': 'effectiveType'
-    }))
-
-    global.navigator.connection.rtt = 'rtt'
-    vitalMetric.update({ value: 1, shouldAddConnectionAttributes: true })
-    expect(vitalMetric.current.attrs).toEqual(expect.objectContaining({
-      'net-type': 'type',
-      'net-etype': 'effectiveType',
-      'net-rtt': 'rtt'
-    }))
-
-    global.navigator.connection.downlink = 'downlink'
-    vitalMetric.update({ value: 1, shouldAddConnectionAttributes: true })
-    expect(vitalMetric.current.attrs).toEqual(expect.objectContaining({
-      'net-type': 'type',
-      'net-etype': 'effectiveType',
-      'net-rtt': 'rtt',
-      'net-dlink': 'downlink'
-    }))
-
-    global.navigator.connection = {
-      type: 'type',
-      effectiveType: 'effectiveType',
-      rtt: 'rtt',
-      downlink: 'downlink'
-    }
-    vitalMetric.update({ value: 1, shouldAddConnectionAttributes: true })
-
-    expect(vitalMetric.current.attrs).toEqual(expect.objectContaining({
-      'net-type': 'type',
-      'net-etype': 'effectiveType',
-      'net-rtt': 'rtt',
-      'net-dlink': 'downlink'
-    }))
-    global.navigator.connection = {}
   })
 })

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -94,6 +94,7 @@ export class Aggregate extends AggregateBase {
 
   addTiming (name, value, attrs) {
     attrs = attrs || {}
+    addConnectionAttributes(attrs)
 
     // If cls was set to another value by `onCLS`, then it's supported and is attached onto any timing but is omitted until such time.
     /*
@@ -174,4 +175,14 @@ export class Aggregate extends AggregateBase {
 
     return payload
   }
+}
+
+function addConnectionAttributes (obj) {
+  var connection = navigator.connection || navigator.mozConnection || navigator.webkitConnection // to date, both window & worker shares the same support for connection
+  if (!connection) return
+
+  if (connection.type) obj['net-type'] = connection.type
+  if (connection.effectiveType) obj['net-etype'] = connection.effectiveType
+  if (connection.rtt) obj['net-rtt'] = connection.rtt
+  if (connection.downlink) obj['net-dlink'] = connection.downlink
 }

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -94,7 +94,7 @@ export class Aggregate extends AggregateBase {
 
   addTiming (name, value, attrs) {
     attrs = attrs || {}
-    addConnectionAttributes(attrs)
+    addConnectionAttributes(attrs) // network conditions may differ from the actual for VitalMetrics when they were captured
 
     // If cls was set to another value by `onCLS`, then it's supported and is attached onto any timing but is omitted until such time.
     /*

--- a/src/features/page_view_timing/aggregate/index.test.js
+++ b/src/features/page_view_timing/aggregate/index.test.js
@@ -39,6 +39,58 @@ describe('PVT aggregate', () => {
       expect(result).toEqual(true) // all events should have the set custom attribute
     })
   })
+
+  test('addConnectionAttributes', () => {
+    global.navigator.connection = {}
+    pvtAgg.addTiming('abc', 1)
+    expect(pvtAgg.timings[0].attrs).toEqual(expect.objectContaining({}))
+
+    global.navigator.connection.type = 'type'
+    pvtAgg.addTiming('abc', 1)
+    expect(pvtAgg.timings[1].attrs).toEqual(expect.objectContaining({
+      'net-type': 'type'
+    }))
+
+    global.navigator.connection.effectiveType = 'effectiveType'
+    pvtAgg.addTiming('abc', 1)
+    expect(pvtAgg.timings[2].attrs).toEqual(expect.objectContaining({
+      'net-type': 'type',
+      'net-etype': 'effectiveType'
+    }))
+
+    global.navigator.connection.rtt = 'rtt'
+    pvtAgg.addTiming('abc', 1)
+    expect(pvtAgg.timings[3].attrs).toEqual(expect.objectContaining({
+      'net-type': 'type',
+      'net-etype': 'effectiveType',
+      'net-rtt': 'rtt'
+    }))
+
+    global.navigator.connection.downlink = 'downlink'
+    pvtAgg.addTiming('abc', 1)
+    expect(pvtAgg.timings[4].attrs).toEqual(expect.objectContaining({
+      'net-type': 'type',
+      'net-etype': 'effectiveType',
+      'net-rtt': 'rtt',
+      'net-dlink': 'downlink'
+    }))
+
+    global.navigator.connection = {
+      type: 'type',
+      effectiveType: 'effectiveType',
+      rtt: 'rtt',
+      downlink: 'downlink'
+    }
+    pvtAgg.addTiming('abc', 1)
+
+    expect(pvtAgg.timings[5].attrs).toEqual(expect.objectContaining({
+      'net-type': 'type',
+      'net-etype': 'effectiveType',
+      'net-rtt': 'rtt',
+      'net-dlink': 'downlink'
+    }))
+    global.navigator.connection = {}
+  })
 })
 
 function testCases () {


### PR DESCRIPTION
Add client network information to all PageViewTiming events in New Relic. The attributes currently only exist on LCP and FI event types and will now be reported with all others such as load and pagehide events.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

FR to add network attributes to other pvt nodes. It'll be shown now via NRQL and may be picked up by UI in the future to highlight the at-the-time network conditions when certain metrics are captured.

### Related Issue(s)

NR-168402

### Testing

Modified existing tests.
