### PR TITLE
fix: Bubble Up API Methods to Top-Level Instance For NPM

### DIFF
--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -78,7 +78,7 @@ export class Recorder {
   store (event, isCheckout) {
     event.__serialized = stringify(event)
 
-    if (!this.parent.scheduler) this.currentBufferTarget = this.#preloaded[this.#preloaded.length - 1]
+    if (!this.parent.scheduler && this.#preloaded.length) this.currentBufferTarget = this.#preloaded[this.#preloaded.length - 1]
     else this.currentBufferTarget = this.#events
 
     if (this.parent.blocked) return

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -78,7 +78,7 @@ export class Recorder {
   store (event, isCheckout) {
     event.__serialized = stringify(event)
 
-    if (!this.parent.scheduler && this.#preloaded.length) this.currentBufferTarget = this.#preloaded[this.#preloaded.length - 1]
+    if (!this.parent.scheduler) this.currentBufferTarget = this.#preloaded[this.#preloaded.length - 1]
     else this.currentBufferTarget = this.#events
 
     if (this.parent.blocked) return

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -5,11 +5,8 @@ import { warn } from '../common/util/console'
 export class AgentBase {
   /** Tries to execute the api and enerates a generic warning message with the api name injected if unsuccessful */
   #try (method, ...args) {
-    try {
-      this.api[method](...args)
-    } catch (err) {
-      warn(`Call to agent api ${method} failed. The agent is not currently initialized.`)
-    }
+    if (typeof this.api?.[method] !== 'function') warn(`Call to agent api ${method} failed. The agent is not currently initialized.`)
+    else this.api[method](...args)
   }
 
   /**

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -2,12 +2,15 @@
 
 import { warn } from '../common/util/console'
 
+/**
+ * @typedef {import('./api/interaction-types').InteractionInstance} InteractionInstance
+ */
+
 export class AgentBase {
   /**
    * Tries to execute the api and generates a generic warning message with the api name injected if unsuccessful
    * @param {string} methodName
    * @param  {...any} args
-   * @returns {any}
    */
   #callMethod (methodName, ...args) {
     if (typeof this.api?.[methodName] !== 'function') warn(`Call to agent api ${methodName} failed. The API is not currently initialized.`)

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -3,9 +3,13 @@
 import { warn } from '../common/util/console'
 
 export class AgentBase {
-  /** Generates a generic warning message with the api name injected */
-  #warnMessage (api) {
-    return `Call to agent api ${api} failed. The agent is not currently initialized.`
+  /** Tries to execute the api and enerates a generic warning message with the api name injected if unsuccessful */
+  #try (method, ...args) {
+    try {
+      this.api[method](...args)
+    } catch (err) {
+      warn(`Call to agent api ${method} failed. The agent is not currently initialized.`)
+    }
   }
 
   /**
@@ -15,7 +19,7 @@ export class AgentBase {
    * @param {object} [attributes] JSON object with one or more key/value pairs. For example: {key:"value"}. The key is reported as its own PageAction attribute with the specified values.
    */
   addPageAction (name, attributes) {
-    warn(this.#warnMessage('addPageAction'))
+    this.#try('addPageAction', name, attributes)
   }
 
   /**
@@ -25,7 +29,7 @@ export class AgentBase {
    * @param {string} [host] Default is http://custom.transaction. Typically set host to your site's domain URI.
    */
   setPageViewName (name, host) {
-    warn(this.#warnMessage('setPageViewName'))
+    this.#try('setPageViewName', name, host)
   }
 
   /**
@@ -36,7 +40,7 @@ export class AgentBase {
    * @param {boolean} [persist] Default false. f set to true, the name-value pair will also be set into the browser's storage API. Then on the following instrumented pages that load within the same session, the pair will be re-applied as a custom attribute.
    */
   setCustomAttribute (name, value, persist) {
-    warn(this.#warnMessage('setCustomAttribute'))
+    this.#try('setCustomAttribute', name, value, persist)
   }
 
   /**
@@ -46,7 +50,7 @@ export class AgentBase {
    * @param {object} [customAttributes] An object containing name/value pairs representing custom attributes.
    */
   noticeError (error, customAttributes) {
-    warn(this.#warnMessage('noticeError'))
+    this.#try('noticeError', error, customAttributes)
   }
 
   /**
@@ -55,7 +59,7 @@ export class AgentBase {
    * @param {string|null} value A string identifier for the end-user, useful for tying all browser events to specific users. The value parameter does not have to be unique. If IDs should be unique, the caller is responsible for that validation. Passing a null value unsets any existing user ID.
    */
   setUserId (value) {
-    warn(this.#warnMessage('setUserId'))
+    this.#try('setUserId', value)
   }
 
   /**
@@ -67,7 +71,7 @@ export class AgentBase {
    * have to be unique. Passing a null value unsets any existing value.
    */
   setApplicationVersion (value) {
-    warn(this.#warnMessage('setApplicationVersion'))
+    this.#try('setApplicationVersion', value)
   }
 
   /**
@@ -76,7 +80,7 @@ export class AgentBase {
    * @param {(error: Error|string) => boolean | { group: string }} callback When an error occurs, the callback is called with the error object as a parameter. The callback will be called with each error, so it is not specific to one error.
    */
   setErrorHandler (callback) {
-    warn(this.#warnMessage('setErrorHandler'))
+    this.#try('setErrorHandler', callback)
   }
 
   /**
@@ -85,7 +89,7 @@ export class AgentBase {
    * @param {number} [timeStamp] Defaults to the current time of the call. If used, this marks the time that the page is "finished" according to your own criteria.
    */
   finished (timeStamp) {
-    warn(this.#warnMessage('finished'))
+    this.#try('finished', timeStamp)
   }
 
   /**
@@ -95,7 +99,7 @@ export class AgentBase {
    * @param {string} id The ID or version of this release; for example, a version number, build number from your CI environment, GitHub SHA, GUID, or a hash of the contents.
    */
   addRelease (name, id) {
-    warn(this.#warnMessage('addRelease'))
+    this.#try('addRelease', name, id)
   }
 
   /**
@@ -104,7 +108,7 @@ export class AgentBase {
    * @param {string|string[]} [featureNames] The name(s) of the features to start.  If no name(s) are passed, all features will be started
    */
   start (featureNames) {
-    warn(this.#warnMessage('start'))
+    this.#try('start', featureNames)
   }
 
   /**
@@ -113,7 +117,7 @@ export class AgentBase {
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/recordReplay/}
    */
   recordReplay () {
-    warn(this.#warnMessage('recordReplay'))
+    this.#try('recordReplay')
   }
 
   /**
@@ -123,6 +127,6 @@ export class AgentBase {
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/recordReplay/}
    */
   pauseReplay () {
-    warn(this.#warnMessage('pauseReplay'))
+    this.#try('pauseReplay')
   }
 }

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -10,7 +10,7 @@ export class AgentBase {
    * @returns {any}
    */
   #callMethod (methodName, ...args) {
-    if (typeof this.api?.[methodName] !== 'function') warn(`Call to agent api ${methodName} failed. The agent is not currently initialized.`)
+    if (typeof this.api?.[methodName] !== 'function') warn(`Call to agent api ${methodName} failed. The API is not currently initialized.`)
     else return this.api[methodName](...args)
   }
 
@@ -130,5 +130,40 @@ export class AgentBase {
    */
   pauseReplay () {
     return this.#callMethod('pauseReplay')
+  }
+
+  /**
+   * Adds a JavaScript object with a custom name, start time, etc. to an in-progress session trace.
+   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/addtotrace/}
+   * @param {{name: string, start: number, end?: number, origin?: string, type?: string}} customAttributes Supply a JavaScript object with these required and optional name/value pairs:
+   *
+   * - Required name/value pairs: name, start
+   * - Optional name/value pairs: end, origin, type
+   * - Note: Does not apply to MicroAgent
+   *
+   * If you are sending the same event object to New Relic as a PageAction, omit the TYPE attribute. (type is a string to describe what type of event you are marking inside of a session trace.) If included, it will override the event type and cause the PageAction event to be sent incorrectly. Instead, use the name attribute for event information.
+   */
+  addToTrace (customAttributes) {
+    return this.#callMethod('addToTrace', customAttributes)
+  }
+
+  /**
+   * Gives SPA routes more accurate names than default names. Monitors specific routes rather than by default grouping.
+   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setcurrentroutename/}
+   * @param {string} name Current route name for the page.
+   *  - Note: Does not apply to MicroAgent
+   */
+  setCurrentRouteName (name) {
+    return this.#callMethod('setCurrentRouteName', name)
+  }
+
+  /**
+   * Returns a new API object that is bound to the current SPA interaction.
+   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/interaction/}
+   * @returns {InteractionInstance} An API object that is bound to a specific BrowserInteraction event. Each time this method is called for the same BrowserInteraction, a new object is created, but it still references the same interaction.
+   *  - Note: Does not apply to MicroAgent
+  */
+  interaction () {
+    return this.#callMethod('interaction')
   }
 }

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -3,10 +3,15 @@
 import { warn } from '../common/util/console'
 
 export class AgentBase {
-  /** Tries to execute the api and enerates a generic warning message with the api name injected if unsuccessful */
-  #try (method, ...args) {
-    if (typeof this.api?.[method] !== 'function') warn(`Call to agent api ${method} failed. The agent is not currently initialized.`)
-    else this.api[method](...args)
+  /**
+   * Tries to execute the api and generates a generic warning message with the api name injected if unsuccessful
+   * @param {string} methodName
+   * @param  {...any} args
+   * @returns {any}
+   */
+  #callMethod (methodName, ...args) {
+    if (typeof this.api?.[methodName] !== 'function') warn(`Call to agent api ${methodName} failed. The agent is not currently initialized.`)
+    else return this.api[methodName](...args)
   }
 
   /**
@@ -16,7 +21,7 @@ export class AgentBase {
    * @param {object} [attributes] JSON object with one or more key/value pairs. For example: {key:"value"}. The key is reported as its own PageAction attribute with the specified values.
    */
   addPageAction (name, attributes) {
-    this.#try('addPageAction', name, attributes)
+    return this.#callMethod('addPageAction', name, attributes)
   }
 
   /**
@@ -26,7 +31,7 @@ export class AgentBase {
    * @param {string} [host] Default is http://custom.transaction. Typically set host to your site's domain URI.
    */
   setPageViewName (name, host) {
-    this.#try('setPageViewName', name, host)
+    return this.#callMethod('setPageViewName', name, host)
   }
 
   /**
@@ -37,7 +42,7 @@ export class AgentBase {
    * @param {boolean} [persist] Default false. f set to true, the name-value pair will also be set into the browser's storage API. Then on the following instrumented pages that load within the same session, the pair will be re-applied as a custom attribute.
    */
   setCustomAttribute (name, value, persist) {
-    this.#try('setCustomAttribute', name, value, persist)
+    return this.#callMethod('setCustomAttribute', name, value, persist)
   }
 
   /**
@@ -47,7 +52,7 @@ export class AgentBase {
    * @param {object} [customAttributes] An object containing name/value pairs representing custom attributes.
    */
   noticeError (error, customAttributes) {
-    this.#try('noticeError', error, customAttributes)
+    return this.#callMethod('noticeError', error, customAttributes)
   }
 
   /**
@@ -56,7 +61,7 @@ export class AgentBase {
    * @param {string|null} value A string identifier for the end-user, useful for tying all browser events to specific users. The value parameter does not have to be unique. If IDs should be unique, the caller is responsible for that validation. Passing a null value unsets any existing user ID.
    */
   setUserId (value) {
-    this.#try('setUserId', value)
+    return this.#callMethod('setUserId', value)
   }
 
   /**
@@ -68,7 +73,7 @@ export class AgentBase {
    * have to be unique. Passing a null value unsets any existing value.
    */
   setApplicationVersion (value) {
-    this.#try('setApplicationVersion', value)
+    return this.#callMethod('setApplicationVersion', value)
   }
 
   /**
@@ -77,7 +82,7 @@ export class AgentBase {
    * @param {(error: Error|string) => boolean | { group: string }} callback When an error occurs, the callback is called with the error object as a parameter. The callback will be called with each error, so it is not specific to one error.
    */
   setErrorHandler (callback) {
-    this.#try('setErrorHandler', callback)
+    return this.#callMethod('setErrorHandler', callback)
   }
 
   /**
@@ -86,7 +91,7 @@ export class AgentBase {
    * @param {number} [timeStamp] Defaults to the current time of the call. If used, this marks the time that the page is "finished" according to your own criteria.
    */
   finished (timeStamp) {
-    this.#try('finished', timeStamp)
+    return this.#callMethod('finished', timeStamp)
   }
 
   /**
@@ -96,7 +101,7 @@ export class AgentBase {
    * @param {string} id The ID or version of this release; for example, a version number, build number from your CI environment, GitHub SHA, GUID, or a hash of the contents.
    */
   addRelease (name, id) {
-    this.#try('addRelease', name, id)
+    return this.#callMethod('addRelease', name, id)
   }
 
   /**
@@ -105,7 +110,7 @@ export class AgentBase {
    * @param {string|string[]} [featureNames] The name(s) of the features to start.  If no name(s) are passed, all features will be started
    */
   start (featureNames) {
-    this.#try('start', featureNames)
+    return this.#callMethod('start', featureNames)
   }
 
   /**
@@ -114,7 +119,7 @@ export class AgentBase {
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/recordReplay/}
    */
   recordReplay () {
-    this.#try('recordReplay')
+    return this.#callMethod('recordReplay')
   }
 
   /**
@@ -124,6 +129,6 @@ export class AgentBase {
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/recordReplay/}
    */
   pauseReplay () {
-    this.#try('pauseReplay')
+    return this.#callMethod('pauseReplay')
   }
 }

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -93,38 +93,4 @@ export class Agent extends AgentBase {
       return false
     }
   }
-
-  /* Below API methods are only available on a standard agent and not the micro agent */
-
-  /**
-   * Adds a JavaScript object with a custom name, start time, etc. to an in-progress session trace.
-   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/addtotrace/}
-   * @param {{name: string, start: number, end?: number, origin?: string, type?: string}} customAttributes Supply a JavaScript object with these required and optional name/value pairs:
-   *
-   * - Required name/value pairs: name, start
-   * - Optional name/value pairs: end, origin, type
-   *
-   * If you are sending the same event object to New Relic as a PageAction, omit the TYPE attribute. (type is a string to describe what type of event you are marking inside of a session trace.) If included, it will override the event type and cause the PageAction event to be sent incorrectly. Instead, use the name attribute for event information.
-   */
-  addToTrace (customAttributes) {
-    warn('Call to agent api addToTrace failed. The session trace feature is not currently initialized.')
-  }
-
-  /**
-   * Gives SPA routes more accurate names than default names. Monitors specific routes rather than by default grouping.
-   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setcurrentroutename/}
-   * @param {string} name Current route name for the page.
-   */
-  setCurrentRouteName (name) {
-    warn('Call to agent api setCurrentRouteName failed. The spa feature is not currently initialized.')
-  }
-
-  /**
-   * Returns a new API object that is bound to the current SPA interaction.
-   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/interaction/}
-   * @returns {InteractionInstance} An API object that is bound to a specific BrowserInteraction event. Each time this method is called for the same BrowserInteraction, a new object is created, but it still references the same interaction.
-   */
-  interaction () {
-    warn('Call to agent api interaction failed. The spa feature is not currently initialized.')
-  }
 }

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -19,10 +19,6 @@ import { stringify } from '../common/util/stringify'
 import { globalScope } from '../common/constants/runtime'
 
 /**
- * @typedef {import('./api/interaction-types').InteractionInstance} InteractionInstance
- */
-
-/**
  * A flexible class that may be used to compose an agent from a select subset of feature modules. In applications
  * sensitive to network load, this may result in smaller builds with slightly lower performance impact.
  */

--- a/tests/dts/api.test-d.ts
+++ b/tests/dts/api.test-d.ts
@@ -1,6 +1,6 @@
 import { BrowserAgent } from '../../dist/types/loaders/browser-agent'
 import { MicroAgent } from '../../dist/types/loaders/micro-agent'
-import { InteractionInstance } from '../../dist/types/loaders/api/interaction-types'
+import { InteractionInstance, getContext, onEnd } from '../../dist/types/loaders/api/interaction-types'
 import { expectType, expectNotType } from 'tsd'
 
 // Browser Agent APIs
@@ -12,54 +12,54 @@ expectType<(customAttributes: {
   end?: number;
   origin?: string;
   type?: string;
-}) => void>(browserAgent.addToTrace)
-expectType<(name: string) => void>(browserAgent.setCurrentRouteName)
+}) => any>(browserAgent.addToTrace)
+expectType<(name: string) => any>(browserAgent.setCurrentRouteName)
 expectType<() => InteractionInstance>(browserAgent.interaction)
 
 // Base Agent APIs
-expectType<(name: string, attributes?: object | undefined) => void>(browserAgent.addPageAction)
-expectType<(name: string, host?: string | undefined) => void>(browserAgent.setPageViewName)
-expectType<(name: string, value: string | number | null, persist?: boolean | undefined) => void>(browserAgent.setCustomAttribute)
-expectType<(error: Error | string, customAttributes?: object | undefined) => void>(browserAgent.noticeError)
-expectType<(value: string | null) => void>(browserAgent.setUserId)
-expectType<(value: string | null) => void>(browserAgent.setApplicationVersion)
-expectType<(callback: (error: Error | string) => boolean | { group: string; }) => void>(browserAgent.setErrorHandler)
-expectType<(timeStamp?: number | undefined) => void>(browserAgent.finished)
-expectType<(name: string, id: string) => void>(browserAgent.addRelease)
+expectType<(name: string, attributes?: object | undefined) => any>(browserAgent.addPageAction)
+expectType<(name: string, host?: string | undefined) => any>(browserAgent.setPageViewName)
+expectType<(name: string, value: string | number | null, persist?: boolean | undefined) => any>(browserAgent.setCustomAttribute)
+expectType<(error: Error | string, customAttributes?: object | undefined) => any>(browserAgent.noticeError)
+expectType<(value: string | null) => any>(browserAgent.setUserId)
+expectType<(value: string | null) => any>(browserAgent.setApplicationVersion)
+expectType<(callback: (error: Error | string) => boolean | { group: string; }) => any>(browserAgent.setErrorHandler)
+expectType<(timeStamp?: number | undefined) => any>(browserAgent.finished)
+expectType<(name: string, id: string) => any>(browserAgent.addRelease)
 
 // SPA APIs
 expectType<() => InteractionInstance>(browserAgent.interaction)
 expectType<(value: string) => InteractionInstance>(browserAgent.interaction().actionText)
 expectType<(name: string, callback?: ((...args: any[]) => any) | undefined) => (...args: any) => any>(browserAgent.interaction().createTracer)
 expectType<() => InteractionInstance>(browserAgent.interaction().end)
-expectType<(callback: (ctx: object) => void) => InteractionInstance>(browserAgent.interaction().getContext)
+expectType<getContext>(browserAgent.interaction().getContext)
 expectType<() => InteractionInstance>(browserAgent.interaction().ignore)
-expectType<(callback: (ctx: object) => void) => InteractionInstance>(browserAgent.interaction().onEnd)
+expectType<onEnd>(browserAgent.interaction().onEnd)
 expectType<(key: string, value: any) => InteractionInstance>(browserAgent.interaction().setAttribute)
 expectType<(name: string, trigger?: string | undefined) => InteractionInstance>(browserAgent.interaction().setName)
 
 // Micro Agent APIs
 const microAgent = new MicroAgent({})
-expectNotType<(customAttributes: {
+expectType<(customAttributes: {
   name: string;
   start: number;
   end?: number;
   origin?: string;
   type?: string;
   // @ts-ignore
-}) => void>(microAgent.addToTrace)
+}) => any>(microAgent.addToTrace)
 // @ts-ignore
-expectNotType<(name: string) => void>(microAgent.setCurrentRouteName)
+expectType<(name: string) => any>(microAgent.setCurrentRouteName)
 // @ts-ignore
-expectNotType<() => InteractionInstance>(microAgent.interaction)
+expectType<() => InteractionInstance>(microAgent.interaction)
 
 // Base Agent APIs
-expectType<(name: string, attributes?: object | undefined) => void>(microAgent.addPageAction)
-expectType<(name: string, host?: string | undefined) => void>(microAgent.setPageViewName)
-expectType<(name: string, value: string | number | null, persist?: boolean | undefined) => void>(microAgent.setCustomAttribute)
-expectType<(error: Error | string, customAttributes?: object | undefined) => void>(microAgent.noticeError)
-expectType<(value: string | null) => void>(microAgent.setUserId)
-expectType<(value: string | null) => void>(microAgent.setApplicationVersion)
-expectType<(callback: (error: Error | string) => boolean | { group: string; }) => void>(microAgent.setErrorHandler)
-expectType<(timeStamp?: number | undefined) => void>(microAgent.finished)
-expectType<(name: string, id: string) => void>(microAgent.addRelease)
+expectType<(name: string, attributes?: object | undefined) => any>(microAgent.addPageAction)
+expectType<(name: string, host?: string | undefined) => any>(microAgent.setPageViewName)
+expectType<(name: string, value: string | number | null, persist?: boolean | undefined) => any>(microAgent.setCustomAttribute)
+expectType<(error: Error | string, customAttributes?: object | undefined) => any>(microAgent.noticeError)
+expectType<(value: string | null) => any>(microAgent.setUserId)
+expectType<(value: string | null) => any>(microAgent.setApplicationVersion)
+expectType<(callback: (error: Error | string) => boolean | { group: string; }) => any>(microAgent.setErrorHandler)
+expectType<(timeStamp?: number | undefined) => any>(microAgent.finished)
+expectType<(name: string, id: string) => any>(microAgent.addRelease)

--- a/tests/specs/npm/index.e2e.js
+++ b/tests/specs/npm/index.e2e.js
@@ -23,7 +23,7 @@ describe.withBrowsersMatching(es2022Support)('basic npm agent', () => {
           browser.testHandle.expectIns(),
           browser.execute(function () {
             window.agent.noticeError('test')
-            window.agent.addPageAction('test')
+            newrelic.addPageAction('test')
           })
         ])
         expect(errorsPromise).toBeDefined()
@@ -44,7 +44,7 @@ describe.withBrowsersMatching(es2022Support)('basic npm agent', () => {
           browser.testHandle.expectIns(),
           browser.execute(function () {
             window.agent.noticeError('test')
-            window.agent.addPageAction('test')
+            newrelic.addPageAction('test')
           })
         ])
         expect(errorsPromise).toBeDefined()
@@ -65,7 +65,7 @@ describe.withBrowsersMatching(es2022Support)('basic npm agent', () => {
       browser.testHandle.expectIns(),
       browser.execute(function () {
         window.agent.noticeError('test')
-        window.agent.addPageAction('test')
+        newrelic.addPageAction('test')
       })
     ])
     expect(errorsPromise).toBeDefined()

--- a/tests/specs/npm/index.e2e.js
+++ b/tests/specs/npm/index.e2e.js
@@ -10,31 +10,65 @@ const testBuilds = [
 
 describe.withBrowsersMatching(es2022Support)('basic npm agent', () => {
   testBuilds.forEach(testBuild => {
-    it(`dist/${testBuild} sends RUM call`, async () => {
+    it(`dist/${testBuild} sends basic calls`, async () => {
       const [rumPromise] = await Promise.all([
         browser.testHandle.expectRum(),
         browser.url(await browser.testHandle.assetURL(`test-builds/browser-agent-wrapper/${testBuild}.html`))
       ])
-
       expect(rumPromise).toBeDefined()
+
+      if (!testBuild.includes('worker') && !testBuild.includes('lite')) {
+        const [errorsPromise, pageActionPromise] = await Promise.all([
+          browser.testHandle.expectErrors(),
+          browser.testHandle.expectIns(),
+          browser.execute(function () {
+            window.agent.noticeError('test')
+            window.agent.addPageAction('test')
+          })
+        ])
+        expect(errorsPromise).toBeDefined()
+        expect(pageActionPromise).toBeDefined()
+      }
     })
 
-    it(`src/${testBuild} sends RUM call`, async () => {
+    it(`src/${testBuild} sends basic calls`, async () => {
       const [rumPromise] = await Promise.all([
         browser.testHandle.expectRum(),
         browser.url(await browser.testHandle.assetURL(`test-builds/raw-src-wrapper/${testBuild}.html`))
       ])
-
       expect(rumPromise).toBeDefined()
+
+      if (!testBuild.includes('worker') && !testBuild.includes('lite')) {
+        const [errorsPromise, pageActionPromise] = await Promise.all([
+          browser.testHandle.expectErrors(),
+          browser.testHandle.expectIns(),
+          browser.execute(function () {
+            window.agent.noticeError('test')
+            window.agent.addPageAction('test')
+          })
+        ])
+        expect(errorsPromise).toBeDefined()
+        expect(pageActionPromise).toBeDefined()
+      }
     })
   })
 
-  it('vite-react-wrapper sends RUM call', async () => {
+  it('vite-react-wrapper sends basic calls', async () => {
     const [rumPromise] = await Promise.all([
       browser.testHandle.expectRum(),
       browser.url(await browser.testHandle.assetURL('test-builds/vite-react-wrapper/index.html'))
     ])
-
     expect(rumPromise).toBeDefined()
+
+    const [errorsPromise, pageActionPromise] = await Promise.all([
+      browser.testHandle.expectErrors(),
+      browser.testHandle.expectIns(),
+      browser.execute(function () {
+        window.agent.noticeError('test')
+        window.agent.addPageAction('test')
+      })
+    ])
+    expect(errorsPromise).toBeDefined()
+    expect(pageActionPromise).toBeDefined()
   })
 })

--- a/tools/test-builds/browser-agent-wrapper/src/browser-agent.js
+++ b/tools/test-builds/browser-agent-wrapper/src/browser-agent.js
@@ -5,4 +5,4 @@ const opts = {
   init: NREUM.init
 }
 
-new BrowserAgent(opts)
+window.agent = new BrowserAgent(opts)

--- a/tools/test-builds/browser-agent-wrapper/src/custom-agent-lite.js
+++ b/tools/test-builds/browser-agent-wrapper/src/custom-agent-lite.js
@@ -3,7 +3,7 @@ import { Metrics } from '@newrelic/browser-agent/features/metrics'
 import { PageViewEvent } from '@newrelic/browser-agent/features/page_view_event'
 import { PageViewTiming } from '@newrelic/browser-agent/features/page_view_timing'
 
-new Agent({
+window.agent = new Agent({
   features: [
     Metrics,
     PageViewEvent,

--- a/tools/test-builds/browser-agent-wrapper/src/custom-agent-pro.js
+++ b/tools/test-builds/browser-agent-wrapper/src/custom-agent-pro.js
@@ -7,7 +7,7 @@ import { PageViewEvent } from '@newrelic/browser-agent/features/page_view_event'
 import { PageViewTiming } from '@newrelic/browser-agent/features/page_view_timing'
 import { SessionTrace } from '@newrelic/browser-agent/features/session_trace'
 
-new Agent({
+window.agent = new Agent({
   features: [
     Ajax,
     JSErrors,

--- a/tools/test-builds/browser-agent-wrapper/src/custom-agent-spa.js
+++ b/tools/test-builds/browser-agent-wrapper/src/custom-agent-spa.js
@@ -8,7 +8,7 @@ import { PageViewTiming } from '@newrelic/browser-agent/features/page_view_timin
 import { SessionTrace } from '@newrelic/browser-agent/features/session_trace'
 import { Spa } from '@newrelic/browser-agent/features/spa'
 
-new Agent({
+window.agent = new Agent({
   features: [
     Ajax,
     JSErrors,

--- a/tools/test-builds/raw-src-wrapper/src/browser-agent.js
+++ b/tools/test-builds/raw-src-wrapper/src/browser-agent.js
@@ -5,4 +5,4 @@ const opts = {
   init: NREUM.init
 }
 
-new BrowserAgent(opts)
+window.agent = new BrowserAgent(opts)

--- a/tools/test-builds/raw-src-wrapper/src/custom-agent-lite.js
+++ b/tools/test-builds/raw-src-wrapper/src/custom-agent-lite.js
@@ -3,7 +3,7 @@ import { Metrics } from '@newrelic/browser-agent/src/features/metrics'
 import { PageViewEvent } from '@newrelic/browser-agent/src/features/page_view_event'
 import { PageViewTiming } from '@newrelic/browser-agent/src/features/page_view_timing'
 
-new Agent({
+window.agent = new Agent({
   features: [
     Metrics,
     PageViewEvent,

--- a/tools/test-builds/raw-src-wrapper/src/custom-agent-pro.js
+++ b/tools/test-builds/raw-src-wrapper/src/custom-agent-pro.js
@@ -7,7 +7,7 @@ import { PageViewEvent } from '@newrelic/browser-agent/src/features/page_view_ev
 import { PageViewTiming } from '@newrelic/browser-agent/src/features/page_view_timing'
 import { SessionTrace } from '@newrelic/browser-agent/src/features/session_trace'
 
-new Agent({
+window.agent = new Agent({
   features: [
     Ajax,
     JSErrors,

--- a/tools/test-builds/raw-src-wrapper/src/custom-agent-spa.js
+++ b/tools/test-builds/raw-src-wrapper/src/custom-agent-spa.js
@@ -8,7 +8,7 @@ import { PageViewTiming } from '@newrelic/browser-agent/src/features/page_view_t
 import { SessionTrace } from '@newrelic/browser-agent/src/features/session_trace'
 import { Spa } from '@newrelic/browser-agent/src/features/spa'
 
-new Agent({
+window.agent = new Agent({
   features: [
     Ajax,
     JSErrors,

--- a/tools/test-builds/vite-react-wrapper/src/newrelic.ts
+++ b/tools/test-builds/vite-react-wrapper/src/newrelic.ts
@@ -1,11 +1,12 @@
 import { BrowserAgent } from "@newrelic/browser-agent/loaders/browser-agent"
 
 declare const NREUM: any;
+declare const window: any;
 
 const opts = {
   info: NREUM.info,
   init: NREUM.init
 }
 
-const agent = new BrowserAgent(opts);
-agent.setPageViewName('vite-react-wrapper');
+window.agent = new BrowserAgent(opts);
+window.agent.setPageViewName('vite-react-wrapper');


### PR DESCRIPTION
Fix an issue where the NPM wrapping of the agent would not bubble the APIs up to the top-level of the instance, causing invalid warnings to log.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR makes sure that the top level instance calls the internal APIs directly instead of relying on object assignment.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-216981
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added to validate that NPM builds have access to the top level api methods
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
