### PR TITLE
feat: Standardize all feature behavior to wait for RUM response

### DIFF
--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -34,7 +34,7 @@ export function registerDrain (agentIdentifier, group) {
 export function deregisterDrain (agentIdentifier, group) {
   curateRegistry(agentIdentifier)
   if (registry[agentIdentifier].get(group)) registry[agentIdentifier].delete(group)
-  checkCanDrainAll(agentIdentifier)
+  if (registry[agentIdentifier].size) checkCanDrainAll(agentIdentifier)
 }
 
 /**

--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -21,7 +21,7 @@ const registry = {}
 export function registerDrain (agentIdentifier, group) {
   // Here `item` captures the registered properties of a feature-group: whether it is ready for its buffered events
   // to be drained (`staged`) and the `priority` order in which it should be drained relative to other feature groups.
-  const item = { staged: false, priority: featurePriority[group] || 0, drained: false }
+  const item = { staged: false, priority: featurePriority[group] || 0 }
   curateRegistry(agentIdentifier)
   if (!registry[agentIdentifier].get(group)) registry[agentIdentifier].set(group, item)
 }
@@ -77,7 +77,6 @@ function checkCanDrainAll (agentIdentifier) {
     items.forEach(([group]) => {
       registry[agentIdentifier].delete(group)
       drainGroup(agentIdentifier, group)
-      if (registry[agentIdentifier].get(group)) registry[agentIdentifier].get(group).drained = true
     })
   }
 }

--- a/src/common/drain/drain.test.js
+++ b/src/common/drain/drain.test.js
@@ -61,10 +61,13 @@ describe('drain', () => {
     expect(emitSpy).toHaveBeenCalledWith('drain-feature', expect.anything())
   })
 
-  test('works on the global ee when agent id not provided', () => {
-    let emitSpy = jest.spyOn(ee, 'emit')
-    drain()
-    expect(emitSpy).toHaveBeenCalledWith('drain-feature', expect.anything())
+  test('fails when agent id not provided', () => {
+    try {
+      drain()
+      expect(1).toEqual(2) // should fail here
+    } catch (err) {
+      expect(1).toEqual(1) // pass
+    }
   })
 })
 
@@ -72,7 +75,6 @@ test('non-feat groups can register and drain too alongside features', () => {
   registerDrain('abcd', 'page_view_event')
   registerDrain('abcd', 'simba')
 
-  console.log(JSON.stringify(ee.get('abcd')))
   let emitSpy = jest.spyOn(ee.get('abcd'), 'emit')
   drain('abcd', 'simba')
   expect(emitSpy).not.toHaveBeenCalled()

--- a/src/common/drain/drain.test.js
+++ b/src/common/drain/drain.test.js
@@ -62,12 +62,7 @@ describe('drain', () => {
   })
 
   test('fails when agent id not provided', () => {
-    try {
-      drain()
-      expect(1).toEqual(2) // should fail here
-    } catch (err) {
-      expect(1).toEqual(1) // pass
-    }
+    expect(() => drain()).toThrow()
   })
 })
 

--- a/src/common/event-emitter/contextual-ee.component-test.js
+++ b/src/common/event-emitter/contextual-ee.component-test.js
@@ -160,7 +160,7 @@ describe('event-emitter buffer', () => {
     const { ee } = await import('./contextual-ee')
     const { drain } = await import('../drain/drain')
     const mockListener = jest.fn()
-    const eventType = faker.datatype.uuid()
+    const eventType = faker.string.uuid()
     const eventArgs = ['a', 'b', 'c']
 
     ee.on(eventType, mockListener)

--- a/src/common/util/feature-flags.js
+++ b/src/common/util/feature-flags.js
@@ -7,6 +7,9 @@ import { dispatchGlobalEvent } from '../dispatch/global-event'
 
 const sentIds = new Set()
 
+/** A map of feature flags and their values as provided by the rum call -- scoped by agent ID */
+export const activatedFeatures = {}
+
 /**
  * Sets the activatedFeatures object, dispatches the global loaded event,
  * and emits the rumresp flag to features
@@ -20,13 +23,13 @@ export function activateFeatures (flags, agentIdentifier) {
   if (!(flags && typeof flags === 'object')) return
   if (sentIds.has(agentIdentifier)) return
 
-  sharedEE.emit('rumresp', [flags])
-  activatedFeatures[agentIdentifier] = flags
+  const frozenFlags = Object.freeze(flags)
+  sharedEE.emit('rumresp', [frozenFlags])
+  activatedFeatures[agentIdentifier] = frozenFlags
+  Object.freeze(activateFeatures[agentIdentifier])
 
   sentIds.add(agentIdentifier)
 
   // let any window level subscribers know that the agent is running
   dispatchGlobalEvent({ loaded: true })
 }
-
-export const activatedFeatures = {}

--- a/src/common/util/feature-flags.js
+++ b/src/common/util/feature-flags.js
@@ -23,10 +23,8 @@ export function activateFeatures (flags, agentIdentifier) {
   if (!(flags && typeof flags === 'object')) return
   if (sentIds.has(agentIdentifier)) return
 
-  const frozenFlags = Object.freeze(flags)
-  sharedEE.emit('rumresp', [frozenFlags])
-  activatedFeatures[agentIdentifier] = frozenFlags
-  Object.freeze(activateFeatures[agentIdentifier])
+  sharedEE.emit('rumresp', [flags])
+  activatedFeatures[agentIdentifier] = flags
 
   sentIds.add(agentIdentifier)
 

--- a/src/common/util/feature-flags.js
+++ b/src/common/util/feature-flags.js
@@ -5,45 +5,28 @@
 import { ee } from '../event-emitter/contextual-ee'
 import { dispatchGlobalEvent } from '../dispatch/global-event'
 
-const expectedFlags = ['stn', 'err', 'ins', 'spa', 'sr']
-const noFlagFeatures = ['xhr', 'pvt']
-
 const sentIds = new Set()
 
-/** Note that this function only processes each unique flag ONCE, with the first occurrence of each flag and numeric value determining its switch on/off setting. */
+/**
+ * Sets the activatedFeatures object, dispatches the global loaded event,
+ * and emits the rumresp flag to features
+ * @param {{[key:string]:number}} flags key-val pair of flag names and numeric
+ * @param {string} agentIdentifier agent instance identifier
+ * @returns {void}
+ */
 export function activateFeatures (flags, agentIdentifier) {
   const sharedEE = ee.get(agentIdentifier)
   activatedFeatures[agentIdentifier] ??= {}
   if (!(flags && typeof flags === 'object')) return
   if (sentIds.has(agentIdentifier)) return
 
-  /** Flags returned from RUM call */
-  Object.entries(flags).forEach(([flag, num]) => {
-    emitFlag(flag, num)
-  })
-
-  /** We gate all features behind a flag for consistency, but some features dont require entitlements before running
-   * So we make our own flags and return them as truthy for now
-  */
-  noFlagFeatures.forEach(flag => {
-    emitFlag(flag, 1)
-  })
-
-  /** Any features that happen to fail to get a flag back from the RUM call would be blocking the rest of the features from operating, so return 0 by default */
-  expectedFlags.forEach(flag => {
-    emitFlag(flag, 0)
-  })
+  sharedEE.emit('rumresp', [flags])
+  activatedFeatures[agentIdentifier] = flags
 
   sentIds.add(agentIdentifier)
 
   // let any window level subscribers know that the agent is running
   dispatchGlobalEvent({ loaded: true })
-
-  function emitFlag (flagName, value) {
-    if (activatedFeatures[agentIdentifier][flagName] !== undefined) return
-    sharedEE.emit(`rumresp-${flagName}`, [value])
-    activatedFeatures[agentIdentifier][flagName] = value
-  }
 }
 
 export const activatedFeatures = {}

--- a/src/common/util/feature-flags.test.js
+++ b/src/common/util/feature-flags.test.js
@@ -33,33 +33,39 @@ test.each([
   expect(activatedFeatures[agentIdentifier]).toEqual({})
 })
 
-const allFlags = ['stn', 'err', 'ins', 'spa', 'sr', 'xhr', 'pvt']
-
 test('emits the right events when feature flag = 1', () => {
-  const flags = {}
-  allFlags.forEach(flag => { flags[flag] = 1 })
+  const flags = {
+    stn: 1,
+    err: 1,
+    ins: 1,
+    spa: 1,
+    sr: 1
+  }
   activateFeatures(flags, agentIdentifier)
 
   const sharedEE = eventEmitterModule.ee.get(agentIdentifier).emit
 
-  expect(sharedEE).toHaveBeenCalledTimes(allFlags.length)
-  expect(sharedEE).toHaveBeenLastCalledWith('rumresp-' + allFlags[allFlags.length - 1], [1])
+  expect(sharedEE).toHaveBeenCalledTimes(1)
+  expect(sharedEE).toHaveBeenLastCalledWith('rumresp', [flags])
 
-  Object.keys(flags).forEach(flag => { flags[flag] = 1 })
   expect(activatedFeatures[agentIdentifier]).toEqual(flags)
 })
 
 test('emits the right events when feature flag = 0', () => {
-  const flags = {}
-  allFlags.forEach(flag => { flags[flag] = 0 })
+  const flags = {
+    stn: 1,
+    err: 1,
+    ins: 1,
+    spa: 1,
+    sr: 1
+  }
   activateFeatures(flags, agentIdentifier)
 
   const sharedEE = eventEmitterModule.ee.get(agentIdentifier).emit
 
-  expect(sharedEE).toHaveBeenCalledTimes(allFlags.length)
-  expect(sharedEE).toHaveBeenLastCalledWith('rumresp-' + allFlags[allFlags.length - 1], [0])
+  expect(sharedEE).toHaveBeenCalledTimes(1)
+  expect(sharedEE).toHaveBeenLastCalledWith('rumresp', [flags])
 
-  Object.keys(flags).forEach(flag => { flags[flag] = 0 })
   expect(activatedFeatures[agentIdentifier]).toEqual(flags)
 })
 
@@ -68,7 +74,7 @@ test('only the first activate of the same feature is respected', () => {
 
   const sharedEE = eventEmitterModule.ee.get(agentIdentifier).emit
 
-  expect(sharedEE).toHaveBeenNthCalledWith(1, 'rumresp-stn', [1])
+  expect(sharedEE).toHaveBeenNthCalledWith(1, 'rumresp', [{ stn: 1 }])
 
   sharedEE.mockClear()
   activateFeatures({ stn: 0 }, agentIdentifier)

--- a/src/common/util/feature-flags.test.js
+++ b/src/common/util/feature-flags.test.js
@@ -3,7 +3,6 @@ import * as eventEmitterModule from '../event-emitter/contextual-ee'
 import * as handleModule from '../event-emitter/handle'
 import * as drainModule from '../drain/drain'
 import { activateFeatures, activatedFeatures } from './feature-flags'
-import { FEATURE_NAMES } from '../../loaders/features/features'
 
 jest.enableAutomock()
 jest.unmock('./feature-flags')
@@ -12,15 +11,15 @@ let agentIdentifier
 
 beforeEach(() => {
   agentIdentifier = faker.string.uuid()
-
+  const emitterFn = jest.fn()
   eventEmitterModule.ee.get = jest.fn(() => ({
-    [faker.string.uuid()]: faker.string.uuid()
+    emit: emitterFn
   }))
 })
 
 afterEach(() => {
   Object.keys(activatedFeatures)
-    .forEach(key => delete activatedFeatures[key])
+    .forEach(key => delete activatedFeatures[agentIdentifier][key])
 })
 
 test.each([
@@ -31,58 +30,47 @@ test.each([
 
   expect(handleModule.handle).not.toHaveBeenCalled()
   expect(drainModule.drain).not.toHaveBeenCalled()
-  expect(activatedFeatures).toEqual({})
+  expect(activatedFeatures[agentIdentifier]).toEqual({})
 })
 
-const bucketMap = {
-  stn: [FEATURE_NAMES.sessionTrace],
-  err: [FEATURE_NAMES.jserrors, FEATURE_NAMES.metrics],
-  ins: [FEATURE_NAMES.pageAction],
-  spa: [FEATURE_NAMES.spa],
-  sr: [FEATURE_NAMES.sessionReplay, FEATURE_NAMES.sessionTrace]
-}
+const allFlags = ['stn', 'err', 'ins', 'spa', 'sr', 'xhr', 'pvt']
 
 test('emits the right events when feature flag = 1', () => {
   const flags = {}
-  Object.keys(bucketMap).forEach(flag => { flags[flag] = 1 })
+  allFlags.forEach(flag => { flags[flag] = 1 })
   activateFeatures(flags, agentIdentifier)
 
-  const sharedEE = jest.mocked(eventEmitterModule.ee.get).mock.results[0].value
+  const sharedEE = eventEmitterModule.ee.get(agentIdentifier).emit
 
-  // each flag gets emitted to each of its mapped features, and a feat- AND a rumresp- for every emit, so (1+2+1+1+2+2)*2 = 16
-  expect(handleModule.handle).toHaveBeenCalledTimes(16)
-  expect(handleModule.handle).toHaveBeenNthCalledWith(1, 'feat-stn', [], undefined, FEATURE_NAMES.sessionTrace, sharedEE)
-  expect(handleModule.handle).toHaveBeenLastCalledWith('rumresp-sr', [true], undefined, FEATURE_NAMES.sessionTrace, sharedEE)
+  expect(sharedEE).toHaveBeenCalledTimes(allFlags.length)
+  expect(sharedEE).toHaveBeenLastCalledWith('rumresp-' + allFlags[allFlags.length - 1], [1])
 
-  Object.keys(flags).forEach(flag => { flags[flag] = true })
-  expect(activatedFeatures).toEqual(flags)
+  Object.keys(flags).forEach(flag => { flags[flag] = 1 })
+  expect(activatedFeatures[agentIdentifier]).toEqual(flags)
 })
 
 test('emits the right events when feature flag = 0', () => {
   const flags = {}
-  Object.keys(bucketMap).forEach(flag => { flags[flag] = 0 })
+  allFlags.forEach(flag => { flags[flag] = 0 })
   activateFeatures(flags, agentIdentifier)
 
-  const sharedEE = jest.mocked(eventEmitterModule.ee.get).mock.results[0].value
+  const sharedEE = eventEmitterModule.ee.get(agentIdentifier).emit
 
-  // each flag gets emitted to each of its mapped features, and a block- AND a rumresp- for every emit, so (1+2+1+1+2+2)*2 = 16
-  expect(handleModule.handle).toHaveBeenCalledTimes(16)
-  expect(handleModule.handle).toHaveBeenNthCalledWith(1, 'block-stn', [], undefined, FEATURE_NAMES.sessionTrace, sharedEE)
-  expect(handleModule.handle).toHaveBeenLastCalledWith('rumresp-sr', [false], undefined, FEATURE_NAMES.sessionTrace, sharedEE)
+  expect(sharedEE).toHaveBeenCalledTimes(allFlags.length)
+  expect(sharedEE).toHaveBeenLastCalledWith('rumresp-' + allFlags[allFlags.length - 1], [0])
 
-  Object.keys(flags).forEach(flag => { flags[flag] = false })
-  expect(activatedFeatures).toEqual(flags)
+  Object.keys(flags).forEach(flag => { flags[flag] = 0 })
+  expect(activatedFeatures[agentIdentifier]).toEqual(flags)
 })
 
 test('only the first activate of the same feature is respected', () => {
   activateFeatures({ stn: 1 }, agentIdentifier)
+
+  const sharedEE = eventEmitterModule.ee.get(agentIdentifier).emit
+
+  expect(sharedEE).toHaveBeenNthCalledWith(1, 'rumresp-stn', [1])
+
+  sharedEE.mockClear()
   activateFeatures({ stn: 0 }, agentIdentifier)
-
-  const sharedEE1 = jest.mocked(eventEmitterModule.ee.get).mock.results[0].value
-  const sharedEE2 = jest.mocked(eventEmitterModule.ee.get).mock.results[1].value
-
-  expect(handleModule.handle).toHaveBeenNthCalledWith(1, 'feat-stn', [], undefined, 'session_trace', sharedEE1)
-  expect(handleModule.handle).toHaveBeenNthCalledWith(2, 'rumresp-stn', [true], undefined, 'session_trace', sharedEE1)
-  expect(handleModule.handle).not.toHaveBeenNthCalledWith(1, 'feat-stn', [], undefined, 'session_trace', sharedEE2)
-  expect(activatedFeatures.stn).toBeTruthy()
+  expect(activatedFeatures[agentIdentifier].stn).toBeTruthy()
 })

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -136,9 +136,7 @@ export class Aggregate extends AggregateBase {
       if (event.gql) handle(SUPPORTABILITY_METRIC_CHANNEL, ['Ajax/Events/GraphQL/Bytes-Added', stringify(event.gql).length], undefined, FEATURE_NAMES.metrics, ee)
 
       const softNavInUse = Boolean(getNREUMInitializedAgent(agentIdentifier)?.features?.[FEATURE_NAMES.softNav])
-      console.log('softNavInUse', softNavInUse)
       if (softNavInUse) { // For newer soft nav (when running), pass the event to it for evaluation -- either part of an interaction or is given back
-        console.log('emit ajax')
         handle('ajax', [event], undefined, FEATURE_NAMES.softNav, ee)
       } else if (this.spaNode) { // For old spa (when running), if the ajax happened inside an interaction, hold it until the interaction finishes
         const interactionId = this.spaNode.interaction.id

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -15,12 +15,11 @@ export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, FEATURE_NAME)
-    let scheduler
 
     this.waitForFlags(['err']).then(([errFlag]) => {
-      // *cli, Mar 23 - Per NR-94597, this feature should only harvest ONCE at the (potential) EoL time of the page.
       if (errFlag) {
-        scheduler = new HarvestScheduler('jserrors', { onUnload: () => this.unload() }, this)
+        // *cli, Mar 23 - Per NR-94597, this feature should only harvest ONCE at the (potential) EoL time of the page.
+        const scheduler = new HarvestScheduler('jserrors', { onUnload: () => this.unload() }, this)
         // this is needed to ensure EoL is "on" and sent
         scheduler.harvest.on('jserrors', () => ({ body: this.aggregator.take(['cm', 'sm']) }))
         this.drain()

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -9,6 +9,7 @@ import { onDOMContentLoaded } from '../../../common/window/load'
 import { windowAddEventListener } from '../../../common/event-listener/event-listener-opts'
 import { isBrowserScope, isWorkerScope } from '../../../common/constants/runtime'
 import { AggregateBase } from '../../utils/aggregate-base'
+import { deregisterDrain } from '../../../common/drain/drain'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -16,11 +17,18 @@ export class Aggregate extends AggregateBase {
     super(agentIdentifier, aggregator, FEATURE_NAME)
     let scheduler
 
-    // If RUM-call's response determines that customer lacks entitlements for the /jserror ingest endpoint, don't harvest at all.
-    registerHandler('block-err', () => {
-      this.blocked = true
-      if (scheduler) scheduler.aborted = true // RUM response may or may not have happened already before scheduler initialization below
-    }, this.featureName, this.ee)
+    this.waitForFlags(['err']).then(([errFlag]) => {
+      // *cli, Mar 23 - Per NR-94597, this feature should only harvest ONCE at the (potential) EoL time of the page.
+      if (errFlag) {
+        scheduler = new HarvestScheduler('jserrors', { onUnload: () => this.unload() }, this)
+        // this is needed to ensure EoL is "on" and sent
+        scheduler.harvest.on('jserrors', () => ({ body: this.aggregator.take(['cm', 'sm']) }))
+        this.drain()
+      } else {
+        this.blocked = true // if rum response determines that customer lacks entitlements for spa endpoint, this feature shouldn't harvest
+        deregisterDrain(this.agentIdentifier, this.featureName)
+      }
+    })
 
     // Allow features external to the metrics feature to capture SMs and CMs through the event emitter
     registerHandler(SUPPORTABILITY_METRIC_CHANNEL, this.storeSupportabilityMetrics.bind(this), this.featureName, this.ee)
@@ -28,14 +36,6 @@ export class Aggregate extends AggregateBase {
 
     this.singleChecks() // checks that are run only one time, at script load
     this.eachSessionChecks() // the start of every time user engages with page
-
-    this.ee.on(`drain-${this.featureName}`, () => {
-      // *cli, Mar 23 - Per NR-94597, this feature should only harvest ONCE at the (potential) EoL time of the page.
-      scheduler = new HarvestScheduler('jserrors', { onUnload: () => this.unload() }, this)
-      scheduler.harvest.on('jserrors', () => ({ body: this.aggregator.take(['cm', 'sm']) }))
-    }) // this is needed to ensure EoL is "on" and sent
-
-    this.drain()
   }
 
   storeSupportabilityMetrics (name, value) {

--- a/src/features/page_action/aggregate/index.js
+++ b/src/features/page_action/aggregate/index.js
@@ -39,7 +39,7 @@ export class Aggregate extends AggregateBase {
         scheduler.startTimer(this.harvestTimeSeconds, 0)
         this.drain()
       } else {
-        this.blocked = true // if rum response determines that customer lacks entitlements for spa endpoint, this feature shouldn't harvest
+        this.blocked = true // if rum response determines that customer lacks entitlements for ins endpoint, this feature shouldn't harvest
         deregisterDrain(this.agentIdentifier, this.featureName)
       }
     })

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -114,7 +114,6 @@ export class Aggregate extends AggregateBase {
         try {
           this.timeKeeper.processRumRequest(xhr, fullUrl)
         } catch (error) {
-          console.log(error)
           handle(SUPPORTABILITY_METRIC_CHANNEL, ['PVE/NRTime/Calculation/Failed'], undefined, FEATURE_NAMES.metrics, this.ee)
           drain(this.agentIdentifier, FEATURE_NAMES.metrics, true)
           this.ee.abort()

--- a/src/features/page_view_timing/aggregate/index.component-test.js
+++ b/src/features/page_view_timing/aggregate/index.component-test.js
@@ -47,6 +47,10 @@ describe('pvt aggregate tests', () => {
       __esModule: true,
       activatedFeatures: { [agentId]: { pvt: 1 } }
     }))
+    // jest.doMock('../../../common/harvest/harvest', () => ({
+    //   __esModule: true,
+    //   send: jest.fn()
+    // }))
 
     setRuntime(agentId, {})
     const { Aggregate } = await import('.')
@@ -58,8 +62,7 @@ describe('pvt aggregate tests', () => {
       downlink: 700
     }
     pvtAgg = new Aggregate(agentId, new Aggregator({ agentIdentifier: agentId, ee }))
-    await pvtAgg.waitForFlags((['pvt']))
-    pvtAgg.scheduler.send = jest.fn(() => ({}))
+    await pvtAgg.waitForFlags(([]))
     pvtAgg.prepareHarvest = jest.fn(() => ({}))
   })
   test('LCP event with CLS attribute', () => {

--- a/src/features/session_replay/aggregate/index.component-test.js
+++ b/src/features/session_replay/aggregate/index.component-test.js
@@ -97,7 +97,7 @@ describe('Session Replay', () => {
 
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.initialized).toBeTruthy()
       expect(sr.recorder.recording).toBeTruthy()
@@ -110,7 +110,7 @@ describe('Session Replay', () => {
     test('When Session Is Paused/Resumed', async () => {
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.initialized).toBeTruthy()
       expect(sr.recorder.recording).toBeTruthy()
@@ -123,7 +123,7 @@ describe('Session Replay', () => {
     test('Session SR mode matches SR mode -- FULL', async () => {
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(session.state.sessionReplayMode).toEqual(sr.mode)
     })
@@ -131,7 +131,7 @@ describe('Session Replay', () => {
     test('Session SR mode matches SR mode -- ERROR', async () => {
       setConfiguration(agentIdentifier, { session_replay: { sampling_rate: 0, error_sampling_rate: 100 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(session.state.sessionReplayMode).toEqual(sr.mode)
     })
@@ -139,7 +139,7 @@ describe('Session Replay', () => {
     test('Session SR mode matches SR mode -- OFF', async () => {
       setConfiguration(agentIdentifier, { session_replay: { sampling_rate: 0, error_sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(session.state.sessionReplayMode).toEqual(sr.mode)
     })
@@ -155,9 +155,9 @@ describe('Session Replay', () => {
       expect(sr.recorder).toBeUndefined()
 
       // emit a false flag
-      sr.ee.emit('rumresp-sr', [false])
+      sr.ee.emit('rumresp', [{ sr: 0 }])
       await wait(1)
-      expect(sr.initialized).toEqual(true)
+      expect(sr.initialized).toEqual(false) // early returns
       expect(sr.recorder).toBeUndefined()
     })
   })
@@ -166,7 +166,7 @@ describe('Session Replay', () => {
     test('New Session -- Full 1 Error 1 === FULL', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 100 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
     })
@@ -174,7 +174,7 @@ describe('Session Replay', () => {
     test('New Session -- Full 1 Error 0 === FULL', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 0, sampling_rate: 100 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
     })
@@ -182,7 +182,7 @@ describe('Session Replay', () => {
     test('New Session -- Full 0 Error 1 === ERROR', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.mode).toEqual(MODE.ERROR)
     })
@@ -190,7 +190,7 @@ describe('Session Replay', () => {
     test('New Session -- Full 0 Error 0 === OFF', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 0, sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.mode).toEqual(MODE.OFF)
     })
@@ -203,7 +203,7 @@ describe('Session Replay', () => {
       // configure to get "error" sample ---> but should inherit FULL from session manager
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
     })
@@ -214,7 +214,7 @@ describe('Session Replay', () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       handle('errorAgg', ['test1'], undefined, FEATURE_NAMES.sessionReplay, ee.get(agentIdentifier))
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(100)
       expect(sr.mode).toEqual(MODE.FULL)
       expect(sr.scheduler.started).toEqual(true)
@@ -223,7 +223,7 @@ describe('Session Replay', () => {
     test('An error AFTER rrweb import changes mode and starts harvester', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.mode).toEqual(MODE.ERROR)
       expect(sr.scheduler.started).toEqual(false)
@@ -240,7 +240,7 @@ describe('Session Replay', () => {
       primeSessionAndReplay(session)
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       const harvestContents = sr.getHarvestContents()
       // query attrs
@@ -261,7 +261,7 @@ describe('Session Replay', () => {
       const { gunzipSync, strFromU8 } = await import('fflate')
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       const [harvestContents] = sr.prepareHarvest()
       expect(harvestContents.qs).toMatchObject(anyQuery)
@@ -279,7 +279,7 @@ describe('Session Replay', () => {
 
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
 
       sr.gzipper = undefined
@@ -297,7 +297,7 @@ describe('Session Replay', () => {
     test('Clears the event buffer when staged for harvesting', async () => {
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
 
       sr.gzipper = undefined
@@ -313,7 +313,7 @@ describe('Session Replay', () => {
       sr.recorder.currentBufferTarget.payloadBytesEstimation = IDEAL_PAYLOAD_SIZE / AVG_COMPRESSION
       const before = Date.now()
       const spy = jest.spyOn(sr.scheduler, 'runHarvest').mockImplementation(() => { after = Date.now() })
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(spy).toHaveBeenCalled()
       expect(after - before).toBeLessThan(sr.harvestTimeSeconds * 1000)
@@ -330,7 +330,7 @@ describe('Session Replay', () => {
       sr.recorder = new Recorder(sr)
       Array.from({ length: 100000 }).forEach(() => sr.recorder.currentBufferTarget.add({ test: 1 })) //  fill the events array with tons of events
       sr.recorder.currentBufferTarget.payloadBytesEstimation = sr.recorder.currentBufferTarget.events.join('').length
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(spy).not.toHaveBeenCalled()
       expect(sr.blocked).toEqual(true)
@@ -340,7 +340,7 @@ describe('Session Replay', () => {
     test('Aborts if 429 response', async () => {
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [1])
+      sr.ee.emit('rumresp', [{ sr: 1 }])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
       sr.onHarvestFinished({ status: 429 })

--- a/src/features/session_replay/aggregate/index.component-test.js
+++ b/src/features/session_replay/aggregate/index.component-test.js
@@ -1,4 +1,3 @@
-import { Aggregate as SessionReplayAgg } from '.'
 import { AVG_COMPRESSION, IDEAL_PAYLOAD_SIZE } from '../constants'
 import { Aggregator } from '../../../common/aggregate/aggregator'
 import { SessionEntity } from '../../../common/session/session-entity'
@@ -7,6 +6,11 @@ import { configure } from '../../../loaders/configure/configure'
 import { Recorder } from '../shared/recorder'
 import { MODE, SESSION_EVENTS } from '../../../common/session/constants'
 import { setNREUMInitializedAgent } from '../../../common/window/nreum'
+import { handle } from '../../../common/event-emitter/handle'
+import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { ee } from '../../../common/event-emitter/contextual-ee'
+
+let sr, session
 
 jest.mock('../../../common/util/console', () => ({
   warn: jest.fn()
@@ -54,9 +58,8 @@ const model = {
   traceHarvestStarted: false,
   custom: {}
 }
-
-let sr, session
-const agentIdentifier = 'abcd'
+let SessionReplayAgg
+let agentIdentifier = 'abcd'
 const info = { licenseKey: 1234, applicationID: 9876 }
 const init = { session_replay: { enabled: true, sampling_rate: 100, error_sampling_rate: 0 } }
 
@@ -70,10 +73,14 @@ const anyQuery = {
 
 describe('Session Replay', () => {
   beforeEach(async () => {
+    agentIdentifier = (Math.random() + 1).toString(36).substring(7)
+    const { Aggregate } = await import('./')
+    SessionReplayAgg = Aggregate
     primeSessionAndReplay()
   })
   afterEach(async () => {
     sr.abort('jest test manually aborted')
+    sr.ee.abort()
     jest.resetAllMocks()
     jest.clearAllMocks()
   })
@@ -90,7 +97,7 @@ describe('Session Replay', () => {
 
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.initialized).toBeTruthy()
       expect(sr.recorder.recording).toBeTruthy()
@@ -103,7 +110,7 @@ describe('Session Replay', () => {
     test('When Session Is Paused/Resumed', async () => {
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.initialized).toBeTruthy()
       expect(sr.recorder.recording).toBeTruthy()
@@ -116,7 +123,7 @@ describe('Session Replay', () => {
     test('Session SR mode matches SR mode -- FULL', async () => {
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(session.state.sessionReplayMode).toEqual(sr.mode)
     })
@@ -124,7 +131,7 @@ describe('Session Replay', () => {
     test('Session SR mode matches SR mode -- ERROR', async () => {
       setConfiguration(agentIdentifier, { session_replay: { sampling_rate: 0, error_sampling_rate: 100 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(session.state.sessionReplayMode).toEqual(sr.mode)
     })
@@ -132,7 +139,7 @@ describe('Session Replay', () => {
     test('Session SR mode matches SR mode -- OFF', async () => {
       setConfiguration(agentIdentifier, { session_replay: { sampling_rate: 0, error_sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(session.state.sessionReplayMode).toEqual(sr.mode)
     })
@@ -159,7 +166,7 @@ describe('Session Replay', () => {
     test('New Session -- Full 1 Error 1 === FULL', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 100 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
     })
@@ -167,7 +174,7 @@ describe('Session Replay', () => {
     test('New Session -- Full 1 Error 0 === FULL', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 0, sampling_rate: 100 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
     })
@@ -175,7 +182,7 @@ describe('Session Replay', () => {
     test('New Session -- Full 0 Error 1 === ERROR', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.mode).toEqual(MODE.ERROR)
     })
@@ -183,7 +190,7 @@ describe('Session Replay', () => {
     test('New Session -- Full 0 Error 0 === OFF', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 0, sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.mode).toEqual(MODE.OFF)
     })
@@ -196,7 +203,7 @@ describe('Session Replay', () => {
       // configure to get "error" sample ---> but should inherit FULL from session manager
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
     })
@@ -205,10 +212,10 @@ describe('Session Replay', () => {
   describe('Session Replay Error Mode Behaviors', () => {
     test('An error BEFORE rrweb import starts running in FULL from beginning', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
+      handle('errorAgg', ['test1'], undefined, FEATURE_NAMES.sessionReplay, ee.get(agentIdentifier))
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('errorAgg')
-      sr.ee.emit('rumresp-sr', [true])
-      await wait(1)
+      sr.ee.emit('rumresp-sr', [1])
+      await wait(100)
       expect(sr.mode).toEqual(MODE.FULL)
       expect(sr.scheduler.started).toEqual(true)
     })
@@ -216,11 +223,11 @@ describe('Session Replay', () => {
     test('An error AFTER rrweb import changes mode and starts harvester', async () => {
       setConfiguration(agentIdentifier, { session_replay: { error_sampling_rate: 100, sampling_rate: 0 } })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.mode).toEqual(MODE.ERROR)
       expect(sr.scheduler.started).toEqual(false)
-      sr.ee.emit('errorAgg')
+      sr.ee.emit('errorAgg', ['test2'])
       expect(sr.mode).toEqual(MODE.FULL)
       expect(sr.scheduler.started).toEqual(true)
     })
@@ -233,7 +240,7 @@ describe('Session Replay', () => {
       primeSessionAndReplay(session)
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       const harvestContents = sr.getHarvestContents()
       // query attrs
@@ -254,7 +261,7 @@ describe('Session Replay', () => {
       const { gunzipSync, strFromU8 } = await import('fflate')
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       const [harvestContents] = sr.prepareHarvest()
       expect(harvestContents.qs).toMatchObject(anyQuery)
@@ -272,7 +279,7 @@ describe('Session Replay', () => {
 
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
 
       sr.gzipper = undefined
@@ -290,7 +297,7 @@ describe('Session Replay', () => {
     test('Clears the event buffer when staged for harvesting', async () => {
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
 
       sr.gzipper = undefined
@@ -306,7 +313,7 @@ describe('Session Replay', () => {
       sr.recorder.currentBufferTarget.payloadBytesEstimation = IDEAL_PAYLOAD_SIZE / AVG_COMPRESSION
       const before = Date.now()
       const spy = jest.spyOn(sr.scheduler, 'runHarvest').mockImplementation(() => { after = Date.now() })
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(spy).toHaveBeenCalled()
       expect(after - before).toBeLessThan(sr.harvestTimeSeconds * 1000)
@@ -323,7 +330,7 @@ describe('Session Replay', () => {
       sr.recorder = new Recorder(sr)
       Array.from({ length: 100000 }).forEach(() => sr.recorder.currentBufferTarget.add({ test: 1 })) //  fill the events array with tons of events
       sr.recorder.currentBufferTarget.payloadBytesEstimation = sr.recorder.currentBufferTarget.events.join('').length
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(spy).not.toHaveBeenCalled()
       expect(sr.blocked).toEqual(true)
@@ -333,7 +340,7 @@ describe('Session Replay', () => {
     test('Aborts if 429 response', async () => {
       setConfiguration(agentIdentifier, { ...init })
       sr = new SessionReplayAgg(agentIdentifier, new Aggregator({}))
-      sr.ee.emit('rumresp-sr', [true])
+      sr.ee.emit('rumresp-sr', [1])
       await wait(1)
       expect(sr.mode).toEqual(MODE.FULL)
       sr.onHarvestFinished({ status: 429 })
@@ -353,5 +360,5 @@ function primeSessionAndReplay (sess = new SessionEntity({ agentIdentifier, key:
   const agent = { agentIdentifier }
   setNREUMInitializedAgent(agentIdentifier, agent)
   session = sess
-  configure(agent, { info, runtime: { session }, init: {} }, 'test', true)
+  configure(agent, { info, runtime: { session, isolatedBacklog: false }, init: {} }, 'test', true)
 }

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -117,10 +117,12 @@ export class Aggregate extends AggregateBase {
 
     this.waitForFlags(['sr']).then(([flagOn]) => {
       this.entitled = flagOn
-      if (!this.entitled && this.recorder?.recording) {
-        this.abort(ABORT_REASONS.ENTITLEMENTS)
-        handle(SUPPORTABILITY_METRIC_CHANNEL, ['SessionReplay/EnabledNotEntitled/Detected'], undefined, FEATURE_NAMES.metrics, this.ee)
+      if (!this.entitled) {
         deregisterDrain(this.agentIdentifier, this.featureName)
+        if (this.recorder?.recording) {
+          this.abort(ABORT_REASONS.ENTITLEMENTS)
+          handle(SUPPORTABILITY_METRIC_CHANNEL, ['SessionReplay/EnabledNotEntitled/Detected'], undefined, FEATURE_NAMES.metrics, this.ee)
+        }
         return
       }
       this.drain()

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -105,7 +105,6 @@ export class Aggregate extends AggregateBase {
     // Wait for an error to be reported.  This currently is wrapped around the "Error" feature.  This is a feature-feature dependency.
     // This was to ensure that all errors, including those on the page before load and those handled with "noticeError" are accounted for. Needs evalulation
     registerHandler('errorAgg', (e) => {
-      console.log('errorAgg', e)
       this.errorNoticed = true
       if (this.recorder) this.recorder.currentBufferTarget.hasError = true
       // run once

--- a/src/features/session_replay/instrument/index.component-test.js
+++ b/src/features/session_replay/instrument/index.component-test.js
@@ -38,6 +38,10 @@ jest.mock('../shared/recorder', () => ({
     }
   })
 }))
+jest.mock('../../../common/util/console', () => ({
+  __esModule: true,
+  warn: jest.fn()
+}))
 
 const agentIdentifier = 'abc'
 

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -109,7 +109,7 @@ export class Aggregate extends AggregateBase {
     if (!sessionEntity) {
       // Since session manager isn't around, do the old Trace behavior of waiting for RUM response to decide feature activation.
       this.isStandalone = true
-      registerHandler('rumresp-stn', (on) => controlTraceOp(on), this.featureName, this.ee)
+      this.waitForFlags((['stn'])).then(([on]) => controlTraceOp(on), this.featureName, this.ee)
     } else {
       registerHandler('errorAgg', () => {
         seenAnError = true
@@ -151,7 +151,7 @@ export class Aggregate extends AggregateBase {
             if (replayMode === MODE.OFF) this.isStandalone = true // without SR, Traces are still subject to old harvest limits
 
             let startingMode
-            if (traceOn === true) { // CASE: both trace (entitlement+sampling) & replay (entitlement) flags are true from RUM
+            if (traceOn) { // CASE: both trace (entitlement+sampling) & replay (entitlement) flags are true from RUM
               startingMode = MODE.FULL // always full capture regardless of replay sampling decisions
             } else { // CASE: trace flag is off, BUT it must still run if replay is on (possibly)
               // At this point, it's possible that 1 or more exception was thrown, in which case just start in full if Replay originally started in ERROR mode.

--- a/src/features/soft_navigations/aggregate/index.js
+++ b/src/features/soft_navigations/aggregate/index.js
@@ -18,8 +18,6 @@ export class Aggregate extends AggregateBase {
   constructor (agentIdentifier, aggregator, { domObserver }) {
     super(agentIdentifier, aggregator, FEATURE_NAME)
 
-    console.log('SOFT NAV')
-
     const harvestTimeSeconds = getConfigurationValue(agentIdentifier, 'soft_navigations.harvestTimeSeconds') || 10
     this.interactionsToHarvest = []
     this.interactionsAwaitingRetry = []
@@ -72,7 +70,6 @@ export class Aggregate extends AggregateBase {
 
   onHarvestStarted (options) {
     if (this.interactionsToHarvest.length === 0 || this.blocked) return
-    console.log('harvestStarted')
     // The payload depacker takes the first ixn of a payload (if there are multiple ixns) and positively offset the subsequent ixns timestamps by that amount.
     // In order to accurately portray the real start & end times of the 2nd & onward ixns, we hence need to negatively offset their start timestamps with that of the 1st ixn.
     let firstIxnStartTime = 0 // the very 1st ixn does not require any offsetting
@@ -164,7 +161,6 @@ export class Aggregate extends AggregateBase {
    * @param {Object} event see Ajax feature's storeXhr function for object definition
    */
   #handleAjaxEvent (event) {
-    console.log('handle ajax')
     const associatedInteraction = this.getInteractionFor(event.startTime)
     if (!associatedInteraction) { // no interaction was happening when this ajax started, so give it back to Ajax feature for processing
       handle('returnAjax', [event], undefined, FEATURE_NAMES.ajax, this.ee)
@@ -188,7 +184,6 @@ export class Aggregate extends AggregateBase {
    * @param {DOMHighResTimeStamp} timestamp time the jserror occurred
    */
   #handleJserror (params, timestamp) {
-    console.log('handleJserror...', params)
     const associatedInteraction = this.getInteractionFor(timestamp)
     if (!associatedInteraction) return // do not need to decorate this jserror params
 

--- a/src/features/soft_navigations/aggregate/index.js
+++ b/src/features/soft_navigations/aggregate/index.js
@@ -18,17 +18,12 @@ export class Aggregate extends AggregateBase {
   constructor (agentIdentifier, aggregator, { domObserver }) {
     super(agentIdentifier, aggregator, FEATURE_NAME)
 
+    console.log('SOFT NAV')
+
     const harvestTimeSeconds = getConfigurationValue(agentIdentifier, 'soft_navigations.harvestTimeSeconds') || 10
     this.interactionsToHarvest = []
     this.interactionsAwaitingRetry = []
     this.domObserver = domObserver
-
-    this.scheduler = new HarvestScheduler('events', {
-      onFinished: this.onHarvestFinished.bind(this),
-      retryDelay: harvestTimeSeconds,
-      onUnload: () => this.interactionInProgress?.done() // return any held ajax or jserr events so they can be sent with EoL harvest
-    }, { agentIdentifier, ee: this.ee })
-    this.scheduler.harvest.on('events', this.onHarvestStarted.bind(this))
 
     this.initialPageLoadInteraction = new InitialPageLoadInteraction(agentIdentifier)
     timeToFirstByte.subscribe(({ entries }) => {
@@ -48,7 +43,13 @@ export class Aggregate extends AggregateBase {
     this.waitForFlags(['spa']).then(([spaOn]) => {
       if (spaOn) {
         this.drain()
-        this.scheduler.startTimer(harvestTimeSeconds, 0)
+        const scheduler = new HarvestScheduler('events', {
+          onFinished: this.onHarvestFinished.bind(this),
+          retryDelay: harvestTimeSeconds,
+          onUnload: () => this.interactionInProgress?.done() // return any held ajax or jserr events so they can be sent with EoL harvest
+        }, { agentIdentifier, ee: this.ee })
+        scheduler.harvest.on('events', this.onHarvestStarted.bind(this))
+        scheduler.startTimer(harvestTimeSeconds, 0)
       } else {
         this.blocked = true // if rum response determines that customer lacks entitlements for spa endpoint, this feature shouldn't harvest
         deregisterDrain(this.agentIdentifier, this.featureName)
@@ -71,7 +72,7 @@ export class Aggregate extends AggregateBase {
 
   onHarvestStarted (options) {
     if (this.interactionsToHarvest.length === 0 || this.blocked) return
-
+    console.log('harvestStarted')
     // The payload depacker takes the first ixn of a payload (if there are multiple ixns) and positively offset the subsequent ixns timestamps by that amount.
     // In order to accurately portray the real start & end times of the 2nd & onward ixns, we hence need to negatively offset their start timestamps with that of the 1st ixn.
     let firstIxnStartTime = 0 // the very 1st ixn does not require any offsetting
@@ -163,6 +164,7 @@ export class Aggregate extends AggregateBase {
    * @param {Object} event see Ajax feature's storeXhr function for object definition
    */
   #handleAjaxEvent (event) {
+    console.log('handle ajax')
     const associatedInteraction = this.getInteractionFor(event.startTime)
     if (!associatedInteraction) { // no interaction was happening when this ajax started, so give it back to Ajax feature for processing
       handle('returnAjax', [event], undefined, FEATURE_NAMES.ajax, this.ee)
@@ -186,6 +188,7 @@ export class Aggregate extends AggregateBase {
    * @param {DOMHighResTimeStamp} timestamp time the jserror occurred
    */
   #handleJserror (params, timestamp) {
+    console.log('handleJserror...', params)
     const associatedInteraction = this.getInteractionFor(timestamp)
     if (!associatedInteraction) return // do not need to decorate this jserror params
 

--- a/src/features/soft_navigations/index.component-test.js
+++ b/src/features/soft_navigations/index.component-test.js
@@ -89,12 +89,11 @@ describe('soft navigations', () => {
       importAggregatorFn()
       await expect(softNavInstrument.onAggregateImported).resolves.toEqual(true)
       softNavAggregate = softNavInstrument.featAggregate
-      softNavAggregate.ee.emit('rumresp-spa', [1])
+      softNavAggregate.ee.emit('rumresp', [{ spa: 1 }])
     })
 
     test('processes regular interactions', () => {
       expect(softNavAggregate.domObserver).toBeTruthy()
-      expect(softNavAggregate.scheduler).toBeTruthy()
       expect(softNavAggregate.initialPageLoadInteraction).toBeTruthy()
 
       executeTTFB({ entries: [{ loadEventEnd: 123 }] })
@@ -172,7 +171,7 @@ describe('soft navigations', () => {
       importAggregatorFn()
       await expect(softNavInstrument.onAggregateImported).resolves.toEqual(true)
       softNavAggregate = softNavInstrument.featAggregate
-      softNavAggregate.ee.emit('rumresp-spa', [1])
+      softNavAggregate.ee.emit('rumresp', [{ spa: 1 }])
     })
     beforeEach(() => {
       softNavAggregate.initialPageLoadInteraction = null

--- a/src/features/soft_navigations/index.component-test.js
+++ b/src/features/soft_navigations/index.component-test.js
@@ -89,6 +89,7 @@ describe('soft navigations', () => {
       importAggregatorFn()
       await expect(softNavInstrument.onAggregateImported).resolves.toEqual(true)
       softNavAggregate = softNavInstrument.featAggregate
+      softNavAggregate.ee.emit('rumresp-spa', [1])
     })
 
     test('processes regular interactions', () => {
@@ -171,6 +172,7 @@ describe('soft navigations', () => {
       importAggregatorFn()
       await expect(softNavInstrument.onAggregateImported).resolves.toEqual(true)
       softNavAggregate = softNavInstrument.featAggregate
+      softNavAggregate.ee.emit('rumresp-spa', [1])
     })
     beforeEach(() => {
       softNavAggregate.initialPageLoadInteraction = null
@@ -268,7 +270,8 @@ describe('soft navigations', () => {
 
       newrelic.interaction('get').interaction('save')
       await new Promise(resolve => _setTimeout(resolve, 301))
-      expect(softNavAggregate.interactionsToHarvest.length).toEqual(3)
+      /** now that we drain **after** the rumcall flags are emitted, some of the ixns try to get harvested.  just check both buckets */
+      expect(softNavAggregate.interactionsToHarvest.length + softNavAggregate.interactionsAwaitingRetry.length).toEqual(3)
     })
 
     test('.interaction gets ixn retroactively too when processed late after ee buffer drain', () => {

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -111,6 +111,7 @@ export class Aggregate extends AggregateBase {
           retryDelay: state.harvestTimeSeconds
         }, { agentIdentifier, ee: baseEE })
         this.scheduler.harvest.on('events', onHarvestStarted)
+        this.drain()
       } else {
         this.blocked = true
         deregisterDrain(this.agentIdentifier, this.featureName)
@@ -743,7 +744,5 @@ export class Aggregate extends AggregateBase {
       var enabled = getConfigurationValue(agentIdentifier, 'spa.enabled')
       return enabled !== false
     }
-
-    this.drain()
   }
 }

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -36,7 +36,6 @@ export class AggregateBase extends FeatureBase {
 
   drain () {
     drain(this.agentIdentifier, this.featureName)
-    this.drained = true
   }
 
   /**

--- a/src/features/utils/aggregate-base.test.js
+++ b/src/features/utils/aggregate-base.test.js
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker'
 import { AggregateBase } from './aggregate-base'
-import { registerHandler } from '../../common/event-emitter/register-handler'
 import { getInfo, isConfigured, getRuntime } from '../../common/config/config'
 import { configure } from '../../loaders/configure/configure'
 import { gosCDN } from '../../common/window/nreum'
@@ -28,6 +27,19 @@ jest.mock('../../common/window/nreum', () => ({
   __esModule: true,
   gosCDN: jest.fn().mockReturnValue({}),
   gosNREUM: jest.fn().mockReturnValue({})
+}))
+jest.mock('../../common/util/feature-flags', () => ({
+  __esModule: true,
+  activatedFeatures: {
+    abcd: {
+      abc: 0,
+      def: 1,
+      ghi: 2,
+      'not-expected0': 0,
+      'not-expected1': 1,
+      'not-expected2': 2
+    }
+  }
 }))
 
 let agentIdentifier
@@ -91,20 +103,38 @@ test('should only configure the agent once', () => {
   expect(configure).not.toHaveBeenCalled()
 })
 
-test('should resolve waitForFlags correctly based on flags', async () => {
-  const flagNames = [faker.string.uuid(), faker.string.uuid()]
+test('should resolve waitForFlags correctly based on flags with real vals', async () => {
+  const flagNames = [faker.string.uuid(), faker.string.uuid(), faker.string.uuid()]
   const aggregateBase = new AggregateBase(agentIdentifier, aggregator, featureName)
-
   const flagWait = aggregateBase.waitForFlags(flagNames)
-  aggregateBase.ee.emit(`rumresp-${flagNames[0]}`, [true])
-  aggregateBase.ee.emit(`rumresp-${flagNames[1]}`, [false])
-
-  await expect(flagWait).resolves.toEqual([true, false])
+  aggregateBase.ee.emit('rumresp', [{
+    [flagNames[0]]: 0,
+    [flagNames[1]]: 1,
+    [flagNames[2]]: 2,
+    'not-expected0': 0,
+    'not-expected1': 1,
+    'not-expected2': 2
+  }])
+  await expect(flagWait).resolves.toEqual([0, 1, 2])
 })
 
-test('should not register any handlers when flagNames is empty', async () => {
+test('should return empty array when flagNames is empty', async () => {
+  const flagNames = [faker.string.uuid(), faker.string.uuid(), faker.string.uuid()]
   const aggregateBase = new AggregateBase(agentIdentifier, aggregator, featureName)
+  const flagWait = aggregateBase.waitForFlags()
+  aggregateBase.ee.emit('rumresp', [{
+    [flagNames[0]]: 0,
+    [flagNames[1]]: 1,
+    [flagNames[2]]: 2,
+    'not-expected0': 0,
+    'not-expected1': 1,
+    'not-expected2': 2
+  }])
+  await expect(flagWait).resolves.toEqual([])
+})
 
-  await expect(aggregateBase.waitForFlags()).resolves.toEqual([])
-  expect(registerHandler).not.toHaveBeenCalled()
+test('should return activatedFeatures values when available', async () => {
+  const aggregateBase = new AggregateBase('abcd', aggregator, featureName) // 'abcd' matches the af mock at the top of this file
+  const flagWait = aggregateBase.waitForFlags()
+  await expect(flagWait).resolves.toEqual([])
 })

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -111,6 +111,7 @@ export class InstrumentBase extends FeatureBase {
         // not supported yet but nice to do: "abort" this agent's EE for this feature specifically
         drain(this.agentIdentifier, this.featureName, true)
         loadedSuccessfully(false)
+        if (this.ee) this.ee.abort()
       }
     }
 

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -85,8 +85,8 @@ export class Agent extends AgentBase {
       delete newrelic.initializedAgents[this.agentIdentifier]?.features // GC mem used internally by features
       delete this.sharedAggregator
       // Keep the initialized agent object with its configs for troubleshooting purposes.
-      newrelic.ee?.abort() // set flag and clear global backlog
-      delete newrelic.ee?.get(this.agentIdentifier) // clear this agent's own backlog too
+      const thisEE = newrelic.ee.get(this.agentIdentifier)
+      thisEE.abort() // set flag and clear backlog
       return false
     }
   }

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -198,7 +198,7 @@ export function setAPI (agentIdentifier, forceDrain, runSoftNavOverSpa = false) 
       drain(agentIdentifier, 'api')
     }).catch(() => {
       warn('Downloading runtime APIs failed...')
-      drain(agentIdentifier, 'api', true)
+      instanceEE.abort()
     })
   }
 

--- a/tests/assets/ajax-and-errors-before-page-load.html
+++ b/tests/assets/ajax-and-errors-before-page-load.html
@@ -4,6 +4,9 @@
     <title>RUM Unit Test</title>
     {init}
     {config}
+    <script>
+      NREUM.init.feature_flags = ['soft_nav']
+    </script>
     {loader}
     <script type="text/javascript">
       const xhr = new XMLHttpRequest()

--- a/tests/browser/spa/helpers.js
+++ b/tests/browser/spa/helpers.js
@@ -20,6 +20,7 @@ const timerEE = wrapTimer(baseEE)
 const { drain } = require('../../../src/common/drain/drain')
 const { mapOwn } = require('../../../src/common/util/map-own')
 const { bundleId } = require('../../../src/common/ids/bundle-id')
+const { activateFeatures } = require('../../../src/common/util/feature-flags.js')
 
 var currentNodeId = () => {
   try { return spaAgg.state.currentNode && spaAgg.state.currentNode.id }
@@ -38,6 +39,7 @@ jil.onWindowLoaded(function () {
     if (!spaAgg) spaAgg = new SpaAggregate(agentIdentifier, aggregator)
     drain(agentIdentifier, 'api')
     drain(agentIdentifier, 'feature')
+    activateFeatures({sr: 1, stn:1, spa:1, ins:1, rum:1, loaded:1}, agentIdentifier)
 
     aggregatorLoaded = true
     for (var i = 0; i < aggregatorLoadQueue.length; i++) {

--- a/tests/specs/session-replay/initialization.e2e.js
+++ b/tests/specs/session-replay/initialization.e2e.js
@@ -22,7 +22,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Initialization', () => {
     expect(JSON.parse(rumResp.reply.body).sr).toEqual(0)
 
     const sr = await getSR()
-    expect(sr.initialized).toEqual(true)
+    expect(sr.initialized).toEqual(false)
     expect(sr.recording).toEqual(false)
   })
 

--- a/tests/specs/session-replay/mode.e2e.js
+++ b/tests/specs/session-replay/mode.e2e.js
@@ -116,14 +116,16 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
     })
   })
 
-  it('Pause API called before page load can still stop replay', async () => {
+  it('Pause API called before page load has no effect', async () => {
     await browser.url(await browser.testHandle.assetURL('rrweb-api-pause-before-load.html', config({ session_replay: { sampling_rate: 100, error_sampling_rate: 0 } })))
       .then(() => browser.waitForSessionReplayRecording())
 
-    await expect(getSR()).resolves.toMatchObject({
+    await expect(getSR()).resolves.toEqual(expect.objectContaining({
+      recording: true,
       initialized: true,
-      mode: 0
-    })
+      events: expect.any(Array),
+      mode: 1
+    }))
   })
 
   it('ERROR (seen after init) => FULL', async () => {

--- a/tests/specs/session-replay/mode.e2e.js
+++ b/tests/specs/session-replay/mode.e2e.js
@@ -105,28 +105,25 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
     expect(sr.mode).toEqual(1)
   })
 
-  it('Record API called before page load does not start a replay (no entitlements yet)', async () => {
+  it('Record API called before page load can trigger replay', async () => {
     await browser.url(await browser.testHandle.assetURL('rrweb-api-record-before-load.html', config({ session_replay: { sampling_rate: 0, error_sampling_rate: 0 } })))
       .then(() => browser.waitForFeatureAggregate('session_replay'))
 
-    await expect(getSR()).resolves.toEqual(expect.objectContaining({
-      recording: false,
+    await browser.pause(1000)
+    await expect(getSR()).resolves.toMatchObject({
       initialized: true,
-      events: expect.any(Array),
-      mode: 0
-    }))
+      mode: 1
+    })
   })
 
-  it('Pause API called before page load has no effect', async () => {
+  it('Pause API called before page load can still stop replay', async () => {
     await browser.url(await browser.testHandle.assetURL('rrweb-api-pause-before-load.html', config({ session_replay: { sampling_rate: 100, error_sampling_rate: 0 } })))
       .then(() => browser.waitForSessionReplayRecording())
 
-    await expect(getSR()).resolves.toEqual(expect.objectContaining({
-      recording: true,
+    await expect(getSR()).resolves.toMatchObject({
       initialized: true,
-      events: expect.any(Array),
-      mode: 1
-    }))
+      mode: 0
+    })
   })
 
   it('ERROR (seen after init) => FULL', async () => {

--- a/tools/browser-matcher/common-matchers.mjs
+++ b/tools/browser-matcher/common-matchers.mjs
@@ -68,7 +68,7 @@ export const onlyAndroid = new SpecMatcher()
 export const onlyChromium = new SpecMatcher()
   .include('chrome')
   .include('edge')
-  .include('android')
+  .include('android>9.0')
 
 /**
  * Matcher based on ES2022 support
@@ -78,7 +78,7 @@ export const es2022Support = new SpecMatcher()
   .include('chrome>=94')
   .include('edge>=94')
   .include('firefox>=93')
-  .include('android>=114')
+  .include('android>=9.0')
   .include('safari>=15.4')
   .include('ios>=15.4')
 

--- a/tools/jil/driver/index.js
+++ b/tools/jil/driver/index.js
@@ -32,7 +32,7 @@ wd.addAsyncMethod('safeGet', function (url, cb) {
 wd.addAsyncMethod('waitForFeature', function (feat, cb) {
   this.waitFor(
     // condition for webpack built agent
-    asserters.jsCondition(`window.NREUM && window.NREUM.activatedFeatures && window.NREUM.activatedFeatures['${feat}']`),
+    asserters.jsCondition(`window.NREUM && window.NREUM.activatedFeatures && Object.values(window.NREUM.activatedFeatures)[0]['${feat}']`),
     this._testDriver.timeout || 85000,
     cb
   )

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -17,7 +17,7 @@ export default class CustomCommands {
     browser.addCommand('waitForAgentLoad', async function () {
       await browser.waitUntil(
         () => browser.execute(function () {
-          return window.NREUM && window.NREUM.activatedFeatures && window.NREUM.activatedFeatures.loaded
+          return window.NREUM && window.NREUM.activatedFeatures && !!Object.values(window.NREUM.activatedFeatures)[0].loaded
         }),
         {
           timeout: 30000,


### PR DESCRIPTION
Force features to wait for entitlement checks from the rum call before processing buffered data
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR does the following:
* Aligns all features to use `waitForFlags` which has a standard promise implementation and allows for multiple flags to be supplied
* Features only drain once their feature flag has been evaluated, preventing processing of buffered data until gate-checking can be conducted
* Features can listen for a list of flags --or-- no flags, which will still enforce waiting for the flags to be emitted
* Normalizes abort behavior to fix some issues popping up in the test suite around bubbling aborts
* alters affected tests that had early-drain assumptions to match the new drain pattern
* Various small optimizations that were encountered through full-suite testing

**This PR is partially an extraction from the ST merge PR**
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-138334
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Any tests that assumed drain to happen immediately (instead of after the flag checks) were fixed to align to the new pattern
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
