### PR TITLE
fix: Prevent null CLS

### DIFF
--- a/src/common/vitals/vital-metric.js
+++ b/src/common/vitals/vital-metric.js
@@ -9,7 +9,7 @@ export class VitalMetric {
   }
 
   update ({ value, attrs = {} }) {
-    if (value < 0) return
+    if (value === undefined || value === null || value < 0) return
     const state = {
       value: this.roundingMethod(value),
       name: this.name,

--- a/tests/unit/common/vitals/cumulative-layout-shift.test.js
+++ b/tests/unit/common/vitals/cumulative-layout-shift.test.js
@@ -10,9 +10,10 @@ const clsAttribution = {
   largestShiftValue: 0.9712,
   loadState: 'dom-content-loaded'
 }
+let mockReturnVal = 0.123
 const getFreshCLSImport = async (codeToRun) => {
   jest.doMock('web-vitals/attribution', () => ({
-    onCLS: jest.fn(cb => cb({ value: 0.123, attribution: clsAttribution, id: 'beepboop' }))
+    onCLS: jest.fn(cb => cb({ value: mockReturnVal, attribution: clsAttribution, id: 'beepboop' }))
   }))
   const { cumulativeLayoutShift } = await import('../../../../src/common/vitals/cumulative-layout-shift')
   codeToRun(cumulativeLayoutShift)
@@ -59,5 +60,25 @@ describe('cls', () => {
         if (witness === 2) done()
       })
     })
+  })
+  test('null value is not reported', done => {
+    mockReturnVal = null
+    getFreshCLSImport(metric => {
+      metric.subscribe(({ value, attrs }) => {
+        console.log('should not have reported...')
+        expect(1).toEqual(2)
+      })
+    })
+    setTimeout(done, 1000) // should not get subscribe invokation
+  })
+  test('undefined value is not reported', done => {
+    mockReturnVal = undefined
+    getFreshCLSImport(metric => {
+      metric.subscribe(({ value, attrs }) => {
+        console.log('should not have reported...')
+        expect(1).toEqual(2)
+      })
+    })
+    setTimeout(done, 1000) // should not get subscribe invokation
   })
 })

--- a/tests/unit/common/vitals/cumulative-layout-shift.test.js
+++ b/tests/unit/common/vitals/cumulative-layout-shift.test.js
@@ -81,4 +81,12 @@ describe('cls', () => {
     })
     setTimeout(done, 1000) // should not get subscribe invokation
   })
+  test('zero value IS reported', done => {
+   mockReturnVal = 0
+    getFreshCLSImport(metric => {
+      metric.subscribe(({ value, attrs }) => {
+        expect(value).toEqual(0)
+        done()
+      })
+    })
 })

--- a/tests/unit/common/vitals/cumulative-layout-shift.test.js
+++ b/tests/unit/common/vitals/cumulative-layout-shift.test.js
@@ -82,11 +82,12 @@ describe('cls', () => {
     setTimeout(done, 1000) // should not get subscribe invokation
   })
   test('zero value IS reported', done => {
-   mockReturnVal = 0
+    mockReturnVal = 0
     getFreshCLSImport(metric => {
       metric.subscribe(({ value, attrs }) => {
         expect(value).toEqual(0)
         done()
       })
     })
+  })
 })


### PR DESCRIPTION
Add check to prevent null and undefined web-vitals values from being reported 
---
### Overview
This PR prevents the vital-metric class from updating/emitting if provided a nullish value.  This was only observed in practice during some wdio test runs (blocking some PRs intermittently) -- And we don't exactly understand why web-vitals would even emit a nullish value -- But this is a simple fix that should prevent issues later if this is actually happening in the wild since we should not be reporting null values.

### Related Issue(s)
NR-260221
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Unit test has been updated to ensure nullish values are not reported to the subscribers
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
