### PR TITLE
feat: Update agent to use new relic server time

### DIFF
--- a/src/common/context/__mocks__/shared-context.js
+++ b/src/common/context/__mocks__/shared-context.js
@@ -3,6 +3,9 @@ export const SharedContext = jest.fn(function () {
     agentIdentifier: 'abcd',
     ee: {
       on: jest.fn()
+    },
+    timeKeeper: {
+      now: jest.fn(() => performance.now())
     }
   }
 })

--- a/src/common/context/shared-context.js
+++ b/src/common/context/shared-context.js
@@ -1,4 +1,5 @@
 import { warn } from '../util/console'
+import { TimeKeeper } from '../timing/time-keeper'
 
 const model = {
   agentIdentifier: '',
@@ -17,5 +18,7 @@ export class SharedContext {
     } catch (err) {
       warn('An error occured while setting SharedContext', err)
     }
+
+    this.timeKeeper = TimeKeeper.getTimeKeeperByAgentIdentifier(this.sharedContext.agentIdentifier)
   }
 }

--- a/src/common/context/shared-context.js
+++ b/src/common/context/shared-context.js
@@ -1,9 +1,9 @@
 import { warn } from '../util/console'
-import { TimeKeeper } from '../timing/time-keeper'
 
 const model = {
   agentIdentifier: '',
-  ee: undefined
+  ee: undefined,
+  timeKeeper: undefined
 }
 
 export class SharedContext {
@@ -16,9 +16,7 @@ export class SharedContext {
         if (Object.keys(model).includes(key)) this.sharedContext[key] = value
       })
     } catch (err) {
-      warn('An error occured while setting SharedContext', err)
+      warn('An error occurred while setting SharedContext', err)
     }
