### PR TITLE
chore: prevent s3-upload of existing files

### DIFF
--- a/.github/actions/s3-upload/index.js
+++ b/.github/actions/s3-upload/index.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import * as core from '@actions/core'
 import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts'
-import { S3Client } from '@aws-sdk/client-s3'
+import { S3Client, HeadObjectCommand, NotFound } from '@aws-sdk/client-s3'
 import { Upload } from '@aws-sdk/lib-storage'
 import mime from 'mime-types'
 import { getAssetCacheHeader } from '../shared-utils/asset-cache.js'
@@ -24,23 +24,17 @@ const s3Client = new S3Client({
   }
 })
 
-const filesToUpload = (await fs.promises.readdir(args.input, { withFileTypes: true }))
+const uploadCommandParams = (await fs.promises.readdir(args.input, { withFileTypes: true }))
   .filter(file => file.isFile())
-  .map(file => ({
-    name: file.name,
-    path: path.resolve(args.input, file.name)
-  }))
-
-const uploads = await Promise.all(filesToUpload
   .map(file => {
     const params = {
       Bucket: args.bucket,
       Key: file.name,
-      Body: fs.createReadStream(file.path, {
+      Body: fs.createReadStream(path.resolve(args.input, file.name), {
         encoding: 'utf-8'
       }),
       ContentType: mime.lookup(file.path) || 'application/javascript',
-      CacheControl: getAssetCacheHeader(args.dir, file.name),
+      CacheControl: getAssetCacheHeader(args.dir, file.name)
     }
 
     if (typeof args.dir === 'string' && args.dir.trim() !== '') {
@@ -53,6 +47,42 @@ const uploads = await Promise.all(filesToUpload
       params.Key = `${dirPath}/${params.Key}`
     }
 
+    return params
+  })
+
+const existingFiles = await Promise.all(uploadCommandParams
+  .filter(params => params.CacheControl.indexOf('max-age=31536000') > 0)
+  .map(async params => {
+    const command = new HeadObjectCommand({
+      Bucket: params.Bucket,
+      Key: params.Key
+    })
+
+    try {
+      await s3Client.send(command)
+
+      console.error(`File ${params.Key} already exists in the bucket.`)
+      return true
+    } catch (error) {
+      if (error instanceof NotFound) {
+        return false
+      }
+
+      console.error(error)
+      return true
+    }
+  })
+)
+
+if (existingFiles.includes(true) && !args.dry) {
+  console.error('Upload failed, long-term cached files already exist.')
+  process.exit(1)
+} else if (existingFiles.includes(true) && args.dry) {
+  console.warn('Upload will fail, long-term cached files already exist.')
+}
+
+const uploads = await Promise.all(uploadCommandParams
+  .map(params => {
     if (args.dry) {
       console.log('running in dry mode, file not uploaded, params:', JSON.stringify({
         ...params,
@@ -96,4 +126,4 @@ Output example:
 */
 
 core.setOutput('results', JSON.stringify(uploads))
-console.log(`Successfully uploaded ${filesToUpload.length} files to S3`)
+console.log(`Successfully uploaded ${uploadCommandParams.length} files to S3`)

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "browser-agent-wrapper",
+  "name": "library-wrapper",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Updated the s3-upload action to first check if any of the files being uploaded have a long-term cache policy and already exist in the s3 bucket. If a file is found matching these two criteria, the action will fail and prevent the uploading of the files.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-185887

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
