### PR TITLE
chore: add jserrors timeline test

### DIFF
--- a/tests/assets/rrweb-instrumented.html
+++ b/tests/assets/rrweb-instrumented.html
@@ -53,6 +53,10 @@
         document.querySelector("img").classList.toggle("left");
         document.querySelector("img").classList.toggle("right");
       }
+
+      setTimeout(() => {
+        newrelic.noticeError()
+      }, 15000)
     </script>
   </body>
 </html>

--- a/tests/specs/session-replay/adjacent-payloads.e2e.js
+++ b/tests/specs/session-replay/adjacent-payloads.e2e.js
@@ -1,0 +1,29 @@
+import { config, decodeAttributes } from './helpers'
+
+describe('errors', () => {
+  beforeEach(async () => {
+    await browser.enableSessionReplay()
+  })
+
+  afterEach(async () => {
+    await browser.destroyAgentSession()
+  })
+
+  it('error timestamp should be contained within replay timestamp', async () => {
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({
+      session_replay: { error_sampling_rate: 100, sampling_rate: 0 }
+    })))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.testHandle.expectBlob(10000, true)
+
+    const [errorPayload, blobPayload] = await Promise.all([
+      await browser.testHandle.expectErrors(15000),
+      await browser.testHandle.expectBlob(15000)
+    ])
+
+    const errorTimestamp = errorPayload.request.body.err[0].params.firstOccurrenceTimestamp
+    const SRTimestamp = decodeAttributes(blobPayload.request.query.attributes)['replay.firstTimestamp']
+    expect(errorTimestamp).toBeGreaterThan(SRTimestamp)
+  })
+})


### PR DESCRIPTION
Add a test to check that a captured error in SR "Error" mode occurs with the correct timing.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
