### PR TITLE
fix: traceids not random when using `webcrypto`

### DIFF
--- a/src/common/ids/unique-id.js
+++ b/src/common/ids/unique-id.js
@@ -73,12 +73,12 @@ export function generateRandomHexString (length) {
   let randomValueIndex = 0
   if (crypto && crypto.getRandomValues) {
     // eslint-disable-next-line
-    randomValueTable = crypto.getRandomValues(new Uint8Array(31))
+    randomValueTable = crypto.getRandomValues(new Uint8Array(length))
   }
 
   const chars = []
   for (var i = 0; i < length; i++) {
-    chars.push(getRandomValue(randomValueTable, ++randomValueIndex).toString(16))
+    chars.push(getRandomValue(randomValueTable, randomValueIndex++).toString(16))
   }
   return chars.join('')
 }

--- a/src/common/ids/unique-id.js
+++ b/src/common/ids/unique-id.js
@@ -43,13 +43,14 @@ export function generateUuid () {
   let randomValueTable
   let randomValueIndex = 0
   if (crypto && crypto.getRandomValues) {
+    // For a UUID, we only need 30 characters since two characters are pre-defined
     // eslint-disable-next-line
-    randomValueTable = crypto.getRandomValues(new Uint8Array(31))
+    randomValueTable = crypto.getRandomValues(new Uint8Array(30))
   }
 
   return uuidv4Template.split('').map(templateInput => {
     if (templateInput === 'x') {
-      return getRandomValue(randomValueTable, ++randomValueIndex).toString(16)
+      return getRandomValue(randomValueTable, randomValueIndex++).toString(16)
     } else if (templateInput === 'y') {
       // this is the uuid variant per spec (8, 9, a, b)
       // % 4, then shift to get values 8-11
@@ -78,7 +79,7 @@ export function generateRandomHexString (length) {
 
   const chars = []
   for (var i = 0; i < length; i++) {
-    chars.push(getRandomValue(randomValueTable, randomValueIndex++).toString(16))
+    chars.push(getRandomValue(randomValueTable, ++randomValueIndex).toString(16))
   }
   return chars.join('')
 }

--- a/src/common/ids/unique-id.test.js
+++ b/src/common/ids/unique-id.test.js
@@ -56,3 +56,96 @@ test('generateTraceId should generate a 32 character hex string', () => {
 
   expect(/^[0-9a-f]{32}$/.test(id)).toEqual(true)
 })
+
+describe('#826 trace id should be unique', () => {
+  test('should not generate subsequent ids that are the same', () => {
+    expect(uniqueId.generateTraceId()).not.toEqual(uniqueId.generateTraceId())
+  })
+})
+
+describe('rough randomness tests', () => {
+  /**
+   * This tests the distribution of each hex character. The distribution of each character
+   * should approach 1.0 to show that each character is being used as evenly as possible to
+   * produce the resulting string.
+   */
+  test('should have sufficient distribution of 8 bit character usage', () => {
+    const tally = new Map()
+    const sampleSize = 100000 // A large sample size but not so large that it causes the test to take forever
+
+    for (let i = 0; i < sampleSize; i++) {
+      const chars = uniqueId.generateTraceId().split('')
+      chars.forEach(char => {
+        if (!tally.has(char)) {
+          tally.set(char, 1)
+        } else {
+          tally.set(char, (tally.get(char)) + 1)
+        }
+      })
+    }
+
+    tally.forEach((distributionCount) => {
+      /*
+        Take the square root of the distribution count as a variance stabilization:
+        https://en.wikipedia.org/wiki/Variance-stabilizing_transformation
+
+        Divide by the total number of possible values accounting for placement within the
+        resulting string:
+        16 === the number of unique hex characters
+        32 === the length of the string returned by our random function
+        sampleSize === the total number of times we are running the function
+
+        Subtract 1 to make the result into a percentage.
+       */
+      const distributionDeviation = 1 - Math.sqrt(distributionCount) / (16 * 32 * sampleSize)
+      expect(distributionDeviation).toBeGreaterThanOrEqual(0.999)
+    })
+  })
+
+  /**
+   * This tests the distribution of each hex character. The distribution of each character
+   * should approach 1.0 to show that each character is being used as evenly as possible to
+   * produce the resulting string.
+   */
+  test('should have sufficient distribution of sequential characters', () => {
+    const tally = new Map()
+    const sampleSize = 100000 // A large sample size but not so large that it causes the test to take forever
+
+    for (let i = 0; i < sampleSize; i++) {
+      const chars = uniqueId.generateTraceId().split('')
+
+      chars.forEach((char, index) => {
+        let charSequence
+
+        if (index === 0) {
+          charSequence = `_${char}`
+        } else {
+          charSequence = `${chars[index - 1]}${char}`
+        }
+
+        if (!tally.has(charSequence)) {
+          tally.set(charSequence, 1)
+        } else {
+          tally.set(charSequence, (tally.get(charSequence)) + 1)
+        }
+      })
+    }
+
+    tally.forEach((distributionCount) => {
+      /*
+        Take the square root of the distribution count as a variance stabilization:
+        https://en.wikipedia.org/wiki/Variance-stabilizing_transformation
+
+        Divide by the total number of possible values accounting for placement within the
+        resulting string:
+        16 === the number of unique hex characters
+        32 === the length of the string returned by our random function
+        sampleSize === the total number of times we are running the function
+
+        Subtract 1 to make the result into a percentage.
+       */
+      const distributionDeviation = 1 - Math.sqrt(distributionCount) / (16 * 32 * sampleSize)
+      expect(distributionDeviation).toBeGreaterThanOrEqual(0.999)
+    })
+  })
+})


### PR DESCRIPTION
Fix non-random hexadecimal generation when using the webcrypto api, which in turn creates non-random traceIds, that always end in 00
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

A bug in the generation of random hexadecimal values when using `webcrypto` means the traceIds used for the distributed tracing spans are not fully random, and all traceIds will end in `00`. The W3C spec says this value should be random, and this can cause issues for organizations who are enforcing browser span sampling by using drop rules versus the last characters of the spans. 

The cause is a double out of bounds, once when iterating over an array using `++var` instead of `var++` and second when the size of the hex value is 32 characters, due to the `Uint8Array` used for the webcrypto random number generation length being hardcoded to `31`.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

Issue: #826 

### Testing
Due to the use of random number generation this requires a slightly different setup. This gist shows the code and results I used to diagnose and test the patch. 

https://gist.github.com/paddyo/c861c640a2328aaf0d09d30c103bb3dd

This was tested on `node 21.2.0` which allowed easy use of module hooks.

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
