### PR TITLE
chore: Fix the cache header for current loader

### DIFF
--- a/.github/actions/update-current/index.js
+++ b/.github/actions/update-current/index.js
@@ -25,12 +25,13 @@ const s3Client = new S3Client({
 const results = await Promise.all(
   constructLoaderFileNames(args.loaderVersion)
     .map(async loader => {
+      const currentLoaderName = loader.replace(args.loaderVersion, 'current')
       const commandOpts = {
         Bucket: args.bucket,
         CopySource: `${args.bucket}/${loader}`,
-        Key: loader.replace(args.loaderVersion, 'current'),
-        ContentType: mime.lookup(loader) || 'application/javascript',
-        CacheControl: getAssetCacheHeader('/', loader),
+        Key: currentLoaderName,
+        ContentType: mime.lookup(currentLoaderName) || 'application/javascript',
+        CacheControl: getAssetCacheHeader('/', currentLoaderName),
         MetadataDirective: 'REPLACE',
         TaggingDirective: 'COPY'
       }


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

The cache header was still being based on the versioned loader name instead of the `current` name.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
