### PR TITLE
chore: Add Metric Tracking Session Replay Harvest Attempts

### DIFF
--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -253,6 +253,8 @@ export class Aggregate extends AggregateBase {
       return
     }
 
+    handle(SUPPORTABILITY_METRIC_CHANNEL, ['SessionReplay/Harvest/Attempts'], undefined, FEATURE_NAMES.metrics, this.ee)
+
     let len = 0
     if (!!this.gzipper && !!this.u8) {
       payload.body = this.gzipper(this.u8(`[${payload.body.map(e => {


### PR DESCRIPTION
Track Session Replay harvest attempts to aid in debugging Session Replay abort rates.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://source.datanerd.us/agents/angler/pull/566
https://newrelic.slack.com/archives/C04QZSS6XPV/p1712681150748099?thread_ts=1712353671.785849&cid=C04QZSS6XPV
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
