### PR TITLE
feat: Decorate errors with hasReplay individually

### DIFF
--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -167,14 +167,15 @@ export class Harvest extends SharedContext {
   }
 
   // The stuff that gets sent every time.
-  baseQueryString (qs) {
+  baseQueryString (qs, endpoint) {
     const runtime = getRuntime(this.sharedContext.agentIdentifier)
     const info = getInfo(this.sharedContext.agentIdentifier)
 
     const location = cleanURL(getLocation())
     const ref = this.obfuscator.shouldObfuscate() ? this.obfuscator.obfuscateString(location) : location
+    const hr = runtime?.session?.state.sessionReplayMode === 1 && endpoint !== 'jserrors'
 
-    return ([
+    const qps = [
       'a=' + info.applicationID,
       encodeParam('sa', (info.sa ? '' + info.sa : '')),
       encodeParam('v', VERSION),
@@ -184,9 +185,10 @@ export class Harvest extends SharedContext {
       '&ck=0', // ck param DEPRECATED - still expected by backend
       '&s=' + (runtime.session?.state.value || '0'), // the 0 id encaps all untrackable and default traffic
       encodeParam('ref', ref),
-      encodeParam('ptid', (runtime.ptid ? '' + runtime.ptid : '')),
-      encodeParam('hr', (runtime?.session?.state.sessionReplayMode === 1 ? '1' : '0'), qs) // hasReplay
-    ].join(''))
+      encodeParam('ptid', (runtime.ptid ? '' + runtime.ptid : ''))
+    ]
+    if (hr) qps.push(encodeParam('hr', '1', qs))
+    return qps.join('')
   }
 
   /**

--- a/src/common/harvest/harvest.js
+++ b/src/common/harvest/harvest.js
@@ -103,7 +103,7 @@ export class Harvest extends SharedContext {
     if (customUrl) url = customUrl
     if (raw) url = `${protocol}://${perceviedBeacon}/${endpoint}`
 
-    const baseParams = !raw && includeBaseParams ? this.baseQueryString(qs) : ''
+    const baseParams = !raw && includeBaseParams ? this.baseQueryString(qs, endpoint) : ''
     let payloadParams = encodeObj(qs, agentRuntime.maxBytes)
     if (!submitMethod) {
       submitMethod = submitData.getSubmitMethod({ isFinalHarvest: opts.unload })

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -172,7 +172,7 @@ export class Aggregate extends AggregateBase {
      * the canonical stack trace excludes items like the column number increasing the hit-rate of different errors potentially
      * bucketing and ultimately resulting in the loss of data in NR1.
      */
-    var bucketHash = stringHashCode(`${stackInfo.name}_${stackInfo.message}_${stackInfo.stackString}_${params.hasReplay}`)
+    var bucketHash = stringHashCode(`${stackInfo.name}_${stackInfo.message}_${stackInfo.stackString}_${params.hasReplay ? 1 : 0}`)
 
     if (!this.stackReported[bucketHash]) {
       this.stackReported[bucketHash] = true

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -172,13 +172,14 @@ export class Aggregate extends AggregateBase {
     // Do not modify the name ('errorGroup') of params without DEM approval!
     if (filterOutput?.group) params.errorGroup = filterOutput.group
 
+    if (hasReplay && !this.replayAborted) params.hasReplay = hasReplay
     /**
      * The bucketHash is different from the params.stackHash because the params.stackHash is based on the canonicalized
      * stack trace and is used downstream in NR1 to attempt to group the same errors across different browsers. However,
      * the canonical stack trace excludes items like the column number increasing the hit-rate of different errors potentially
      * bucketing and ultimately resulting in the loss of data in NR1.
      */
-    var bucketHash = stringHashCode(`${stackInfo.name}_${stackInfo.message}_${stackInfo.stackString}`)
+    var bucketHash = stringHashCode(`${stackInfo.name}_${stackInfo.message}_${stackInfo.stackString}_${params.hasReplay}`)
 
     if (!this.stackReported[bucketHash]) {
       this.stackReported[bucketHash] = true
@@ -199,7 +200,6 @@ export class Aggregate extends AggregateBase {
       this.pageviewReported[bucketHash] = true
     }
 
-    if (hasReplay && !this.replayAborted) params.hasReplay = hasReplay
     params.firstOccurrenceTimestamp = this.observedAt[bucketHash]
     params.timestamp = this.observedAt[bucketHash]
 

--- a/tests/assets/rrweb-duplicate-errors-split.html
+++ b/tests/assets/rrweb-duplicate-errors-split.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    <style>
+      .left {
+        position: absolute;
+        left: 50px;
+        top: 200px;
+      }
+      .right {
+        position: absolute;
+        right: 50px;
+        top: 200px;
+      }
+    </style>
+    <link rel="stylesheet" type="text/css" href="style.css" /> 
+    {init} {config} {loader}
+    <script>
+      inv = setInterval(() => {
+        if (performance.now() > 5000) clearInterval(inv)
+        newrelic.noticeError('test')
+      }, 50)
+    </script>
+    <script>
+      window.wasPreloaded = false;
+      window.addEventListener("load", () => {
+        try {
+          window.wasPreloaded = !!Object.values(newrelic.initializedAgents)[0].features.session_replay.recorder
+        } catch (err) {
+          // do nothing because it failed to get the recorder -- which inherently also means it was not preloaded
+        }
+      });
+    </script>
+  </head>
+  <body>
+    this is a page that provides several types of elements with selectors that session_replay can interact with based on how it is configured
+    <hr />
+    <hr />
+    <textarea id="plain"></textarea>
+    <textarea id="ignore" class="nr-ignore"></textarea>
+    <textarea id="block" class="nr-block"></textarea>
+    <textarea id="mask" class="nr-mask"></textarea>
+    <textarea id="nr-block" data-nr-block></textarea>
+    <textarea id="other-block" data-other-block></textarea>
+    <textarea id="unmask-class" class="nr-unmask"></textarea>
+    <textarea id="unmask-data" data-nr-unmask></textarea>
+    <input type="text" id="unmask-class" class="nr-unmask" />
+    <input type="text" id="unmask-data" data-nr-unmask />
+    <input type="password" id="unmask-pass-input" data-nr-unmask />
+    <input type="password" id="pass-input" />
+    <input type="text" id="text-input" />
+    <hr />
+    <button onclick="moveImage()">Click</button>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/d/d7/House_of_Commons_Chamber_1.png" />
+    <a href="./rrweb-instrumented.html" target="_blank">New Tab</a>
+    <script>
+      function moveImage() {
+        document.querySelector("img").classList.toggle("left");
+        document.querySelector("img").classList.toggle("right");
+      }
+    </script>
+  </body>
+</html>

--- a/tests/assets/rrweb-duplicate-errors-split.html
+++ b/tests/assets/rrweb-duplicate-errors-split.html
@@ -23,7 +23,6 @@
     <script>
       pre = 0, post = 0
       inv = setInterval(() => {
-        console.log(pre, post)
         // run error 500 times before load, and 500 times after load, creating a duplicate stack track for all errors
         if (++pre >= 500 && post >= 500) clearInterval(inv)
         newrelic.noticeError(new Error('test'))

--- a/tests/assets/rrweb-duplicate-errors-split.html
+++ b/tests/assets/rrweb-duplicate-errors-split.html
@@ -21,20 +21,14 @@
     <link rel="stylesheet" type="text/css" href="style.css" /> 
     {init} {config} {loader}
     <script>
+      pre = 0, post = 0
       inv = setInterval(() => {
-        if (performance.now() > 5000) clearInterval(inv)
-        newrelic.noticeError('test')
-      }, 50)
-    </script>
-    <script>
-      window.wasPreloaded = false;
-      window.addEventListener("load", () => {
-        try {
-          window.wasPreloaded = !!Object.values(newrelic.initializedAgents)[0].features.session_replay.recorder
-        } catch (err) {
-          // do nothing because it failed to get the recorder -- which inherently also means it was not preloaded
-        }
-      });
+        console.log(pre, post)
+        // run error 500 times before load, and 500 times after load, creating a duplicate stack track for all errors
+        if (++pre >= 500 && post >= 500) clearInterval(inv)
+        newrelic.noticeError(new Error('test'))
+        if ( document.readyState === 'complete') post++
+      }, 5)
     </script>
   </head>
   <body>

--- a/tests/components/spa/initial-page-load.test.js
+++ b/tests/components/spa/initial-page-load.test.js
@@ -50,7 +50,6 @@ test('initial page load timing', done => {
   }
 
   function afterInteractionDone (interaction) {
-    console.log(interaction)
     setTimeout(() => {
       expect(interaction.root.attrs.trigger).toEqual('initialPageLoad')
       expect(interaction.root.end).toBeGreaterThan(0) // interaction should be finished and have an end time

--- a/tests/specs/session-replay/mode.e2e.js
+++ b/tests/specs/session-replay/mode.e2e.js
@@ -249,6 +249,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
       .then(() => browser.waitForSessionReplayRecording('session_replay'))
 
     const errors = await browser.testHandle.expectErrors()
+    expect(errors.request.query.hr).toEqual(undefined)
     const errAggSet1 = errors.request.body.err[0]
     const errAggSet2 = errors.request.body.err[1]
     expect(errAggSet1.params.hasReplay).toEqual(undefined)


### PR DESCRIPTION
Change the error aggregation method to consider errors with a hasReplay flag separately to ensure timestamps are always correct. Decorate each aggregation set with hasReplay directly instead of a request-level query param
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR abstracts the aggregation of errors with hasReplay to their own set, which ensures that the `firstOccurrenceTimestamp` is not applied to duplicate errors that may have happened outside of a replay's import logic.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-260137
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added which check that duplicated errors are buckets and decorated correctly.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
