### PR TITLE
feat: Expose library versions used to capture session replay data

### DIFF
--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -312,7 +312,7 @@ export class Aggregate extends AggregateBase {
           hasError: this.hasError,
           isFirstChunk: agentRuntime.session.state.sessionReplaySentFirstChunk === false,
           decompressedBytes: this.payloadBytesEstimation,
-          'nr.rrweb.version': RRWEB_VERSION
+          'rrweb.version': RRWEB_VERSION
         }, MAX_PAYLOAD_SIZE - this.payloadBytesEstimation).substring(1) // remove the leading '&'
       },
       body: this.events

--- a/src/loaders/configure/nonce.js
+++ b/src/loaders/configure/nonce.js
@@ -2,7 +2,7 @@
 
 __webpack_require__.nc = (() => {
   try {
-    if (document.currentScript && document.currentScript.nonce) {
+    if (document && document.currentScript && document.currentScript.nonce) {
       return document.currentScript.nonce
     }
   } catch (ex) {

--- a/tests/specs/session-replay/helpers.js
+++ b/tests/specs/session-replay/helpers.js
@@ -37,7 +37,7 @@ export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasEr
     agentVersion: expect.any(String),
     isFirstChunk: isFirstChunk || expect.any(Boolean),
     decompressedBytes: decompressedBytes || expect.any(Number),
-    'nr.rrweb.version': expect.any(String)
+    'rrweb.version': expect.any(String)
   })
 
   expect(data.body).toEqual(expect.any(Array))


### PR DESCRIPTION
Expose library versions used to capture session replay data, to help sync visualizations in the UI Replayer components across version migrations.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR exposes the rrweb lib version used to capture the reply data to a public namespace to be used for UI syncing purposes.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-178304
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been updated to account for the change
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
