### PR TITLE
feat: JSErrors timestamped per harvest

### DIFF
--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -34,6 +34,7 @@ export class Aggregate extends AggregateBase {
 
     this.stackReported = {}
     this.observedAt = {}
+    this.harvestObservedAt = {}
     this.pageviewReported = {}
     this.bufferedErrorsUnderSpa = {}
     this.currentBody = undefined
@@ -85,6 +86,7 @@ export class Aggregate extends AggregateBase {
         this.errorOnPage = true
       }
     }
+    this.harvestObservedAt = {}
     return payload
   }
 
@@ -194,7 +196,11 @@ export class Aggregate extends AggregateBase {
     }
 
     params.firstOccurrenceTimestamp = this.observedAt[bucketHash]
-    params.timestamp = this.observedAt[bucketHash]
+
+    if (!this.harvestObservedAt[bucketHash]) {
+      this.harvestObservedAt[bucketHash] = agentRuntime.timeKeeper.convertRelativeTimestamp(time)
+    }
+    params.timestamp = this.harvestObservedAt[bucketHash]
 
     var type = internal ? 'ierr' : 'err'
     var newMetrics = { time }

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -34,7 +34,6 @@ export class Aggregate extends AggregateBase {
 
     this.stackReported = {}
     this.observedAt = {}
-    this.harvestObservedAt = {}
     this.pageviewReported = {}
     this.bufferedErrorsUnderSpa = {}
     this.currentBody = undefined
@@ -86,7 +85,7 @@ export class Aggregate extends AggregateBase {
         this.errorOnPage = true
       }
     }
-    this.harvestObservedAt = {}
+
     return payload
   }
 
@@ -196,11 +195,7 @@ export class Aggregate extends AggregateBase {
     }
 
     params.firstOccurrenceTimestamp = this.observedAt[bucketHash]
-
-    if (!this.harvestObservedAt[bucketHash]) {
-      this.harvestObservedAt[bucketHash] = agentRuntime.timeKeeper.convertRelativeTimestamp(time)
-    }
-    params.timestamp = this.harvestObservedAt[bucketHash]
+    params.timestamp = agentRuntime.timeKeeper.convertRelativeTimestamp(time)
 
     var type = internal ? 'ierr' : 'err'
     var newMetrics = { time }

--- a/tests/specs/err/error-payload.e2e.js
+++ b/tests/specs/err/error-payload.e2e.js
@@ -59,6 +59,7 @@ describe('error payloads', () => {
     const { request: { body: { err: err2 } } } = await browser.testHandle.expectErrors()
 
     expect(err2[0].params.firstOccurrenceTimestamp).toEqual(err1[0].params.firstOccurrenceTimestamp)
+    expect(err2[0].params.timestamp).not.toEqual(err1[0].params.timestamp)
   })
 
   it('subsequent errors - should set a timestamp, tied to the FIRST error seen - thrown errors', async () => {
@@ -78,5 +79,6 @@ describe('error payloads', () => {
     const { request: { body: { err: err2 } } } = await browser.testHandle.expectErrors()
 
     expect(err2[0].params.firstOccurrenceTimestamp).toEqual(err1[0].params.firstOccurrenceTimestamp)
+    expect(err2[0].params.timestamp).not.toEqual(err1[0].params.timestamp)
   })
 })


### PR DESCRIPTION
JSErrors that happen multiple times throughout a page's life will now receive a timestamp unique to the agent harvest cycle instead of always reporting the timestamp of the first occurrence of that error.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Modified the JSErrors feature to cache the error timestamp per harvest cycle instead of per page lifecycle.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-261440

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
