### PR TITLE
feat: maintain a harvestCount for use later with harvestId

### DIFF
--- a/src/common/config/state/runtime.js
+++ b/src/common/config/state/runtime.js
@@ -21,7 +21,8 @@ const model = {
   session: undefined,
   xhrWrappable: typeof globalScope.XMLHttpRequest?.prototype?.addEventListener === 'function',
   version: VERSION,
-  denyList: undefined
+  denyList: undefined,
+  harvestCount: 0
 }
 
 const _cache = {}

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -160,6 +160,9 @@ export class Harvest extends SharedContext {
       }, eventListenerOpts(false))
     }
 
+    const runtime = getRuntime(this.sharedContext.agentIdentifier)
+    runtime.harvestCount++
+
     return result
   }
 

--- a/src/common/harvest/harvest.test.js
+++ b/src/common/harvest/harvest.test.js
@@ -156,7 +156,8 @@ describe('_send', () => {
       licenseKey
     })
     jest.mocked(configModule.getRuntime).mockReturnValue({
-      maxBytes: Infinity
+      maxBytes: Infinity,
+      harvestCount: 0
     })
     jest.mocked(configModule.getConfiguration).mockReturnValue({
       ssl: undefined,
@@ -177,6 +178,14 @@ describe('_send', () => {
     }
     submitMethod = jest.fn().mockReturnValue(true)
     jest.mocked(submitDataModule.getSubmitMethod).mockReturnValue(submitMethod)
+  })
+
+  test('should increment harvestCount every time _send is called', () => {
+    while (configModule.getRuntime().harvestCount < 10) {
+      const prev = configModule.getRuntime().harvestCount
+      harvestInstance._send(spec)
+      expect(configModule.getRuntime().harvestCount).toEqual(prev + 1)
+    }
   })
 
   test('should return false when info.errorBeacon is not defined', () => {


### PR DESCRIPTION
Add a counter which increments after every harvest. This will be used in a future effort to curate a unique harvest ID for API paging purposes.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR adds a harvestCount int to the runtime object, which increments every time `_send` is completed.  `_send` is used under the hood by all harvest methods to send data.  The plan for the future will be to concat this harvestCount with the `ptid` and `session` values to create a unique harvest identifier on blob-consumer payloads.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-238623
https://new-relic.atlassian.net/browse/NR-238628
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new, simple jest test has been added to confirm this behavior.  WDIO test should be added later when implemented in outgoing harvests
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
