### PR TITLE
fix: Fix deferred Session Replay payloads

### DIFF
--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -102,7 +102,7 @@ export class Aggregate extends AggregateBase {
 
     // [Temporary] Report restores from BFCache to NR1 while feature flag is in place in lieu of sending pageshow events.
     windowAddEventListener('pageshow', (evt) => {
-      if (evt.persisted) { this.storeSupportabilityMetrics('Generic/BFCache/PageRestored') }
+      if (evt?.persisted) { this.storeSupportabilityMetrics('Generic/BFCache/PageRestored') }
     })
   }
 

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -28,8 +28,6 @@ import { MODE, SESSION_EVENTS, SESSION_EVENT_TYPES } from '../../../common/sessi
 import { stringify } from '../../../common/util/stringify'
 import { stylesheetEvaluator } from '../shared/stylesheet-evaluator'
 
-let gzipper, u8
-
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
   // pass the recorder into the aggregator
@@ -41,8 +39,10 @@ export class Aggregate extends AggregateBase {
     this.initialized = false
     /** Set once the feature has been "aborted" to prevent other side-effects from continuing */
     this.blocked = false
-    /** can shut off efforts to compress the data */
-    this.shouldCompress = true
+    /** populated with the gzipper lib async */
+    this.gzipper = undefined
+    /** populated with the u8 string lib async */
+    this.u8 = undefined
     /** the mode to start in.  Defaults to off */
     const { session } = getRuntime(this.agentIdentifier)
     this.mode = session.state.sessionReplayMode || MODE.OFF
@@ -90,6 +90,12 @@ export class Aggregate extends AggregateBase {
         getPayload: this.prepareHarvest.bind(this),
         raw: true
       }, this)
