### PR TITLE
fix: Revert "Generate PTID in Agent"

### DIFF
--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -145,7 +145,7 @@ export class Harvest extends SharedContext {
       result.addEventListener('loadend', function () {
         // `this` refers to the XHR object in this scope, do not change this to a fat arrow
         // status 0 refers to a local error, such as CORS or network failure, or a blocked request by the browser (e.g. adblocker)
-        const cbResult = { sent: this.status !== 0, status: this.status, failed: this.status === 0 || this.status >= 400, xhr: this, fullUrl }
+        const cbResult = { sent: this.status !== 0, status: this.status, xhr: this, fullUrl }
         if (this.status === 429) {
           cbResult.retry = true
           cbResult.delay = harvestScope.tooManyRequestsDelay

--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -52,7 +52,6 @@ export function configure (agent, opts = {}, loaderType, forceDrain) {
     ...(updatedInit.ajax.deny_list || []),
     ...(updatedInit.ajax.block_internal ? internalTrafficList : [])
   ]
-  runtime.ptid = agent.agentIdentifier
   setRuntime(agent.agentIdentifier, runtime)
 
   if (agent.api === undefined) agent.api = setAPI(agent.agentIdentifier, forceDrain, agent.runSoftNavOverSpa)

--- a/tests/functional/stn/index.test.js
+++ b/tests/functional/stn/index.test.js
@@ -9,13 +9,12 @@ testDriver.test('posts session traces', function (t, browser, router) {
   let rumPromise = router.expectRum()
   let resourcePromise = router.expectResources()
   let loadPromise = browser.get(router.assetURL('lotsatimers.html')).waitForFeature('loaded')
-  let ptid
+
   Promise.all([resourcePromise, rumPromise, loadPromise]).then(([{ request: { query } }]) => {
     t.ok(+query.st > 1408126770885, `Got start time ${query.st}`)
-    ptid = query.ptid
-    t.ok(query.ptid, 'ptid on first harvest')
+    t.notok(query.ptid, 'No ptid on first harvest')
     return router.expectResources().then(({ request: { query } }) => {
-      t.equals(query.ptid, ptid, `ptid on second harvest ${query.ptid}`)
+      t.ok(query.ptid, `ptid on second harvest ${query.ptid}`)
       t.end()
     })
   }).catch(fail)

--- a/tests/specs/harvesting/index.e2e.js
+++ b/tests/specs/harvesting/index.e2e.js
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker'
+import { testResourcesRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('harvesting', () => {
   it('should include the base query parameters', async () => {
@@ -45,14 +46,18 @@ describe('harvesting', () => {
   })
 
   it('should include the ptid query parameter on requests after the first session trace harvest', async () => {
-    const [rumRequest] = await Promise.all([
+    const ptid = faker.string.uuid()
+    browser.testHandle.scheduleReply('bamServer', {
+      test: testResourcesRequest,
+      body: ptid
+    })
+
+    await Promise.all([
       browser.testHandle.expectRum(),
       browser.testHandle.expectResources(),
       browser.url(await browser.testHandle.assetURL('obfuscate-pii.html'))
         .then(() => browser.waitForAgentLoad())
     ])
-
-    const ptid = rumRequest.request.query.ptid
 
     const [
       resourcesResults,

--- a/tests/specs/stn/retry-harvesting.e2e.js
+++ b/tests/specs/stn/retry-harvesting.e2e.js
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import { testResourcesRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('stn retry harvesting', () => {
@@ -20,7 +21,7 @@ describe('stn retry harvesting', () => {
       await browser.pause(500)
       await browser.testHandle.clearScheduledReplies('bamServer')
 
-      const ptid = firstResourcesHarvest.request.query.ptid
+      const ptid = faker.string.uuid()
       await browser.testHandle.scheduleReply('bamServer', {
         test: testResourcesRequest,
         permanent: true,
@@ -35,7 +36,7 @@ describe('stn retry harvesting', () => {
 
       expect(firstResourcesHarvest.reply.statusCode).toEqual(statusCode)
       expect(secondResourcesHarvest.request.body.res).toEqual(expect.arrayContaining(firstResourcesHarvest.request.body.res))
-      expect(secondResourcesHarvest.request.query.ptid).toEqual(ptid)
+      expect(secondResourcesHarvest.request.query.ptid).toBeUndefined()
       expect(thirdResourcesHarvest.request.query.ptid).toEqual(ptid)
     })
   );
@@ -55,7 +56,27 @@ describe('stn retry harvesting', () => {
           .then(() => browser.waitForAgentLoad())
       ])
 
+      // Pause a bit for browsers built-in automated retry logic crap
+      // await browser.pause(500)
+      // await browser.testHandle.clearScheduledReplies('bamServer')
+
+      // const ptid = faker.string.uuid()
+      // await browser.testHandle.scheduleReply('bamServer', {
+      //   test: testResourcesRequest,
+      //   permanent: true,
+      //   body: ptid
+      // })
+
+      // const secondResourcesHarvest = await browser.testHandle.expectResources()
+      // const [thirdResourcesHarvest] = await Promise.all([
+      //   browser.testHandle.expectResources(),
+      //   $('#trigger').click()
+      // ])
+
       expect(firstResourcesHarvest.reply.statusCode).toEqual(statusCode)
+      // expect(secondResourcesHarvest.request.body.res).not.toEqual(expect.arrayContaining(firstResourcesHarvest.request.body.res))
+      // expect(secondResourcesHarvest.request.query.ptid).toBeUndefined()
+      // expect(thirdResourcesHarvest.request.query.ptid).toEqual(ptid)
       await expect(browser.testHandle.expectResources(10000, true)).resolves.toBeUndefined()
     })
   )

--- a/tests/specs/stn/with-session-replay.e2e.js
+++ b/tests/specs/stn/with-session-replay.e2e.js
@@ -84,7 +84,7 @@ describe.withBrowsersMatching(notIE)('stn with session replay', () => {
       let initSTReceived = await loadPageAndGetResource(['stn/instrumented.html', { init: { privacy: { cookies_enabled: true }, session_replay: { enabled: false } } }], 3001)
       let firstPageAgentVals = await getTraceValues()
       expect(initSTReceived).toBeTruthy() // that is, trace should still fully run when the replay feature isn't around
-      expect(initSTReceived.request.query.ptid).not.toBeUndefined() // trace has ptid on first initial harvest
+      expect(initSTReceived.request.query.ptid).toBeUndefined() // trace doesn't have ptid on first initial harvest
       expect(firstPageAgentVals).toEqual([true, MODE.FULL, expect.any(String)])
 
       await navigateToRootDir()
@@ -94,7 +94,7 @@ describe.withBrowsersMatching(notIE)('stn with session replay', () => {
       let secondPageAgentVals = await getTraceValues()
       // On subsequent page load or refresh, trace should maintain the set mode, standalone, and same sessionid but have a new ptid corresponding to new page visit.
       expect(secondInitST.request.query.s).toEqual(initSTReceived.request.query.s)
-      expect(secondInitST.request.query.ptid).not.toBeUndefined()
+      expect(secondInitST.request.query.ptid).toBeUndefined()
       expect(secondPageAgentVals).toEqual([true, MODE.FULL, expect.any(String)]) // note it's expected & assumed that the replay mode is OFF
 
       expect(secondPageAgentVals[2]).not.toEqual(firstPageAgentVals[2]) // ptids
@@ -118,7 +118,7 @@ describe.withBrowsersMatching(notIE)('stn with session replay', () => {
         let initSTReceived = await loadPageAndGetResource(['stn/instrumented.html', config({ session_replay: replayConfig })], 3003)
         let firstPageAgentVals = await getRuntimeValues()
         expect(initSTReceived).toBeTruthy()
-        expect(initSTReceived.request.query.ptid).not.toBeUndefined()
+        expect(initSTReceived.request.query.ptid).toBeUndefined()
         if (replayMode === 'OFF') {
           expect(firstPageAgentVals).toEqual([true, MODE.FULL, true])
           expect(Number(initSTReceived.request.query.hr)).toEqual(0)
@@ -134,7 +134,7 @@ describe.withBrowsersMatching(notIE)('stn with session replay', () => {
         let secondPageAgentVals = await getRuntimeValues()
         // On subsequent page load or refresh, trace should maintain FULL mode and session id.
         expect(secondInitST.request.query.s).toEqual(initSTReceived.request.query.s)
-        expect(secondInitST.request.query.ptid).not.toBeUndefined() // this validates we're actually getting the 2nd page's initial res, not 1st page's unload res
+        expect(secondInitST.request.query.ptid).toBeUndefined() // this validates we're actually getting the 2nd page's initial res, not 1st page's unload res
         if (replayMode === 'OFF') {
           expect(secondPageAgentVals).toEqual([true, MODE.FULL, null]) // session_replay.featAggregate will be null as it's OFF and not imported on subsequent pages
           expect(Number(secondInitST.request.query.hr)).toEqual(0)

--- a/tests/unit/common/harvest/harvest.test.js
+++ b/tests/unit/common/harvest/harvest.test.js
@@ -377,7 +377,7 @@ describe('_send', () => {
     expect(xhrAddEventListener).toHaveBeenCalledWith('loadend', expect.any(Function), expect.any(Object))
     expect(result).toEqual(jest.mocked(submitDataModule.xhr).mock.results[0].value)
     expect(submitMethod).not.toHaveBeenCalled()
-    expect(spec.cbFinished).toHaveBeenCalledWith({ ...xhrState, sent: true, xhr: xhrState, failed: false, fullUrl: expect.any(String) })
+    expect(spec.cbFinished).toHaveBeenCalledWith({ ...xhrState, sent: true, xhr: xhrState, fullUrl: expect.any(String) })
   })
 
   test('should set cbFinished state retry to true with delay when xhr has 429 status', () => {
@@ -403,7 +403,6 @@ describe('_send', () => {
       retry: true,
       delay: harvestInstance.tooManyRequestsDelay,
       xhr: xhrState,
-      failed: true,
       fullUrl: expect.any(String)
     })
   })
@@ -431,7 +430,6 @@ describe('_send', () => {
       sent: true,
       retry: true,
       xhr: xhrState,
-      failed: true,
       fullUrl: expect.any(String)
     })
   })
@@ -458,7 +456,6 @@ describe('_send', () => {
       ...xhrState,
       sent: true,
       xhr: xhrState,
-      failed: false,
       fullUrl: expect.any(String)
     })
   })
@@ -486,7 +483,6 @@ describe('_send', () => {
       responseText: undefined,
       sent: true,
       xhr: xhrState,
-      failed: false,
       fullUrl: expect.any(String)
     })
   })
@@ -511,7 +507,6 @@ describe('_send', () => {
       ...xhrState,
       sent: false,
       xhr: xhrState,
-      failed: true,
       fullUrl: expect.any(String)
     })
   })


### PR DESCRIPTION
Revert a change causing Trace to begin harvest even when the rum flag given is `0`.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

This reverts commit af7b6764f40cb1ddfb3ab2ca16d05d8e4f459f4e.

### Related Issue(s)

Escalation https://newrelic.slack.com/archives/C0193KAHHAS/p1713186294566949 & #emergency-room on 15/4/2024

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
