### PR TITLE
fix: JSEerrors harvest hasReplay decoration

### DIFF
--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -38,12 +38,9 @@ export class Aggregate extends AggregateBase {
     this.bufferedErrorsUnderSpa = {}
     this.currentBody = undefined
     this.errorOnPage = false
-    this.replayAborted = false
 
     // this will need to change to match whatever ee we use in the instrument
     this.ee.on('interactionDone', (interaction, wasSaved) => this.onInteractionDone(interaction, wasSaved))
-
-    this.ee.on('REPLAY_ABORTED', () => { this.replayAborted = true })
 
     register('err', (...args) => this.storeError(...args), this.featureName, this.ee)
     register('ierr', (...args) => this.storeError(...args), this.featureName, this.ee)
@@ -82,11 +79,7 @@ export class Aggregate extends AggregateBase {
     }
 
     if (body && body.err && body.err.length) {
-      if (this.replayAborted) {
-        body.err.forEach((e) => {
-          delete e.params?.hasReplay
-        })
-      }
+      this.#runCrossFeatureChecks(body.err)
       if (!this.errorOnPage) {
         payload.qs.pve = '1'
         this.errorOnPage = true
@@ -295,5 +288,28 @@ export class Aggregate extends AggregateBase {
       this.#storeJserrorForHarvest(jsErrorEvent, wasFinished, softNavAttrs) // this should not modify the re-used softNavAttrs contents
     )
     delete this.bufferedErrorsUnderSpa[interactionId] // wipe the list of jserrors so they aren't duplicated by another call to the same id
+  }
+
+  /**
+   * Dispatches a cross-feature communication event to allow other
+   * features to provide flags and data that can be used to mutation
+   * to the payload and to allow features to know about a feature
+   * harvest happening.
+   * @param {any[]} errors Array of errors from the payload body
+   */
+  #runCrossFeatureChecks (errors) {
+    const errorHashes = errors.map(error => error.params.stackHash)
+    const crossFeatureData = {
+      errorHashes
+    }
+    this.ee.emit(`cfc.${this.featureName}`, [crossFeatureData])
+
+    let hasReplayFlag = errors.find(err => err.params.hasReplay)
+    if (hasReplayFlag && !crossFeatureData.hasReplay) {
+      // Some errors have `hasReplay` and a replay is not being recorded
+      errors.forEach(error => {
+        delete error.params.hasReplay
+      })
+    }
   }
 }

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -192,7 +192,7 @@ export class Aggregate extends AggregateBase {
       this.pageviewReported[bucketHash] = true
     }
 
