### PR TITLE
chore: Tweak payload-metadata test for safari

### DIFF
--- a/tests/specs/stn/payload-metadata.e2e.js
+++ b/tests/specs/stn/payload-metadata.e2e.js
@@ -20,7 +20,6 @@ describe('STN Payload metadata checks', () => {
   })
 
   it('fsh is included and correctly set with session enabled', async () => {
-    await browser.destroyAgentSession()
     let testURL = await browser.testHandle.assetURL('stn/instrumented.html', { init: { privacy: { cookies_enabled: true } } })
 
     let stnToHarvest = browser.testHandle.expectResources()

--- a/tests/specs/stn/payload-metadata.e2e.js
+++ b/tests/specs/stn/payload-metadata.e2e.js
@@ -20,7 +20,8 @@ describe('STN Payload metadata checks', () => {
   })
 
   it('fsh is included and correctly set with session enabled', async () => {
-    const testURL = await browser.testHandle.assetURL('stn/instrumented.html', { init: { privacy: { cookies_enabled: true } } })
+    await browser.destroyAgentSession()
+    let testURL = await browser.testHandle.assetURL('stn/instrumented.html', { init: { privacy: { cookies_enabled: true } } })
 
     let stnToHarvest = browser.testHandle.expectResources()
     await browser.url(testURL).then(() => browser.waitForAgentLoad())
@@ -34,7 +35,8 @@ describe('STN Payload metadata checks', () => {
 
     expect(stn.request.query.fsh).toEqual('0') // basically any subsequent harvests
 
-    // Load the page again a second time within same session, and the first harvest should not have fsh = 1 this time.
+    // Load another page within same session, and the first harvest should not have fsh = 1 this time.
+    testURL = await browser.testHandle.assetURL('instrumented.html', { init: { privacy: { cookies_enabled: true } } })
     stnToHarvest = browser.testHandle.expectResources()
     await browser.url(testURL).then(() => browser.waitForAgentLoad())
     stn = await stnToHarvest


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Just making test previously merged by #765 work for Safari too

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
