### PR TITLE
feat: Add relative timestamps to Session Replay payloads

### DIFF
--- a/src/loaders/configure/nonce.js
+++ b/src/loaders/configure/nonce.js
@@ -2,7 +2,7 @@
 
 __webpack_require__.nc = (() => {
   try {
-    if (document.currentScript && document.currentScript.nonce) {
+    if (document && document.currentScript && document.currentScript.nonce) {
       return document.currentScript.nonce
     }
   } catch (ex) {

--- a/tests/specs/session-replay/helpers.js
+++ b/tests/specs/session-replay/helpers.js
@@ -28,9 +28,11 @@ export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasEr
   expect(decodedObj).toMatchObject({
     ...(contentEncoding && { content_encoding: 'gzip' }),
     'replay.firstTimestamp': expect.any(Number),
+    'replay.firstTimestampOffset': expect.any(Number),
     'replay.lastTimestamp': expect.any(Number),
     'replay.durationMs': expect.any(Number),
     session: session || expect.any(String),
+    rst: expect.any(Number),
     hasMeta: hasMeta || expect.any(Boolean),
     hasSnapshot: hasSnapshot || expect.any(Boolean),
     hasError: hasError || expect.any(Boolean),


### PR DESCRIPTION
Add relative timestamps to Session Replay payloads to allow for server-side clock skew adjustments and improve the API pagination experience.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds the `rst` param, which is seen on all other browser agent payloads, as well as a relative representation of the first payload node to allow for server-side clock skew adjustments if the server time and the rst time differ drastically.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-177602
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been updated to account for the extra params
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
