### PR TITLE
fix: temporary workaround for spa interactions containing ajax nodes

### DIFF
--- a/src/common/config/state/configurable.js
+++ b/src/common/config/state/configurable.js
@@ -13,7 +13,8 @@ export function getModeledObject (obj, model) {
     for (let key in target) {
       if (obj[key] !== undefined) {
         try {
-          if (typeof obj[key] === 'object' && typeof model[key] === 'object') output[key] = getModeledObject(obj[key], model[key])
+          if (Array.isArray(obj[key]) && Array.isArray(model[key])) output[key] = Array.from(new Set([...obj[key], ...model[key]]))
+          else if (typeof obj[key] === 'object' && typeof model[key] === 'object') output[key] = getModeledObject(obj[key], model[key])
           else output[key] = obj[key]
         } catch (e) {
           warn('An error occurred while setting a property of a Configurable', e)

--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -29,6 +29,7 @@ const model = () => {
     }
   }
   return {
+    feature_flags: [],
     proxy: {
       assets: undefined, // if this value is set, it will be used to overwrite the webpack asset path used to fetch assets
       beacon: undefined // likewise for the url to which we send analytics

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -46,8 +46,12 @@ export class Aggregate extends AggregateBase {
       depth: 0,
       harvestTimeSeconds: getConfigurationValue(agentIdentifier, 'spa.harvestTimeSeconds') || 10,
       interactionsToHarvest: [],
-      interactionsSent: []
+      interactionsSent: [],
+      // The below feature flag is used to disable the SPA ajax fix for specific customers, see https://new-relic.atlassian.net/browse/NR-172169
+      disableSpaFix: (getConfigurationValue(agentIdentifier, 'feature_flags') || []).indexOf('disable-spa-fix') > -1
     }
+
+    console.dir(getConfigurationValue(agentIdentifier, 'feature_flags'))
 
     this.serializer = new Serializer(this)
 
@@ -279,7 +283,7 @@ export class Aggregate extends AggregateBase {
     // context is stored on the xhr and is shared with all callbacks associated
     // with the new xhr
     register('new-xhr', function () {
-      if (!state.currentNode && state.prevInteraction && !state.prevInteraction.ignored) {
+      if (!state.disableSpaFix && !state.currentNode && state.prevInteraction && !state.prevInteraction.ignored) {
         /*
          * The previous interaction was discarded before a route change. Restore the interaction
          * in case this XHR is associated with a route change.
@@ -382,7 +386,7 @@ export class Aggregate extends AggregateBase {
 
     register(FETCH_START, function (fetchArguments, dtPayload) {
       if (fetchArguments) {
-        if (!state.currentNode && state.prevInteraction && !state.prevInteraction.ignored) {
+        if (!state.disableSpaFix && !state.currentNode && state.prevInteraction && !state.prevInteraction.ignored) {
           /*
            * The previous interaction was discarded before a route change. Restore the interaction
            * in case this XHR is associated with a route change.


### PR DESCRIPTION
Implementing a feature flag that will disable the fix [315](https://github.com/newrelic/newrelic-browser-agent/pull/315). That fix was specifically around Angular, React, and Vue applications with routes containing network calls resulting in browser interactions missing those ajax calls. This feature flag should not be enabled unless specifically instructed to do so by support.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

This PR introduces a new `init` configuration section called `feature_flags`. This configuration is expected to be an array of strings where those strings are feature flags that we use within the agent. Feature flags are meant to be temporary, not long lasting or complex configuration.

The feature flag implemented here disables a previous fix made to the SPA feature for Angular, React, and Vue application where those application contained routes with ajax calls but the ajax calls were not being captured with the browser interaction. See the ticket for more details around the customer(s) needing this feature flag as a temporary workaround.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-172169

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
