### PR TITLE
fix: Agent class type declarations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'tests/assets/scripts/**/*',
     'tests/assets/test-builds/**/*',
     'tests/assets/modular/js-errors/js/vendor/**/*',
+    'tests/dts/**/*',
 
     // Ignore JIL code since it is being replaced with WDIO
     'tools/jil/**/*',

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -21,6 +21,10 @@ import { globalScope } from '../common/constants/runtime'
  * sensitive to network load, this may result in smaller builds with slightly lower performance impact.
  */
 export class Agent extends AgentBase {
+  /**
+   * @param {any} options Options to initialize agent with
+   * @param {string} [agentIdentifier] Optional identifier of agent
+   */
   constructor (options, agentIdentifier) {
     super(agentIdentifier)
 

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -22,7 +22,7 @@ import { globalScope } from '../common/constants/runtime'
  */
 export class Agent extends AgentBase {
   /**
-   * @param {any} options Options to initialize agent with
+   * @param {Object} options Options to initialize agent with
    * @param {string} [agentIdentifier] Optional identifier of agent
    */
   constructor (options, agentIdentifier) {

--- a/tests/dts/agent.test-d.ts
+++ b/tests/dts/agent.test-d.ts
@@ -1,0 +1,6 @@
+import { Agent } from '../../dist/types/loaders/agent'
+import { AgentBase } from '../../dist/types/loaders/agent-base'
+import { expectAssignable } from 'tsd'
+
+const agent = new Agent({})
+expectAssignable<AgentBase>(agent)

--- a/tests/dts/api.test-d.ts
+++ b/tests/dts/api.test-d.ts
@@ -1,7 +1,7 @@
 import { BrowserAgent } from '../../dist/types/loaders/browser-agent'
 import { MicroAgent } from '../../dist/types/loaders/micro-agent'
 import { InteractionInstance, getContext, onEnd } from '../../dist/types/loaders/api/interaction-types'
-import { expectType, expectNotType } from 'tsd'
+import { expectType } from 'tsd'
 
 // Browser Agent APIs
 const browserAgent = new BrowserAgent({})


### PR DESCRIPTION
Fixing incorrect type declarations for the constructor parameters of the Agent class.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Fixing incorrect type declarations for the constructor parameters of the Agent class.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://github.com/newrelic/newrelic-browser-agent/issues/952

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
