### PR TITLE
chore: Enabling bam ajax metrics blocking internally

### DIFF
--- a/.github/actions/build-ab/templates/experiments.js
+++ b/.github/actions/build-ab/templates/experiments.js
@@ -6,7 +6,7 @@ window.NREUM.info.licenseKey = '{{{args.abLicenseKey}}}'
 window.NREUM.init.proxy = {} // Proxy won't work for experiments
 window.NREUM.init.session_replay.enabled = false
 window.NREUM.init.session_trace.enabled = false
-window.NREUM.init.feature_flags = ['soft_nav']
+window.NREUM.init.feature_flags = ['ajax_metrics_deny_list','soft_nav']
 
 {{#if experimentScripts}}
 {{#each experimentScripts}}

--- a/.github/actions/build-ab/templates/latest.js
+++ b/.github/actions/build-ab/templates/latest.js
@@ -4,5 +4,6 @@ window.NREUM.loader_config.licenseKey = '{{{args.abLicenseKey}}}'
 window.NREUM.info.applicationID = '{{{args.abAppId}}}'
 window.NREUM.info.licenseKey = '{{{args.abLicenseKey}}}'
 window.NREUM.init.proxy.assets = 'https://staging-js-agent.newrelic.com/dev'
+window.NREUM.init.feature_flags = ['ajax_metrics_deny_list']
 
 {{{latestScript}}}


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Updating our internal A/B scripts to enable the feature flag for blocking the collection of ajax metrics for domains in the deny list.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-239922

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
