### PR TITLE
fix: Server Timing - Remove reliance on performance API

### DIFF
--- a/src/common/timing/time-keeper.test.js
+++ b/src/common/timing/time-keeper.test.js
@@ -1,10 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { globalScope } from '../constants/runtime'
 import { TimeKeeper } from './time-keeper'
 import * as configModule from '../config/config'
 
 jest.enableAutomock()
 jest.unmock('./time-keeper')
+
+const startTime = 450
+const endTime = 600
 
 let localTime
 let serverTime
@@ -37,15 +39,7 @@ describe('processRumRequest', () => {
       getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl)
+    timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
     expect(timeKeeper.correctedPageOriginTime).toEqual(1706213060475)
   })
@@ -57,15 +51,7 @@ describe('processRumRequest', () => {
       getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl)
+    timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
     expect(timeKeeper.correctedPageOriginTime).toEqual(1706213055475)
   })
@@ -75,24 +61,13 @@ describe('processRumRequest', () => {
       getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart,
-      responseEnd: 600,
-      fetchStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl)
+    timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
     expect(timeKeeper.correctedPageOriginTime).toEqual(1706213060475)
   })
 
   it.each([null, undefined])('should throw an error when rumRequest is %s', (rumRequest) => {
-    const rumRequestUrl = faker.internet.url()
-
-    expect(() => timeKeeper.processRumRequest(rumRequest, rumRequestUrl))
+    expect(() => timeKeeper.processRumRequest(rumRequest, startTime, endTime))
       .toThrowError()
   })
 
@@ -101,15 +76,7 @@ describe('processRumRequest', () => {
       getResponseHeader: jest.fn(() => dateHeader)
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    expect(() => timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl))
+    expect(() => timeKeeper.processRumRequest(mockRumRequest, startTime, endTime))
       .toThrowError()
   })
 
@@ -118,53 +85,7 @@ describe('processRumRequest', () => {
       getResponseHeader: jest.fn(() => { throw new Error('test error') })
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    expect(() => timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl))
-      .toThrowError()
-  })
-
-  it('should throw an error when getEntriesByName throws error', () => {
-    const mockRumRequest = {
-      getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
-    }
-
-    const rumRequestUrl = faker.internet.url()
-    globalScope.performance.getEntriesByName = jest.fn(() => { throw new Error('test error') })
-
-    const timeKeeper = new TimeKeeper(mockAgent)
-
-    expect(() => timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl))
-      .toThrowError()
-  })
-
-  it.each([null, undefined, {}])('should throw an error when getEntriesByName returns %s instead of an array', (performanceEntries) => {
-    const mockRumRequest = {
-      getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
-    }
-
-    const rumRequestUrl = faker.internet.url()
-    globalScope.performance.getEntriesByName = jest.fn(() => performanceEntries)
-
-    expect(() => timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl))
-      .toThrowError()
-  })
-
-  it('should throw an error when getEntriesByName returns an empty array', () => {
-    const mockRumRequest = {
-      getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
-    }
-
-    const rumRequestUrl = faker.internet.url()
-    globalScope.performance.getEntriesByName = jest.fn(() => [])
-
-    expect(() => timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl))
+    expect(() => timeKeeper.processRumRequest(mockRumRequest, startTime, endTime))
       .toThrowError()
   })
 
@@ -173,15 +94,7 @@ describe('processRumRequest', () => {
       getResponseHeader: jest.fn(() => serverTime)
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    expect(() => timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl))
+    expect(() => timeKeeper.processRumRequest(mockRumRequest, startTime, endTime))
       .toThrowError()
   })
 })
@@ -192,15 +105,7 @@ describe('corrected time calculations', () => {
       getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl)
+    timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
     const relativeTimeA = 225
     const correctedRelativeTimeA = timeKeeper.convertRelativeTimestamp(relativeTimeA)
@@ -218,15 +123,7 @@ describe('corrected time calculations', () => {
       getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl)
+    timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
     const relativeTimeA = 225
     const correctedRelativeTimeA = timeKeeper.convertRelativeTimestamp(relativeTimeA)
@@ -242,15 +139,7 @@ describe('corrected time calculations', () => {
       getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl)
+    timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
     const absoluteTimeA = 1706213058225
     const correctedAbsoluteTimeA = timeKeeper.correctAbsoluteTimestamp(absoluteTimeA)
@@ -268,15 +157,7 @@ describe('corrected time calculations', () => {
       getResponseHeader: jest.fn(() => (new Date(serverTime)).toUTCString())
     }
 
-    const rumRequestUrl = faker.internet.url()
-    const rumRequestPerformanceEntry = {
-      name: rumRequestUrl,
-      responseStart: 600,
-      requestStart: 450
-    }
-    globalScope.performance.getEntriesByName = jest.fn(() => [rumRequestPerformanceEntry])
-
-    timeKeeper.processRumRequest(mockRumRequest, rumRequestUrl)
+    timeKeeper.processRumRequest(mockRumRequest, startTime, endTime)
 
     const absoluteTimeA = 1706213058225
     const correctedAbsoluteTimeA = timeKeeper.correctAbsoluteTimestamp(absoluteTimeA)


### PR DESCRIPTION
Removing reliance on the browser resources API for the calculation of New Relic server time. On site with many resource requests, there was a small chance that the RUM network call would be flushed from the resources API cache before we could capture it and calculate server time.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Simplifying the NR server time calculation to use our own captured start and end times for the RUM network request. On our internal NR site, we were rarely seeing an error related to the time keeper not being able to calculate server time. The cause was found to be the RUM call missing from the resources API buffer. This is most likely because there is a max buffer size in the browser after which the browser starts dropping older resource requests.

We decided to not use a more precise method of setting up a resource observer simply because it has a lot of code and logic overhead for little gain (hundreds of milliseconds). We are also planning to cache the server time across page loads and tabs.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

N/A - Pre-release issue

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
