### PR TITLE
chore: Post release repo updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8503,9 +8503,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001581",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001581.tgz",
-      "integrity": "sha512-whlTkwhqV2tUmP3oYhtNfaWGYHDdS3JYFQBKXxcUR9qqPWsRhFHhoISO2Xnl/g0xyKzht9mI1LZpiNWfMzHixQ==",
+      "version": "1.0.30001587",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz",
+      "integrity": "sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==",
       "dev": true,
       "funding": [
         {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Jan 29 2024 21:25:03 GMT+0000 (Coordinated Universal Time)",
+  "lastUpdated": "Tue Feb 13 2024 00:41:03 GMT+0000 (Coordinated Universal Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -48,15 +48,15 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "117",
-      "browserVersion": "117"
+      "version": "118",
+      "browserVersion": "118"
     },
     {
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "120",
-      "browserVersion": "120"
+      "version": "121",
+      "browserVersion": "121"
     }
   ],
   "firefox": [
@@ -78,15 +78,15 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "118",
-      "browserVersion": "118"
+      "version": "119",
+      "browserVersion": "119"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "121",
-      "browserVersion": "121"
+      "version": "122",
+      "browserVersion": "122"
     }
   ],
   "safari": [

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.251.1.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.252.0.tgz"
   }
 }

--- a/tools/test-builds/browser-tests/package.json
+++ b/tools/test-builds/browser-tests/package.json
@@ -9,6 +9,6 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.251.1.tgz"
+        "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.252.0.tgz"
     }
 }

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/client": "^3.8.8",
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.251.1.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.252.0.tgz",
     "graphql": "^16.8.1"
   }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.251.1.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.252.0.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.251.1.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.252.0.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
When this PR is merged, caniuse-lite database is updated, latest browserslist for SauceLabs is retrieved, and third-party dependencies docs are updates.
---

This PR was generated with post-release-updates GitHub action.