### PR TITLE
fix: Fix adblock memory leak

### DIFF
--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -41,13 +41,14 @@ function curateRegistry (agentIdentifier) {
  * its own named group explicitly, when ready.
  * @param {string} agentIdentifier - A unique 16 character ID corresponding to an instantiated agent.
  * @param {string} featureName - A named group into which the feature's buffered events are bucketed.
+ * @param {boolean} force - Whether to force the drain to occur immediately, bypassing the registry and staging logic.
  */
-export function drain (agentIdentifier = '', featureName = 'feature') {
+export function drain (agentIdentifier = '', featureName = 'feature', force = false) {
   curateRegistry(agentIdentifier)
   // If the feature for the specified agent is not in the registry, that means the instrument file was bypassed.
   // This could happen in tests, or loaders that directly import the aggregator. In these cases it is safe to
   // drain the feature group immediately rather than waiting to drain all at once.
-  if (!agentIdentifier || !registry[agentIdentifier].get(featureName)) return drainGroup(featureName)
+  if (!agentIdentifier || !registry[agentIdentifier].get(featureName) || force) return drainGroup(featureName)
 
   // When `drain` is called, this feature is ready to drain (staged).
   registry[agentIdentifier].get(featureName).staged = true

--- a/src/common/drain/drain.test.js
+++ b/src/common/drain/drain.test.js
@@ -46,6 +46,15 @@ describe('drain', () => {
     expect(emitSpy).toHaveBeenCalledWith('drain-pumbaa', expect.anything())
   })
 
+  test('immediately drains when force is true', () => {
+    registerDrain('abcd', 'page_view_timing')
+    registerDrain('abcd', 'page_view_event')
+
+    let emitSpy = jest.spyOn(ee.get('abcd'), 'emit')
+    drain('abcd', 'page_view_event', true)
+    expect(emitSpy).toHaveBeenNthCalledWith(1, 'drain-page_view_event', expect.anything())
+  })
+
   test('defaults to "feature" group when not provided one', () => {
     let emitSpy = jest.spyOn(ee.get('abcd'), 'emit')
     drain('abcd')

--- a/src/common/event-emitter/contextual-ee.component-test.js
+++ b/src/common/event-emitter/contextual-ee.component-test.js
@@ -143,6 +143,19 @@ describe('event-emitter buffer', () => {
     expect(ee.isBuffering(eventType)).toEqual(false)
   })
 
+  test('it should empty the backlog on abort as opposed to replacing it', async () => {
+    const { ee } = await import('./contextual-ee')
+
+    const backlog = {
+      api: ['foo', 'bar', 'baz']
+    }
+    ee.backlog = backlog
+    ee.abort()
+
+    expect(ee.backlog).toBe(backlog)
+    expect(ee.backlog).toEqual({})
+  })
+
   test('it should not buffer after drain', async () => {
     const { ee } = await import('./contextual-ee')
     const { drain } = await import('../drain/drain')

--- a/src/common/event-emitter/contextual-ee.js
+++ b/src/common/event-emitter/contextual-ee.js
@@ -144,5 +144,11 @@ function ee (old, debugId) {
 
 function abort () {
   globalInstance.aborted = true
-  globalInstance.backlog = {}
+  // The global backlog can be referenced directly by other emitters,
+  // so we need to delete its contents as opposed to replacing it.
+  // Otherwise, these references to the old backlog would still exist
+  // and the keys will not be garbage collected.
+  Object.keys(globalInstance.backlog).forEach(key => {
+    delete globalInstance.backlog[key]
+  })
 }

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -142,9 +142,10 @@ export class Harvest extends SharedContext {
 
     if (!opts.unload && cbFinished && submitMethod === submitData.xhr) {
       const harvestScope = this
-      result.addEventListener('load', function () {
+      result.addEventListener('loadend', function () {
         // `this` refers to the XHR object in this scope, do not change this to a fat arrow
-        const cbResult = { sent: true, status: this.status }
+        // status 0 refers to a local error, such as CORS or network failure, or a blocked request by the browser (e.g. adblocker)
+        const cbResult = { sent: this.status !== 0, status: this.status }
         if (this.status === 429) {
           cbResult.retry = true
           cbResult.delay = harvestScope.tooManyRequestsDelay

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -358,14 +358,14 @@ describe('_send', () => {
 
     const result = harvestInstance._send(spec)
     const xhrAddEventListener = jest.mocked(submitDataModule.xhr).mock.results[0].value.addEventListener
-    const xhrLoadHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
+    const xhrLoadEndHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
 
     const xhrState = {
       status: faker.string.uuid()
     }
-    xhrLoadHandler.call(xhrState)
+    xhrLoadEndHandler.call(xhrState)
 
-    expect(xhrAddEventListener).toHaveBeenCalledWith('load', expect.any(Function), expect.any(Object))
+    expect(xhrAddEventListener).toHaveBeenCalledWith('loadend', expect.any(Function), expect.any(Object))
     expect(result).toEqual(jest.mocked(submitDataModule.xhr).mock.results[0].value)
     expect(submitMethod).not.toHaveBeenCalled()
     expect(spec.cbFinished).toHaveBeenCalledWith({ ...xhrState, sent: true })
@@ -378,14 +378,14 @@ describe('_send', () => {
 
     const result = harvestInstance._send(spec)
     const xhrAddEventListener = jest.mocked(submitDataModule.xhr).mock.results[0].value.addEventListener
-    const xhrLoadHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
+    const xhrLoadEndHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
 
     const xhrState = {
       status: 429
     }
-    xhrLoadHandler.call(xhrState)
+    xhrLoadEndHandler.call(xhrState)
 
-    expect(xhrAddEventListener).toHaveBeenCalledWith('load', expect.any(Function), expect.any(Object))
+    expect(xhrAddEventListener).toHaveBeenCalledWith('loadend', expect.any(Function), expect.any(Object))
     expect(result).toEqual(jest.mocked(submitDataModule.xhr).mock.results[0].value)
     expect(submitMethod).not.toHaveBeenCalled()
     expect(spec.cbFinished).toHaveBeenCalledWith({
@@ -404,14 +404,14 @@ describe('_send', () => {
 
     const result = harvestInstance._send(spec)
     const xhrAddEventListener = jest.mocked(submitDataModule.xhr).mock.results[0].value.addEventListener
-    const xhrLoadHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
+    const xhrLoadEndHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
 
     const xhrState = {
       status: statusCode
     }
-    xhrLoadHandler.call(xhrState)
+    xhrLoadEndHandler.call(xhrState)
 
-    expect(xhrAddEventListener).toHaveBeenCalledWith('load', expect.any(Function), expect.any(Object))
+    expect(xhrAddEventListener).toHaveBeenCalledWith('loadend', expect.any(Function), expect.any(Object))
     expect(result).toEqual(jest.mocked(submitDataModule.xhr).mock.results[0].value)
     expect(submitMethod).not.toHaveBeenCalled()
     expect(spec.cbFinished).toHaveBeenCalledWith({
@@ -428,15 +428,15 @@ describe('_send', () => {
 
     const result = harvestInstance._send(spec)
     const xhrAddEventListener = jest.mocked(submitDataModule.xhr).mock.results[0].value.addEventListener
-    const xhrLoadHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
+    const xhrLoadEndHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
 
     const xhrState = {
       status: faker.string.uuid(),
       responseText: faker.lorem.sentence()
     }
-    xhrLoadHandler.call(xhrState)
+    xhrLoadEndHandler.call(xhrState)
 
-    expect(xhrAddEventListener).toHaveBeenCalledWith('load', expect.any(Function), expect.any(Object))
+    expect(xhrAddEventListener).toHaveBeenCalledWith('loadend', expect.any(Function), expect.any(Object))
     expect(result).toEqual(jest.mocked(submitDataModule.xhr).mock.results[0].value)
     expect(submitMethod).not.toHaveBeenCalled()
     expect(spec.cbFinished).toHaveBeenCalledWith({
@@ -452,21 +452,43 @@ describe('_send', () => {
 
     const result = harvestInstance._send(spec)
     const xhrAddEventListener = jest.mocked(submitDataModule.xhr).mock.results[0].value.addEventListener
-    const xhrLoadHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
+    const xhrLoadEndHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
 
     const xhrState = {
       status: faker.string.uuid(),
       responseText: faker.lorem.sentence()
     }
-    xhrLoadHandler.call(xhrState)
+    xhrLoadEndHandler.call(xhrState)
 
-    expect(xhrAddEventListener).toHaveBeenCalledWith('load', expect.any(Function), expect.any(Object))
+    expect(xhrAddEventListener).toHaveBeenCalledWith('loadend', expect.any(Function), expect.any(Object))
     expect(result).toEqual(jest.mocked(submitDataModule.xhr).mock.results[0].value)
     expect(submitMethod).not.toHaveBeenCalled()
     expect(spec.cbFinished).toHaveBeenCalledWith({
       ...xhrState,
       responseText: undefined,
       sent: true
+    })
+  })
+
+  test('should call cbFinished with sent false and status 0 when xhr failed locally', () => {
+    jest.mocked(submitDataModule.getSubmitMethod).mockReturnValue(submitDataModule.xhr)
+    spec.cbFinished = jest.fn()
+
+    const result = harvestInstance._send(spec)
+    const xhrAddEventListener = jest.mocked(submitDataModule.xhr).mock.results[0].value.addEventListener
+    const xhrLoadEndHandler = jest.mocked(xhrAddEventListener).mock.calls[0][1]
+
+    const xhrState = {
+      status: 0
+    }
+    xhrLoadEndHandler.call(xhrState)
+
+    expect(xhrAddEventListener).toHaveBeenCalledWith('loadend', expect.any(Function), expect.any(Object))
+    expect(result).toEqual(jest.mocked(submitDataModule.xhr).mock.results[0].value)
+    expect(submitMethod).not.toHaveBeenCalled()
+    expect(spec.cbFinished).toHaveBeenCalledWith({
+      ...xhrState,
+      sent: false
     })
   })
 })

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -101,7 +101,7 @@ export class Aggregate extends AggregateBase {
       payload: { qs: queryParameters, body },
       opts: { needResponse: true, sendEmptyBody: true },
       cbFinished: ({ status, responseText }) => {
-        if (status >= 400) {
+        if (status >= 400 || status === 0) {
           // Adding retry logic for the rum call will be a separate change
           this.ee.abort()
           return

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -108,7 +108,7 @@ export class InstrumentBase extends FeatureBase {
         warn(`Downloading and initializing ${this.featureName} failed...`, e)
         this.abortHandler?.() // undo any important alterations made to the page
         // not supported yet but nice to do: "abort" this agent's EE for this feature specifically
-        drain(this.agentIdentifier, this.featureName)
+        drain(this.agentIdentifier, this.featureName, true)
         loadedSuccessfully(false)
       }
     }

--- a/src/features/utils/instrument-base.test.js
+++ b/src/features/utils/instrument-base.test.js
@@ -211,6 +211,7 @@ test('no uncaught async exception is thrown when an import fails', async () => {
 
   expect(warn).toHaveBeenNthCalledWith(2, expect.stringContaining(`Downloading and initializing ${featureName} failed`), expect.any(Error))
   expect(instrument.abortHandler).toHaveBeenCalled()
+  expect(drain).toHaveBeenCalledWith(agentIdentifier, featureName, true)
   await expect(instrument.onAggregateImported).resolves.toBe(false)
   expect(mockOnError).not.toHaveBeenCalled()
 })

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -207,7 +207,10 @@ export function setAPI (agentIdentifier, forceDrain) {
     import(/* webpackChunkName: "async-api" */'./apiAsync').then(({ setAPI }) => {
       setAPI(agentIdentifier)
       drain(agentIdentifier, 'api')
-    }).catch(() => warn('Downloading runtime APIs failed...'))
+    }).catch(() => {
+      warn('Downloading runtime APIs failed...')
+      drain(agentIdentifier, 'api', true)
+    })
   }
 
   return apiInterface

--- a/tests/assets/adblocker-assets.html
+++ b/tests/assets/adblocker-assets.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>RUM Unit Test</title>
+  {init} {config}
+
+  <script type="text/javascript">
+    // Use proxy to simulate adblock of assets
+    window.NREUM||(NREUM={});NREUM.init=NREUM.init||{};NREUM.init.proxy=NREUM.init.proxy||{};NREUM.init.proxy.assets="http://foobar"
+  </script>
+
+  {loader}
+</head>
+<body>
+This page simulates the agent assets being blocked by using a bad asset proxy setting.
+</body>
+</html>

--- a/tests/assets/adblocker-ingest.html
+++ b/tests/assets/adblocker-ingest.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <script type="text/javascript">
+      var xhrOpen = XMLHttpRequest.prototype.open
+      var xhrSend = XMLHttpRequest.prototype.send
+
+      var urlCache = {}
+      XMLHttpRequest.prototype.open = function () {
+        urlCache[this] = arguments[1]
+        return xhrOpen.apply(this, arguments)
+      }
+      XMLHttpRequest.prototype.send = function () {
+        var url = urlCache[this]
+        var result = xhrSend.apply(this, arguments)
+        if (/\/1\/[\w-_]*\?/.test(url)) {
+          var xhr = this
+          setTimeout(function () { xhr.abort() }, 1)
+        }
+        return result
+      }
+    </script>
+    <title>RUM Unit Test</title>
+    {init} {config} {loader}
+  </head>
+  <body>
+    This page simulates the ingest XHR calls being blocked by aborting the rum call.
+  </body>
+</html>

--- a/tests/specs/adblocker.e2e.js
+++ b/tests/specs/adblocker.e2e.js
@@ -1,0 +1,72 @@
+import { config } from './session-replay/helpers'
+
+describe('adblocker', () => {
+  beforeEach(async () => {
+    await browser.enableSessionReplay()
+  })
+
+  afterEach(async () => {
+    await browser.destroyAgentSession()
+  })
+
+  it('should abort the global event emitter when rum call is blocked', async () => {
+    await browser.url(await browser.testHandle.assetURL('adblocker-ingest.html', config({ session_replay: { sampling_rate: 100, error_sampling_rate: 100 } })))
+
+    await browser.waitUntil(() => browser.execute(function () {
+      return newrelic.ee.aborted
+    }), {
+      timeoutMsg: 'expected global event emitter to abort'
+    })
+
+    // Simulate adding an item to the event emitter backlog
+    await browser.execute(function () {
+      newrelic.addRelease('foobar', 'bizbaz')
+    })
+
+    const eventEmitterBufferCleared = await browser.execute(function () {
+      var eeCleared = {
+        result: true,
+        errors: []
+      }
+
+      Object.entries(newrelic.ee.backlog).forEach(function (bl) {
+        if (Array.isArray(bl[1]) && bl[1].length > 0) {
+          eeCleared.result = false
+          eeCleared.errors.push('newrelic.ee.backlog[' + bl[0] + '] not cleared: ' + bl[1].length + ' entries')
+        }
+      })
+
+      Object.values(newrelic.initializedAgents).forEach(function (agent) {
+        Object.entries(agent.features).forEach(function (feat) {
+          if (feat[1].ee.backlog !== newrelic.ee.backlog) {
+            eeCleared.result = false
+            eeCleared.errors.push('feature ' + feat[0] + ' backlog is not global backlog')
+          }
+        })
+      })
+
+      return eeCleared
+    })
+
+    expect(eventEmitterBufferCleared.result).toEqual(true)
+    expect(eventEmitterBufferCleared.errors).toEqual([])
+  })
+
+  it('should drain and null out all event emitter buffers when assets fail to load', async () => {
+    await browser.url(await browser.testHandle.assetURL('adblocker-assets.html', config({ session_replay: { sampling_rate: 100, error_sampling_rate: 100 } })))
+
+    await browser.waitUntil(() => browser.execute(function () {
+      var eeBacklogNulled = true
+
+      Object.values(newrelic.ee.backlog).forEach(function (bl) {
+        if (bl !== null) {
+          eeBacklogNulled = false
+        }
+      })
+
+      return eeBacklogNulled
+    }), {
+      timeoutMsg: 'expected global event emitter backlog to be nulled'
+    })
+  })
+})


### PR DESCRIPTION
Fixed memory leaks caused by request resolve failure (e.G. due to adblocker)
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

On our website ( playbook.com ), some users were noticing severe performance degredation when uploading big files. Memory usage grew, and cancelling of the upload did not resolve the issue, eventually causing in a crash of the upload or the website itself.

After investigation, we were able to pin down the issue to the New Relic Browser Agent. However, the issue only occured when adblock (in my case: uBlock Origin) was enabled.

We noticed that two URLs specifically were being blocked: `https://js-agent.newrelic.com/nr-spa-1.245.0.min.js` and `https://bam.nr-data.net/`. 

(Note: Issue occured also with newest version of Browser Agent)

The issue itself is not actually related to uploading - this only made the symptoms much more obvious, due to the size of chunked ArrayBuffers. Even when using the website normally, a slow upwards creep of memory heap size happens.

The main problem is the `buffer` / `backlog` of the ee (event emitter?) holding on to every raw event, but in case of failure to load additional assets or submitting them it's never getting flushed. This results in the backlog growing indefinitely, slowly consuming the users memory. Upload makes this particularly noticable because the buffer (in this case, I think it was `spa` specifically) holds on to every ArrayBuffer reference.

We were able to work around the issue with some monkeypatching - it would be great to get these issues fixed upstream, instead.

We found 3 specific places that resulted in this problem:

---
**Problem #1: `send()` method of `harvest.js` is not using the appropriate event listener for failing requests**

[Link to Change](https://github.com/newrelic/newrelic-browser-agent/pull/877/commits/77accde396872122ae014a6da54c9cd1f5b1db30)

The harvester attempts to submit data to `https://bam.nr-data.net/`.

The `load` [event](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/load_event) is not fired if the XHR is aborted client-side. This causes the callback to never be fired - in turn, never calling `cbCallback` (even with a 400+), which in turn again, never causes the abort [here](https://github.com/newrelic/newrelic-browser-agent/pull/877/files#diff-f006e010fc9058844e6c293ce7f7248a2c743172b1d28bdb11eba9ae236d2627R114) to be called.

Replacing this event with the `loadend` [event](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/loadend_event) seems appropriate. It fires even on an error, but returns an "failed" XHR object with status code 0. 

I've adjusted the `sent` boolean to return `false` if the request has not been sent (eg, didn't leave the client). **I'm not 100% sure on the implications here, and this change is irrelevant for the fix itself.**

With this change, the callback is now successfully invoked for any successful, failed, or errored request.

---
**Problem #2: The `abort()` function of the `contextual-ee.js` replaces the backlog object**

[Link to change](https://github.com/newrelic/newrelic-browser-agent/pull/877/commits/7dec931bd0fe05817223e10a0b3d932286c8b075)

When `abort()` is called, it replaces `globalInstance.backlog` with a fresh new `{}` object. However, all "sub-features" (or emitters, I guess?) hold a direct reference to the original `ee.backlog` object. As they reference this object directly, two things happen:
- Even when the main emitter is aborted, in some circumstances `force` was true, causing the emitter to continue trying to emit
- Because the sub-emitter is using a direct reference to `backlog` (which has been stored on initialization), it accesses the "old" (already discarded by the main emitter) object indefinitely. On this object, the feature / group still exists, so it passes the `if (bufferGroup)` check and continues pushing events to the buffer. This also causes it to never be garbage collected, as references still exist, obviously.

Instead of replacing the main emitter with an empty object, instead iterate over its keys and delete all the existing groups. This clears the buffer, as expected.

---
**Problem #3: Failure to import additional code does not drain buffers and does not unset handlers**

[Link to change](https://github.com/newrelic/newrelic-browser-agent/pull/877/commits/020c6f6e25ab696878e47115366e37a6908cc507)


There's two distinct places I could find that try to initiate an additional import of code from `https://js-agent.newrelic.com/` to import additional features. In both of these, if they fail, the corresponding buffers are not drained adequately, and keep emitting to the buffer. 
The first case is in `api.js`, which, if it fails, only raises a warning that `Downloading runtime APIs failed`. No effort is made in draining and de-registering the `api` buffer/feature.

The second case is in `instrument-base.js`, in which it does start a drain in the exception handler for each drain that failed, but the drain is immediately short-circuiting because the feature is already registered in the registry for the agent. 

I went with a "crude" fix here, still aligning with what I think is the spirit of the architecture, in the form of an `force` parameter, which forces the method to drain the group immediately. 


---

All three of these fixes were necessary to banish the memory leak and make things work properly. They're separated neatly in their own commits.

### Related Issue(s)

[I found this unresolved issue from a year ago.](https://forum.newrelic.com/s/hubtopic/aAX8W0000008fH8WAI/memory-leak-caused-when-browseragent-not-initialized-propertly#:~:text=Memory%20leak%20caused%20when%20BrowserAgent%20not%20initialized%20propertly,-4&text=There%20seems%20to%20be%20an,is%20causing%20a%20memory%20leak.&text=After%20some%20investigation%2C%20we%20found,associated%20with%20the%20loaded%20page.)

### Testing

Replicating this is suprisingly simple. Install `uBlock origin`, or, alternatively, block both urls locally in your environments. 
If you're testing locally, `uBlock Origin` will only block the egress traffic to `https://bam.nr-data.net/`, but allow loading more data through `localhost:63342/build/nr-spa.min.js`. Depending on what you're testing, you may have to block the import URL or not.

Create a simple index.html file similar to the github instructions, importing `nr-loader-spa.min.js`. 

Evaluate `newrelic.ee.backlog`  - you'll observe that it's filled with data. Depending on the activities you do on the website, you'll also see that the backlog keeps increasing. 

If you've *only* blocked the data egress sink:

When applying the commit that fixes the harvest callback: 
you'll notice that `newrelic.ee.aborted == true`, and that `newrelic.ee.backlog == {}`, but if you check out `newrelic.initializedAgents[<foobar>].features[<barfoo>].ee.backlog`, you'll see it's still referencing the old buffer. 

Additionally, applying the commit that fixes abort:
You'll notice that now, the ee of the features of the initializedAgents are also empty, as the original `newrelic.ee.backlog` now got emptied, as opposed to replaced with an empty object.

If you've also blocked importing additional code from `nr-spa.min.js`:
Load the page, observe how `newrelic.ee.backlog` is filled with data. that may keep growing and isn't flushed.

Apply the commit that fixes the drain on import error.

Observe how `newrelic.ee.backlog` is now empty, and does not grow anymore.