+
+      if (this.recorder?.getEvents().type === 'preloaded') {
+        this.prepUtils().then(() => {
+          this.scheduler.runHarvest()
+        })
+      }
 
       registerHandler('recordReplay', () => {
         // if it has aborted or BCS returned bad entitlements, do not allow
@@ -197,18 +203,22 @@ export class Aggregate extends AggregateBase {
       this.scheduler.startTimer(this.harvestTimeSeconds)
     }
 
-    try {
-      // Do not change the webpackChunkName or it will break the webpack nrba-chunking plugin
-      const { gzipSync, strToU8 } = await import(/* webpackChunkName: "compressor" */'fflate')
-      gzipper = gzipSync
-      u8 = strToU8
-    } catch (err) {
-      // compressor failed to load, but we can still record without compression as a last ditch effort
-      this.shouldCompress = false
-    }
+    await this.prepUtils()
+
     if (!this.recorder.recording) this.recorder.startRecording()
 
     this.syncWithSessionManager({ sessionReplayMode: this.mode })
+  }
+
+  async prepUtils () {
+    try {
+      // Do not change the webpackChunkName or it will break the webpack nrba-chunking plugin
+      const { gzipSync, strToU8 } = await import(/* webpackChunkName: "compressor" */'fflate')
+      this.gzipper = gzipSync
+      this.u8 = strToU8
+    } catch (err) {
+      // compressor failed to load, but we can still record without compression as a last ditch effort
+    }
   }
 
   prepareHarvest () {
@@ -224,8 +234,8 @@ export class Aggregate extends AggregateBase {
     }
 
     let len = 0
-    if (this.shouldCompress) {
-      payload.body = gzipper(u8(`[${payload.body.map(e => e.__serialized).join(',')}]`))
+    if (!!this.gzipper && !!this.u8) {
+      payload.body = this.gzipper(this.u8(`[${payload.body.map(e => e.__serialized).join(',')}]`))
       len = payload.body.length
       this.scheduler.opts.gzip = true
     } else {
@@ -276,7 +286,7 @@ export class Aggregate extends AggregateBase {
 
     const firstEventTimestamp = events[0]?.timestamp // from rrweb node
     const lastEventTimestamp = events[events.length - 1]?.timestamp // from rrweb node
-    const firstTimestamp = firstEventTimestamp || recorderEvents.cycleTimestamp
+    const firstTimestamp = firstEventTimestamp || recorderEvents.cycleTimestamp // from rrweb node || from when the harvest cycle started
     const lastTimestamp = lastEventTimestamp || agentOffset + relativeNow
 
     return {
@@ -288,7 +298,7 @@ export class Aggregate extends AggregateBase {
         attributes: encodeObj({
           // this section of attributes must be controllable and stay below the query param padding limit -- see QUERY_PARAM_PADDING
           // if not, data could be lost to truncation at time of sending, potentially breaking parsing / API behavior in NR1
-          ...(this.shouldCompress && { content_encoding: 'gzip' }),
+          ...(!!this.gzipper && !!this.u8 && { content_encoding: 'gzip' }),
           'replay.firstTimestamp': firstTimestamp,
           'replay.firstTimestampOffset': firstTimestamp - agentOffset,
           'replay.lastTimestamp': lastTimestamp,

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -184,7 +184,7 @@ export class Recorder {
    * https://staging.onenr.io/037jbJWxbjy
    * */
   estimateCompression (data) {
-    if (this.shouldCompress) return data * AVG_COMPRESSION
+    if (!!this.parent.gzipper && !!this.parent.u8) return data * AVG_COMPRESSION
     return data
   }
 }

--- a/src/features/session_replay/shared/stylesheet-evaluator.js
+++ b/src/features/session_replay/shared/stylesheet-evaluator.js
@@ -55,27 +55,32 @@ class StylesheetEvaluator {
  * @returns {Promise}
  */
   async #fetchAndOverride (target, href) {
-    const stylesheetContents = await originals.FETCH.bind(window)(href)
-    if (!stylesheetContents.ok) {
-      this.failedToFix = true
-      return
-    }
-    const stylesheetText = await stylesheetContents.text()
     try {
-      const cssSheet = new CSSStyleSheet()
-      await cssSheet.replace(stylesheetText)
-      Object.defineProperty(target, 'cssRules', {
-        get () { return cssSheet.cssRules }
-      })
-      Object.defineProperty(target, 'rules', {
-        get () { return cssSheet.rules }
-      })
-    } catch (err) {
+      const stylesheetContents = await originals.FETCH.bind(window)(href)
+      if (!stylesheetContents.ok) {
+        this.failedToFix = true
+        return
+      }
+      const stylesheetText = await stylesheetContents.text()
+      try {
+        const cssSheet = new CSSStyleSheet()
+        await cssSheet.replace(stylesheetText)
+        Object.defineProperty(target, 'cssRules', {
+          get () { return cssSheet.cssRules }
+        })
+        Object.defineProperty(target, 'rules', {
+          get () { return cssSheet.rules }
+        })
+      } catch (err) {
       // cant make new dynamic stylesheets, browser likely doesn't support `.replace()`...
       // this is appended in prep of forking rrweb
-      Object.defineProperty(target, 'cssText', {
-        get () { return stylesheetText }
-      })
+        Object.defineProperty(target, 'cssText', {
+          get () { return stylesheetText }
+        })
+        this.failedToFix = true
+      }
+    } catch (err) {
+    // failed to fetch
       this.failedToFix = true
     }
   }

--- a/tests/specs/session-replay/session-pages.e2e.js
+++ b/tests/specs/session-replay/session-pages.e2e.js
@@ -1,4 +1,3 @@
-import { testRumRequest } from '../../../tools/testing-server/utils/expect-tests.js'
 import { config, getSR, testExpectedReplay } from './helpers'
 import { supportsMultipleTabs, notIE, notSafari } from '../../../tools/browser-matcher/common-matchers.mjs'
 
@@ -39,25 +38,14 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
     const { request: page1Contents } = await browser.testHandle.expectBlob(10000)
     testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
 
-    await browser.testHandle.scheduleReply('bamServer', {
-      test: testRumRequest,
-      body: JSON.stringify({
-        stn: 1,
-        err: 1,
-        ins: 1,
-        cap: 1,
-        spa: 1,
-        loaded: 1,
-        sr: 1
-      })
-    })
-
     await browser.enableSessionReplay()
 
-    await browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
-      .then(() => browser.waitForAgentLoad())
+    const [{ request: page2Contents }] = await Promise.all([
+      browser.testHandle.expectBlob(15000),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
+        .then(() => browser.waitForAgentLoad())
+    ])
 
-    const { request: page2Contents } = await browser.testHandle.expectBlob(10000)
     testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
   })
 
@@ -74,10 +62,11 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
     const newTab = await browser.createWindow('tab')
     await browser.switchToWindow(newTab.handle)
     await browser.enableSessionReplay()
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config()))
-      .then(() => browser.waitForAgentLoad())
-
-    const { request: page2Contents } = await browser.testHandle.expectBlob(10000)
+    const [{ request: page2Contents }] = await Promise.all([
+      browser.testHandle.expectBlob(15000),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
+        .then(() => browser.waitForAgentLoad())
+    ])
 
     testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
 
@@ -118,10 +107,11 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
     const newTab = await browser.createWindow('tab')
     await browser.switchToWindow(newTab.handle)
     await browser.enableSessionReplay()
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config()))
-      .then(() => browser.waitForAgentLoad())
-
-    const { request: page2Contents } = await browser.testHandle.expectBlob(10000)
+    const [{ request: page2Contents }] = await Promise.all([
+      browser.testHandle.expectBlob(15000),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
+        .then(() => browser.waitForAgentLoad())
+    ])
 
     testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
 

--- a/tests/specs/session-replay/session-pages.e2e.js
+++ b/tests/specs/session-replay/session-pages.e2e.js
@@ -56,22 +56,26 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
 
     const { request: page1Contents } = await browser.testHandle.expectBlob(10000)
     const { localStorage } = await browser.getAgentSessionInfo()
-
     testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
 
+    /** This should fire when the tab changes, it's easier to stage it this way before hand, and allows for the super early staging for the next expect */
+    browser.testHandle.expectBlob(15000).then(({ request: page1UnloadContents }) => {
+      testExpectedReplay({ data: page1UnloadContents, session: localStorage.value, hasError: false, hasMeta: false, hasSnapshot: false, isFirstChunk: false })
+    })
+
+    /** This is scoped out this way to guarantee we have it staged in time since preload can harvest super early, sometimes earlier than wdio can expect normally */
+    /** see next `testExpectedReplay` */
+    browser.testHandle.expectBlob(15000).then(async ({ request: page2Contents }) => {
+      testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
+      // await browser.closeWindow()
+      // await browser.switchToWindow((await browser.getWindowHandles())[0])
+    })
+
+    await browser.enableSessionReplay()
     const newTab = await browser.createWindow('tab')
     await browser.switchToWindow(newTab.handle)
-    await browser.enableSessionReplay()
-    const [{ request: page2Contents }] = await Promise.all([
-      browser.testHandle.expectBlob(15000),
-      browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
-        .then(() => browser.waitForAgentLoad())
-    ])
-
-    testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
-
-    await browser.closeWindow()
-    await browser.switchToWindow((await browser.getWindowHandles())[0])
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
+      .then(() => browser.waitForSessionReplayRecording())
   })
 
   it('should not record across navigations if not active', async () => {
@@ -104,16 +108,22 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
 
     testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
 
+    /** This should fire when the tab changes, it's easier to stage it this way before hand, and allows for the super early staging for the next expect */
+    browser.testHandle.expectBlob(15000).then(({ request: page1UnloadContents }) => {
+      testExpectedReplay({ data: page1UnloadContents, session: localStorage.value, hasError: false, hasMeta: false, hasSnapshot: false, isFirstChunk: false })
+    })
+
+    /** This is scoped out this way to guarantee we have it staged in time since preload can harvest super early, sometimes earlier than wdio can expect normally */
+    /** see next `testExpectedReplay` */
+    browser.testHandle.expectBlob(15000).then(async ({ request: page2Contents }) => {
+      testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
+    })
+
+    await browser.enableSessionReplay()
     const newTab = await browser.createWindow('tab')
     await browser.switchToWindow(newTab.handle)
-    await browser.enableSessionReplay()
-    const [{ request: page2Contents }] = await Promise.all([
-      browser.testHandle.expectBlob(15000),
-      browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
-        .then(() => browser.waitForAgentLoad())
-    ])
-
-    testExpectedReplay({ data: page2Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: false })
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
+      .then(() => browser.waitForSessionReplayRecording())
 
     const page2Blocked = await browser.execute(function () {
       try {
@@ -124,9 +134,6 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
         return false
       }
     })
-    await browser.closeWindow()
-    await browser.switchToWindow((await browser.getWindowHandles())[0])
-
     expect(page2Blocked).toEqual(true)
     await expect(getSR()).resolves.toEqual(expect.objectContaining({
       events: [],

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -144,13 +144,20 @@ export default class CustomCommands {
         () => browser.execute(function () {
           try {
             var initializedAgent = Object.values(newrelic.initializedAgents)[0]
-            return !!(initializedAgent &&
+            return !!(
+              (initializedAgent &&
+              initializedAgent.features &&
+              initializedAgent.features.session_replay &&
+              initializedAgent.features.session_replay.recorder &&
+              initializedAgent.features.session_replay.recorder.recording) ||
+              (initializedAgent &&
               initializedAgent.features &&
               initializedAgent.features.session_replay &&
               initializedAgent.features.session_replay.featAggregate &&
               initializedAgent.features.session_replay.featAggregate.initialized &&
               initializedAgent.features.session_replay.featAggregate.recorder &&
               initializedAgent.features.session_replay.featAggregate.recorder.recording)
+            )
           } catch (err) {
             console.error(err)
             return false


### PR DESCRIPTION
Force agent to send preloaded session replay payloads if present at load time.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR forces the agent to harvest at agg load time if there are preload payloads.  This alleviates an issue where the payload would race with standard payloads at unload time.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added and old tests have been modified to account for earlier harvests
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
