### PR TITLE
fix: Add safe logic to snapshots

### DIFF
--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -166,7 +166,12 @@ export class Recorder {
 
   /** force the recording lib to take a full DOM snapshot.  This needs to occur in certain cases, like visibility changes */
   takeFullSnapshot () {
-    recorder.takeFullSnapshot()
+    try {
+      if (!this.recording) return
+      recorder.takeFullSnapshot()
+    } catch (err) {
+      // in the off chance we think we are recording, but rrweb does not, rrweb's lib will throw an error.  This catch is just a precaution
+    }
   }
 
   clearTimestamps () {


### PR DESCRIPTION
Safe-guarded a race condition where an asynchronous call to fix a stylesheet could trigger the agent to try to force a snapshot after it has already stopped recording due to a visibility change.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
The agent makes an async call to attempt to fix non-inlinable stylesheets, but this operation is asynchronous.  If anything triggers the agent to stop recording before the async job resolves, it will errantly attempt to take a snapshot with no active recording.  This behavior safe-guards that in two ways with a status check and a try/catch.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://newrelic.slack.com/archives/C04QZSS6XPV/p1707505446130859
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
