### PR TITLE
chore: Upgrade codecov and upload-artifact to v4

### DIFF
--- a/.github/actions/size-diff/action.yml
+++ b/.github/actions/size-diff/action.yml
@@ -25,7 +25,7 @@ runs:
           --format terminal json markdown
       shell: bash
     - name: Archive asset size report results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: asset-size-report
         path: |

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -69,7 +69,7 @@ jobs:
           verbose: true
       - name: Archive code coverage results
         if: ${{ inputs.coverage }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jest-code-coverage-report
           path: coverage/

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -52,7 +52,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload pr code coverage
         if: ${{ inputs.coverage && steps.pull-request-target.outputs.results }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           override_commit: ${{ fromJSON(steps.pull-request-target.outputs.results).head_sha }}
@@ -62,7 +62,7 @@ jobs:
           verbose: true
       - name: Upload branch code coverage
         if: ${{ inputs.coverage && !steps.pull-request-target.outputs.results }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit-tests

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -93,7 +93,7 @@ jobs:
           comment: ${{ steps.asset-size-report.outputs.results }}
           comment_tag: <!-- browser_agent asset size report -->
       - name: Archive asset size report results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: asset-size-report
           path: |

--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -82,7 +82,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload pr code coverage
         if: ${{ !cancelled() && inputs.coverage && steps.pull-request-target.outputs.results }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           override_commit: ${{ fromJSON(steps.pull-request-target.outputs.results).head_sha }}
@@ -92,7 +92,7 @@ jobs:
           verbose: true
       - name: Upload branch code coverage
         if: ${{ !cancelled() && inputs.coverage && !steps.pull-request-target.outputs.results }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration-tests

--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -99,7 +99,7 @@ jobs:
           verbose: true
       - name: Archive code coverage results
         if: ${{ !cancelled() && inputs.coverage }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration-code-coverage-report
           path: coverage-e2e/


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Change GH actions inside workflows to use v4 of codecov-action and upload-artifact instead of v3.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-253209
https://new-relic.atlassian.net/browse/NR-253206

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
