### PR TITLE
feat: Add harvestId to Session Replay payloads

### DIFF
--- a/src/common/config/state/runtime.js
+++ b/src/common/config/state/runtime.js
@@ -25,7 +25,10 @@ const model = {
   version: VERSION,
   denyList: undefined,
   harvestCount: 0,
-  timeKeeper: undefined
+  timeKeeper: undefined,
+  get harvestId () {
+    return [this.session?.state.value, this.ptid, this.harvestCount].filter(x => x).join('_')
+  }
 }
 
 const _cache = {}

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -353,6 +353,7 @@ export class Aggregate extends AggregateBase {
           // if not, data could be lost to truncation at time of sending, potentially breaking parsing / API behavior in NR1
           ...(!!this.gzipper && !!this.u8 && { content_encoding: 'gzip' }),
           ...(agentMetadata.entityGuid && { entityGuid: agentMetadata.entityGuid }),
+          harvestId: agentRuntime.harvestId,
           'replay.firstTimestamp': firstTimestamp,
           'replay.lastTimestamp': lastTimestamp,
           'replay.nodes': events.length,

--- a/tests/specs/session-replay/helpers.js
+++ b/tests/specs/session-replay/helpers.js
@@ -14,7 +14,7 @@ export const RRWEB_EVENT_TYPES = {
   Custom: 5
 }
 
-export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes, appId, entityGuid }) {
+export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes, appId, entityGuid, harvestId }) {
   expect(data.query).toMatchObject({
     browser_monitoring_key: expect.any(String),
     type: 'SessionReplay',
@@ -29,6 +29,7 @@ export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasEr
   expect(decodedObj).toMatchObject({
     ...(contentEncoding && { content_encoding: 'gzip' }),
     ...(entityGuid && { entityGuid }),
+    harvestId: harvestId || expect.any(String),
     'replay.firstTimestamp': expect.any(Number),
     'replay.lastTimestamp': expect.any(Number),
     session: session || expect.any(String),


### PR DESCRIPTION
Adds a unique harvest ID to Session Replay payloads to support better indexing and querying on the platform.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR is partially abstracted out of the ST merge PR (#821), as that is currently blocked
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-238623
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Test platform has been updated to check for harvestID in all SR tests
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
