### PR TITLE
fix: Adjust session entity to not race between tabs

### DIFF
--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -64,8 +64,10 @@ export class SessionEntity {
   }
 
   setup ({ value = generateRandomHexString(16), expiresMs = DEFAULT_EXPIRES_MS, inactiveMs = DEFAULT_INACTIVE_MS }) {
+    /** Ensure that certain properties are preserved across a reset if already set */
+    const persistentAttributes = { serverTimeDiff: this.state.serverTimeDiff || model.serverTimeDiff }
     this.state = {}
-    this.sync(model)
+    this.sync({ ...model, ...persistentAttributes })
 
     // value is intended to act as the primary value of the k=v pair
     this.state.value = value

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -97,7 +97,7 @@ export class TimeKeeper {
   /** Process the session entity and use the info to set the main time calculations if present */
   processStoredDiff () {
     const storedServerTimeDiff = this.#session?.read()?.serverTimeDiff
-    if (storedServerTimeDiff) {
+    if (!(isNaN(storedServerTimeDiff))) {
       this.#localTimeDiff = storedServerTimeDiff
       this.#correctedOriginTime = originTime - this.#localTimeDiff
       this.#ready = true

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -1,7 +1,5 @@
 import { originTime } from '../constants/runtime'
-import { ee as baseEE } from '../event-emitter/contextual-ee'
 import { getRuntime } from '../config/config'
-import { SESSION_EVENT_TYPES, SESSION_EVENTS } from '../session/constants'
 
 /**
  * Class used to adjust the timestamp of harvested data to New Relic server time. This
@@ -37,17 +35,7 @@ export class TimeKeeper {
 
   constructor (agentIdentifier) {
     this.#session = getRuntime(agentIdentifier)?.session
-
-    if (this.#session) {
-      const ee = baseEE.get(agentIdentifier)
-      ee.on(SESSION_EVENTS.UPDATE, this.#processSessionUpdate.bind(this))
-      ee.on(SESSION_EVENTS.STARTED, () => {
-        if (this.#ready) {
-          this.#session.write({ serverTimeDiff: this.#localTimeDiff })
-        }
-      })
-      this.#processSessionUpdate(null, this.#session.read())
-    }
+    this.processStoredDiff()
   }
 
   get ready () {
@@ -65,8 +53,8 @@ export class TimeKeeper {
    * @param endTime {number} The end time of the RUM request
    */
   processRumRequest (rumRequest, startTime, endTime) {
+    this.processStoredDiff()
     if (this.#ready) return // Server time calculated from session entity
-
     const responseDateHeader = rumRequest.getResponseHeader('Date')
     if (!responseDateHeader) {
       throw new Error('Missing date header on rum response.')
@@ -83,7 +71,7 @@ export class TimeKeeper {
       throw new Error('Date header invalid format.')
     }
 
-    if (this.#session) this.#session.write({ serverTimeDiff: this.#localTimeDiff })
+    this.#session?.write({ serverTimeDiff: this.#localTimeDiff })
     this.#ready = true
   }
 
@@ -106,20 +94,11 @@ export class TimeKeeper {
     return Math.floor(timestamp - this.#localTimeDiff)
   }
 
-  /**
-   * Processes a session entity update payload to extract the server time calculated.
-   * @param {import('../session/constants').SESSION_EVENT_TYPES | null} type
-   * @param {Object} data
-   */
-  #processSessionUpdate (type, data) {
-    if (typeof data?.serverTimeDiff !== 'number') return
-
-    if (
-      (!type && !this.#ready) || // This captures the initial read from the session entity when the timekeeper first initializes
-      type === SESSION_EVENT_TYPES.CROSS_TAB // This captures any cross-tab write of the session entity
-    ) {
-      // This captures the initial read from the session entity when the timekeeper first initializes
-      this.#localTimeDiff = data.serverTimeDiff
+  /** Process the session entity and use the info to set the main time calculations if present */
+  processStoredDiff () {
+    const storedServerTimeDiff = this.#session?.read()?.serverTimeDiff
+    if (storedServerTimeDiff) {
+      this.#localTimeDiff = storedServerTimeDiff
       this.#correctedOriginTime = originTime - this.#localTimeDiff
       this.#ready = true
     }

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -67,7 +67,7 @@ export class TimeKeeper {
     this.#correctedOriginTime = Math.floor(Date.parse(responseDateHeader) - serverOffset)
     this.#localTimeDiff = originTime - this.#correctedOriginTime
 
-    if (Number.isNaN(this.#correctedOriginTime)) {
+    if (isNaN(this.#correctedOriginTime)) {
       throw new Error('Date header invalid format.')
     }
 
@@ -97,7 +97,7 @@ export class TimeKeeper {
   /** Process the session entity and use the info to set the main time calculations if present */
   processStoredDiff () {
     const storedServerTimeDiff = this.#session?.read()?.serverTimeDiff
-    if (!(isNaN(storedServerTimeDiff))) {
+    if (typeof storedServerTimeDiff === 'number' && !isNaN(storedServerTimeDiff)) {
       this.#localTimeDiff = storedServerTimeDiff
       this.#correctedOriginTime = originTime - this.#localTimeDiff
       this.#ready = true

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { srConfig, decodeAttributes } from './util/helpers'
-import { notIE, supportsFetch, supportsMultipleTabs, notSafari } from '../../tools/browser-matcher/common-matchers.mjs'
+import { notIE, supportsFetch } from '../../tools/browser-matcher/common-matchers.mjs'
 
 let serverTime
 describe('NR Server Time', () => {
@@ -332,36 +332,6 @@ describe('NR Server Time', () => {
 
       expect(subsequentServerTimeDiff).toEqual(initialServerTimeDiff)
       expect(subsequentSession.localStorage.serverTimeDiff).toEqual(initialSession.localStorage.serverTimeDiff)
-    })
-
-    it.withBrowsersMatching([supportsMultipleTabs, notSafari])('should store the server time diff from a cross-tab session update', async () => {
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', {
-        init: {
-          privacy: { cookies_enabled: true }
-        }
-      })).then(() => browser.waitForAgentLoad())
-
-      const newTab = await browser.createWindow('tab')
-      await browser.switchToWindow(newTab.handle)
-      await browser.url(await browser.testHandle.assetURL('api.html', {
-        init: {
-          privacy: { cookies_enabled: true }
-        }
-      })).then(() => browser.waitForAgentLoad())
-
-      await browser.execute(function () {
-        Object.values(newrelic.initializedAgents)[0].runtime.session.write({ serverTimeDiff: 1000 })
-      })
-      await browser.pause(5000)
-      await browser.closeWindow()
-      await browser.switchToWindow((await browser.getWindowHandles())[0])
-
-      const session = await browser.getAgentSessionInfo()
-      const serverTime = await browser.getPageTime()
-      const serverTimeDiff = serverTime.originTime - serverTime.correctedOriginTime
-
-      expect(serverTimeDiff).toEqual(1000)
-      expect(session.localStorage.serverTimeDiff).toEqual(1000)
     })
   })
 })


### PR DESCRIPTION
Allow first tab to fully instantiate a time correction to take precedence
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://newrelic.slack.com/archives/C04QZSS6XPV/p1715357189958959
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Existing tests have been updated
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
