### PR TITLE
feat: Add a flag to note that a payload occurred during a replay

### DIFF
--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -103,7 +103,7 @@ export class Harvest extends SharedContext {
     if (customUrl) url = customUrl
     if (raw) url = `${protocol}://${perceviedBeacon}/${endpoint}`
 
-    const baseParams = !raw && includeBaseParams ? this.baseQueryString() : ''
+    const baseParams = !raw && includeBaseParams ? this.baseQueryString(qs) : ''
     let payloadParams = encodeObj(qs, agentRuntime.maxBytes)
     if (!submitMethod) {
       submitMethod = submitData.getSubmitMethod({ isFinalHarvest: opts.unload })
@@ -163,7 +163,7 @@ export class Harvest extends SharedContext {
   }
 
   // The stuff that gets sent every time.
-  baseQueryString () {
+  baseQueryString (qs) {
     const runtime = getRuntime(this.sharedContext.agentIdentifier)
     const info = getInfo(this.sharedContext.agentIdentifier)
 
@@ -180,7 +180,8 @@ export class Harvest extends SharedContext {
       '&ck=0', // ck param DEPRECATED - still expected by backend
       '&s=' + (runtime.session?.state.value || '0'), // the 0 id encaps all untrackable and default traffic
       encodeParam('ref', ref),
-      encodeParam('ptid', (runtime.ptid ? '' + runtime.ptid : ''))
+      encodeParam('ptid', (runtime.ptid ? '' + runtime.ptid : '')),
+      encodeParam('hr', (runtime?.session?.state.sessionReplayMode === 1 ? '1' : '0'), qs) // hasReplay
     ].join(''))
   }
 

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -10,7 +10,6 @@ import { Harvest } from './harvest'
 
 jest.enableAutomock()
 jest.unmock('./harvest')
-
 let harvestInstance
 
 beforeEach(() => {

--- a/src/common/url/encode.js
+++ b/src/common/url/encode.js
@@ -67,7 +67,8 @@ export function obj (payload, maxBytes) {
 }
 
 // Constructs an HTTP parameter to add to the BAM router URL
-export function param (name, value) {
+export function param (name, value, base = {}) {
+  if (Object.keys(base).includes(name)) return '' // we assume if feature supplied a matching qp to the base, we should honor what the feature sent over the default
   if (value && typeof (value) === 'string') {
     return '&' + name + '=' + qs(value)
   }


### PR DESCRIPTION
Added a flag to mark harvests as having occurred during an active session replay. This will aid cross-feature querying in NR1.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds the `hr` flag to note that a payload "has replay".  This was already implemented in Session Traces so this extends that pattern to all payloads. This is a very simple implementation, only reading from the session entity at harvest time to determine the replay mode.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-189641
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests should continue to pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
