### PR TITLE
feat: Allow empty string for Session Replay masking value

### DIFF
--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -75,8 +75,7 @@ const model = () => {
       get mask_text_selector () { return hiddenState.mask_selector },
       set mask_text_selector (val) {
         if (isValidSelector(val)) hiddenState.mask_selector = `${val},${nrMask}`
-        else if (val === '') hiddenState.mask_selector = nrMask
-        else if (val === null) hiddenState.mask_selector = val // null is acceptable, which completely disables the behavior
+        else if (val === '' || val === null) hiddenState.mask_selector = nrMask
         else warn('An invalid session_replay.mask_selector was provided. \'*\' will be used.', val)
       },
       // these properties only have getters because they are enforcable constants and should error if someone tries to override them

--- a/src/common/config/state/init.js
+++ b/src/common/config/state/init.js
@@ -4,6 +4,8 @@ import { warn } from '../../util/console'
 import { getNREUMInitializedAgent } from '../../window/nreum'
 import { getModeledObject } from './configurable'
 
+const nrMask = '[data-nr-mask]'
+
 const model = () => {
   const hiddenState = {
     mask_selector: '*',
@@ -72,9 +74,10 @@ const model = () => {
       // this has a getter/setter to facilitate validation of the selectors
       get mask_text_selector () { return hiddenState.mask_selector },
       set mask_text_selector (val) {
-        if (isValidSelector(val)) hiddenState.mask_selector = val + ',[data-nr-mask]'
+        if (isValidSelector(val)) hiddenState.mask_selector = `${val},${nrMask}`
+        else if (val === '') hiddenState.mask_selector = nrMask
         else if (val === null) hiddenState.mask_selector = val // null is acceptable, which completely disables the behavior
-        else warn('An invalid session_replay.mask_selector was provided and will not be used', val)
+        else warn('An invalid session_replay.mask_selector was provided. \'*\' will be used.', val)
       },
       // these properties only have getters because they are enforcable constants and should error if someone tries to override them
       get block_class () { return 'nr-block' },

--- a/src/common/config/state/init.test.js
+++ b/src/common/config/state/init.test.js
@@ -66,4 +66,14 @@ describe('property getters/setters used for validation', () => {
 
     expect(getConfigurationValue('34567', 'session_replay.mask_text_selector')).toEqual(null)
   })
+
+  test('empty string accepted for mask_text', () => {
+    setConfiguration('34567', {
+      session_replay: {
+        mask_text_selector: ''
+      }
+    })
+
+    expect(getConfigurationValue('34567', 'session_replay.mask_text_selector')).toEqual('[data-nr-mask]')
+  })
 })

--- a/src/common/config/state/init.test.js
+++ b/src/common/config/state/init.test.js
@@ -64,7 +64,7 @@ describe('property getters/setters used for validation', () => {
       }
     })
 
-    expect(getConfigurationValue('34567', 'session_replay.mask_text_selector')).toEqual(null)
+    expect(getConfigurationValue('34567', 'session_replay.mask_text_selector')).toEqual('[data-nr-mask]')
   })
 
   test('empty string accepted for mask_text', () => {


### PR DESCRIPTION
Allow empty strings to be provided for Session Replay masking values.  This will help the UI/API provide sane fallbacks for never-set values.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR sets the SR mask state to the default `[data-nr-mask]` if an empty string is provided
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-184724
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new basic test case has been added to validate this behavior
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
