### PR TITLE
chore: Post release repo updates

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -63,6 +63,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-brow
 * [eslint](#eslint)
 * [fastify-plugin](#fastify-plugin)
 * [fastify](#fastify)
+* [form-data](#form-data)
 * [fs-extra](#fs-extra)
 * [function-bind](#function-bind)
 * [glob](#glob)
@@ -2188,6 +2189,33 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+```
+
+### form-data
+
+This product includes source derived from [form-data](https://github.com/form-data/form-data) ([v4.0.0](https://github.com/form-data/form-data/tree/v4.0.0)), distributed under the [MIT License](https://github.com/form-data/form-data/blob/v4.0.0/License):
+
+```
+Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
 
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8504,9 +8504,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001617",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
-      "integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
+      "version": "1.0.30001620",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001620.tgz",
+      "integrity": "sha512-WJvYsOjd1/BYUY6SNGUosK9DUidBPDTnOARHp3fSmFO1ekdxaY6nKRttEVrfMmYi80ctS0kz1wiWmm14fVc3ew==",
       "dev": true,
       "funding": [
         {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon May 13 2024 21:55:47 GMT+0000 (Coordinated Universal Time)",
+  "lastUpdated": "Mon May 20 2024 17:44:31 GMT+0000 (Coordinated Universal Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,
@@ -599,6 +599,20 @@
       "licenseTextSource": "file",
       "publisher": "Matteo Collina",
       "email": "hello@matteocollina.com"
+    },
+    "form-data@4.0.0": {
+      "name": "form-data",
+      "version": "4.0.0",
+      "range": "^4.0.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/form-data/form-data",
+      "versionedRepoUrl": "https://github.com/form-data/form-data/tree/v4.0.0",
+      "licenseFile": "node_modules/form-data/License",
+      "licenseUrl": "https://github.com/form-data/form-data/blob/v4.0.0/License",
+      "licenseTextSource": "file",
+      "publisher": "Felix Geisendörfer",
+      "email": "felix@debuggable.com",
+      "url": "http://debuggable.com/"
     },
     "fs-extra@11.2.0": {
       "name": "fs-extra",

--- a/tools/browsers-lists/browsers-supported.json
+++ b/tools/browsers-lists/browsers-supported.json
@@ -4,29 +4,29 @@
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "115",
-      "browserVersion": "115"
+      "version": "116",
+      "browserVersion": "116"
     },
     {
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "118",
-      "browserVersion": "118"
+      "version": "119",
+      "browserVersion": "119"
     },
     {
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "121",
-      "browserVersion": "121"
+      "version": "122",
+      "browserVersion": "122"
     },
     {
       "browserName": "chrome",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "124",
-      "browserVersion": "124"
+      "version": "125",
+      "browserVersion": "125"
     }
   ],
   "edge": [
@@ -48,15 +48,15 @@
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "120",
-      "browserVersion": "120"
+      "version": "121",
+      "browserVersion": "121"
     },
     {
       "browserName": "MicrosoftEdge",
       "platformName": "Windows 11",
       "platform": "Windows 11",
-      "version": "123",
-      "browserVersion": "123"
+      "version": "124",
+      "browserVersion": "124"
     }
   ],
   "firefox": [
@@ -64,29 +64,29 @@
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "116",
-      "browserVersion": "116"
+      "version": "117",
+      "browserVersion": "117"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "119",
-      "browserVersion": "119"
+      "version": "120",
+      "browserVersion": "120"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "122",
-      "browserVersion": "122"
+      "version": "123",
+      "browserVersion": "123"
     },
     {
       "browserName": "firefox",
       "platformName": "Windows 10",
       "platform": "Windows 10",
-      "version": "125",
-      "browserVersion": "125"
+      "version": "126",
+      "browserVersion": "126"
     }
   ],
   "safari": [

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz"
   }
 }

--- a/tools/test-builds/browser-tests/package.json
+++ b/tools/test-builds/browser-tests/package.json
@@ -9,6 +9,6 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.0.tgz"
+        "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz"
     }
 }

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/client": "^3.8.8",
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz",
     "graphql": "^16.8.1"
   }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
When this PR is merged, caniuse-lite database is updated, latest browserslist for SauceLabs is retrieved, and third-party dependencies docs are updates.
---

This PR was generated with post-release-updates GitHub action.