### PR TITLE
chore: Pin iOS testing to >= 15.5

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -3,4 +3,9 @@ last 10 Safari versions
 last 10 Firefox versions
 last 10 Edge versions
 last 10 ChromeAndroid versions
-last 10 iOS versions
+
+# last 10 iOS versions
+# SauceLabs does not support testing iOS 15.6 or 15.7. Until the browserslist query
+# of `last 10 iOS versions` no longer returns 15.6 and 15.7, we will pin our testing
+# to `iOS >= 15.5`
+iOS >= 15.5

--- a/.github/workflows/wdio-all-browsers.yml
+++ b/.github/workflows/wdio-all-browsers.yml
@@ -57,18 +57,18 @@ jobs:
       browser-target: ios@16.0
     secrets: inherit
 
+  ios-16_1:
+    uses: ./.github/workflows/wdio-single-browser.yml
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      browser-target: ios@16.1
+    secrets: inherit
+
   ios-16_2:
     uses: ./.github/workflows/wdio-single-browser.yml
     with:
       ref: ${{ inputs.ref || github.ref }}
       browser-target: ios@16.2
-    secrets: inherit
-
-  ios-17_0:
-    uses: ./.github/workflows/wdio-single-browser.yml
-    with:
-      ref: ${{ inputs.ref || github.ref }}
-      browser-target: ios@17.0
     secrets: inherit
 
   android:

--- a/.github/workflows/wdio-all-browsers.yml
+++ b/.github/workflows/wdio-all-browsers.yml
@@ -57,18 +57,18 @@ jobs:
       browser-target: ios@16.0
     secrets: inherit
 
-  ios-16_1:
-    uses: ./.github/workflows/wdio-single-browser.yml
-    with:
-      ref: ${{ inputs.ref || github.ref }}
-      browser-target: ios@16.1
-    secrets: inherit
-
   ios-16_2:
     uses: ./.github/workflows/wdio-single-browser.yml
     with:
       ref: ${{ inputs.ref || github.ref }}
       browser-target: ios@16.2
+    secrets: inherit
+
+  ios-17_0:
+    uses: ./.github/workflows/wdio-single-browser.yml
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      browser-target: ios@17.0
     secrets: inherit
 
   android:

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -168,10 +168,10 @@
       "browserName": "Safari",
       "platformName": "iOS",
       "platform": "iOS",
-      "version": "16.2",
+      "version": "16.1",
       "device": "iPhone Simulator",
       "appium:deviceName": "iPhone Simulator",
-      "appium:platformVersion": "16.2",
+      "appium:platformVersion": "16.1",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "2.0.0"
@@ -182,13 +182,13 @@
       "browserName": "Safari",
       "platformName": "iOS",
       "platform": "iOS",
-      "version": "17.0",
+      "version": "16.2",
       "device": "iPhone Simulator",
       "appium:deviceName": "iPhone Simulator",
-      "appium:platformVersion": "17.0",
+      "appium:platformVersion": "16.2",
       "appium:automationName": "XCUITest",
       "sauce:options": {
-        "appiumVersion": "2.1.3"
+        "appiumVersion": "2.0.0"
       },
       "acceptInsecureCerts": false
     }

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -18,15 +18,15 @@
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "115",
-      "browserVersion": "115"
+      "version": "116",
+      "browserVersion": "116"
     },
     {
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "118",
-      "browserVersion": "118"
+      "version": "119",
+      "browserVersion": "119"
     }
   ],
   "edge": [
@@ -48,15 +48,15 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "114",
-      "browserVersion": "114"
+      "version": "115",
+      "browserVersion": "115"
     },
     {
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "117",
-      "browserVersion": "117"
+      "version": "118",
+      "browserVersion": "118"
     }
   ],
   "firefox": [
@@ -78,15 +78,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "115",
-      "browserVersion": "115"
+      "version": "116",
+      "browserVersion": "116"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "118",
-      "browserVersion": "118"
+      "version": "119",
+      "browserVersion": "119"
     }
   ],
   "safari": [
@@ -140,10 +140,10 @@
       "browserName": "Safari",
       "platformName": "iOS",
       "platform": "iOS",
-      "version": "16.0",
+      "version": "15.5",
       "device": "iPhone Simulator",
       "appium:deviceName": "iPhone Simulator",
-      "appium:platformVersion": "16.0",
+      "appium:platformVersion": "15.5",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "2.0.0"
@@ -154,10 +154,10 @@
       "browserName": "Safari",
       "platformName": "iOS",
       "platform": "iOS",
-      "version": "16.1",
+      "version": "16.0",
       "device": "iPhone Simulator",
       "appium:deviceName": "iPhone Simulator",
-      "appium:platformVersion": "16.1",
+      "appium:platformVersion": "16.0",
       "appium:automationName": "XCUITest",
       "sauce:options": {
         "appiumVersion": "2.0.0"

--- a/tools/browsers-lists/sauce-browsers.mjs
+++ b/tools/browsers-lists/sauce-browsers.mjs
@@ -73,7 +73,10 @@ const minSupportedVersion = apiName => {
       return 9
     case 'ios':
     case 'iphone':
-      return browserslistMinVersion('last 10 iOS versions')
+      // SauceLabs does not support testing iOS 15.6 or 15.7. Until the browserslist query
+      // of `last 10 iOS versions` no longer returns 15.6 and 15.7, we will pin our testing
+      // to `iOS >= 15.5`
+      return browserslistMinVersion('iOS >= 15.5')
   }
 }
 


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Temporarily pinning our iOS support to 15.5 or later. SauceLabs does not have VMs available for iOS 15.6 or 15.7 so we cannot test those browsers at the moment. Once iOS 15.x drops out of our `last 10 iOS versions` query, we can revert this.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
