### PR TITLE
feat: Add session durationMs to Session Replay payloads

### DIFF
--- a/src/features/session_replay/aggregate/index.component-test.js
+++ b/src/features/session_replay/aggregate/index.component-test.js
@@ -4,6 +4,10 @@ import { SESSION_EVENTS, SessionEntity, MODE } from '../../../common/session/ses
 import { setConfiguration } from '../../../common/config/config'
 import { configure } from '../../../loaders/configure/configure'
 
+jest.mock('../../../common/util/console', () => ({
+  warn: jest.fn()
+}))
+
 class LocalMemory {
   constructor (initialState = {}) {
     this.state = initialState
@@ -66,6 +70,7 @@ describe('Session Replay', () => {
   })
   afterEach(async () => {
     sr.abort('jest test manually aborted')
+    jest.resetAllMocks()
     jest.clearAllMocks()
   })
 
@@ -224,12 +229,19 @@ describe('Session Replay', () => {
 
   describe('Session Replay Payload Validation', () => {
     test('Payload', async () => {
+      const storage = new LocalMemory({ NRBA_SESSION: { ...model, value: 'abcdefghijklmnop', expiresAt: Date.now() + 10000, inactiveAt: Date.now() + 10000, sessionReplayMode: MODE.FULL, sessionReplaySentFirstChunk: true, sessionTraceMode: MODE.FULL } })
+      session = new SessionEntity({ agentIdentifier, key: 'SESSION', storage })
+      primeSessionAndReplay(session)
       setConfiguration(agentIdentifier, { ...init })
       sr.ee.emit('rumresp-sr', [true])
       await wait(1)
       const harvestContents = sr.getHarvestContents()
       // query attrs
       expect(harvestContents.qs).toMatchObject(anyQuery)
+
+      expect(harvestContents.qs.attributes.includes('session.durationMs')).toEqual(true)
+      const urlParams = new URLSearchParams(harvestContents.qs.attributes)
+      expect(Number(urlParams.get('session.durationMs'))).toBeGreaterThan(0)
 
       expect(harvestContents.body).toEqual(expect.any(Array))
 

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -304,6 +304,7 @@ export class Aggregate extends AggregateBase {
           'replay.lastTimestamp': lastTimestamp,
           'replay.durationMs': lastTimestamp - firstTimestamp,
           'replay.nodes': this.events.length,
+          'session.durationMs': agentRuntime.session.getDuration(),
           agentVersion: agentRuntime.version,
           session: agentRuntime.session.state.value,
           hasMeta: this.hasMeta,

--- a/tests/specs/session-replay/harvest.e2e.js
+++ b/tests/specs/session-replay/harvest.e2e.js
@@ -81,6 +81,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Harvest Behavior', () => {
     expect(attr1['replay.lastTimestamp']).toBeGreaterThan(0)
     expect(attr1['replay.firstTimestamp']).toEqual(blobHarvest.body[0].timestamp)
     expect(attr1['replay.lastTimestamp']).toEqual(blobHarvest.body[blobHarvest.body.length - 1].timestamp)
+    expect(attr1['session.durationMs']).toBeGreaterThan(0)
 
     const { request: blobHarvest2 } = await browser.testHandle.expectBlob()
     expect(blobHarvest2.body.length).toBeGreaterThan(0)
@@ -89,6 +90,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Harvest Behavior', () => {
     expect(attr2['replay.lastTimestamp']).toBeGreaterThan(0)
     expect(attr2['replay.firstTimestamp']).toEqual(blobHarvest2.body[0].timestamp)
     expect(attr2['replay.lastTimestamp']).toEqual(blobHarvest2.body[blobHarvest2.body.length - 1].timestamp)
+    expect(attr2['session.durationMs']).toBeGreaterThan(0)
 
     expect(attr1['replay.firstTimestamp']).not.toEqual(attr2['replay.firstTimestamp'])
     expect(attr1['replay.lastTimestamp']).not.toEqual(attr2['replay.lastTimestamp'])


### PR DESCRIPTION
Add current session's running duration to all outgoing session replay payloads for use with ingest estimations
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds the current session's running duration to all outgoing payloads.  Intended to be digested by using latest(session.durationMs) via NRQL for ingest estimation purposes.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-173704

### Testing
Tests have been updated to account for the new property
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
