### PR TITLE
feat: Allow boolean values in setCustomAttribute

### DIFF
--- a/src/loaders/api/api.component-test.js
+++ b/src/loaders/api/api.component-test.js
@@ -274,12 +274,12 @@ describe('setAPI', () => {
       expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Name must be a string type'))
     })
 
-    test.each([undefined, {}, []])('should return early and warn when value is not a string, number, or null (%s)', (value) => {
+    test.each([undefined, {}, [], Symbol])('should return early and warn when value is not a string, number, or null (%s)', (value) => {
       const args = [faker.datatype.uuid(), value]
       apiInterface.setCustomAttribute(...args)
 
       expect(console.warn).toHaveBeenCalledTimes(1)
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Non-null value must be a string or number type'))
+      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Non-null value must be a string, number or boolean type'))
     })
 
     test('should set a custom attribute with a string value', () => {
@@ -291,6 +291,13 @@ describe('setAPI', () => {
 
     test('should set a custom attribute with a number value', () => {
       const args = [faker.datatype.uuid(), faker.datatype.number()]
+      apiInterface.setCustomAttribute(...args)
+
+      expect(getInfo(agentId).jsAttributes[args[0]]).toEqual(args[1])
+    })
+
+    test('should set a custom attribute with a boolean value', () => {
+      const args = [faker.datatype.uuid(), faker.datatype.boolean()]
       apiInterface.setCustomAttribute(...args)
 
       expect(getInfo(agentId).jsAttributes[args[0]]).toEqual(args[1])

--- a/src/loaders/api/api.component-test.js
+++ b/src/loaders/api/api.component-test.js
@@ -274,7 +274,7 @@ describe('setAPI', () => {
       expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Name must be a string type'))
     })
 
-    test.each([undefined, {}, [], Symbol])('should return early and warn when value is not a string, number, or null (%s)', (value) => {
+    test.each([undefined, {}, [], Symbol('foobar')])('should return early and warn when value is not a string, number, or null (%s)', (value) => {
       const args = [faker.datatype.uuid(), value]
       apiInterface.setCustomAttribute(...args)
 

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -89,8 +89,8 @@ export function setAPI (agentIdentifier, forceDrain) {
       warn(`Failed to execute setCustomAttribute.\nName must be a string type, but a type of <${typeof name}> was provided.`)
       return
     }
-    if (!(['string', 'number'].includes(typeof value) || value === null)) {
-      warn(`Failed to execute setCustomAttribute.\nNon-null value must be a string or number type, but a type of <${typeof value}> was provided.`)
+    if (!(['string', 'number', 'boolean'].includes(typeof value) || value === null)) {
+      warn(`Failed to execute setCustomAttribute.\nNon-null value must be a string, number or boolean type, but a type of <${typeof value}> was provided.`)
       return
     }
     return appendJsAttribute(name, value, 'setCustomAttribute', persistAttribute)


### PR DESCRIPTION
Allow boolean values to be supplied to newrelic.setCustomAttribute() API calls.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Old versions of the agent allowed boolean values for setCustomAttribute, which did not match our documentation.  An effort was conducted some time ago to align the agent with the docs, and booleans were forcibly denied.  This is causing some migration issues for some customers, and there is no clear reason to exclude booleans from this API.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-171312
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been updated to account for the change
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
