### PR TITLE
feat: Bump rrweb to 2.0.0.11 and make constant dynamic at build time

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,14 +1,17 @@
 const process = require('process')
+const pkg = require('./package.json')
 
 module.exports = function (api, ...args) {
   api.cache(true)
 
   if (!process.env.BUILD_VERSION) {
-    process.env.BUILD_VERSION = process.env.VERSION_OVERRIDE || require('./package.json').version
+    process.env.BUILD_VERSION = process.env.VERSION_OVERRIDE || pkg.version
   }
   if (!process.env.BUILD_ENV) {
     process.env.BUILD_ENV = 'CDN'
   }
+
+  process.env.RRWEB_VERSION = pkg.dependencies.rrweb
 
   const ignore = [
     '**/*.test.js',
@@ -26,7 +29,7 @@ module.exports = function (api, ...args) {
     [
       'transform-inline-environment-variables',
       {
-        include: ['BUILD_VERSION', 'BUILD_ENV']
+        include: ['BUILD_VERSION', 'BUILD_ENV', 'RRWEB_VERSION']
       }
     ]
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "core-js": "^3.26.0",
         "fflate": "^0.7.4",
-        "rrweb": "2.0.0-alpha.8",
+        "rrweb": "2.0.0-alpha.11",
         "web-vitals": "^3.1.0"
       },
       "devDependencies": {
@@ -6055,11 +6055,11 @@
       }
     },
     "node_modules/@rrweb/types": {
-      "version": "2.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.8.tgz",
-      "integrity": "sha512-yAr6ZQrgmr7+qZU5DMGqYXnVsolC5epftmZtkOtgFD/bbvCWflNnl09M32hUjttlKCV1ohhmQGioXkCQ37IF7A==",
+      "version": "2.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.11.tgz",
+      "integrity": "sha512-8ccocIkT5J/bfNRQY85qR/g6p5YQFpgFO2cMt4+Ex7w31Lq0yqZBRaoYEsawQKpLrn5KOHkdn2UTUrna7WMQuA==",
       "dependencies": {
-        "rrweb-snapshot": "^2.0.0-alpha.8"
+        "rrweb-snapshot": "^2.0.0-alpha.11"
       }
     },
     "node_modules/@sideway/address": {
@@ -21373,32 +21373,32 @@
       }
     },
     "node_modules/rrdom": {
-      "version": "2.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.8.tgz",
-      "integrity": "sha512-rUyeS9fSOO6uSxCdeY5bQkKQTPECIgxsOCb/WR7eA/UsVkVpdDOyCV43wxm92V2JOtqMuv+36rUpEDFW+YFjOw==",
+      "version": "2.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.11.tgz",
+      "integrity": "sha512-U37m0t4jTz63wnVRcOQ5qFzSTrI5RdNgeXnHAha2Fmh9+1K+XuCx421a8D1wZk3WcDc2sFz/04FVdM0OD2caHg==",
       "dependencies": {
-        "rrweb-snapshot": "^2.0.0-alpha.8"
+        "rrweb-snapshot": "^2.0.0-alpha.11"
       }
     },
     "node_modules/rrweb": {
-      "version": "2.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.8.tgz",
-      "integrity": "sha512-JtJCeUjZ91/qJ6gvLmZw/1Bxuddt06pD887shIYzGhKuOgjtvkUdhBtB5uXrV7Bvi3WELYGZr1stqBugWa9MXg==",
+      "version": "2.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.11.tgz",
+      "integrity": "sha512-vJ2gNvF+pUG9C2aaau7iSNqhWBSc4BwtUO4FpegOtDObuH4PIaxNJOlgHz82+WxKr9XPm93ER0LqmNpy0KYdKg==",
       "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.8",
+        "@rrweb/types": "^2.0.0-alpha.11",
         "@types/css-font-loading-module": "0.0.7",
         "@xstate/fsm": "^1.4.0",
         "base64-arraybuffer": "^1.0.1",
         "fflate": "^0.4.4",
         "mitt": "^3.0.0",
-        "rrdom": "^2.0.0-alpha.8",
-        "rrweb-snapshot": "^2.0.0-alpha.8"
+        "rrdom": "^2.0.0-alpha.11",
+        "rrweb-snapshot": "^2.0.0-alpha.11"
       }
     },
     "node_modules/rrweb-snapshot": {
-      "version": "2.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.8.tgz",
-      "integrity": "sha512-3Rb7c+mnDEADQ8N9qn9SDH5PzCyHlZ1cwZC932qRyt9O8kJWLM11JLYqqEyQCa2FZVQbzH2iAaCgnyM7A32p7A=="
+      "version": "2.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.11.tgz",
+      "integrity": "sha512-N0dzeJA2VhrlSOadkKwCVmV/DuNOwBH+Lhx89hAf9PQK4lCS8AP4AaylhqUdZOYHqwVjqsYel/uZ4hN79vuLhw=="
     },
     "node_modules/rrweb/node_modules/fflate": {
       "version": "0.4.8",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
   "dependencies": {
     "core-js": "^3.26.0",
     "fflate": "^0.7.4",
-    "rrweb": "2.0.0-alpha.8",
+    "rrweb": "2.0.0-alpha.11",
     "web-vitals": "^3.1.0"
   },
   "devDependencies": {

--- a/src/common/constants/__mocks__/env.js
+++ b/src/common/constants/__mocks__/env.js
@@ -1,3 +1,4 @@
 export const VERSION = '0.0.0'
 export const BUILD_ENV = 'TEST'
 export const DIST_METHOD = 'TEST'
+export const RRWEB_VERSION = '0.0.0'

--- a/src/common/constants/env.cdn.js
+++ b/src/common/constants/env.cdn.js
@@ -18,3 +18,8 @@ export const BUILD_ENV = process.env.BUILD_ENV
  * Exposes the distribution method of the agent
  */
 export const DIST_METHOD = 'CDN'
+
+/**
+ * Exposes the lib version of rrweb
+ */
+export const RRWEB_VERSION = process.env.RRWEB_VERSION

--- a/src/common/constants/env.js
+++ b/src/common/constants/env.js
@@ -21,3 +21,8 @@ export const BUILD_ENV = 'NPM'
  * Exposes the distribution method of the agent
  */
 export const DIST_METHOD = 'NPM'
+
+/**
+ * Exposes the lib version of rrweb
+ */
+export const RRWEB_VERSION = pkgJSON.dependencies.rrweb

--- a/src/common/constants/env.npm.js
+++ b/src/common/constants/env.npm.js
@@ -19,3 +19,8 @@ export const BUILD_ENV = 'NPM'
  * Valid valuse are CDN, NPM
  */
 export const DIST_METHOD = 'NPM'
+
+/**
+ * Exposes the lib version of rrweb
+ */
+export const RRWEB_VERSION = process.env.RRWEB_VERSION

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -24,9 +24,7 @@ import { globalScope } from '../../../common/constants/runtime'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { handle } from '../../../common/event-emitter/handle'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
-
-// would be better to get this dynamically in some way
-export const RRWEB_VERSION = '2.0.0-alpha.8'
+import { RRWEB_VERSION } from '../../../common/constants/env'
 
 export const AVG_COMPRESSION = 0.12
 


### PR DESCRIPTION
Bump rrweb dependency version to 2.0.0.11 and include in Session Replay payload metadata dynamically
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR updates the rrweb dependency version and updates the build process to include it dynamically instead of as a hard-coded constant value.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://newrelic.slack.com/archives/C04QZSS6XPV/p1696953790363509
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
All existing tests should continue to pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
