### PR TITLE
fix: stabilize timestamp corrections

### DIFF
--- a/src/common/constants/runtime.js
+++ b/src/common/constants/runtime.js
@@ -74,4 +74,4 @@ export const isIE = Boolean(isBrowserScope && window.document.documentMode) // d
 
 export const supportsSendBeacon = !!globalScope.navigator?.sendBeacon
 
-export const offset = Math.floor(globalScope?.performance?.timeOrigin || globalScope?.performance?.timing?.navigationStart || Date.now())
+export const offset = Math.floor(Date.now() - performance.now())

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -1,5 +1,3 @@
-import { globalScope } from '../constants/runtime'
-
 /**
  * Class used to adjust the timestamp of harvested data to New Relic server time. This
  * is done by tracking the performance timings of the RUM call and applying a calculation
@@ -33,7 +31,7 @@ export class TimeKeeper {
   #ready = false
 
   constructor () {
-    this.#originTime = globalScope.performance.timeOrigin || globalScope.performance.timing.navigationStart
+    this.#originTime = Date.now() - performance.now()
   }
 
   get ready () {

--- a/src/features/session_replay/shared/recorder-events.js
+++ b/src/features/session_replay/shared/recorder-events.js
@@ -1,16 +1,11 @@
 export class RecorderEvents {
-  constructor ({ canCorrectTimestamps }) {
+  constructor () {
     /** The buffer to hold recorder event nodes */
     this.events = []
     /** Payload metadata -- Should indicate when a replay blob started recording.  Resets each time a harvest occurs.
      * cycle timestamps are used as fallbacks if event timestamps cannot be used
      */
     this.cycleTimestamp = Date.now()
-    /** Payload metadata -- Whether timestamps can be corrected, defaults as false, can be set to true if timekeeper is present at init time.  Used to determine
-     * if harvest needs to re-loop through nodes and correct them before sending.  Ideal behavior is to correct them as they flow into the recorder
-     * to prevent re-looping, but is not always possible since the timekeeper is not set until after page load and the recorder can be preloaded.
-    */
-    this.canCorrectTimestamps = !!canCorrectTimestamps
     /** A value which increments with every new mutation node reported. Resets after a harvest is sent */
     this.payloadBytesEstimation = 0
     /** Payload metadata -- Should indicate that the payload being sent has a full DOM snapshot. This can happen

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -20,9 +20,9 @@ export class Recorder {
   #fixing = false
 
   constructor (parent) {
-    this.#events = new RecorderEvents({ canCorrectTimestamps: !!parent.timeKeeper?.ready })
-    this.#backloggedEvents = new RecorderEvents({ canCorrectTimestamps: !!parent.timeKeeper?.ready })
-    this.#preloaded = [new RecorderEvents({ canCorrectTimestamps: !!parent.timeKeeper?.ready })]
+    this.#events = new RecorderEvents()
+    this.#backloggedEvents = new RecorderEvents()
+    this.#preloaded = [new RecorderEvents()]
     /** True when actively recording, false when paused or stopped */
     this.recording = false
     /** The pointer to the current bucket holding rrweb events */
