### PR TITLE
fix: Page load after session timeouts don't start new session

### DIFF
--- a/src/common/session/session-entity.component-test.js
+++ b/src/common/session/session-entity.component-test.js
@@ -236,25 +236,25 @@ describe('reset()', () => {
 })
 
 describe('isNew', () => {
-    test('isNew is true after the session resets by timers | true -> true', async () => {
+    test('is true after the session resets by timers | true -> true', async () => {
       const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
       expect(sessionInstance.isNew).toEqual(true)
       sessionInstance.reset() // imitate what expireMs and inactiveMs does on activation
       expect(sessionInstance.isNew).toEqual(true)
     })
-    test('isNew is true after the session resets by timers | false -> true', () => {
+    test('is true after the session resets by timers | false -> true', () => {
       storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
       const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
       expect(sessionInstance.isNew).toEqual(false)
       sessionInstance.reset()
       expect(sessionInstance.isNew).toEqual(true)
     })
-    test('isNew is true if reset happens on initialization after time outs off-view | expiresAt', () => {
+    test('is true if reset happens on initialization after time outs off-view | expiresAt', () => {
       storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() - 1, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
       const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
       expect(sessionInstance.isNew).toEqual(true)
     })
-    test('isNew is true if reset happens on initialization after time outs off-view | inactiveAt', () => {
+    test('is true if reset happens on initialization after time outs off-view | inactiveAt', () => {
       storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() - 1, updatedAt: Date.now() })
       const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
       expect(sessionInstance.isNew).toEqual(true)

--- a/src/common/session/session-entity.component-test.js
+++ b/src/common/session/session-entity.component-test.js
@@ -235,6 +235,18 @@ describe('reset()', () => {
   })
 })
 
+test('isNew is true after the session resets by timers', async () => {
+  const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+  expect(sessionInstance.isNew).toEqual(true)
+  sessionInstance.reset() // imitate what expireMs and inactiveMs does on activation
+  expect(sessionInstance.isNew).toEqual(true)
+})
+test('isNew is true if reset happens on initialization after time outs off-view', () => {
+  storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() - 1, inactiveAt: Date.now() - 1, updatedAt: Date.now() })
+  const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+  expect(sessionInstance.isNew).toEqual(true)
+})
+
 describe('read()', () => {
   test('"new" sessions get data from read()', () => {
     const newSession = new SessionEntity({ agentIdentifier, key, storage, expiresMs: 10 })

--- a/src/common/session/session-entity.component-test.js
+++ b/src/common/session/session-entity.component-test.js
@@ -235,18 +235,31 @@ describe('reset()', () => {
   })
 })
 
-test('isNew is true after the session resets by timers', async () => {
-  const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
-  expect(sessionInstance.isNew).toEqual(true)
-  sessionInstance.reset() // imitate what expireMs and inactiveMs does on activation
-  expect(sessionInstance.isNew).toEqual(true)
-})
-test('isNew is true if reset happens on initialization after time outs off-view', () => {
-  storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() - 1, inactiveAt: Date.now() - 1, updatedAt: Date.now() })
-  const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
-  expect(sessionInstance.isNew).toEqual(true)
-})
-
+describe('isNew', () => {
+    test('isNew is true after the session resets by timers | true -> true', async () => {
+      const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+      expect(sessionInstance.isNew).toEqual(true)
+      sessionInstance.reset() // imitate what expireMs and inactiveMs does on activation
+      expect(sessionInstance.isNew).toEqual(true)
+    })
+    test('isNew is true after the session resets by timers | false -> true', () => {
+      storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
+      const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+      expect(sessionInstance.isNew).toEqual(false)
+      sessionInstance.reset()
+      expect(sessionInstance.isNew).toEqual(true)
+    })
+    test('isNew is true if reset happens on initialization after time outs off-view | expiresAt', () => {
+      storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() - 1, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
+      const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+      expect(sessionInstance.isNew).toEqual(true)
+    })
+    test('isNew is true if reset happens on initialization after time outs off-view | inactiveAt', () => {
+      storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() - 1, updatedAt: Date.now() })
+      const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+      expect(sessionInstance.isNew).toEqual(true)
+    })
+  })
 describe('read()', () => {
   test('"new" sessions get data from read()', () => {
     const newSession = new SessionEntity({ agentIdentifier, key, storage, expiresMs: 10 })

--- a/src/common/session/session-entity.component-test.js
+++ b/src/common/session/session-entity.component-test.js
@@ -236,30 +236,30 @@ describe('reset()', () => {
 })
 
 describe('isNew', () => {
-    test('is true after the session resets by timers | true -> true', async () => {
-      const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
-      expect(sessionInstance.isNew).toEqual(true)
-      sessionInstance.reset() // imitate what expireMs and inactiveMs does on activation
-      expect(sessionInstance.isNew).toEqual(true)
-    })
-    test('is true after the session resets by timers | false -> true', () => {
-      storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
-      const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
-      expect(sessionInstance.isNew).toEqual(false)
-      sessionInstance.reset()
-      expect(sessionInstance.isNew).toEqual(true)
-    })
-    test('is true if reset happens on initialization after time outs off-view | expiresAt', () => {
-      storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() - 1, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
-      const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
-      expect(sessionInstance.isNew).toEqual(true)
-    })
-    test('is true if reset happens on initialization after time outs off-view | inactiveAt', () => {
-      storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() - 1, updatedAt: Date.now() })
-      const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
-      expect(sessionInstance.isNew).toEqual(true)
-    })
+  test('is true after the session resets by timers | true -> true', async () => {
+    const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+    expect(sessionInstance.isNew).toEqual(true)
+    sessionInstance.reset() // imitate what expireMs and inactiveMs does on activation
+    expect(sessionInstance.isNew).toEqual(true)
   })
+  test('is true after the session resets by timers | false -> true', () => {
+    storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
+    const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+    expect(sessionInstance.isNew).toEqual(false)
+    sessionInstance.reset()
+    expect(sessionInstance.isNew).toEqual(true)
+  })
+  test('is true if reset happens on initialization after time outs off-view | expiresAt', () => {
+    storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() - 1, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
+    const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+    expect(sessionInstance.isNew).toEqual(true)
+  })
+  test('is true if reset happens on initialization after time outs off-view | inactiveAt', () => {
+    storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() - 1, updatedAt: Date.now() })
+    const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
+    expect(sessionInstance.isNew).toEqual(true)
+  })
+})
 describe('read()', () => {
   test('"new" sessions get data from read()', () => {
     const newSession = new SessionEntity({ agentIdentifier, key, storage, expiresMs: 10 })

--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -125,7 +125,9 @@ export class SessionEntity {
 
     // The fact that the session is "new" or pre-existing is used in some places in the agent.  Session Replay and Trace
     // can use this info to inform whether to trust a new sampling decision vs continue a previous tracking effort.
-    this.isNew = !Object.keys(initialRead).length
+    /* [NR-230914] 02/2024 - the logical OR assignment is used so that isNew remains 'true' if it was already set as such. This fixes the expires and inactive timestamps timing out in localStorage
+      while no page for a given domain is in-use and the session resetting upon user returning to the page as part of a fresh session. */
+    this.isNew ||= !Object.keys(initialRead).length
     // if its a "new" session, we write to storage API with the default values.  These values may change over the lifespan of the agent run.
     // we can use a modeled object here to help us know and manage what values are being used. -- see "model" above
     if (this.isNew) this.write(getModeledObject(this.state, model), true)


### PR DESCRIPTION
When a session expires or becomes inactive while the user does not have the page open and they re-open the page, that is now treated as a new session.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

We had an issue where off-page expiration or timeouts of session resulted in the next on-page load to initialize a session that isn't new (i.e. `isNew` false). This is not intended and has been fixed.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-230914

### Testing

New jest test cases added to check for correct program flow and `isNew` value rather than with entire agent. This suffices to get the behavior we want.
