### PR TITLE
fix: Prevent noticeError() API from running if not given an argument

### DIFF
--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -138,6 +138,7 @@ export class Aggregate extends AggregateBase {
   }
 
   storeError (err, time, internal, customAttributes, hasReplay) {
+    if (!err) return
     // are we in an interaction
     time = time || now()
     const agentRuntime = getRuntime(this.agentIdentifier)
@@ -206,7 +207,7 @@ export class Aggregate extends AggregateBase {
     // still send EE events for other features such as above, but stop this one from aggregating internal data
     if (this.blocked) return
 
-    if (err.__newrelic?.[this.agentIdentifier]) {
+    if (err?.__newrelic?.[this.agentIdentifier]) {
       params._interactionId = err.__newrelic[this.agentIdentifier].interactionId
       params._interactionNodeId = err.__newrelic[this.agentIdentifier].interactionNodeId
     }

--- a/tests/specs/err/error-payload.e2e.js
+++ b/tests/specs/err/error-payload.e2e.js
@@ -91,4 +91,13 @@ describe('error payloads', () => {
 
     expect(err[0].params.stack_trace.match(/<inline>:[0-9]+:[0-9]+/).length).toEqual(1)
   })
+
+  it('noticeError called with no arguments does not throw or capture any error', async () => {
+    await Promise.all([
+      browser.testHandle.expectErrors(10000, true), // should not harvest an error (neither the noticeError call or an error from calling the API with no arg)
+      browser.url(await browser.testHandle.assetURL('instrumented.html')) // Setup expects before loading the page
+        .then(() => browser.waitForFeatureAggregate('jserrors'))
+        .then(() => browser.execute(function () { newrelic.noticeError() }))
+    ])
+  })
 })


### PR DESCRIPTION
Short circuit the execution of the noticeError API if an argument is not supplied
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This also tangentially fixes an issue introduced in #1014  
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new test has been added
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
