### PR TITLE
fix: Fix webpack imports in npm package

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -97,9 +97,9 @@ module.exports = function (api, ...args) {
         [
           './tools/babel/plugins/transform-import',
           {
-            '(constants/)env$': '$1env.npm',
-            '(configure/)public-path$': '$1public-path.npm',
-            '(configure/)nonce$': '$1nonce.npm'
+            '(/constants/|^\\./)env$': '$1env.npm',
+            '(/configure/|^\\./)public-path$': '$1public-path.npm',
+            '(/configure/|^\\./)nonce$': '$1nonce.npm'
           }
         ]
       ]
@@ -117,9 +117,9 @@ module.exports = function (api, ...args) {
         [
           './tools/babel/plugins/transform-import',
           {
-            '(constants/)env$': '$1env.npm',
-            '(configure/)public-path$': '$1public-path.npm',
-            '(configure/)nonce$': '$1nonce.npm'
+            '(/constants/|^\\./)env$': '$1env.npm',
+            '(/configure/|^\\./)public-path$': '$1public-path.npm',
+            '(/configure/|^\\./)nonce$': '$1nonce.npm'
           }
         ]
       ]


### PR DESCRIPTION
Fixing some import overrides in our NPM package build to prevent imports existing that include code reliant on webpack globals. This will resolve the error `Uncaught ReferenceError: __webpack_require__ is not defined` when using the NPM package in a project that does not use webpack.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Our import overrides for the couple of files that access webpack globals was not being applied correctly. This resulted in imports for code that relied on webpack globals in the NPM package. If the customer is not using webpack, this will result in a runtime error.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://new-relic.atlassian.net/browse/NR-233660

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
I could not find a good way to test this issue in an automated way. To verify manually, search the `dist` directory for imports of `nonce` and `public-path`