-    if (hasReplay && !this.replayAborted) params.hasReplay = hasReplay
+    if (hasReplay) params.hasReplay = hasReplay
     params.firstOccurrenceTimestamp = this.observedAt[bucketHash]
     params.timestamp = this.observedAt[bucketHash]
 

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -59,6 +59,14 @@ export class Aggregate extends AggregateBase {
 
     handle(SUPPORTABILITY_METRIC_CHANNEL, ['Config/SessionReplay/Enabled'], undefined, FEATURE_NAMES.metrics, this.ee)
 
+    this.ee.on(`cfc.${FEATURE_NAMES.jserrors}`, (crossFeatureData) => {
+      crossFeatureData.hasReplay = !!(this.scheduler?.started &&
+        this.recorder &&
+        this.mode === MODE.FULL &&
+        !this.blocked &&
+        this.entitled)
+    })
+
     // The SessionEntity class can emit a message indicating the session was cleared and reset (expiry, inactivity). This feature must abort and never resume if that occurs.
     this.ee.on(SESSION_EVENTS.RESET, () => {
       this.abort(ABORT_REASONS.RESET)

--- a/tests/specs/session-replay/adjacent-payloads.e2e.js
+++ b/tests/specs/session-replay/adjacent-payloads.e2e.js
@@ -1,34 +1,56 @@
 import { notIE } from '../../../tools/browser-matcher/common-matchers.mjs'
 import { config, decodeAttributes } from './helpers'
 
-describe('errors', () => {
-  beforeEach(async () => {
-    await browser.enableSessionReplay()
-  })
+describe.withBrowsersMatching(notIE)('Adjacent Payloads', () => {
+  describe('JSErrors', () => {
+    beforeEach(async () => {
+      await browser.enableSessionReplay()
+    })
 
-  afterEach(async () => {
-    await browser.destroyAgentSession()
-  })
+    afterEach(async () => {
+      await browser.destroyAgentSession()
+    })
 
-  it.withBrowsersMatching(notIE)('error timestamp should be contained within replay timestamp', async () => {
-    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({
-      session_replay: { error_sampling_rate: 100, sampling_rate: 0 }
-    })))
-      .then(() => browser.waitForAgentLoad())
+    it('error timestamp should be contained within replay timestamp', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({
+        session_replay: { error_sampling_rate: 100, sampling_rate: 0 }
+      })))
+        .then(() => browser.waitForAgentLoad())
 
-    // this issue was seen when some time had passed from agg load time and was running in error mode
-    await browser.pause(5000)
+      // this issue was seen when some time had passed from agg load time and was running in error mode
+      await browser.pause(5000)
 
-    const [errorPayload, blobPayload] = await Promise.all([
-      browser.testHandle.expectErrors(10000),
-      browser.testHandle.expectBlob(10000),
-      browser.execute(function () {
-        newrelic.noticeError(new Error('test'))
-      })
-    ])
+      const [errorPayload, blobPayload] = await Promise.all([
+        browser.testHandle.expectErrors(10000),
+        browser.testHandle.expectBlob(10000),
+        browser.execute(function () {
+          newrelic.noticeError(new Error('test'))
+        })
+      ])
 
-    const errorTimestamp = errorPayload.request.body.err[0].params.firstOccurrenceTimestamp
-    const SRTimestamp = decodeAttributes(blobPayload.request.query.attributes)['replay.firstTimestamp']
-    expect(errorTimestamp).toBeGreaterThan(SRTimestamp)
+      const errorTimestamp = errorPayload.request.body.err[0].params.firstOccurrenceTimestamp
+      const SRTimestamp = decodeAttributes(blobPayload.request.query.attributes)['replay.firstTimestamp']
+      expect(errorTimestamp).toBeGreaterThan(SRTimestamp)
+      expect(errorPayload.request.body.err[0].params.hasReplay).toEqual(true)
+    })
+
+    it('error should have hasReplay removed when preloaded but not autostarted', async () => {
+      await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', config({
+        session_replay: { preload: true, error_sampling_rate: 0, sampling_rate: 100, autoStart: false }
+      })))
+        .then(() => browser.waitForAgentLoad())
+
+      // this issue was seen when some time had passed from agg load time and was running in error mode
+      await browser.pause(5000)
+
+      const [errorPayload] = await Promise.all([
+        browser.testHandle.expectErrors(10000),
+        browser.execute(function () {
+          newrelic.noticeError(new Error('test'))
+        })
+      ])
+
+      expect(errorPayload.request.body.err[0].params.hasReplay).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
In scenarios where the SessionReplay feature was preloaded but a recording was never started, errors happening on the page would be improperly decorated with the `hasReplay` flag.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

This introduces a pre-harvest cross-feature communication event within the JSErrors feature. When a harvest occurs, the JSErrors feature will send out the `cfc.jserrors` event with an object containing information about the errors being harvested.

The SessionReplay feature has been updated to listen to the `cfc.jserrors` event and decorate the event payload with a `hasReplay` flag in the aggregate. The flag will be true only if the aggregate loaded, the aggregate has a running harvest scheduler, the aggregate has a recorder initialized, the mode is in `FULL`, the aggregate is not blocked, and the aggregate is entitled to harvest.

A check as been added to the JSErrors `cfc` function to check for the event data flag `hasReplay`. If any of the errors being harvested has the `hasReplay` flag present and truethy, but the `cfc` event data is missing the `hasReplay` flag or the flag is falsey, the harvest payload will be updated to remove the `hasReplay` flag off all the error params objects.

**Note:** If the `hasReplay` flag is missing in the `cfc` event data, it is indicative of the SessionReplay aggregate never loading. If it is present but has a false value, one of the above checks failed in the SessionReplay feature. 

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-260139

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
A wdio test was added that presents a reproducible scenario where the SessionReplay feature is preloaded but not auto started. In such a scenario, the errors harvested would always have `hasReplay` but shouldn't.