### PR TITLE
chore: Enable FOSSA by updating package-lock to v3

### DIFF
--- a/tools/jil/package-lock.json
+++ b/tools/jil/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "jil",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {


### PR DESCRIPTION
Updates to testing packages needed to enable FOSSA scanning.
---
### Overview

Update tools/jil/package-lock.json to a v3 lockfile
This change enables our license scanning tool, FOSSA, to run without errors. This tool will soon be required for all public repos. 
The lockfile is already in a valid format, only the version number needs to be changed. 

### Related Issue(s)

N/A

### Testing

This has been validated with a local run of the FOSSA CLI. The tool ran successfully.
