### PR TITLE
chore: fix s3 upload mime lookup

### DIFF
--- a/.github/actions/s3-upload/index.js
+++ b/.github/actions/s3-upload/index.js
@@ -33,7 +33,7 @@ const uploadCommandParams = (await fs.promises.readdir(args.input, { withFileTyp
       Body: fs.createReadStream(path.resolve(args.input, file.name), {
         encoding: 'utf-8'
       }),
-      ContentType: mime.lookup(file.path) || 'application/javascript',
+      ContentType: mime.lookup(file.name) || 'application/javascript',
       CacheControl: getAssetCacheHeader(args.dir, file.name)
     }
 


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

It was found in the last release that all the size report html files had a mime type of `application/javascript`. This was due to a mistake in the s3 upload code where the mime lookup was being based on the file directory location instead of the file name.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

N/A

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