@@ -40,14 +40,9 @@ export class Recorder {
   }
 
   getEvents () {
-    if (this.#preloaded[0]?.events.length) {
-      const preloadedEvents = this.returnCorrectTimestamps(this.#preloaded[0])
-      return { ...this.#preloaded[0], events: preloadedEvents, type: 'preloaded' }
-    }
-    const backloggedEvents = this.returnCorrectTimestamps(this.#backloggedEvents)
-    const events = this.returnCorrectTimestamps(this.#events)
+    if (this.#preloaded[0]?.events.length) return { ...this.#preloaded[0], type: 'preloaded' }
     return {
-      events: [...backloggedEvents, ...events].filter(x => x),
+      events: [...this.#backloggedEvents.events, ...this.#events.events].filter(x => x),
       type: 'standard',
       cycleTimestamp: Math.min(this.#backloggedEvents.cycleTimestamp, this.#events.cycleTimestamp),
       payloadBytesEstimation: this.#backloggedEvents.payloadBytesEstimation + this.#events.payloadBytesEstimation,
@@ -58,24 +53,12 @@ export class Recorder {
     }
   }
 
-  /**
-   * Returns time-corrected events. If the events were correctable from the beginning, this correction will have already been applied.
-   * @param {SessionReplayEvent[]} events The array of buffered SR nodes
-   * @returns {CorrectedSessionReplayEvent[]}
-   */
-  returnCorrectTimestamps (events) {
-    if (!this.parent.timeKeeper?.ready) return events.events
-    return events.canCorrectTimestamps
-      ? events.events
-      : events.events.map(({ __serialized, timestamp, ...e }) => ({ timestamp: this.parent.timeKeeper.correctAbsoluteTimestamp(timestamp), ...e }))
-  }
-
   /** Clears the buffer (this.#events), and resets all payload metadata properties */
   clearBuffer () {
     if (this.#preloaded[0]?.events.length) this.#preloaded.shift()
     else if (this.parent.mode === MODE.ERROR) this.#backloggedEvents = this.#events
-    else this.#backloggedEvents = new RecorderEvents({ canCorrectTimestamps: !!this.parent.timeKeeper?.ready })
-    this.#events = new RecorderEvents({ canCorrectTimestamps: !!this.parent.timeKeeper?.ready })
+    else this.#backloggedEvents = new RecorderEvents()
+    this.#events = new RecorderEvents()
   }
 
   /** Begin recording using configured recording lib */
@@ -157,8 +140,9 @@ export class Recorder {
 
     if (this.parent.blocked) return
 
-    if (this.currentBufferTarget.canCorrectTimestamps) {
+    if (this.parent.timeKeeper?.ready && !event.__corrected) {
       event.timestamp = this.parent.timeKeeper.correctAbsoluteTimestamp(event.timestamp)
+      event.__corrected = true
     }
     event.__serialized = stringify(event)
     const eventBytes = event.__serialized.length
@@ -193,7 +177,7 @@ export class Recorder {
         this.parent.scheduler.runHarvest()
       } else {
         // we are still in "preload" and it triggered a "stop point".  Make a new set, which will get pointed at on next cycle
-        this.#preloaded.push(new RecorderEvents({ canCorrectTimestamps: !!this.parent.timeKeeper?.ready }))
+        this.#preloaded.push(new RecorderEvents())
       }
     }
   }

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -8,6 +8,7 @@ import { stylesheetEvaluator } from './stylesheet-evaluator'
 import { handle } from '../../../common/event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { buildNRMetaNode } from './utils'
 
 export class Recorder {
   /** Each page mutation or event will be stored (raw) in this array. This array will be cleared on each harvest */
@@ -140,9 +141,9 @@ export class Recorder {
 
     if (this.parent.blocked) return
 
-    if (this.parent.timeKeeper?.ready && !event.__corrected) {
+    if (this.parent.timeKeeper?.ready && !event.__newrelic) {
+      event.__newrelic = buildNRMetaNode(event.timestamp, this.parent.timeKeeper)
       event.timestamp = this.parent.timeKeeper.correctAbsoluteTimestamp(event.timestamp)
-      event.__corrected = true
     }
     event.__serialized = stringify(event)
     const eventBytes = event.__serialized.length

--- a/src/features/session_replay/shared/utils.js
+++ b/src/features/session_replay/shared/utils.js
@@ -17,3 +17,15 @@ export function canImportReplayAgg (agentId, sessionMgr) {
   if (!hasReplayPrerequisite(agentId)) return false
   return !!sessionMgr?.isNew || !!sessionMgr?.state.sessionReplayMode // Session Replay should only try to run if already running from a previous page, or at the beginning of a session
 }
+
+export function buildNRMetaNode (timestamp, timeKeeper) {
+  const correctedTimestamp = timeKeeper.correctAbsoluteTimestamp(timestamp)
+  return {
+    originalTimestamp: timestamp,
+    correctedTimestamp,
+    timestampDiff: timestamp - correctedTimestamp,
+    timeKeeperOriginTime: timeKeeper.originTime,
+    timeKeeperCorrectedOriginTime: timeKeeper.correctedOriginTime,
+    timeKeeperDiff: Math.floor(timeKeeper.originTime - timeKeeper.correctedOriginTime)
+  }
+}

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -51,7 +51,19 @@ describe('NR Server Time', () => {
     ])
 
     replayData.body.forEach(x => {
-      expect(x.__corrected).toEqual(true)
+      expect(x.__newrelic).toMatchObject({
+        originalTimestamp: expect.any(Number),
+        correctedTimestamp: expect.any(Number),
+        timestampDiff: expect.any(Number),
+        timeKeeperOriginTime: expect.any(Number),
+        timeKeeperCorrectedOriginTime: expect.any(Number),
+        timeKeeperDiff: expect.any(Number)
+      })
+      expect(x.__newrelic.timestampDiff - x.__newrelic.timeKeeperDiff).toBeLessThanOrEqual(1) //  account for rounding error
+      testTimeExpectations(x.__newrelic.correctedTimestamp, {
+        originTime: x.__newrelic.timeKeeperOriginTime,
+        correctedOriginTime: x.__newrelic.timeKeeperCorrectedOriginTime
+      }, true)
     })
     const attrs = decodeAttributes(replayData.query.attributes)
     const firstTimestamp = attrs['replay.firstTimestamp']
@@ -70,6 +82,21 @@ describe('NR Server Time', () => {
         .then(() => browser.waitForSessionReplayRecording())
         .then(() => browser.getTimeKeeper())
     ])
+    replayData.body.forEach(x => {
+      expect(x.__newrelic).toMatchObject({
+        originalTimestamp: expect.any(Number),
+        correctedTimestamp: expect.any(Number),
+        timestampDiff: expect.any(Number),
+        timeKeeperOriginTime: expect.any(Number),
+        timeKeeperCorrectedOriginTime: expect.any(Number),
+        timeKeeperDiff: expect.any(Number)
+      })
+      expect(x.__newrelic.timestampDiff - x.__newrelic.timeKeeperDiff).toBeLessThanOrEqual(1) //  account for rounding error
+      testTimeExpectations(x.__newrelic.correctedTimestamp, {
+        originTime: x.__newrelic.timeKeeperOriginTime,
+        correctedOriginTime: x.__newrelic.timeKeeperCorrectedOriginTime
+      }, true)
+    })
     const attrs = decodeAttributes(replayData.query.attributes)
     const firstTimestamp = attrs['replay.firstTimestamp']
     testTimeExpectations(firstTimestamp, timeKeeper, false)

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -44,12 +44,15 @@ describe('NR Server Time', () => {
     await browser.testHandle.clearScheduledReplies('bamServer')
     serverTime = await browser.mockDateResponse(undefined, { flags: { sr: 1 } })
     const [{ request: replayData }, timeKeeper] = await Promise.all([
-      browser.testHandle.expectBlob(),
+      browser.testHandle.expectBlob(10000),
       browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({ session_replay: { sampling_rate: 100, preload: true } })))
         .then(() => browser.waitForSessionReplayRecording())
         .then(() => browser.getTimeKeeper())
     ])
 
+    replayData.body.forEach(x => {
+      expect(x.__corrected).toEqual(true)
+    })
     const attrs = decodeAttributes(replayData.query.attributes)
     const firstTimestamp = attrs['replay.firstTimestamp']
     testTimeExpectations(firstTimestamp, timeKeeper, true)
@@ -193,6 +196,7 @@ function testTimeExpectations (timestamp, timeKeeper, before) {
   if (originTime && correctedOriginTime) {
     expect(Math.abs(serverTime - originTime + 3600000)).toBeLessThan(10000) // origin time should be about an hour ahead (3600000 ms)
     expect(Math.abs(serverTime - correctedOriginTime)).toBeLessThan(10000) // corrected origin time should roughly match the server time on our side
+    expect(Math.abs(correctedOriginTime - originTime + 3600000)).toBeLessThan(10000)
 
     expect(Math.abs(timestamp - correctedOriginTime)).toBeLessThan(10000) // should expect a reasonable tolerance (and much less than an hour)
     expect(Math.abs(timestamp - originTime + 3600000)).toBeLessThan(10000) // should expect a reasonable tolerance (and much less than an hour)


### PR DESCRIPTION
Ensure Session Replay timestamps are only ever adjusted once and fix correction factor to alleviate timeOrigin inconsistencies
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR ensures that SR timestamps are only ever adjusted once, and that the origin time they use to correct the issue does not fall victim to a known timeOrigin bug in Chromium and Firefox browsers. 
* https://issues.chromium.org/issues/40866530
* https://bugzilla.mozilla.org/show_bug.cgi?id=1710762
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
