### PR TITLE
fix: Run inside cross-origin iframes for firefox/safari

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,7 +47,7 @@ module.exports = {
     },
     {
       files: ['src/**/*.js'],
-      excludedFiles: ['*.test.js', '*.component-test.js', '__mocks__/**/*'],
+      excludedFiles: ['__mocks__/**/*'],
       env: {
         browser: true
       },
@@ -86,7 +86,7 @@ module.exports = {
       env: {
         browser: true,
         node: true,
-        jest: true
+        mocha: true
       },
       parserOptions: {
         sourceType: 'module'

--- a/src/common/vitals/time-to-first-byte.js
+++ b/src/common/vitals/time-to-first-byte.js
@@ -5,7 +5,14 @@ import { onTTFB } from 'web-vitals/attribution'
 
 export const timeToFirstByte = new VitalMetric(VITAL_NAMES.TIME_TO_FIRST_BYTE)
 
-if (isBrowserScope && typeof PerformanceNavigationTiming !== 'undefined' && !isiOS) {
+/**
+ * onTTFB is not supported in the following scenarios:
+ * - in a non-browser scope
+ * - in browsers that do not support PerformanceNavigationTiming API
+ * - in an iOS browser
+ * - cross-origin iframes specifically in firefox and safari
+ */
+if (isBrowserScope && typeof PerformanceNavigationTiming !== 'undefined' && !isiOS && window === window.parent) {
   onTTFB(({ value, attribution }) => {
     if (timeToFirstByte.isValid) return
     timeToFirstByte.update({ value, attrs: { navigationEntry: attribution.navigationEntry } })

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -17,15 +17,14 @@ import { handle } from '../../../common/event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { now } from '../../../common/timing/now'
 import { TimeKeeper } from '../../../common/timing/time-keeper'
-// import { onWindowLoad } from '../../../common/window/load'
 import { single } from '../../../common/util/invoke'
+
+console.log(single)
 
 export class Aggregate extends AggregateBase {
   static featureName = CONSTANTS.FEATURE_NAME
   constructor (agentIdentifier, aggregator) {
     super(agentIdentifier, aggregator, CONSTANTS.FEATURE_NAME)
-
-    // setTimeout(this.sendRum.bind(this), 0)
 
     this.timeToFirstByte = 0
     this.firstByteToWindowLoad = 0 // our "frontend" duration
@@ -47,7 +46,7 @@ export class Aggregate extends AggregateBase {
     }
   }
 
-  sendRum = single(() => {
+  sendRum () {
     const info = getInfo(this.agentIdentifier)
     const agentRuntime = getRuntime(this.agentIdentifier)
     const harvester = new Harvest(this)
@@ -159,5 +158,5 @@ export class Aggregate extends AggregateBase {
         }
       }
     })
-  })
+  }
 }

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -17,9 +17,6 @@ import { handle } from '../../../common/event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { now } from '../../../common/timing/now'
 import { TimeKeeper } from '../../../common/timing/time-keeper'
-import { single } from '../../../common/util/invoke'
-
-console.log(single)
 
 export class Aggregate extends AggregateBase {
   static featureName = CONSTANTS.FEATURE_NAME
@@ -39,7 +36,6 @@ export class Aggregate extends AggregateBase {
 
         this.sendRum()
       })
-      // setTimeout(this.sendRum.bind(this), 50)
     } else {
       // worker agent build does not get TTFB values, use default 0 values
       this.sendRum()
@@ -58,19 +54,6 @@ export class Aggregate extends AggregateBase {
     // These 3 values should've been recorded after load and before this func runs. They are part of the minimum required for PageView events to be created.
     // Following PR #428, which demands that all agents send RUM call, these need to be sent even outside of the main window context where PerformanceTiming
     // or PerformanceNavigationTiming do not exists. Hence, they'll be filled in by 0s instead in, for example, worker threads that still init the PVE module.
-    // if (!timeToFirstByte.isValid) {
-    //   console.log('timeToFirstByte not valid')
-    //   this.aggregator.store('measures', 'be', { value: 0 })
-    //   this.aggregator.store('measures', 'fe', { value: 0 })
-    //   this.aggregator.store('measures', 'dc', { value: 0 })
-    // } else {
-    //   const currentTTFB = timeToFirstByte.current
-    //   this.aggregator.store('measures', 'be', { value: currentTTFB.value })
-    //
-    //   const navEntry = currentTTFB.attrs.navigationEntry
-    //   this.aggregator.store('measures', 'fe', { value: Math.max(Math.round((navEntry?.loadEventEnd || 0) - currentTTFB.value), 0) })
-    //   this.aggregator.store('measures', 'dc', { value: Math.max(Math.round((navEntry?.domContentLoadedEventEnd || 0) - currentTTFB.value), 0) })
-    // }
     this.aggregator.store('measures', 'be', { value: this.timeToFirstByte })
     this.aggregator.store('measures', 'fe', { value: this.firstByteToWindowLoad })
     this.aggregator.store('measures', 'dc', { value: this.firstByteToDomContent })

--- a/tests/assets/iframe/cross-origin.html
+++ b/tests/assets/iframe/cross-origin.html
@@ -29,7 +29,7 @@
     iframe.src += queryParams[i]
   }
 
-  document.body.append(iframe)
+  document.body.appendChild(iframe)
 </script>
 </body>
 </html>

--- a/tests/assets/iframe/cross-origin.html
+++ b/tests/assets/iframe/cross-origin.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>RUM IFrame</title>
+  {init} {config}
+</head>
+<body>
+<script type="text/javascript">
+  var iframe = document.createElement('iframe')
+
+  if (!NREUM.init.ssl) {
+    iframe.src = 'http://' + NREUM.info.beacon + '/tests/assets/iframe/iframe.html'
+  } else {
+    iframe.src = 'https://' + NREUM.info.beacon + '/tests/assets/iframe/iframe.html'
+  }
+
+  var queryParams = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&')
+  for (var i = 0; i < queryParams.length; i++) {
+    if (i === 0) {
+      iframe.src += '?'
+    } else {
+      iframe.src += '&'
+    }
+
+    iframe.src += queryParams[i]
+  }
+
+  document.body.append(iframe)
+</script>
+</body>
+</html>

--- a/tests/assets/iframe/iframe.html
+++ b/tests/assets/iframe/iframe.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>RUM Instrumented</title>
+  {init} {config} {loader}
+</head>
+<body>
+  This page is instrumented and meant to be loaded in an iframe.
+</body>
+</html>

--- a/tests/assets/iframe/same-origin.html
+++ b/tests/assets/iframe/same-origin.html
@@ -12,7 +12,7 @@
 <script type="text/javascript">
   var iframe = document.createElement('iframe')
   iframe.src = window.location.href.replace('iframe/same-origin.html', 'iframe/iframe.html')
-  document.body.append(iframe)
+  document.body.appendChild(iframe)
 </script>
 </body>
 </html>

--- a/tests/assets/iframe/same-origin.html
+++ b/tests/assets/iframe/same-origin.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>RUM IFrame</title>
+  {init} {config}
+</head>
+<body>
+<script type="text/javascript">
+  var iframe = document.createElement('iframe')
+  iframe.src = window.location.href.replace('iframe/same-origin.html', 'iframe/iframe.html')
+  document.body.append(iframe)
+</script>
+</body>
+</html>

--- a/tests/specs/rum/index.e2e.js
+++ b/tests/specs/rum/index.e2e.js
@@ -1,0 +1,37 @@
+import { checkRum } from '../../util/basic-checks'
+import { testAssetRequest } from '../../../tools/testing-server/utils/expect-tests'
+
+describe('basic pve capturing', () => {
+  ['same-origin', 'cross-origin'].forEach(page => {
+    it(`should send rum when ${page} page loads in an iframe`, async () => {
+      const [
+        rumResults
+      ] = await Promise.all([
+        browser.testHandle.expectRum(),
+        browser.url(await browser.testHandle.assetURL(`iframe/${page}.html`))
+      ])
+
+      checkRum(rumResults.request)
+    })
+  })
+
+  it('should capture page load timings', async () => {
+    await browser.testHandle.scheduleReply('assetServer', {
+      test: testAssetRequest,
+      permanent: true,
+      delay: 500
+    })
+
+    const [
+      rumResults
+    ] = await Promise.all([
+      browser.testHandle.expectRum(),
+      browser.url(await browser.testHandle.assetURL('64kb-dom.html'))
+    ])
+
+    checkRum(rumResults.request)
+    expect(parseInt(rumResults.request.query.be, 10)).toBeGreaterThanOrEqual(500)
+    expect(parseInt(rumResults.request.query.fe, 10)).toBeGreaterThanOrEqual(100)
+    expect(parseInt(rumResults.request.query.dc, 10)).toBeGreaterThanOrEqual(100)
+  })
+})

--- a/tests/webview-specs/ios/index.e2e.js
+++ b/tests/webview-specs/ios/index.e2e.js
@@ -1,10 +1,13 @@
 import { onlyIOS } from '../../../tools/browser-matcher/common-matchers.mjs'
 
 describe.withBrowsersMatching(onlyIOS)('ios webview', () => {
-  it('should load the agent and send back data', async () => {
+  before(async () => {
     // Load the webview screen
     await $('-ios predicate string: name == "WebView"').click()
+    await driver.pause(5000)
+  })
 
+  it('should load the agent and send back data', async () => {
     // Load up the test page
     const url = await driver.testHandle.assetURL('instrumented.html')
     await driver.setClipboard(Buffer.from(url).toString('base64'), 'plaintext')
@@ -20,7 +23,7 @@ describe.withBrowsersMatching(onlyIOS)('ios webview', () => {
       {
         action: 'wait',
         options: {
-          ms: 200
+          ms: 500
         }
       },
       {
@@ -28,7 +31,7 @@ describe.withBrowsersMatching(onlyIOS)('ios webview', () => {
         options: {}
       }
     ])
-    await $('-ios predicate string: label == "Paste" AND name == "Paste" AND value == "Paste"')
+    await $('-ios predicate string: type == "XCUIElementTypeMenuItem" AND label == "Paste" AND name == "Paste"')
       .click()
 
     // // Setup expects and submit the url
@@ -36,9 +39,12 @@ describe.withBrowsersMatching(onlyIOS)('ios webview', () => {
       driver.testHandle.expectRum(),
       driver.testHandle.expectResources(),
       driver.testHandle.expectInteractionEvents(),
-      $('-ios predicate string: name == "Return"').click()
+      $('-ios predicate string: type == "XCUIElementTypeButton" AND name == "Return"').click()
     ])
 
+    console.log(rumResult)
+    console.log(resourcesResult)
+    console.log(spaResult)
     expect(rumResult.request.body).toEqual('')
     expect(rumResult.request.query).toEqual(expect.objectContaining({
       ref: url.slice(0, url.indexOf('?')),

--- a/tests/webview-specs/ios/index.e2e.js
+++ b/tests/webview-specs/ios/index.e2e.js
@@ -42,9 +42,6 @@ describe.withBrowsersMatching(onlyIOS)('ios webview', () => {
       $('-ios predicate string: type == "XCUIElementTypeButton" AND name == "Return"').click()
     ])
 
-    console.log(rumResult)
-    console.log(resourcesResult)
-    console.log(spaResult)
     expect(rumResult.request.body).toEqual('')
     expect(rumResult.request.query).toEqual(expect.objectContaining({
       ref: url.slice(0, url.indexOf('?')),

--- a/tools/testing-server/index.js
+++ b/tools/testing-server/index.js
@@ -190,6 +190,7 @@ class TestServer {
     this.#assetServer = fastify(this.#defaultServerConfig)
 
     this.#assetServer.decorate('testServerId', 'assetServer')
+    this.#assetServer.register(require('./plugins/cache-interceptor')) // pre-process the request to help prevent cache responses
     this.#assetServer.register(require('@fastify/compress')) // handle gzip payloads, reply with gzip'd content
     this.#assetServer.decorate('testServerLogger', this.#logger)
     this.#assetServer.register(require('@fastify/multipart'), {
@@ -203,9 +204,7 @@ class TestServer {
     this.#assetServer.register(require('@fastify/static'), {
       root: paths.rootDir,
       prefix: '/',
-      index: ['index.html'],
-      cacheControl: false,
-      etag: false
+      index: ['index.html']
     })
     this.#assetServer.register(require('./plugins/agent-injector'), this)
     this.#assetServer.register(require('./plugins/browser-scripts'), this)
@@ -220,6 +219,7 @@ class TestServer {
     this.#bamServer = fastify(this.#defaultServerConfig)
 
     this.#bamServer.decorate('testServerId', 'bamServer')
+    this.#bamServer.register(require('./plugins/cache-interceptor')) // pre-process the request to help prevent cache responses
     this.#bamServer.register(require('./plugins/compression-interceptor')) // pre-process the request to help it conform with compression standards
     this.#bamServer.register(require('@fastify/compress')) // handle gzip payloads, reply with gzip'd content
     this.#bamServer.decorate('testServerLogger', this.#logger)
@@ -234,9 +234,7 @@ class TestServer {
     this.#bamServer.register(require('@fastify/static'), {
       root: paths.rootDir,
       prefix: '/',
-      index: ['index.html'],
-      cacheControl: false,
-      etag: false
+      index: ['index.html']
     })
     this.#bamServer.register(require('./plugins/agent-injector'), this)
     this.#bamServer.register(require('./plugins/browser-scripts'), this)

--- a/tools/testing-server/plugins/cache-interceptor/index.js
+++ b/tools/testing-server/plugins/cache-interceptor/index.js
@@ -1,0 +1,19 @@
+const fp = require('fastify-plugin')
+
+/**
+ * Fastify plugin to intercept requests before they reach the static plugin. This will set
+ * proper cache headers on requests for asset files to prevent those files from being cached.
+ * @param {import('fastify').FastifyInstance} fastify the fastify server instance
+ */
+module.exports = fp(async function (fastify) {
+  fastify.addHook('preParsing', (request, reply, payload, done) => {
+    if (request.routeOptions.url === '/*') {
+      delete request.headers['if-none-match']
+      delete request.headers['if-modified-since']
+      request.headers['cache-control'] = 'no-cache'
+      request.headers.pragma = 'no-cache'
+    }
+
+    done(null, payload)
+  })
+})

--- a/tools/testing-server/utils/expect-tests.js
+++ b/tools/testing-server/utils/expect-tests.js
@@ -12,6 +12,11 @@
  *
  */
 
+module.exports.testAssetRequest = function testAssetRequest (request) {
+  const url = new URL(request.url, 'resolve://')
+  return url.pathname.indexOf('.html') > -1
+}
+
 module.exports.testRumRequest = function testRumRequest (request) {
   const url = new URL(request.url, 'resolve://')
   return url.pathname === `/1/${this.testId}`


### PR DESCRIPTION
Resolve a bug that prevented the agent from running in cross-origin iFrames for Firefox and Safari due to how the browsers implement context security.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

If the agent is running inside an iframe, it will skip subscribing to the `onTTFB` event. If the iframe is cross-origin, some browsers will block access to the `responseStart` property of the navigation performance entry. This was caused by a change in the [WebVitals](https://github.com/GoogleChrome/web-vitals) library to treat `0` as an [invalid timestamp value](https://github.com/GoogleChrome/web-vitals/blob/main/src/lib/isInvalidTimestamp.ts#L21-L24).

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-262293
https://github.com/GoogleChrome/web-vitals/issues/275

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
