### PR TITLE
feat: Generate PTID in Agent

### DIFF
--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -145,7 +145,7 @@ export class Harvest extends SharedContext {
       result.addEventListener('loadend', function () {
         // `this` refers to the XHR object in this scope, do not change this to a fat arrow
         // status 0 refers to a local error, such as CORS or network failure, or a blocked request by the browser (e.g. adblocker)
-        const cbResult = { sent: this.status !== 0, status: this.status, xhr: this, fullUrl }
+        const cbResult = { sent: this.status !== 0, status: this.status, failed: this.status === 0 || this.status >= 400, xhr: this, fullUrl }
         if (this.status === 429) {
           cbResult.retry = true
           cbResult.delay = harvestScope.tooManyRequestsDelay

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -47,6 +47,7 @@ export class Aggregate extends AggregateBase {
     this.trace = {}
     this.nodeCount = 0
     this.sentTrace = null
+    this.everSent = false
     this.harvestTimeSeconds = getConfigurationValue(agentIdentifier, 'session_trace.harvestTimeSeconds') || 10
     this.maxNodesPerHarvest = getConfigurationValue(agentIdentifier, 'session_trace.maxNodesPerHarvest') || 1000
     /**
@@ -99,7 +100,7 @@ export class Aggregate extends AggregateBase {
 
         if (prevMode === MODE.ERROR && this.#scheduler) {
           this.trimSTNs(ERROR_MODE_SECONDS_WINDOW) // up until now, Trace would've been just buffering nodes up to max, which needs to be trimmed to last X seconds
-          this.#scheduler.runHarvest()
+          this.#scheduler.runHarvest({})
         } else {
           controlTraceOp(MODE.FULL)
         }
@@ -119,7 +120,7 @@ export class Aggregate extends AggregateBase {
       const stopTracePerm = () => {
         if (sessionEntity.state.sessionTraceMode !== MODE.OFF) sessionEntity.write({ sessionTraceMode: MODE.OFF })
         operationalGate.permanentlyDecide(false)
-        if (mostRecentModeKnown === MODE.FULL) this.#scheduler?.runHarvest() // allow queued nodes (past opGate) to final harvest, unless they were buffered in other modes
+        if (mostRecentModeKnown === MODE.FULL) this.#scheduler?.runHarvest({}) // allow queued nodes (past opGate) to final harvest, unless they were buffered in other modes
         this.#scheduler?.stopTimer(true) // the 'true' arg here will forcibly block any future call to runHarvest, so the last runHarvest above must be prior
         this.#scheduler = null
       }
@@ -138,7 +139,7 @@ export class Aggregate extends AggregateBase {
           this.ee.on(SESSION_EVENTS.RESUME, () => {
             const updatedTraceMode = sessionEntity.state.sessionTraceMode
             if (updatedTraceMode === MODE.OFF) stopTracePerm()
-            else if (updatedTraceMode === MODE.FULL && this.#scheduler && !this.#scheduler.started) this.#scheduler.runHarvest()
+            else if (updatedTraceMode === MODE.FULL && this.#scheduler && !this.#scheduler.started) this.#scheduler.runHarvest({})
             mostRecentModeKnown = updatedTraceMode
           })
           this.ee.on(SESSION_EVENTS.PAUSE, () => { mostRecentModeKnown = sessionEntity.state.sessionTraceMode })
@@ -189,7 +190,7 @@ export class Aggregate extends AggregateBase {
       retryDelay: this.harvestTimeSeconds
     }, this)
     this.#scheduler.harvest.on('resources', this.#prepareHarvest.bind(this))
-    if (dontStartHarvestYet === false) this.#scheduler.runHarvest() // sends first stn harvest immediately
+    if (dontStartHarvestYet === false) this.#scheduler.runHarvest({}) // sends first stn harvest immediately
     startupBuffer.decide(true) // signal to ALLOW & process data in EE's buffer into internal nodes queued for next harvest
   }
 
@@ -216,7 +217,7 @@ export class Aggregate extends AggregateBase {
         options.isFinalHarvest = true
         this.operationalGate.permanentlyDecide(false)
         this.#scheduler.stopTimer(true)
-      } else if (this.ptid && this.nodeCount <= REQ_THRESHOLD_TO_SEND && !options.isFinalHarvest) {
+      } else if (this.everSent && this.nodeCount <= REQ_THRESHOLD_TO_SEND && !options.isFinalHarvest) {
         // Only harvest when more than some threshold of nodes are pending, after the very first harvest, with the exception of the last outgoing harvest.
         return
       }
@@ -230,7 +231,7 @@ export class Aggregate extends AggregateBase {
       if (currentMode === MODE.OFF && Object.keys(this.trace).length === 0) return
       if (currentMode === MODE.ERROR) return // Trace in this mode should never be harvesting, even on unload
     }
-
+    this.everSent = true
     return this.takeSTNs(options.retry)
   }
 

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -43,7 +43,7 @@ export class Aggregate extends AggregateBase {
     if (!this.agentRuntime.xhrWrappable) return
 
     this.resourceObserver = argsObj?.resourceObserver // undefined if observer couldn't be created
-    this.ptid = ''
+    this.ptid = this.agentRuntime.ptid
     this.trace = {}
     this.nodeCount = 0
     this.sentTrace = null

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -195,7 +195,7 @@ export class Aggregate extends AggregateBase {
   }
 
   #onHarvestFinished (result) {
-    if (result.sent && !result.failed && !this.everSent) { // continue interval harvest only after first call
+    if (result.sent && !result.failed && !this.#scheduler.started) { // continue interval harvest only after first call
       this.#scheduler.startTimer(this.harvestTimeSeconds)
     }
 

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -195,7 +195,7 @@ export class Aggregate extends AggregateBase {
   }
 
   #onHarvestFinished (result) {
-    if (result.sent && !result.failed && !this.#scheduler.started) { // continue interval harvest only after first call
+    if (result.sent && !result.failed && !this.everSent) { // continue interval harvest only after first call
       this.#scheduler.startTimer(this.harvestTimeSeconds)
     }
 

--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -52,6 +52,7 @@ export function configure (agent, opts = {}, loaderType, forceDrain) {
     ...(updatedInit.ajax.deny_list || []),
     ...(updatedInit.ajax.block_internal ? internalTrafficList : [])
   ]
+  runtime.ptid = agent.agentIdentifier
   setRuntime(agent.agentIdentifier, runtime)
 
   if (agent.api === undefined) agent.api = setAPI(agent.agentIdentifier, forceDrain, agent.runSoftNavOverSpa)

--- a/tests/functional/stn/index.test.js
+++ b/tests/functional/stn/index.test.js
@@ -9,12 +9,13 @@ testDriver.test('posts session traces', function (t, browser, router) {
   let rumPromise = router.expectRum()
   let resourcePromise = router.expectResources()
   let loadPromise = browser.get(router.assetURL('lotsatimers.html')).waitForFeature('loaded')
-
+  let ptid
   Promise.all([resourcePromise, rumPromise, loadPromise]).then(([{ request: { query } }]) => {
     t.ok(+query.st > 1408126770885, `Got start time ${query.st}`)
-    t.notok(query.ptid, 'No ptid on first harvest')
+    ptid = query.ptid
+    t.ok(query.ptid, 'ptid on first harvest')
     return router.expectResources().then(({ request: { query } }) => {
-      t.ok(query.ptid, `ptid on second harvest ${query.ptid}`)
+      t.equals(query.ptid, ptid, `ptid on second harvest ${query.ptid}`)
       t.end()
     })
   }).catch(fail)

--- a/tests/specs/harvesting/index.e2e.js
+++ b/tests/specs/harvesting/index.e2e.js
@@ -1,5 +1,4 @@
 import { faker } from '@faker-js/faker'
-import { testResourcesRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('harvesting', () => {
   it('should include the base query parameters', async () => {
@@ -46,18 +45,14 @@ describe('harvesting', () => {
   })
 
   it('should include the ptid query parameter on requests after the first session trace harvest', async () => {
-    const ptid = faker.string.uuid()
-    browser.testHandle.scheduleReply('bamServer', {
-      test: testResourcesRequest,
-      body: ptid
-    })
-
-    await Promise.all([
+    const [rumRequest] = await Promise.all([
       browser.testHandle.expectRum(),
       browser.testHandle.expectResources(),
       browser.url(await browser.testHandle.assetURL('obfuscate-pii.html'))
         .then(() => browser.waitForAgentLoad())
     ])
+
+    const ptid = rumRequest.request.query.ptid
 
     const [
       resourcesResults,

--- a/tests/specs/stn/retry-harvesting.e2e.js
+++ b/tests/specs/stn/retry-harvesting.e2e.js
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker'
 import { testResourcesRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('stn retry harvesting', () => {
@@ -21,7 +20,7 @@ describe('stn retry harvesting', () => {
       await browser.pause(500)
       await browser.testHandle.clearScheduledReplies('bamServer')
 
-      const ptid = faker.string.uuid()
+      const ptid = firstResourcesHarvest.request.query.ptid
       await browser.testHandle.scheduleReply('bamServer', {
         test: testResourcesRequest,
         permanent: true,
@@ -36,7 +35,7 @@ describe('stn retry harvesting', () => {
 
       expect(firstResourcesHarvest.reply.statusCode).toEqual(statusCode)
       expect(secondResourcesHarvest.request.body.res).toEqual(expect.arrayContaining(firstResourcesHarvest.request.body.res))
-      expect(secondResourcesHarvest.request.query.ptid).toBeUndefined()
+      expect(secondResourcesHarvest.request.query.ptid).toEqual(ptid)
       expect(thirdResourcesHarvest.request.query.ptid).toEqual(ptid)
     })
   );
@@ -56,27 +55,7 @@ describe('stn retry harvesting', () => {
           .then(() => browser.waitForAgentLoad())
       ])
 
-      // Pause a bit for browsers built-in automated retry logic crap
-      // await browser.pause(500)
-      // await browser.testHandle.clearScheduledReplies('bamServer')
-
-      // const ptid = faker.string.uuid()
-      // await browser.testHandle.scheduleReply('bamServer', {
-      //   test: testResourcesRequest,
-      //   permanent: true,
-      //   body: ptid
-      // })
-
-      // const secondResourcesHarvest = await browser.testHandle.expectResources()
-      // const [thirdResourcesHarvest] = await Promise.all([
-      //   browser.testHandle.expectResources(),
-      //   $('#trigger').click()
-      // ])
-
       expect(firstResourcesHarvest.reply.statusCode).toEqual(statusCode)
-      // expect(secondResourcesHarvest.request.body.res).not.toEqual(expect.arrayContaining(firstResourcesHarvest.request.body.res))
-      // expect(secondResourcesHarvest.request.query.ptid).toBeUndefined()
-      // expect(thirdResourcesHarvest.request.query.ptid).toEqual(ptid)
       await expect(browser.testHandle.expectResources(10000, true)).resolves.toBeUndefined()
     })
   )

--- a/tests/specs/stn/with-session-replay.e2e.js
+++ b/tests/specs/stn/with-session-replay.e2e.js
@@ -84,7 +84,7 @@ describe.withBrowsersMatching(notIE)('stn with session replay', () => {
       let initSTReceived = await loadPageAndGetResource(['stn/instrumented.html', { init: { privacy: { cookies_enabled: true }, session_replay: { enabled: false } } }], 3001)
       let firstPageAgentVals = await getTraceValues()
       expect(initSTReceived).toBeTruthy() // that is, trace should still fully run when the replay feature isn't around
-      expect(initSTReceived.request.query.ptid).toBeUndefined() // trace doesn't have ptid on first initial harvest
+      expect(initSTReceived.request.query.ptid).not.toBeUndefined() // trace has ptid on first initial harvest
       expect(firstPageAgentVals).toEqual([true, MODE.FULL, expect.any(String)])
 
       await navigateToRootDir()
@@ -94,7 +94,7 @@ describe.withBrowsersMatching(notIE)('stn with session replay', () => {
       let secondPageAgentVals = await getTraceValues()
       // On subsequent page load or refresh, trace should maintain the set mode, standalone, and same sessionid but have a new ptid corresponding to new page visit.
       expect(secondInitST.request.query.s).toEqual(initSTReceived.request.query.s)
-      expect(secondInitST.request.query.ptid).toBeUndefined()
+      expect(secondInitST.request.query.ptid).not.toBeUndefined()
       expect(secondPageAgentVals).toEqual([true, MODE.FULL, expect.any(String)]) // note it's expected & assumed that the replay mode is OFF
 
       expect(secondPageAgentVals[2]).not.toEqual(firstPageAgentVals[2]) // ptids
@@ -118,7 +118,7 @@ describe.withBrowsersMatching(notIE)('stn with session replay', () => {
         let initSTReceived = await loadPageAndGetResource(['stn/instrumented.html', config({ session_replay: replayConfig })], 3003)
         let firstPageAgentVals = await getRuntimeValues()
         expect(initSTReceived).toBeTruthy()
-        expect(initSTReceived.request.query.ptid).toBeUndefined()
+        expect(initSTReceived.request.query.ptid).not.toBeUndefined()
         if (replayMode === 'OFF') {
           expect(firstPageAgentVals).toEqual([true, MODE.FULL, true])
           expect(Number(initSTReceived.request.query.hr)).toEqual(0)
@@ -134,7 +134,7 @@ describe.withBrowsersMatching(notIE)('stn with session replay', () => {
         let secondPageAgentVals = await getRuntimeValues()
         // On subsequent page load or refresh, trace should maintain FULL mode and session id.
         expect(secondInitST.request.query.s).toEqual(initSTReceived.request.query.s)
-        expect(secondInitST.request.query.ptid).toBeUndefined() // this validates we're actually getting the 2nd page's initial res, not 1st page's unload res
+        expect(secondInitST.request.query.ptid).not.toBeUndefined() // this validates we're actually getting the 2nd page's initial res, not 1st page's unload res
         if (replayMode === 'OFF') {
           expect(secondPageAgentVals).toEqual([true, MODE.FULL, null]) // session_replay.featAggregate will be null as it's OFF and not imported on subsequent pages
           expect(Number(secondInitST.request.query.hr)).toEqual(0)

--- a/tests/unit/common/harvest/harvest.test.js
+++ b/tests/unit/common/harvest/harvest.test.js
@@ -377,7 +377,7 @@ describe('_send', () => {
     expect(xhrAddEventListener).toHaveBeenCalledWith('loadend', expect.any(Function), expect.any(Object))
     expect(result).toEqual(jest.mocked(submitDataModule.xhr).mock.results[0].value)
     expect(submitMethod).not.toHaveBeenCalled()
-    expect(spec.cbFinished).toHaveBeenCalledWith({ ...xhrState, sent: true, xhr: xhrState, fullUrl: expect.any(String) })
+    expect(spec.cbFinished).toHaveBeenCalledWith({ ...xhrState, sent: true, xhr: xhrState, failed: false, fullUrl: expect.any(String) })
   })
 
   test('should set cbFinished state retry to true with delay when xhr has 429 status', () => {
@@ -403,6 +403,7 @@ describe('_send', () => {
       retry: true,
       delay: harvestInstance.tooManyRequestsDelay,
       xhr: xhrState,
+      failed: true,
       fullUrl: expect.any(String)
     })
   })
@@ -430,6 +431,7 @@ describe('_send', () => {
       sent: true,
       retry: true,
       xhr: xhrState,
+      failed: true,
       fullUrl: expect.any(String)
     })
   })
@@ -456,6 +458,7 @@ describe('_send', () => {
       ...xhrState,
       sent: true,
       xhr: xhrState,
+      failed: false,
       fullUrl: expect.any(String)
     })
   })
@@ -483,6 +486,7 @@ describe('_send', () => {
       responseText: undefined,
       sent: true,
       xhr: xhrState,
+      failed: false,
       fullUrl: expect.any(String)
     })
   })
@@ -507,6 +511,7 @@ describe('_send', () => {
       ...xhrState,
       sent: false,
       xhr: xhrState,
+      failed: true,
       fullUrl: expect.any(String)
     })
   })


### PR DESCRIPTION
Generate PTID in agent instead of in RUM response.  This allows PageView events to be decorated with a page trace ID.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This abstracts the action of generating our own PTID out of the ST merge PR into a standalone PR
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-166514
NR-167098
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Affected tests have been updated
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
