### PR TITLE
feat: align browser reported uncaught syntax errors

### DIFF
--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -128,7 +128,8 @@ export class Instrument extends InstrumentBase {
    * @returns {Error|UncaughtError} The error event converted to an Error object
    */
   #castErrorEvent (errorEvent) {
-    if (errorEvent.error instanceof SyntaxError) {
+    console.log(errorEvent)
+    if (errorEvent.error instanceof SyntaxError && !/:\d?$/.test(errorEvent.error.stack)) {
       const error = new UncaughtError(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno)
       error.name = SyntaxError.name
       return error

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -128,7 +128,6 @@ export class Instrument extends InstrumentBase {
    * @returns {Error|UncaughtError} The error event converted to an Error object
    */
   #castErrorEvent (errorEvent) {
-    console.log(errorEvent)
     if (errorEvent.error instanceof SyntaxError && !/:\d+$/.test(errorEvent.error.stack?.trim())) {
       const error = new UncaughtError(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno)
       error.name = SyntaxError.name

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -129,7 +129,7 @@ export class Instrument extends InstrumentBase {
    */
   #castErrorEvent (errorEvent) {
     console.log(errorEvent)
-    if (errorEvent.error instanceof SyntaxError && !/:\d?$/.test(errorEvent.error.stack)) {
+    if (errorEvent.error instanceof SyntaxError && !/:\d?$/.test(errorEvent.error.stack?.trim())) {
       const error = new UncaughtError(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno)
       error.name = SyntaxError.name
       return error

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -128,6 +128,12 @@ export class Instrument extends InstrumentBase {
    * @returns {Error|UncaughtError} The error event converted to an Error object
    */
   #castErrorEvent (errorEvent) {
+    if (errorEvent.error instanceof SyntaxError) {
+      const error = new UncaughtError(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno)
+      error.name = SyntaxError.name
+      return error
+    }
+
     if (errorEvent.error instanceof Error) {
       return errorEvent.error
     }

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -129,7 +129,7 @@ export class Instrument extends InstrumentBase {
    */
   #castErrorEvent (errorEvent) {
     console.log(errorEvent)
-    if (errorEvent.error instanceof SyntaxError && !/:\d?$/.test(errorEvent.error.stack?.trim())) {
+    if (errorEvent.error instanceof SyntaxError && !/:\d+$/.test(errorEvent.error.stack?.trim())) {
       const error = new UncaughtError(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno)
       error.name = SyntaxError.name
       return error

--- a/tests/assets/js-error-syntax-error.html
+++ b/tests/assets/js-error-syntax-error.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>RUM Unit Test</title>
+  {init} {config} {loader}
+</head>
+<body>
+This page throws an uncaught SyntaxError exception
+
+<!-- Fail with syntax error -->
+<script>
+  -
+</script>
+</body>
+</html>

--- a/tests/assets/js-error-syntax-error.html
+++ b/tests/assets/js-error-syntax-error.html
@@ -15,5 +15,10 @@ This page throws an uncaught SyntaxError exception
 <script>
   -
 </script>
+
+<!-- Fail with an eval syntax error -->
+<script>
+  eval('-')
+</script>
 </body>
 </html>

--- a/tests/specs/err/index.e2e.js
+++ b/tests/specs/err/index.e2e.js
@@ -61,6 +61,13 @@ describe('basic error capturing', () => {
             exceptionClass: 'SyntaxError',
             stack_trace: expect.stringContaining('<inline>:18')
           })
+        }),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            stackHash: 334471761,
+            exceptionClass: 'SyntaxError',
+            stack_trace: expect.stringContaining('<inline>:22')
+          })
         })
       ]))
     } else {
@@ -70,6 +77,13 @@ describe('basic error capturing', () => {
             stackHash: 334471735,
             exceptionClass: 'UncaughtError',
             stack_trace: expect.stringContaining('<inline>:17')
+          })
+        }),
+        expect.objectContaining({
+          params: expect.objectContaining({
+            stackHash: 334471760,
+            exceptionClass: 'SyntaxError',
+            stack_trace: expect.stringContaining('<inline>:21')
           })
         })
       ]))

--- a/tests/specs/err/index.e2e.js
+++ b/tests/specs/err/index.e2e.js
@@ -45,4 +45,34 @@ describe('basic error capturing', () => {
     expect(errors.request.body.err.length).toEqual(expected.length)
     expect(errors.request.body.err).toEqual(expect.arrayContaining(expected))
   })
+
+  it('should capture file and line number for syntax errors', async () => {
+    const [errors] = await Promise.all([
+      browser.testHandle.expectErrors(),
+      browser.url(await browser.testHandle.assetURL('js-error-syntax-error.html'))
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    if (browserMatch(notIE)) {
+      expect(errors.request.body.err).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          params: expect.objectContaining({
+            stackHash: 334471736,
+            exceptionClass: 'SyntaxError',
+            stack_trace: expect.stringContaining('<inline>:18')
+          })
+        })
+      ]))
+    } else {
+      expect(errors.request.body.err).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          params: expect.objectContaining({
+            stackHash: 334471735,
+            exceptionClass: 'UncaughtError',
+            stack_trace: expect.stringContaining('<inline>:17')
+          })
+        })
+      ]))
+    }
+  })
 })

--- a/tests/specs/err/index.e2e.js
+++ b/tests/specs/err/index.e2e.js
@@ -81,9 +81,9 @@ describe('basic error capturing', () => {
         }),
         expect.objectContaining({
           params: expect.objectContaining({
-            stackHash: 334471760,
-            exceptionClass: 'SyntaxError',
-            stack_trace: expect.stringContaining('<inline>:21')
+            stackHash: 334471761,
+            exceptionClass: 'unknown',
+            stack_trace: expect.stringContaining('<inline>:22')
           })
         })
       ]))


### PR DESCRIPTION
Aligning the data reported for uncaught syntax errors across modern browsers. Chrome specifically fails to include the file name and line number in instances of SyntaxError. This could also cause issue in the New Relic error inbox where Chrome syntax errors were not being properly grouped.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

For uncaught instances of SyntaxError, we now purposefully extract the error details from the error event itself instead of passing the `event.error` object through the event emitter. This ensure we extract the file name and line number for all browsers.

While IE is tested in the new e2e tests, IE does not provide an `event.error` property so all uncaught exceptions are reported as instances of our internal `UncaughtError` class.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-190314
https://github.com/newrelic/newrelic-browser-agent/issues/836

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
