### PR TITLE
fix: Add fallback for currentBufferTarget

### DIFF
--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -78,7 +78,7 @@ export class Recorder {
   store (event, isCheckout) {
     event.__serialized = stringify(event)
 
-    if (!this.parent.scheduler) this.currentBufferTarget = this.#preloaded[this.#preloaded.length - 1]
+    if (!this.parent.scheduler && this.#preloaded.length) this.currentBufferTarget = this.#preloaded[this.#preloaded.length - 1]
     else this.currentBufferTarget = this.#events
 
     if (this.parent.blocked) return


### PR DESCRIPTION
Add a fallback to the currentBufferTarget for cases where the preload buffer has been cleared 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR sets the currentBufferTarget to the preload buffer only if it exists.  This should alleviate an edge-case issue where the payloadBytesEstimation throws an error because the buffer target does not exist.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-215642
