### PR TITLE
fix: Remove API start()'s features param

### DIFF
--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -52,7 +52,7 @@ export class InstrumentBase extends FeatureBase {
     /** if the feature requires opt-in (!auto-start), it will get registered once the api has been called */
     if (this.auto) registerDrain(agentIdentifier, featureName)
     else {
-      this.ee.on(`${this.featureName}-opt-in`, single(() => {
+      this.ee.on('manual-start-all', single(() => {
         // register the feature to drain only once the API has been called, it will drain when importAggregator finishes for all the features
         // called by the api in that cycle
         registerDrain(this.agentIdentifier, this.featureName)

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -117,20 +117,10 @@ export function setAPI (agentIdentifier, forceDrain, runSoftNavOverSpa = false) 
     return appendJsAttribute('application.version', value, 'setApplicationVersion', false)
   }
 
-  apiInterface.start = (features) => {
+  apiInterface.start = () => {
     try {
-      const smTag = !features ? 'undefined' : 'defined'
-      handle(SUPPORTABILITY_METRIC_CHANNEL, [`API/start/${smTag}/called`], undefined, FEATURE_NAMES.metrics, instanceEE)
-      const featNames = Object.values(FEATURE_NAMES)
-      if (features === undefined) features = featNames
-      else {
-        features = Array.isArray(features) && features.length ? features : [features]
-        if (features.some(f => !featNames.includes(f))) return warn(`Invalid feature name supplied. Acceptable feature names are: ${featNames}`)
-        if (!features.includes(FEATURE_NAMES.pageViewEvent)) features.push(FEATURE_NAMES.pageViewEvent)
-      }
-      features.forEach(feature => {
-        instanceEE.emit(`${feature}-opt-in`)
-      })
+      handle(SUPPORTABILITY_METRIC_CHANNEL, ['API/start/called'], undefined, FEATURE_NAMES.metrics, instanceEE)
+      instanceEE.emit('manual-start-all')
     } catch (err) {
       warn('An unexpected issue occurred', err)
     }

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -468,66 +468,31 @@ describe('setAPI', () => {
       await new Promise(process.nextTick)
     })
 
-    test('should create SM event emitter event for calls to API when features are undefined', () => {
+    test('should create SM event emitter event for calls to API', () => {
       apiInterface.start()
 
       expect(handleModule.handle).toHaveBeenCalledTimes(1)
       expect(handleModule.handle).toHaveBeenCalledWith(
         SUPPORTABILITY_METRIC_CHANNEL,
-        ['API/start/undefined/called'],
+        ['API/start/called'],
         undefined,
         FEATURE_NAMES.metrics,
         instanceEE
       )
     })
 
-    test('should create SM event emitter event for calls to API when features are undefined', () => {
-      const features = [faker.string.uuid()]
-      apiInterface.start(features)
-
-      expect(handleModule.handle).toHaveBeenCalledTimes(1)
-      expect(handleModule.handle).toHaveBeenCalledWith(
-        SUPPORTABILITY_METRIC_CHANNEL,
-        ['API/start/defined/called'],
-        undefined,
-        FEATURE_NAMES.metrics,
-        instanceEE
-      )
-    })
-
-    test('should emit event emitter events for all features when input is undefined', () => {
+    test('should emit event to start all features (if not auto)', () => {
       apiInterface.start()
-
-      Object.values(FEATURE_NAMES).forEach(featureName => {
-        expect(instanceEE.emit).toHaveBeenCalledWith(`${featureName}-opt-in`)
-      })
+      expect(instanceEE.emit).toHaveBeenCalledWith('manual-start-all')
     })
 
-    test('should emit event emitter events for all features when input is set', () => {
-      apiInterface.start(Object.values(FEATURE_NAMES))
-
-      Object.values(FEATURE_NAMES).forEach(featureName => {
-        expect(instanceEE.emit).toHaveBeenCalledWith(`${featureName}-opt-in`)
-      })
-    })
-
-    test('should return early and warn for invalid feature names', () => {
+    test('should emit start even if some arg is passed', () => {
       const badFeatureName = faker.string.uuid()
       apiInterface.start(badFeatureName)
 
-      Object.values(FEATURE_NAMES).forEach(featureName => {
-        expect(instanceEE.emit).not.toHaveBeenCalledWith(`${featureName}-opt-in`)
-      })
-      expect(instanceEE.emit).not.toHaveBeenCalledWith(`${badFeatureName}-opt-in`)
-      expect(console.warn).toHaveBeenCalledTimes(1)
-      expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Invalid feature name supplied'))
-    })
-
-    test('should always include page view event feature', () => {
-      apiInterface.start(['spa'])
-
-      expect(instanceEE.emit).toHaveBeenCalledWith('page_view_event-opt-in')
-      expect(instanceEE.emit).toHaveBeenCalledWith('spa-opt-in')
+      expect(instanceEE.emit).toHaveBeenCalledWith('manual-start-all')
+      expect(instanceEE.emit).not.toHaveBeenCalledWith(badFeatureName)
+      expect(console.warn).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
The `start()` method in agent API no longer accepts an argument. It will forcibly start all features that were marked `autoStart: false` in the configuration that has not yet started when it is called. If `page_view_event` had this property set to false, the agent will not send anything until `start` is called.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

No. more. feature-specific start(). This is due to use case feedback and unneeded complexity with all the possible auto/manual start permutations.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-260970

### Testing

Edited
