### PR TITLE
fix: Wrapped promise allows ES6 sub-classing

### DIFF
--- a/.github/actions/size-diff/get-stats.js
+++ b/.github/actions/size-diff/get-stats.js
@@ -29,14 +29,14 @@ async function getStats (version, reportSetting) {
     return await getDevStats(reportSetting)
   }
 
-  return getVersionedStats(version, reportSetting)
+  return getVersionedStats(`-${version}`, reportSetting)
 }
 
 async function getLocalStats (reportSetting) {
   const statsFileName = await findLocalStatsFile(reportSetting.statsFileNameTemplate)
   const statsFileContent = JSON.parse(await fs.promises.readFile(statsFileName))
 
-  return parseStatsFile(reportSetting, statsFileContent)
+  return parseStatsFile(reportSetting, statsFileContent, '(?:-[\\d\\.\\-]*?)?')
 }
 
 async function getDevStats (reportSetting) {
@@ -54,7 +54,7 @@ async function getDevStats (reportSetting) {
 }
 
 async function getVersionedStats (version, reportSetting) {
-  const statsFileName = reportSetting.statsFileNameTemplate.replace('{{version}}', `-${version}`)
+  const statsFileName = reportSetting.statsFileNameTemplate.replace('{{version}}', version)
 
   try {
     const statsFileRequest = await fetchRetry(`https://js-agent.newrelic.com/${statsFileName}?_nocache=${uuidv4()}`, { retry: 3 })
@@ -78,6 +78,8 @@ function parseStatsFile (reportSetting, statsFileContent, version) {
     )
 
     if (!assetFileStats) {
+      console.log(statsFileContent)
+      console.log(assetFileNameRegex)
       throw new Error(`No stats exist matching pattern ${assetFileNameRegex.toString()}.`)
     }
 

--- a/.github/actions/size-diff/report-settings.js
+++ b/.github/actions/size-diff/report-settings.js
@@ -9,7 +9,7 @@ function createRegExpFn (agentType, assetType) {
     if (typeof version !== 'string' || version.trim() === '') {
       return new RegExp(`nr${assetType}-${agentType}.min.js`)
     } else {
-      return new RegExp(`nr${assetType}-${agentType}(?:\\.[\\w\\d]{8})?-${version}.min.js`)
+      return new RegExp(`nr${assetType}-${agentType}(?:\\.[\\w\\d]{8})?${version}.min.js`)
     }
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -65,7 +65,7 @@ module.exports = function (api, ...args) {
           '@babel/preset-env', {
             useBuiltIns: 'entry',
             corejs: { version: 3.23, proposals: true },
-            loose: true,
+            loose: false,
             targets: {
               browsers: [
                 'ie >= 11' // Does not affect webpack's own runtime output; see `target` webpack config property.

--- a/src/common/event-emitter/contextual-ee.js
+++ b/src/common/event-emitter/contextual-ee.js
@@ -52,8 +52,8 @@ function ee (old, debugId) {
     aborted: false,
     isBuffering,
     debugId,
-    backlog: isolatedBacklog ? {} : old && typeof old.backlog === 'object' ? old.backlog : {}
-
+    backlog: isolatedBacklog ? {} : old && typeof old.backlog === 'object' ? old.backlog : {},
+    hasChildEmitter
   }
 
   return emitter
@@ -113,6 +113,10 @@ function ee (old, debugId) {
 
   function getOrCreate (name) {
     return (emitters[name] = emitters[name] || ee(emitter, name))
+  }
+
+  function hasChildEmitter (name) {
+    return Object.hasOwnProperty.call(emitters, name)
   }
 
   function bufferEventsByGroup (types, group) {

--- a/src/common/wrap/wrap-promise.component-test.js
+++ b/src/common/wrap/wrap-promise.component-test.js
@@ -1,21 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { globalScope } from '../constants/runtime'
 
-let promiseConstructorCalls
-
 beforeEach(async () => {
-  promiseConstructorCalls = []
-
-  // Proxy the global Promise to prevent the wrapping from
-  // messing with Jest internal promises
-  window.Promise = new Proxy(class extends Promise {}, {
-    construct (target, args) {
-      promiseConstructorCalls.push(args)
-
-      return Reflect.construct(target, args)
-    }
-  })
-
   ;(await import('./wrap-promise')).wrapPromise()
 })
 
@@ -27,7 +13,7 @@ test('should wrap promise constructor', async () => {
   const promiseInstance = new globalScope.Promise(jest.fn())
 
   expect(promiseInstance).toBeInstanceOf(Promise)
-  expect(promiseConstructorCalls.length).toBeGreaterThan(0)
+  expect(promiseInstance.ctx).toBeDefined()
   expect(globalScope.Promise.toString()).toMatch(/\[native code\]/)
   expect(globalScope.Promise.name).toEqual('Promise')
 })

--- a/src/common/wrap/wrap-promise.js
+++ b/src/common/wrap/wrap-promise.js
@@ -7,11 +7,10 @@
  * This module is used by: spa.
  */
 
-import { createWrapperWithEmitter as wrapFn, flag } from './wrap-function'
 import { ee as baseEE } from '../event-emitter/contextual-ee'
 import { globalScope } from '../constants/runtime'
 
-const wrapped = {}
+// const wrapped = {}
 
 /**
  * Wraps the native Promise object so that it will emit events for start, end and error in the context of a new event
@@ -20,150 +19,139 @@ const wrapped = {}
  * @param {Object} sharedEE - The shared event emitter on which a new scoped event emitter will be based.
  * @returns {Object} Scoped event emitter with a debug ID of `promise`.
  */
-export function wrapPromise (sharedEE) {
-  const promiseEE = scopedEE(sharedEE)
-
-  // Notice if our wrapping never ran yet, the falsy NaN will not early return; but if it has,
-  // then we increment the count to track # of feats using this at runtime.
-  if (wrapped[promiseEE.debugId]) return promiseEE
-  wrapped[promiseEE.debugId] = true // otherwise, first feature to wrap promise
-
-  var getContext = promiseEE.context
-  var promiseWrapper = wrapFn(promiseEE)
-  var prevPromiseObj = globalScope.Promise
-
-  if (prevPromiseObj) { // ensure there's a Promise API (native or otherwise) to even wrap
-    wrap()
+export const wrapPromise = (sharedEE = baseEE) => {
+  if (sharedEE.hasChildEmitter('promise')) {
+    return sharedEE.get('promise')
   }
 
-  function wrap () {
-    globalScope.Promise = WrappedPromise
+  const promiseEE = sharedEE.get('promise')
+  const promiseGlobal = globalScope.Promise
 
-    // Renamed from "WrappedPromise" back to "Promise" & toString() so that we appear "native" to TP libraries...
-    Object.defineProperty(WrappedPromise, 'name', {
-      value: 'Promise'
-    })
-    WrappedPromise.toString = function () { return prevPromiseObj.toString() }
+  if (!promiseGlobal) {
+    return promiseEE
+  }
 
-    /**
-     * This constitutes the global used when calling "Promise.staticMethod" or chaining off a "new Promise()" object.
-     * @param {Function} executor - to be executed by the original Promise constructor
-     * @returns A new WrappedPromise object prototyped off the original.
-     */
-    function WrappedPromise (executor) {
-      var ctx = promiseEE.context()
-      var wrappedExecutor = promiseWrapper(executor, 'executor-', ctx, null, false)
+  const nrWrapper = class extends promiseGlobal {
+    ctx
+    constructor (executor) {
+      let executorContext
 
-      const existingInstanceDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf(this))
-      const newCustomPromiseInst = Reflect.construct(prevPromiseObj, [wrappedExecutor], WrappedPromise) // new Promises will use WrappedPromise.prototype as theirs prototype
-      Object.entries(existingInstanceDescriptors).forEach(([key, value]) => {
-        Object.defineProperty(newCustomPromiseInst, key, value)
-      })
+      let wrappedExecutor
+      if (executor) {
+        wrappedExecutor = function nrWrapper () {
+          const args = [...arguments]
+          executorContext = promiseEE.context(this)
+          promiseEE.emit('executor-start', [args, this, executor.name], executorContext, false)
 
-      promiseEE.context(newCustomPromiseInst).getCtx = function () {
-        return ctx
-      }
-      return newCustomPromiseInst
-    }
-
-    // Make WrappedPromise inherit statics from the orig Promise.
-    Object.setPrototypeOf(WrappedPromise, prevPromiseObj);
-
-    ['all', 'race'].forEach(function (method) {
-      const prevStaticFn = prevPromiseObj[method]
-      WrappedPromise[method] = function (subPromises) { // use our own wrapped version of "Promise.all" and ".race" static fns
-        let finalized = false
-
-        ;[...subPromises || []].forEach(sub => {
-          this.resolve(sub).then(setNrId(method === 'all'), setNrId(false))
-        })
-
-        const origFnCallWithThis = prevStaticFn.apply(this, arguments)
-        return origFnCallWithThis
-
-        function setNrId (overwrite) {
-          return function () {
-            promiseEE.emit('propagate', [null, !finalized], origFnCallWithThis, false, false)
-            finalized = finalized || !overwrite
+          let result
+          try {
+            result = executor.apply(this, args)
+            return result
+          } catch (err) {
+            promiseEE.emit('executor-err', [args, this, err], executorContext, false)
+            throw err
+          } finally {
+            promiseEE.emit('executor-end', [args, this, result], executorContext, false)
           }
         }
       }
-    });
-    ['resolve', 'reject'].forEach(function (method) {
-      const prevStaticFn = prevPromiseObj[method]
-      WrappedPromise[method] = function (val) { // and the same for ".resolve" and ".reject"
-        const origFnCallWithThis = prevStaticFn.apply(this, arguments)
 
-        if (val !== origFnCallWithThis) {
-          promiseEE.emit('propagate', [val, true], origFnCallWithThis, false, false)
-        }
-        return origFnCallWithThis
-      }
-    })
+      super(wrappedExecutor || executor)
 
-    /*
-     * Ideally, we create a new WrappedPromise.prototype chained off the original Promise's so that we don't alter it.
-     * However, there's no way to make the (native) promise returned from async functions use our WrappedPromise,
-     * so we have to modify the original prototype. This ensures that promises returned from async functions execute
-     * the same instance methods as promises created with "new Promise()", and also that instanceof async() is
-     * the global Promise (see GH issue #409). This also affects the promise returned from fetch().
-     */
-    WrappedPromise.prototype = prevPromiseObj.prototype
-
-    // Note that this wrapping affects the same originals.PR (prototype) object.
-    const prevPromiseOrigThen = prevPromiseObj.prototype.then
-    prevPromiseObj.prototype.then = function wrappedThen (...args) {
-      var originalThis = this
-      var ctx = getContext(originalThis)
-      ctx.promise = originalThis
-      args[0] = promiseWrapper(args[0], 'cb-', ctx, null, false)
-      args[1] = promiseWrapper(args[1], 'cb-', ctx, null, false)
-
-      const origFnCallWithThis = prevPromiseOrigThen.apply(this, args)
-
-      ctx.nextPromise = origFnCallWithThis
-      promiseEE.emit('propagate', [originalThis, true], origFnCallWithThis, false, false)
-
-      return origFnCallWithThis
+      this.ctx = executorContext
     }
-    prevPromiseObj.prototype.then[flag] = prevPromiseOrigThen
 
-    promiseEE.on('executor-start', function (args) {
-      args[0] = promiseWrapper(args[0], 'resolve-', this, null, false)
-      args[1] = promiseWrapper(args[1], 'resolve-', this, null, false)
-    })
+    static resolve (value) {
+      const superValue = super.resolve(value)
 
-    promiseEE.on('executor-err', function (args, originalThis, err) {
-      args[1](err)
-    })
+      if (value !== superValue) {
+        promiseEE.emit('propagate', [value, true], superValue, false, false)
+      }
 
-    promiseEE.on('cb-end', function (args, originalThis, result) {
-      promiseEE.emit('propagate', [result, true], this.nextPromise, false, false)
-    })
+      return superValue
+    }
 
-    promiseEE.on('propagate', function (val, overwrite, trigger) {
-      if (!this.getCtx || overwrite) {
-        this.getCtx = function () {
-          // eslint-disable-next-line
-          if (val instanceof Promise) {
-            var store = promiseEE.context(val)
+    static reject (value) {
+      const superValue = super.reject(value)
+
+      if (value !== superValue) {
+        promiseEE.emit('propagate', [value, true], superValue, false, false)
+      }
+
+      return superValue
+    }
+
+    static all (iterable) {
+      return super.all(iterable)
+    }
+
+    static race (iterable) {
+      return super.race(iterable)
+    }
+
+    static toString () {
+      // Force toString return value to appear native to JS libraries
+      return '[native code]'
+    }
+
+    static get name () {
+      return 'Promise'
+    }
+
+    then (resolve, reject) {
+      const self = this
+
+      let wrappedResolve
+      if (resolve) {
+        wrappedResolve = function nrWrapper () {
+          const args = [...arguments]
+          promiseEE.emit('cb-start', [args, this, resolve.name], self.ctx, false)
+
+          let result
+          try {
+            result = resolve.apply(this, args)
+            return result
+          } catch (err) {
+            promiseEE.emit('cb-err', [args, this, err], self.ctx, false)
+            throw err
+          } finally {
+            promiseEE.emit('cb-end', [args, this, result], self.ctx, false)
           }
-
-          return store && store.getCtx ? store.getCtx() : this
         }
+      }
+
+      let wrappedReject
+      if (reject) {
+        wrappedReject = function nrWrapper () {
+          const args = [...arguments]
+          promiseEE.emit('cb-start', [args, this, reject.name], self.ctx, false)
+
+          let result
+          try {
+            result = reject.apply(this, args)
+            return result
+          } catch (err) {
+            promiseEE.emit('cb-err', [args, this, err], self.ctx, false)
+            throw err
+          } finally {
+            promiseEE.emit('cb-end', [args, this, result], self.ctx, false)
+          }
+        }
+      }
+
+      return super.then(wrappedResolve, wrappedReject)
+    }
+  }
+
+  if (typeof Symbol !== 'undefined' && typeof Symbol.hasInstance === 'symbol') {
+    Object.defineProperty(nrWrapper.prototype.constructor, Symbol.hasInstance, {
+      value: function (instance) {
+        return instance instanceof promiseGlobal
       }
     })
   }
+
+  globalScope.Promise = nrWrapper
+
   return promiseEE
-}
-
-/**
- * Returns an event emitter scoped specifically for the `promise` context. This scoping is a remnant from when all the
- * features shared the same group in the event, to isolate events between features. It will likely be revisited.
- * @param {Object} sharedEE - Optional event emitter on which to base the scoped emitter.
- *     Uses `ee` on the global scope if undefined).
- * @returns {Object} Scoped event emitter with a debug ID of 'promise'.
- */
-export function scopedEE (sharedEE) {
-  return (sharedEE || baseEE).get('promise')
 }

--- a/src/common/wrap/wrap-promise.js
+++ b/src/common/wrap/wrap-promise.js
@@ -54,7 +54,11 @@ export function wrapPromise (sharedEE) {
       var ctx = promiseEE.context()
       var wrappedExecutor = promiseWrapper(executor, 'executor-', ctx, null, false)
 
+      const existingInstanceDescriptors = Object.getOwnPropertyDescriptors(Object.getPrototypeOf(this))
       const newCustomPromiseInst = Reflect.construct(prevPromiseObj, [wrappedExecutor], WrappedPromise) // new Promises will use WrappedPromise.prototype as theirs prototype
+      Object.entries(existingInstanceDescriptors).forEach(([key, value]) => {
+        Object.defineProperty(newCustomPromiseInst, key, value)
+      })
 
       promiseEE.context(newCustomPromiseInst).getCtx = function () {
         return ctx

--- a/tests/assets/promise-instanceof.html
+++ b/tests/assets/promise-instanceof.html
@@ -17,7 +17,7 @@
     window.isNewPromise = new Promise(function () {}) instanceof Promise
     window.isFetchPromise = fetch("example") instanceof Promise
 
-    async function asyncP() {}; var p = asyncP(); 
+    async function asyncP() {}; var p = asyncP();
     window.isAsyncPromise = p instanceof Promise
     </script>
 </body>


### PR DESCRIPTION
Sub-classing the global Promise using ES6 classes after the agent has loaded results in the extended class properties not being present on the created promise instance. The wrapper has been moved to use ES6 sub-classing allowing further sub-classing.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Rewrote the promise wrapper to use ES6 sub-classing of the global Promise.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-155491

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