-
-    this.timeKeeper = TimeKeeper.getTimeKeeperByAgentIdentifier(this.sharedContext.agentIdentifier)
   }
 }

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -179,7 +179,7 @@ export class Harvest extends SharedContext {
       encodeParam('v', VERSION),
       transactionNameParam(info),
       encodeParam('ct', runtime.customTransaction),
-      '&rst=' + this.timeKeeper.now(),
+      '&rst=' + this.sharedContext.timeKeeper.now(),
       '&ck=0', // ck param DEPRECATED - still expected by backend
       '&s=' + (runtime.session?.state.value || '0'), // the 0 id encaps all untrackable and default traffic
       encodeParam('ref', ref),

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -9,7 +9,6 @@ import * as submitData from '../util/submit-data'
 import { getLocation } from '../url/location'
 import { getInfo, getConfigurationValue, getRuntime, getConfiguration } from '../config/config'
 import { cleanURL } from '../url/clean-url'
-import { now } from '../timing/now'
 import { eventListenerOpts } from '../event-listener/event-listener-opts'
 import { Obfuscator } from '../util/obfuscate'
 import { applyFnToProps } from '../util/traverse'
@@ -180,7 +179,7 @@ export class Harvest extends SharedContext {
       encodeParam('v', VERSION),
       transactionNameParam(info),
       encodeParam('ct', runtime.customTransaction),
-      '&rst=' + now(),
+      '&rst=' + this.timeKeeper.now(),
       '&ck=0', // ck param DEPRECATED - still expected by backend
       '&s=' + (runtime.session?.state.value || '0'), // the 0 id encaps all untrackable and default traffic
       encodeParam('ref', ref),

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -16,6 +16,7 @@ import { SharedContext } from '../context/shared-context'
 import { VERSION } from '../constants/env'
 import { isWorkerScope, isIE } from '../constants/runtime'
 import { warn } from '../util/console'
+import { TimeKeeper } from '../timing/time-keeper'
 
 const warnings = {}
 
@@ -179,7 +180,7 @@ export class Harvest extends SharedContext {
       encodeParam('v', VERSION),
       transactionNameParam(info),
       encodeParam('ct', runtime.customTransaction),
-      '&rst=' + this.sharedContext.timeKeeper.now(),
+      '&rst=' + TimeKeeper.now(),
       '&ck=0', // ck param DEPRECATED - still expected by backend
       '&s=' + (runtime.session?.state.value || '0'), // the 0 id encaps all untrackable and default traffic
       encodeParam('ref', ref),

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -14,6 +14,9 @@ let harvestInstance
 
 beforeEach(() => {
   harvestInstance = new Harvest()
+  harvestInstance.timeKeeper = {
+    now: jest.fn(() => performance.now())
+  }
 })
 
 afterEach(() => {

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -14,9 +14,6 @@ let harvestInstance
 
 beforeEach(() => {
   harvestInstance = new Harvest()
-  harvestInstance.timeKeeper = {
-    now: jest.fn(() => performance.now())
-  }
 })
 
 afterEach(() => {

--- a/src/common/timing/__mocks__/now.js
+++ b/src/common/timing/__mocks__/now.js
@@ -1,1 +1,0 @@
-export const now = jest.fn(() => performance.now())

--- a/src/common/timing/__mocks__/time-keeper.js
+++ b/src/common/timing/__mocks__/time-keeper.js
@@ -1,0 +1,3 @@
+export const TimeKeeper = jest.fn(function () {})
+TimeKeeper.now = jest.fn(() => performance.now())
+TimeKeeper.getTimeKeeperByAgentIdentifier = jest.fn(() => new TimeKeeper())

--- a/src/common/timing/now.js
+++ b/src/common/timing/now.js
@@ -1,9 +1,0 @@
-/*
- * Copyright 2020 New Relic Corporation. All rights reserved.
- * SPDX-License-Identifier: Apache-2.0
- */
-
-// This is our own layer around performance.now. It's not strictly necessary, but we keep it in case of future mod-ing of the value for refactor purpose.
-export function now () {
-  return Math.floor(performance.now())
-}

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -37,6 +37,14 @@ export class TimeKeeper {
       : undefined
   }
 
+  /**
+   * Returns the current time offset from page origin.
+   * @return {number}
+   */
+  static now () {
+    return Math.floor(performance.now())
+  }
+
   get originTime () {
     return this.#originTime
   }
@@ -89,13 +97,5 @@ export class TimeKeeper {
   correctAbsoluteTimestamp (timestamp) {
     if (!this.#localTimeDiff) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
     return Math.floor(timestamp - this.#localTimeDiff)
-  }
-
-  /**
-   * Returns the current time offset from page origin.
-   * @return {number}
-   */
-  now () {
-    return Math.floor(performance.now())
   }
 }

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -55,7 +55,6 @@ export class TimeKeeper {
   processRumRequest (rumRequest, startTime, endTime) {
     const responseDateHeader = rumRequest.getResponseHeader('Date')
     if (!responseDateHeader) {
-      console.log('Missing date header')
       throw new Error('Missing date header on rum response.')
     }
 
@@ -65,10 +64,6 @@ export class TimeKeeper {
     // Corrected page origin time
     this.#correctedOriginTime = Math.floor(Date.parse(responseDateHeader) - serverOffset)
     this.#localTimeDiff = this.#originTime - this.#correctedOriginTime
-    console.log('medianRumOffset', medianRumOffset)
-    console.log('serverOffset', serverOffset)
-    console.log('this.#correctedOriginTime', this.#correctedOriginTime)
-    console.log('this.#localTimeDiff', this.#localTimeDiff)
 
     if (Number.isNaN(this.#correctedOriginTime)) {
       throw new Error('Date header invalid format.')
@@ -82,7 +77,6 @@ export class TimeKeeper {
    * @returns {number} Corrected unix/epoch timestamp
    */
   convertRelativeTimestamp (relativeTime) {
-    console.log('convertRelativeTimestamp called', relativeTime)
     if (!this.#correctedOriginTime) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
     return this.#correctedOriginTime + relativeTime
   }
@@ -93,7 +87,6 @@ export class TimeKeeper {
    * @return {number} Corrected unix/epoch timestamp
    */
   correctAbsoluteTimestamp (timestamp) {
-    console.log('correctAbsoluteTimestamp called', timestamp)
     if (!this.#localTimeDiff) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
     return Math.floor(timestamp - this.#localTimeDiff)
   }

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -1,5 +1,4 @@
 import { gosNREUM } from '../window/nreum'
-import { getRuntime } from '../config/config'
 
 /**
  * Class used to adjust the timestamp of harvested data to New Relic server time. This
@@ -7,7 +6,11 @@ import { getRuntime } from '../config/config'
  * to the harvested data event offset time.
  */
 export class TimeKeeper {
-  #agent
+  /**
+   * Represents the browser origin time.
+   * @type {number}
+   */
+  #originTime
 
   /**
    * Represents the browser origin time corrected to NR server time.
@@ -22,8 +25,9 @@ export class TimeKeeper {
    */
   #localTimeDiff
 
-  constructor (agent) {
-    this.#agent = agent
+  constructor (originTime) {
+    if (!originTime) throw new Error('TimeKeeper must be supplied a browser origin time.')
+    this.#originTime = originTime
   }
 
   static getTimeKeeperByAgentIdentifier (agentIdentifier) {
@@ -33,7 +37,12 @@ export class TimeKeeper {
       : undefined
   }
 
-  get correctedPageOriginTime () {
+  get originTime () {
+    return this.#originTime
+  }
+
+  get correctedOriginTime () {
+    if (!this.#correctedOriginTime) throw new Error('InvalidState: Access to correctedOriginTime attempted before NR time calculated.')
     return this.#correctedOriginTime
   }
 
@@ -54,7 +63,7 @@ export class TimeKeeper {
 
     // Corrected page origin time
     this.#correctedOriginTime = Math.floor(Date.parse(responseDateHeader) - serverOffset)
-    this.#localTimeDiff = getRuntime(this.#agent.agentIdentifier).offset - this.#correctedOriginTime
+    this.#localTimeDiff = this.#originTime - this.#correctedOriginTime
 
     if (Number.isNaN(this.#correctedOriginTime)) {
       throw new Error('Date header invalid format.')
@@ -65,9 +74,10 @@ export class TimeKeeper {
    * Converts a page origin relative time to an absolute timestamp
    * corrected to NR server time.
    * @param relativeTime {number} The relative time of the event in milliseconds
-   * @returns {number} The correct timestamp as a unix/epoch timestamp value
+   * @returns {number} Corrected unix/epoch timestamp
    */
   convertRelativeTimestamp (relativeTime) {
+    if (!this.#correctedOriginTime) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
     return this.#correctedOriginTime + relativeTime
   }
 
@@ -77,6 +87,7 @@ export class TimeKeeper {
    * @return {number} Corrected unix/epoch timestamp
    */
   correctAbsoluteTimestamp (timestamp) {
+    if (!this.#localTimeDiff) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
     return Math.floor(timestamp - this.#localTimeDiff)
   }
 

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -55,6 +55,7 @@ export class TimeKeeper {
   processRumRequest (rumRequest, startTime, endTime) {
     const responseDateHeader = rumRequest.getResponseHeader('Date')
     if (!responseDateHeader) {
+      console.log('Missing date header')
       throw new Error('Missing date header on rum response.')
     }
 
@@ -64,6 +65,10 @@ export class TimeKeeper {
     // Corrected page origin time
     this.#correctedOriginTime = Math.floor(Date.parse(responseDateHeader) - serverOffset)
     this.#localTimeDiff = this.#originTime - this.#correctedOriginTime
+    console.log('medianRumOffset', medianRumOffset)
+    console.log('serverOffset', serverOffset)
+    console.log('this.#correctedOriginTime', this.#correctedOriginTime)
+    console.log('this.#localTimeDiff', this.#localTimeDiff)
 
     if (Number.isNaN(this.#correctedOriginTime)) {
       throw new Error('Date header invalid format.')
@@ -77,6 +82,7 @@ export class TimeKeeper {
    * @returns {number} Corrected unix/epoch timestamp
    */
   convertRelativeTimestamp (relativeTime) {
+    console.log('convertRelativeTimestamp called', relativeTime)
     if (!this.#correctedOriginTime) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
     return this.#correctedOriginTime + relativeTime
   }
@@ -87,6 +93,7 @@ export class TimeKeeper {
    * @return {number} Corrected unix/epoch timestamp
    */
   correctAbsoluteTimestamp (timestamp) {
+    console.log('correctAbsoluteTimestamp called', timestamp)
     if (!this.#localTimeDiff) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
     return Math.floor(timestamp - this.#localTimeDiff)
   }

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -85,7 +85,7 @@ export class TimeKeeper {
    * @returns {number} Corrected unix/epoch timestamp
    */
   convertRelativeTimestamp (relativeTime) {
-    if (!this.#correctedOriginTime) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
+    if (!this.#correctedOriginTime) return this.originTime + relativeTime
     return this.#correctedOriginTime + relativeTime
   }
 
@@ -95,7 +95,7 @@ export class TimeKeeper {
    * @return {number} Corrected unix/epoch timestamp
    */
   correctAbsoluteTimestamp (timestamp) {
-    if (!this.#localTimeDiff) throw new Error('InvalidState: Timing correction attempted before NR time calculated.')
+    if (!this.#localTimeDiff) return timestamp
     return Math.floor(timestamp - this.#localTimeDiff)
   }
 }

--- a/src/common/timing/time-keeper.test.js
+++ b/src/common/timing/time-keeper.test.js
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker'
 import { TimeKeeper } from './time-keeper'
 import * as configModule from '../config/config'
 
@@ -10,7 +9,6 @@ const endTime = 600
 
 let localTime
 let serverTime
-let mockAgent
 let runtimeConfig
 let timeKeeper
 beforeEach(() => {
@@ -21,16 +19,13 @@ beforeEach(() => {
     now: localTime
   })
 
-  mockAgent = {
-    agentIdentifier: faker.string.uuid()
-  }
   runtimeConfig = {
     offset: localTime
   }
 
   jest.spyOn(configModule, 'getRuntime').mockImplementation(() => runtimeConfig)
 
-  timeKeeper = new TimeKeeper(mockAgent)
+  timeKeeper = new TimeKeeper(Date.now())
 })
 
 describe('processRumRequest', () => {
@@ -41,7 +36,7 @@ describe('processRumRequest', () => {
 
     timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
-    expect(timeKeeper.correctedPageOriginTime).toEqual(1706213060475)
+    expect(timeKeeper.correctedOriginTime).toEqual(1706213060475)
   })
 
   it('should calculate a newer corrected page origin', () => {
@@ -53,7 +48,7 @@ describe('processRumRequest', () => {
 
     timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
-    expect(timeKeeper.correctedPageOriginTime).toEqual(1706213055475)
+    expect(timeKeeper.correctedOriginTime).toEqual(1706213055475)
   })
 
   it.each([undefined, null, 0])('should fallback to unprotected time values when responseStart is %s', (responseStart) => {
@@ -63,7 +58,7 @@ describe('processRumRequest', () => {
 
     timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
-    expect(timeKeeper.correctedPageOriginTime).toEqual(1706213060475)
+    expect(timeKeeper.correctedOriginTime).toEqual(1706213060475)
   })
 
   it.each([null, undefined])('should throw an error when rumRequest is %s', (rumRequest) => {

--- a/src/common/window/nreum.js
+++ b/src/common/window/nreum.js
@@ -1,4 +1,3 @@
-import { now } from '../timing/now'
 import { globalScope } from '../constants/runtime'
 
 export const defaults = {
@@ -71,7 +70,7 @@ export function setNREUMInitializedAgent (id, newAgentInstance) {
   let nr = gosNREUM()
   nr.initializedAgents ??= {}
   newAgentInstance.initializedAt = {
-    ms: now(),
+    ms: newAgentInstance.timeKeeper.now(),
     date: new Date()
   }
   nr.initializedAgents[id] = newAgentInstance

--- a/src/common/window/nreum.js
+++ b/src/common/window/nreum.js
@@ -1,4 +1,5 @@
 import { globalScope } from '../constants/runtime'
+import { TimeKeeper } from '../timing/time-keeper'
 
 export const defaults = {
   beacon: 'bam.nr-data.net',
@@ -70,7 +71,7 @@ export function setNREUMInitializedAgent (id, newAgentInstance) {
   let nr = gosNREUM()
   nr.initializedAgents ??= {}
   newAgentInstance.initializedAt = {
-    ms: newAgentInstance.timeKeeper.now(),
+    ms: TimeKeeper.now(),
     date: new Date()
   }
   nr.initializedAgents[id] = newAgentInstance

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -40,6 +40,7 @@ export class Aggregate extends AggregateBase {
     let spaAjaxEvents = {}
     let sentAjaxEvents = []
     const ee = this.ee
+    const timeKeeper = this.timeKeeper
 
     const harvestTimeSeconds = agentInit.ajax.harvestTimeSeconds || 10
     const MAX_PAYLOAD_SIZE = agentInit.ajax.maxPayloadSize || 1000000
@@ -125,7 +126,7 @@ export class Aggregate extends AggregateBase {
       if (xhrContext.dt) {
         event.spanId = xhrContext.dt.spanId
         event.traceId = xhrContext.dt.traceId
-        event.spanTimestamp = xhrContext.dt.timestamp
+        event.spanTimestamp = timeKeeper.correctAbsoluteTimestamp(xhrContext.dt.timestamp)
       }
 
       // parsed from the AJAX body, looking for operationName param & parsing query for operationType

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -21,6 +21,7 @@ import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { getNREUMInitializedAgent } from '../../../common/window/nreum'
 import { deregisterDrain } from '../../../common/drain/drain'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 /**
  * @typedef {import('./compute-stack-trace.js').StackInfo} StackInfo
@@ -134,7 +135,7 @@ export class Aggregate extends AggregateBase {
 
   storeError (err, time, internal, customAttributes) {
     // are we in an interaction
-    time = time || this.timeKeeper.now()
+    time = time || TimeKeeper.now()
     const agentRuntime = getRuntime(this.agentIdentifier)
     let filterOutput
 

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -14,7 +14,6 @@ import { stringify } from '../../../common/util/stringify'
 import { handle } from '../../../common/event-emitter/handle'
 import { mapOwn } from '../../../common/util/map-own'
 import { getInfo, getConfigurationValue, getRuntime } from '../../../common/config/config'
-import { now } from '../../../common/timing/now'
 import { globalScope } from '../../../common/constants/runtime'
 
 import { FEATURE_NAME } from '../constants'
@@ -135,7 +134,7 @@ export class Aggregate extends AggregateBase {
 
   storeError (err, time, internal, customAttributes) {
     // are we in an interaction
-    time = time || now()
+    time = time || this.timeKeeper.now()
     const agentRuntime = getRuntime(this.agentIdentifier)
     let filterOutput
 
@@ -173,7 +172,7 @@ export class Aggregate extends AggregateBase {
     if (!this.stackReported[bucketHash]) {
       this.stackReported[bucketHash] = true
       params.stack_trace = truncateSize(stackInfo.stackString)
-      this.observedAt[bucketHash] = agentRuntime.offset + time
+      this.observedAt[bucketHash] = this.timeKeeper.convertRelativeTimestamp(time)
     } else {
       params.browser_stack_hash = stringHashCode(stackInfo.stackString)
     }
@@ -191,6 +190,7 @@ export class Aggregate extends AggregateBase {
 
     if (agentRuntime?.session?.state?.sessionReplayMode) params.hasReplay = true
     params.firstOccurrenceTimestamp = this.observedAt[bucketHash]
+    params.timestamp = this.observedAt[bucketHash]
 
     var type = internal ? 'ierr' : 'err'
     var newMetrics = { time }

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -4,7 +4,6 @@
  */
 
 import { handle } from '../../../common/event-emitter/handle'
-import { now } from '../../../common/timing/now'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
@@ -31,18 +30,18 @@ export class Instrument extends InstrumentBase {
       if (!this.abortHandler || this.#seenErrors.has(error)) return
       this.#seenErrors.add(error)
 
-      handle('err', [this.#castError(error), now()], undefined, FEATURE_NAMES.jserrors, this.ee)
+      handle('err', [this.#castError(error), this.timeKeeper.now()], undefined, FEATURE_NAMES.jserrors, this.ee)
     })
 
     this.ee.on('internal-error', (error) => {
       if (!this.abortHandler) return
-      handle('ierr', [this.#castError(error), now(), true], undefined, FEATURE_NAMES.jserrors, this.ee)
+      handle('ierr', [this.#castError(error), this.timeKeeper.now(), true], undefined, FEATURE_NAMES.jserrors, this.ee)
     })
 
     globalScope.addEventListener('unhandledrejection', (promiseRejectionEvent) => {
       if (!this.abortHandler) return
 
-      handle('err', [this.#castPromiseRejectionEvent(promiseRejectionEvent), now(), false, { unhandledPromiseRejection: 1 }], undefined, FEATURE_NAMES.jserrors, this.ee)
+      handle('err', [this.#castPromiseRejectionEvent(promiseRejectionEvent), this.timeKeeper.now(), false, { unhandledPromiseRejection: 1 }], undefined, FEATURE_NAMES.jserrors, this.ee)
     }, eventListenerOpts(false, this.removeOnAbort?.signal))
 
     globalScope.addEventListener('error', (errorEvent) => {
@@ -57,7 +56,7 @@ export class Instrument extends InstrumentBase {
         return
       }
 
-      handle('err', [this.#castErrorEvent(errorEvent), now()], undefined, FEATURE_NAMES.jserrors, this.ee)
+      handle('err', [this.#castErrorEvent(errorEvent), this.timeKeeper.now()], undefined, FEATURE_NAMES.jserrors, this.ee)
     }, eventListenerOpts(false, this.removeOnAbort?.signal))
 
     this.abortHandler = this.#abort // we also use this as a flag to denote that the feature is active or on and handling errors

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -11,6 +11,7 @@ import { globalScope } from '../../../common/constants/runtime'
 import { eventListenerOpts } from '../../../common/event-listener/event-listener-opts'
 import { stringify } from '../../../common/util/stringify'
 import { UncaughtError } from './uncaught-error'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
@@ -30,18 +31,18 @@ export class Instrument extends InstrumentBase {
       if (!this.abortHandler || this.#seenErrors.has(error)) return
       this.#seenErrors.add(error)
 
-      handle('err', [this.#castError(error), this.timeKeeper.now()], undefined, FEATURE_NAMES.jserrors, this.ee)
+      handle('err', [this.#castError(error), TimeKeeper.now()], undefined, FEATURE_NAMES.jserrors, this.ee)
     })
 
     this.ee.on('internal-error', (error) => {
       if (!this.abortHandler) return
-      handle('ierr', [this.#castError(error), this.timeKeeper.now(), true], undefined, FEATURE_NAMES.jserrors, this.ee)
+      handle('ierr', [this.#castError(error), TimeKeeper.now(), true], undefined, FEATURE_NAMES.jserrors, this.ee)
     })
 
     globalScope.addEventListener('unhandledrejection', (promiseRejectionEvent) => {
       if (!this.abortHandler) return
 
-      handle('err', [this.#castPromiseRejectionEvent(promiseRejectionEvent), this.timeKeeper.now(), false, { unhandledPromiseRejection: 1 }], undefined, FEATURE_NAMES.jserrors, this.ee)
+      handle('err', [this.#castPromiseRejectionEvent(promiseRejectionEvent), TimeKeeper.now(), false, { unhandledPromiseRejection: 1 }], undefined, FEATURE_NAMES.jserrors, this.ee)
     }, eventListenerOpts(false, this.removeOnAbort?.signal))
 
     globalScope.addEventListener('error', (errorEvent) => {
@@ -56,7 +57,7 @@ export class Instrument extends InstrumentBase {
         return
       }
 
-      handle('err', [this.#castErrorEvent(errorEvent), this.timeKeeper.now()], undefined, FEATURE_NAMES.jserrors, this.ee)
+      handle('err', [this.#castErrorEvent(errorEvent), TimeKeeper.now()], undefined, FEATURE_NAMES.jserrors, this.ee)
     }, eventListenerOpts(false, this.removeOnAbort?.signal))
 
     this.abortHandler = this.#abort // we also use this as a flag to denote that the feature is active or on and handling errors

--- a/src/features/page_action/aggregate/index.js
+++ b/src/features/page_action/aggregate/index.js
@@ -87,7 +87,7 @@ export class Aggregate extends AggregateBase {
     }
 
     var defaults = {
-      timestamp: t + getRuntime(this.agentIdentifier).offset,
+      timestamp: this.timeKeeper.convertRelativeTimestamp(t),
       timeSinceLoad: t / 1000,
       browserWidth: width,
       browserHeight: height,

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -15,6 +15,7 @@ import { drain } from '../../../common/drain/drain'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { handle } from '../../../common/event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 export class Aggregate extends AggregateBase {
   static featureName = CONSTANTS.FEATURE_NAME
@@ -100,13 +101,13 @@ export class Aggregate extends AggregateBase {
     queryParameters.fp = firstPaint.current.value
     queryParameters.fcp = firstContentfulPaint.current.value
 
-    const rumStartTime = this.timeKeeper.now()
+    const rumStartTime = TimeKeeper.now()
     harvester.send({
       endpoint: 'rum',
       payload: { qs: queryParameters, body },
       opts: { needResponse: true, sendEmptyBody: true },
       cbFinished: ({ status, responseText, xhr }) => {
-        const rumEndTime = this.timeKeeper.now()
+        const rumEndTime = TimeKeeper.now()
 
         if (status >= 400 || status === 0) {
           // Adding retry logic for the rum call will be a separate change

--- a/src/features/page_view_timing/instrument/index.js
+++ b/src/features/page_view_timing/instrument/index.js
@@ -5,10 +5,10 @@
 import { handle } from '../../../common/event-emitter/handle'
 import { subscribeToVisibilityChange } from '../../../common/window/page-visibility'
 import { windowAddEventListener } from '../../../common/event-listener/event-listener-opts'
-import { now } from '../../../common/timing/now'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
 import { isBrowserScope } from '../../../common/constants/runtime'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
@@ -17,10 +17,10 @@ export class Instrument extends InstrumentBase {
     if (!isBrowserScope) return // CWV is irrelevant outside web context
 
     // While we try to replicate web-vital's visibilitywatcher logic in an effort to defer that library to post-pageload, this isn't perfect and doesn't consider prerendering.
-    subscribeToVisibilityChange(() => handle('docHidden', [now()], undefined, FEATURE_NAME, this.ee), true)
+    subscribeToVisibilityChange(() => handle('docHidden', [TimeKeeper.now()], undefined, FEATURE_NAME, this.ee), true)
 
     // Window fires its pagehide event (typically on navigation--this occurrence is a *subset* of vis change); don't defer this unless it's guarantee it cannot happen before load(?)
-    windowAddEventListener('pagehide', () => handle('winPagehide', [now()], undefined, FEATURE_NAME, this.ee))
+    windowAddEventListener('pagehide', () => handle('winPagehide', [TimeKeeper.now()], undefined, FEATURE_NAME, this.ee))
 
     this.importAggregator()
   }

--- a/src/features/session_replay/aggregate/index.component-test.js
+++ b/src/features/session_replay/aggregate/index.component-test.js
@@ -9,6 +9,7 @@ import { setNREUMInitializedAgent } from '../../../common/window/nreum'
 import { handle } from '../../../common/event-emitter/handle'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { ee } from '../../../common/event-emitter/contextual-ee'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 let sr, session
 
@@ -357,7 +358,8 @@ function wait (ms = 0) {
 }
 
 function primeSessionAndReplay (sess = new SessionEntity({ agentIdentifier, key: 'SESSION', storage: new LocalMemory() })) {
-  const agent = { agentIdentifier }
+  const timeKeeper = new TimeKeeper(Date.now())
+  const agent = { agentIdentifier, timeKeeper }
   setNREUMInitializedAgent(agentIdentifier, agent)
   session = sess
   configure(agent, { info, runtime: { session, isolatedBacklog: false }, init: {} }, 'test', true)

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -23,11 +23,11 @@ import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { handle } from '../../../common/event-emitter/handle'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { RRWEB_VERSION } from '../../../common/constants/env'
-import { now } from '../../../common/timing/now'
 import { MODE, SESSION_EVENTS, SESSION_EVENT_TYPES } from '../../../common/session/constants'
 import { stringify } from '../../../common/util/stringify'
 import { stylesheetEvaluator } from '../shared/stylesheet-evaluator'
 import { deregisterDrain } from '../../../common/drain/drain'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -301,7 +301,7 @@ export class Aggregate extends AggregateBase {
     }
 
     const agentOffset = getRuntime(this.agentIdentifier).offset
-    const relativeNow = now()
+    const relativeNow = TimeKeeper.now()
 
     const firstEventTimestamp = events[0]?.timestamp // from rrweb node
     const lastEventTimestamp = events[events.length - 1]?.timestamp // from rrweb node

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -6,12 +6,12 @@ import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { parseUrl } from '../../../common/url/parse-url'
 import { getConfigurationValue, getRuntime } from '../../../common/config/config'
-import { now } from '../../../common/timing/now'
 import { FEATURE_NAME } from '../constants'
 import { HandlerCache } from '../../utils/handler-cache'
 import { getSessionReplayMode } from '../../session_replay/shared/replay-mode'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { MODE, SESSION_EVENTS } from '../../../common/session/constants'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 const ignoredEvents = {
   // we find that certain events make the data too noisy to be useful
@@ -212,7 +212,7 @@ export class Aggregate extends AggregateBase {
 
   #prepareHarvest (options) {
     if (this.isStandalone) {
-      if (this.ptid && now() >= MAX_TRACE_DURATION) {
+      if (this.ptid && TimeKeeper.now() >= MAX_TRACE_DURATION) {
         // Perform a final harvest once we hit or exceed the max session trace time
         options.isFinalHarvest = true
         this.operationalGate.permanentlyDecide(false)
@@ -419,7 +419,7 @@ export class Aggregate extends AggregateBase {
       if (openedSpace === 0) return
     }
 
-    if (this.isStandalone && now() >= MAX_TRACE_DURATION) {
+    if (this.isStandalone && TimeKeeper.now() >= MAX_TRACE_DURATION) {
       return
     }
 
@@ -436,7 +436,7 @@ export class Aggregate extends AggregateBase {
    */
   trimSTNs (lookbackDuration) {
     let prunedNodes = 0
-    const cutoffHighResTime = Math.max(now() - lookbackDuration, 0)
+    const cutoffHighResTime = Math.max(TimeKeeper.now() - lookbackDuration, 0)
     Object.keys(this.trace).forEach(nameCategory => {
       const nodeList = this.trace[nameCategory]
       /* Notice nodes are appending under their name's list as they end and are stored. This means each list is already (roughly) sorted in chronological order by end time.

--- a/src/features/session_trace/instrument/index.js
+++ b/src/features/session_trace/instrument/index.js
@@ -4,11 +4,11 @@
  */
 import { handle } from '../../../common/event-emitter/handle'
 import { wrapHistory, wrapEvents } from '../../../common/wrap'
-import { now } from '../../../common/timing/now'
 import { InstrumentBase } from '../../utils/instrument-base'
 import * as CONSTANTS from '../constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { isBrowserScope } from '../../../common/constants/runtime'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 const {
   BST_RESOURCE, RESOURCE, START, END, FEATURE_NAME, FN_END, FN_START, PUSH_STATE
@@ -25,16 +25,16 @@ export class Instrument extends InstrumentBase {
     this.eventsEE = wrapEvents(thisInstrumentEE)
 
     this.eventsEE.on(FN_START, function (args, target) {
-      this.bstStart = now()
+      this.bstStart = TimeKeeper.now()
     })
     this.eventsEE.on(FN_END, function (args, target) {
       // ISSUE: when target is XMLHttpRequest, nr@context should have params so we can calculate event origin
       // When ajax is disabled, this may fail without making ajax a dependency of session_trace
-      handle('bst', [args[0], target, this.bstStart, now()], undefined, FEATURE_NAMES.sessionTrace, thisInstrumentEE)
+      handle('bst', [args[0], target, this.bstStart, TimeKeeper.now()], undefined, FEATURE_NAMES.sessionTrace, thisInstrumentEE)
     })
 
     thisInstrumentEE.on(PUSH_STATE + START, function (args) {
-      this.time = now()
+      this.time = TimeKeeper.now()
       this.startPath = location.pathname + location.hash
     })
     thisInstrumentEE.on(PUSH_STATE + END, function (args) {

--- a/src/features/soft_navigations/aggregate/bel-node.js
+++ b/src/features/soft_navigations/aggregate/bel-node.js
@@ -1,4 +1,4 @@
-import { now } from '../../../common/timing/now'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 let nodesSeen = 0
 
@@ -6,7 +6,7 @@ export class BelNode {
   belType
   /** List of other BelNode derivatives. Each children should be of a subclass that implements its own 'serialize' function. */
   children = []
-  start = now()
+  start = TimeKeeper.now()
   end
   callbackEnd = 0
   callbackDuration = 0

--- a/src/features/soft_navigations/instrument/index.js
+++ b/src/features/soft_navigations/instrument/index.js
@@ -2,11 +2,11 @@ import { originals } from '../../../common/config/config'
 import { isBrowserScope } from '../../../common/constants/runtime'
 import { handle } from '../../../common/event-emitter/handle'
 import { windowAddEventListener } from '../../../common/event-listener/event-listener-opts'
-import { now } from '../../../common/timing/now'
 import { debounce } from '../../../common/util/invoke'
 import { wrapEvents, wrapHistory } from '../../../common/wrap'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME, INTERACTION_TRIGGERS } from '../constants'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 /** The minimal time after a UI event for which no further events will be processed - i.e. a throttling rate to reduce spam.
  * This also give some time for the new interaction to complete without being discarded by a subsequent UI event and wrongly attributed.
@@ -23,7 +23,7 @@ export class Instrument extends InstrumentBase {
     const historyEE = wrapHistory(this.ee)
     const eventsEE = wrapEvents(this.ee)
 
-    const trackURLChange = () => handle('newURL', [now(), '' + window.location], undefined, this.featureName, this.ee)
+    const trackURLChange = () => handle('newURL', [TimeKeeper.now(), '' + window.location], undefined, this.featureName, this.ee)
     historyEE.on('pushState-end', trackURLChange)
     historyEE.on('replaceState-end', trackURLChange)
 
@@ -38,7 +38,7 @@ export class Instrument extends InstrumentBase {
       if (oncePerFrame) return
       oncePerFrame = true
       requestAnimationFrame(() => { // waiting for next frame to time when any visuals are supposedly updated
-        handle('newDom', [now()], undefined, this.featureName, this.ee)
+        handle('newDom', [TimeKeeper.now()], undefined, this.featureName, this.ee)
         oncePerFrame = false
       })
     })

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -406,9 +406,11 @@ export class Aggregate extends AggregateBase {
 
         if (state.currentNode) {
           this[SPA_NODE] = state.currentNode.child('ajax', this[FETCH_START])
-          if (dtPayload && this[SPA_NODE]) this[SPA_NODE].dt = dtPayload
-          if (this[SPA_NODE].dt?.timestamp) {
-            this[SPA_NODE].dt.timestamp = timeKeeper.correctAbsoluteTimestamp(this[SPA_NODE].dt.timestamp)
+          if (dtPayload && this[SPA_NODE]) {
+            this[SPA_NODE].dt = dtPayload
+            if (this[SPA_NODE].dt?.timestamp) {
+              this[SPA_NODE].dt.timestamp = timeKeeper.correctAbsoluteTimestamp(this[SPA_NODE].dt.timestamp)
+            }
           }
         }
       }

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -308,7 +308,7 @@ export class Aggregate extends AggregateBase {
       if (node && !this.sent) {
         this.sent = true
         node.dt = this.dt
-        if (node.dt.timestamp) {
+        if (node.dt?.timestamp) {
           node.dt.timestamp = timeKeeper.correctAbsoluteTimestamp(node.dt.timestamp)
         }
         node.jsEnd = node.start = this.startTime

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -407,6 +407,9 @@ export class Aggregate extends AggregateBase {
         if (state.currentNode) {
           this[SPA_NODE] = state.currentNode.child('ajax', this[FETCH_START])
           if (dtPayload && this[SPA_NODE]) this[SPA_NODE].dt = dtPayload
+          if (this[SPA_NODE].dt?.timestamp) {
+            this[SPA_NODE].dt.timestamp = timeKeeper.correctAbsoluteTimestamp(this[SPA_NODE].dt.timestamp)
+          }
         }
       }
     }, this.featureName, fetchEE)

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -58,7 +58,7 @@ export class Aggregate extends AggregateBase {
     let scheduler
     this.serializer = new Serializer(this)
 
-    const { state, serializer } = this
+    const { state, serializer, timeKeeper } = this
     let { blocked } = this
 
     const baseEE = ee.get(agentIdentifier) // <-- parent baseEE
@@ -308,6 +308,9 @@ export class Aggregate extends AggregateBase {
       if (node && !this.sent) {
         this.sent = true
         node.dt = this.dt
+        if (node.dt.timestamp) {
+          node.dt.timestamp = timeKeeper.correctAbsoluteTimestamp(node.dt.timestamp)
+        }
         node.jsEnd = node.start = this.startTime
         node[INTERACTION][REMAINING]++
       }

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -8,7 +8,6 @@ import {
 import { eventListenerOpts } from '../../../common/event-listener/event-listener-opts'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { getRuntime } from '../../../common/config/config'
-import { now } from '../../../common/timing/now'
 import * as CONSTANTS from '../constants'
 import { isBrowserScope } from '../../../common/constants/runtime'
 
@@ -82,7 +81,7 @@ export class Instrument extends InstrumentBase {
     function startTimestamp () {
       depth++
       startHash = window.location.hash
-      this[FN_START] = now()
+      this[FN_START] = this.timeKeeper.now()
     }
 
     function endTimestamp () {
@@ -91,14 +90,14 @@ export class Instrument extends InstrumentBase {
         trackURLChange(0, true)
       }
 
-      var time = now()
+      var time = this.timeKeeper.now()
       this[JS_TIME] = (~~this[JS_TIME]) + time - this[FN_START]
       this[FN_END] = time
     }
 
     function timestamp (ee, type) {
       ee.on(type, function () {
-        this[type] = now()
+        this[type] = this.timeKeeper.now()
       })
     }
 

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -30,6 +30,7 @@ export class Instrument extends InstrumentBase {
     let depth = 0
     let startHash
 
+    const timeKeeper = this.timeKeeper
     const tracerEE = this.ee.get('tracer')
     const jsonpEE = wrapJsonP(this.ee)
     const promiseEE = wrapPromise(this.ee)
@@ -81,7 +82,7 @@ export class Instrument extends InstrumentBase {
     function startTimestamp () {
       depth++
       startHash = window.location.hash
-      this[FN_START] = this.timeKeeper.now()
+      this[FN_START] = timeKeeper.now()
     }
 
     function endTimestamp () {
@@ -90,14 +91,14 @@ export class Instrument extends InstrumentBase {
         trackURLChange(0, true)
       }
 
-      var time = this.timeKeeper.now()
+      var time = timeKeeper.now()
       this[JS_TIME] = (~~this[JS_TIME]) + time - this[FN_START]
       this[FN_END] = time
     }
 
     function timestamp (ee, type) {
       ee.on(type, function () {
-        this[type] = this.timeKeeper.now()
+        this[type] = timeKeeper.now()
       })
     }
 

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -10,6 +10,7 @@ import { InstrumentBase } from '../../utils/instrument-base'
 import { getRuntime } from '../../../common/config/config'
 import * as CONSTANTS from '../constants'
 import { isBrowserScope } from '../../../common/constants/runtime'
+import { TimeKeeper } from '../../../common/timing/time-keeper'
 
 const {
   FEATURE_NAME, START, END, BODY, CB_END, JS_TIME, FETCH, FN_START, CB_START, FN_END
@@ -30,7 +31,6 @@ export class Instrument extends InstrumentBase {
     let depth = 0
     let startHash
 
-    const timeKeeper = this.timeKeeper
     const tracerEE = this.ee.get('tracer')
     const jsonpEE = wrapJsonP(this.ee)
     const promiseEE = wrapPromise(this.ee)
@@ -82,7 +82,7 @@ export class Instrument extends InstrumentBase {
     function startTimestamp () {
       depth++
       startHash = window.location.hash
-      this[FN_START] = timeKeeper.now()
+      this[FN_START] = TimeKeeper.now()
     }
 
     function endTimestamp () {
@@ -91,14 +91,14 @@ export class Instrument extends InstrumentBase {
         trackURLChange(0, true)
       }
 
-      var time = timeKeeper.now()
+      var time = TimeKeeper.now()
       this[JS_TIME] = (~~this[JS_TIME]) + time - this[FN_START]
       this[FN_END] = time
     }
 
     function timestamp (ee, type) {
       ee.on(type, function () {
-        this[type] = timeKeeper.now()
+        this[type] = TimeKeeper.now()
       })
     }
 

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -101,6 +101,7 @@ export class InstrumentBase extends FeatureBase {
           loadedSuccessfully(false) // aggregate module isn't loaded at all
           return
         }
+        console.log('Starting feature aggregate import', this.featureName)
         const { lazyFeatureLoader } = await import(/* webpackChunkName: "lazy-feature-loader" */ './lazy-feature-loader')
         const { Aggregate } = await lazyFeatureLoader(this.featureName, 'aggregate')
         this.featAggregate = new Aggregate(this.agentIdentifier, this.aggregator, argsObjFromInstrument)

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -101,7 +101,6 @@ export class InstrumentBase extends FeatureBase {
           loadedSuccessfully(false) // aggregate module isn't loaded at all
           return
         }
-        console.log('Starting feature aggregate import', this.featureName)
         const { lazyFeatureLoader } = await import(/* webpackChunkName: "lazy-feature-loader" */ './lazy-feature-loader')
         const { Aggregate } = await lazyFeatureLoader(this.featureName, 'aggregate')
         this.featAggregate = new Aggregate(this.agentIdentifier, this.aggregator, argsObjFromInstrument)

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -4,6 +4,7 @@ import { warn } from '../common/util/console'
 import { SR_EVENT_EMITTER_TYPES } from '../features/session_replay/constants'
 import { generateRandomHexString } from '../common/ids/unique-id'
 import { TimeKeeper } from '../common/timing/time-keeper'
+import { globalScope } from '../common/constants/runtime'
 
 /**
  * @typedef {import('./api/interaction-types').InteractionInstance} InteractionInstance
@@ -11,7 +12,7 @@ import { TimeKeeper } from '../common/timing/time-keeper'
 
 export class AgentBase {
   agentIdentifier
-  timeKeeper = new TimeKeeper(this)
+  timeKeeper = new TimeKeeper(Math.floor(globalScope?.performance?.timeOrigin || globalScope?.performance?.timing?.navigationStart || Date.now()))
 
   constructor (agentIdentifier = generateRandomHexString(16)) {
     this.agentIdentifier = agentIdentifier

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -27,7 +27,7 @@ export class Agent extends AgentBase {
     if (!globalScope) {
       // We could not determine the runtime environment. Short-circuite the agent here
       // to avoid possible exceptions later that may cause issues with customer's application.
-      warn('Failed to initial the agent. Could not determine the runtime environment.')
+      warn('Failed to initialize the agent. Could not determine the runtime environment.')
       return
     }
 

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -5,7 +5,6 @@ import { configure } from './configure/configure'
 // core files
 import { Aggregator } from '../common/aggregate/aggregator'
 import { setNREUMInitializedAgent } from '../common/window/nreum'
-import { generateRandomHexString } from '../common/ids/unique-id'
 import { getConfiguration, getConfigurationValue, getInfo, getLoaderConfig, getRuntime } from '../common/config/config'
 import { FEATURE_NAMES } from './features/features'
 import { warn } from '../common/util/console'
@@ -28,13 +27,12 @@ export class MicroAgent extends AgentBase {
    * @param {Object} options - Specifies features and runtime configuration,
    * @param {string=} agentIdentifier - The optional unique ID of the agent.
    */
-  constructor (options, agentIdentifier = generateRandomHexString(16)) {
-    super()
+  constructor (options, agentIdentifier) {
+    super(agentIdentifier)
 
-    this.agentIdentifier = agentIdentifier
     this.sharedAggregator = new Aggregator({ agentIdentifier: this.agentIdentifier })
     this.features = {}
-    setNREUMInitializedAgent(agentIdentifier, this)
+    setNREUMInitializedAgent(this.agentIdentifier, this)
 
     configure(this, { ...options, runtime: { isolatedBacklog: true } }, options.loaderType || 'micro-agent')
     Object.assign(this, this.api) // the APIs should be available at the class level for micro-agent
@@ -45,7 +43,7 @@ export class MicroAgent extends AgentBase {
      * @param {string|string[]|undefined} name The feature name(s) to start.  If no name(s) are passed, all features will be started
      */
     this.start = features => this.run(features)
-    this.run(nonAutoFeatures.filter(featureName => getConfigurationValue(agentIdentifier, `${featureName}.autoStart`)))
+    this.run(nonAutoFeatures.filter(featureName => getConfigurationValue(this.agentIdentifier, `${featureName}.autoStart`)))
   }
 
   get config () {

--- a/tests/assets/nr-server-time/error-before-load.html
+++ b/tests/assets/nr-server-time/error-before-load.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  {init}
+  {config}
+  {loader}
+
+  <script>
+    throw new Error("My error")
+  </script>
+  <title>RUM Unit Test</title>
+</head>
+<body>
+This page throws a new error with a caught exception before the page loads
+</body>
+</html>

--- a/tests/assets/nr-server-time/error-before-load.html
+++ b/tests/assets/nr-server-time/error-before-load.html
@@ -9,12 +9,12 @@
   {config}
   {loader}
 
-  <script>
+  <script type="text/javascript">
     throw new Error("My error")
   </script>
   <title>RUM Unit Test</title>
 </head>
 <body>
-This page throws a new error with a caught exception before the page loads
+  This page throws an uncaught exception before page load.
 </body>
 </html>

--- a/tests/assets/nr-server-time/page-action-before-load.html
+++ b/tests/assets/nr-server-time/page-action-before-load.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  {init}
+  {config}
+  {loader}
+
+  <script>
+    newrelic.addPageAction('foobar')
+  </script>
+  <title>RUM Unit Test</title>
+</head>
+<body>
+This page throws a new error with a caught exception before the page loads
+</body>
+</html>

--- a/tests/assets/nr-server-time/xhr-before-load.html
+++ b/tests/assets/nr-server-time/xhr-before-load.html
@@ -10,11 +10,17 @@
   {loader}
 
   <script type="text/javascript">
-    newrelic.addPageAction('foobar')
+    var xhr = new XMLHttpRequest()
+    xhr.open('GET', '/json')
+    xhr.send()
+
+    if (typeof fetch !== 'undefined') {
+      fetch('/json')
+    }
   </script>
   <title>RUM Unit Test</title>
 </head>
 <body>
-  This page adds a page action before page load.
+  This page makes an xhr call before page load.
 </body>
 </html>

--- a/tests/browser/spa/fetch-body-propagation.browser.js
+++ b/tests/browser/spa/fetch-body-propagation.browser.js
@@ -46,7 +46,7 @@ bodyMethods.forEach((bodyMethod) => {
     function onInteractionStart (cb) {
       window.fetch('/json')
         .then(function (res) {
-          const { now } = require('../../../src/common/timing/now')
+          const now = require('../../../src/common/timing/time-keeper').TimeKeeper.now
           resTime = now()
           return res[bodyMethod]()
         }).then(function () {
@@ -141,7 +141,7 @@ jil.browserTest('Response.formData', function (t) {
 
   function onInteractionStart (cb) {
     window.fetch('/formdata', { method: 'POST', body: new FormData() }).then(function (res) {
-      const { now } = require('../../../src/common/timing/now')
+      const now = require('../../../src/common/timing/time-keeper').TimeKeeper.now
       resTime = now()
       if (res.formData) {
         res.formData().catch(function () {

--- a/tests/specs/err/attributes.e2e.js
+++ b/tests/specs/err/attributes.e2e.js
@@ -15,7 +15,6 @@ describe('error attributes with spa loader', () => {
         })
       ])
 
-      console.log(JSON.stringify(errorResult.request.body))
       expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
       expect(errorResult.request.body.err[0].custom.customParamKey).toBe(0)
       expect(errorResult.request.body.err[1].custom.customParamKey).toBe(1)

--- a/tests/specs/err/attributes.e2e.js
+++ b/tests/specs/err/attributes.e2e.js
@@ -15,6 +15,7 @@ describe('error attributes with spa loader', () => {
         })
       ])
 
+      console.log(JSON.stringify(errorResult.request.body))
       expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
       expect(errorResult.request.body.err[0].custom.customParamKey).toBe(0)
       expect(errorResult.request.body.err[1].custom.customParamKey).toBe(1)

--- a/tests/specs/harvesting/final-harvesting.e2e.js
+++ b/tests/specs/harvesting/final-harvesting.e2e.js
@@ -154,7 +154,8 @@ describe.withBrowsersMatching(notIE)('final harvesting', () => {
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
       statusCode: 400,
-      body: ''
+      body: '',
+      permanent: true
     })
 
     let rumPromise = browser.testHandle.expectRum()
@@ -163,10 +164,10 @@ describe.withBrowsersMatching(notIE)('final harvesting', () => {
 
     // PVE feature should've fully imported and ran, with the RUM response coming back as the 400 we set. This should subsequently cause agent to not send anything else even at EoL.
     await expect(rumPromise).resolves.toEqual(expect.objectContaining({
-      reply: {
+      reply: expect.objectContaining({
         statusCode: 400,
         body: ''
-      }
+      })
     }))
 
     let anyFollowingReq = browser.testHandle.expect('bamServer', {

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -1,0 +1,71 @@
+import { testRumRequest } from '../../tools/testing-server/utils/expect-tests'
+
+describe('NR Server Time', () => {
+  let serverTime
+
+  beforeEach(async () => {
+    serverTime = Date.now() - (60 * 60 * 1000) // Subtract an hour to make testing easier
+
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      permanent: true,
+      setHeaders: [
+        { key: 'Date', value: (new Date(serverTime)).toUTCString() }
+      ]
+    })
+  })
+
+  it('should send jserror with timestamp prior to rum date header', async () => {
+    const [errors] = await Promise.all([
+      browser.testHandle.expectErrors(),
+      browser.url(await browser.testHandle.assetURL('nr-server-time/error-before-load.html'))
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    const error = errors.request.body.err[0]
+    expect(error.params.firstOccurrenceTimestamp).toEqual(error.params.timestamp)
+    expect(error.params.timestamp).toBeWithin(serverTime - 5000, serverTime)
+  })
+
+  it('should send jserror with timestamp after rum date header', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    const [errors] = await Promise.all([
+      browser.testHandle.expectErrors(),
+      browser.execute(function () {
+        newrelic.noticeError(new Error('test error'))
+      })
+    ])
+
+    const error = errors.request.body.err[0]
+    expect(error.params.firstOccurrenceTimestamp).toEqual(error.params.timestamp)
+    expect(error.params.timestamp).toBeWithin(serverTime, serverTime + 5000)
+  })
+
+  it('should send page action with timestamp before rum date header', async () => {
+    const [pageActions] = await Promise.all([
+      browser.testHandle.expectIns(),
+      browser.url(await browser.testHandle.assetURL('nr-server-time/page-action-before-load.html'))
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    const pageAction = pageActions.request.body.ins[0]
+    expect(pageAction.timestamp).toBeWithin(serverTime - 5000, serverTime)
+  })
+
+  it('should send page action with timestamp after rum date header', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    const [pageActions] = await Promise.all([
+      browser.testHandle.expectIns(),
+      browser.execute(function () {
+        newrelic.addPageAction('bizbaz')
+      })
+    ])
+
+    const pageAction = pageActions.request.body.ins[0]
+    expect(pageAction.timestamp).toBeWithin(serverTime, serverTime + 5000)
+  })
+})

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -1,4 +1,6 @@
 import { testRumRequest } from '../../tools/testing-server/utils/expect-tests'
+import { faker } from '@faker-js/faker'
+import { supportsFetch } from '../../tools/browser-matcher/common-matchers.mjs'
 
 describe('NR Server Time', () => {
   let serverTime
@@ -67,5 +69,81 @@ describe('NR Server Time', () => {
 
     const pageAction = pageActions.request.body.ins[0]
     expect(pageAction.timestamp).toBeWithin(serverTime, serverTime + 5000)
+  })
+
+  it('should send xhr with distributed tracing timestamp before rum date header', async () => {
+    const url = await browser.testHandle.assetURL('nr-server-time/xhr-before-load.html', {
+      config: {
+        accountID: faker.string.hexadecimal({ length: 16, prefix: '' }),
+        agentID: faker.string.hexadecimal({ length: 16, prefix: '' }),
+        trustKey: faker.string.hexadecimal({ length: 16, prefix: '' })
+      },
+      injectUpdatedLoaderConfig: true,
+      init: {
+        distributed_tracing: {
+          enabled: true,
+          cors_use_newrelic_header: true,
+          cors_use_tracecontext_headers: true,
+          allowed_origins: ['http://' + browser.testHandle.assetServerConfig.host + ':' + browser.testHandle.assetServerConfig.port]
+        }
+      }
+    })
+
+    const [interactionEvents] = await Promise.all([
+      browser.testHandle.expectInteractionEvents(),
+      browser.url(url)
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    const ajaxEvent = interactionEvents.request.body[0].children.find(r => r.path === '/json' && r.requestedWith === 'XMLHttpRequest')
+    expect(ajaxEvent.timestamp).toBeWithin(serverTime - 5000, serverTime)
+
+    if (!browserMatch(supportsFetch)) {
+      const fetchEvent = interactionEvents.request.body[0].children.find(r => r.path === '/json' && r.requestedWith === 'fetch')
+      expect(fetchEvent.timestamp).toBeWithin(serverTime - 5000, serverTime)
+    }
+  })
+
+  it('should send xhr with distributed tracing timestamp after rum date header', async () => {
+    const url = await browser.testHandle.assetURL('instrumented.html', {
+      config: {
+        accountID: faker.string.hexadecimal({ length: 16, prefix: '' }),
+        agentID: faker.string.hexadecimal({ length: 16, prefix: '' }),
+        trustKey: faker.string.hexadecimal({ length: 16, prefix: '' })
+      },
+      injectUpdatedLoaderConfig: true,
+      init: {
+        distributed_tracing: {
+          enabled: true,
+          cors_use_newrelic_header: true,
+          cors_use_tracecontext_headers: true,
+          allowed_origins: ['http://' + browser.testHandle.assetServerConfig.host + ':' + browser.testHandle.assetServerConfig.port]
+        }
+      }
+    })
+
+    await browser.url(url)
+      .then(() => browser.waitForAgentLoad())
+
+    const [ajaxEvents] = await Promise.all([
+      browser.testHandle.expectAjaxEvents(),
+      browser.execute(function () {
+        var xhr = new XMLHttpRequest()
+        xhr.open('GET', '/json')
+        xhr.send()
+
+        if (typeof fetch !== 'undefined') {
+          fetch('/json')
+        }
+      })
+    ])
+
+    const ajaxEvent = ajaxEvents.request.body.find(r => r.path === '/json' && r.requestedWith === 'XMLHttpRequest')
+    expect(ajaxEvent.timestamp).toBeWithin(serverTime, serverTime + 5000)
+
+    if (!browserMatch(supportsFetch)) {
+      const fetchEvent = ajaxEvents.request.body.find(r => r.path === '/json' && r.requestedWith === 'fetch')
+      expect(fetchEvent.timestamp).toBeWithin(serverTime, serverTime + 5000)
+    }
   })
 })

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -98,7 +98,7 @@ describe('NR Server Time', () => {
     const ajaxEvent = interactionEvents.request.body[0].children.find(r => r.path === '/json' && r.requestedWith === 'XMLHttpRequest')
     expect(ajaxEvent.timestamp).toBeWithin(serverTime - 5000, serverTime)
 
-    if (!browserMatch(supportsFetch)) {
+    if (browserMatch(supportsFetch)) {
       const fetchEvent = interactionEvents.request.body[0].children.find(r => r.path === '/json' && r.requestedWith === 'fetch')
       expect(fetchEvent.timestamp).toBeWithin(serverTime - 5000, serverTime)
     }
@@ -141,7 +141,7 @@ describe('NR Server Time', () => {
     const ajaxEvent = ajaxEvents.request.body.find(r => r.path === '/json' && r.requestedWith === 'XMLHttpRequest')
     expect(ajaxEvent.timestamp).toBeWithin(serverTime, serverTime + 5000)
 
-    if (!browserMatch(supportsFetch)) {
+    if (browserMatch(supportsFetch)) {
       const fetchEvent = ajaxEvents.request.body.find(r => r.path === '/json' && r.requestedWith === 'fetch')
       expect(fetchEvent.timestamp).toBeWithin(serverTime, serverTime + 5000)
     }

--- a/tests/specs/session-replay/rrweb-configuration.e2e.js
+++ b/tests/specs/session-replay/rrweb-configuration.e2e.js
@@ -13,7 +13,7 @@ describe.withBrowsersMatching(notIE)('RRWeb Configuration', () => {
   describe('enabled', () => {
     it('enabled: true should import feature', async () => {
       await browser.url(await browser.testHandle.assetURL('instrumented.html', config()))
-        .then(() => browser.waitForFeatureAggregate('session_replay'))
+        .then(() => browser.waitForAgentLoad())
 
       const wasInitialized = await browser.execute(function () {
         return Object.values(newrelic.initializedAgents)[0].features.session_replay.featAggregate.initialized

--- a/tools/testing-server/plugins/test-handle/index.js
+++ b/tools/testing-server/plugins/test-handle/index.js
@@ -60,6 +60,7 @@ module.exports = fp(async function (fastify, testServer) {
         },
         reply: {
           statusCode: reply.statusCode,
+          headers: reply.getHeaders(),
           body: request.url.startsWith('/tests/assets')
             ? 'HTML asset content'
             : payload

--- a/tools/testing-server/routes/mock-apis.js
+++ b/tools/testing-server/routes/mock-apis.js
@@ -177,7 +177,6 @@ module.exports = fp(async function (fastify, testServer) {
       assert.strictEqual(request.body.x.value, '5')
       reply.send('good')
     } catch (e) {
-      console.log(e)
       reply.send('bad')
     }
   })

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -17,7 +17,7 @@ export default class CustomCommands {
     browser.addCommand('waitForAgentLoad', async function () {
       await browser.waitUntil(
         () => browser.execute(function () {
-          return window.NREUM && window.NREUM.activatedFeatures && !!Object.values(window.NREUM.activatedFeatures)[0].loaded
+          return window.NREUM && window.NREUM.activatedFeatures && Object.values(window.NREUM.activatedFeatures)[0] && !!Object.values(window.NREUM.activatedFeatures)[0].loaded
         }),
         {
           timeout: 30000,


### PR DESCRIPTION
Update the agent to use New Relic server time as the timestamp for harvested page action and error data.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

This updates all the harvested data to use the calculated NR server time as the the basis for timestamping harvested data. See the [CDD](https://newrelic.atlassian.net/wiki/spaces/INST/pages/3180429574/Normalize+Browser+Agent+Timestamps) for spec changes.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-222430
https://new-relic.atlassian.net/browse/NR-222419
https://new-relic.atlassian.net/browse/NR-222426

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
