### PR TITLE
fix: Clean up xhrWrappable

### DIFF
--- a/src/common/config/state/runtime.js
+++ b/src/common/config/state/runtime.js
@@ -21,7 +21,6 @@ const model = {
   /** Agent-specific metadata found in the RUM call response. ex. entityGuid */
   appMetadata: {},
   session: undefined,
-  xhrWrappable: typeof globalScope.XMLHttpRequest?.prototype?.addEventListener === 'function',
   version: VERSION,
   denyList: undefined,
   harvestCount: 0,

--- a/src/features/ajax/instrument/index.js
+++ b/src/features/ajax/instrument/index.js
@@ -2,7 +2,7 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { originals, getLoaderConfig, getRuntime } from '../../../common/config/config'
+import { originals, getLoaderConfig } from '../../../common/config/config'
 import { handle } from '../../../common/event-emitter/handle'
 import { id } from '../../../common/ids/id'
 import { ffVersion, globalScope, isBrowserScope } from '../../../common/constants/runtime'
@@ -28,9 +28,6 @@ export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator, auto = true) {
     super(agentIdentifier, aggregator, FEATURE_NAME, auto)
-
-    // Very unlikely, but in case the existing XMLHttpRequest.prototype object on the page couldn't be wrapped.
-    if (!getRuntime(agentIdentifier).xhrWrappable) return
 
     this.dt = new DT(agentIdentifier)
 

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -38,10 +38,6 @@ export class Aggregate extends AggregateBase {
   constructor (agentIdentifier, aggregator, argsObj) {
     super(agentIdentifier, aggregator, FEATURE_NAME)
     this.agentRuntime = getRuntime(agentIdentifier)
-
-    // Very unlikely, but in case the existing XMLHttpRequest.prototype object on the page couldn't be wrapped.
-    if (!this.agentRuntime.xhrWrappable) return
-
     this.resourceObserver = argsObj?.resourceObserver // undefined if observer couldn't be created
     this.ptid = ''
     this.trace = {}

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -7,7 +7,6 @@ import {
 } from '../../../common/wrap'
 import { eventListenerOpts } from '../../../common/event-listener/event-listener-opts'
 import { InstrumentBase } from '../../utils/instrument-base'
-import { getRuntime } from '../../../common/config/config'
 import * as CONSTANTS from '../constants'
 import { isBrowserScope } from '../../../common/constants/runtime'
 import { now } from '../../../common/timing/now'
@@ -21,8 +20,6 @@ export class Instrument extends InstrumentBase {
   constructor (agentIdentifier, aggregator, auto = true) {
     super(agentIdentifier, aggregator, FEATURE_NAME, auto)
     if (!isBrowserScope) return // SPA not supported outside web env
-
-    if (!getRuntime(agentIdentifier).xhrWrappable) return
 
     try {
       this.removeOnAbort = new AbortController()

--- a/tests/components/session_trace/index.test.js
+++ b/tests/components/session_trace/index.test.js
@@ -7,7 +7,6 @@ jest.mock('../../../src/common/config/config', () => ({
   getConfigurationValue: jest.fn().mockReturnValue(undefined),
   isConfigured: jest.fn().mockReturnValue(true),
   getRuntime: jest.fn().mockReturnValue({
-    xhrWrappable: true,
     offset: Date.now()
   })
 }))

--- a/tests/components/spa/api.test.js
+++ b/tests/components/spa/api.test.js
@@ -19,7 +19,7 @@ jest.mock('../../../src/common/config/config', () => ({
     ST: setTimeout,
     CT: clearTimeout
   },
-  getRuntime: jest.fn().mockReturnValue({ xhrWrappable: true }),
+  getRuntime: jest.fn().mockReturnValue({}),
   isConfigured: jest.fn().mockReturnValue(true),
   getInfo: jest.fn()
 }))

--- a/tests/components/spa/initial-page-load.test.js
+++ b/tests/components/spa/initial-page-load.test.js
@@ -8,7 +8,7 @@ jest.mock('../../../src/common/config/config', () => ({
   __esModule: true,
   getConfigurationValue: jest.fn(),
   originals: { ST: setTimeout },
-  getRuntime: jest.fn().mockReturnValue({ xhrWrappable: true }),
+  getRuntime: jest.fn().mockReturnValue({}),
   isConfigured: jest.fn().mockReturnValue(true),
   getInfo: jest.fn().mockReturnValue({ jsAttributes: {} })
 }))

--- a/tests/components/spa/nested-timer.test.js
+++ b/tests/components/spa/nested-timer.test.js
@@ -8,7 +8,7 @@ jest.mock('../../../src/common/config/config', () => ({
   __esModule: true,
   getConfigurationValue: jest.fn(),
   originals: { ST: setTimeout },
-  getRuntime: jest.fn().mockReturnValue({ xhrWrappable: true }),
+  getRuntime: jest.fn().mockReturnValue({}),
   isConfigured: jest.fn().mockReturnValue(true),
   getInfo: jest.fn().mockReturnValue({ jsAttributes: {} })
 }))

--- a/tests/functional/spa/fetch.test.js
+++ b/tests/functional/spa/fetch.test.js
@@ -78,7 +78,7 @@ testDriver.test('response size', supported, function (t, browser, router) {
   var testCases = [
     {
       name: 'with request that returns content-length header',
-      responseBodySize: 10,
+      responseBodySize: 'abc123'.length,
       asset: 'spa/fetch-simple.html'
     },
     {


### PR DESCRIPTION
Remove `xhrWrappable` which is an old variable checking for `addEventListener` on XHR. It is expected to have no compatibility impact on modern standard frameworks or browsers.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Delete presumably dead and ineffectively redundant code blocking trace, ajax, and spa if the addEventListener on XHR prototype somehow isn't a function. We've had no report of such case. This is a remnant of old IE.

### Related Issue(s)

Follow-up of https://new-relic.atlassian.net/browse/NR-57395

### Testing

Standard
