### PR TITLE
fix: Prevent new sessions from harvesting session trace data

### DIFF
--- a/tests/components/session_trace/index.test.js
+++ b/tests/components/session_trace/index.test.js
@@ -17,7 +17,7 @@ jest.mock('../../../src/common/config/config', () => ({
   }),
   isConfigured: jest.fn().mockReturnValue(true),
   getRuntime: jest.fn().mockReturnValue({
-    session: { state: { value: 'sessionID' }, write: jest.fn() },
+    session: { state: { value: 'sessionID', sessionTraceMode: 1 }, write: jest.fn() },
     timeKeeper: { ready: true, correctedOriginTime: 0, convertRelativeTimestamp: jest.fn() }
   })
 }))
@@ -100,7 +100,7 @@ describe('session trace', () => {
     const spy = jest.spyOn(traceAggregate.traceStorage, 'takeSTNs')
     let payload
     expect(() => (payload = traceAggregate.prepareHarvest())).not.toThrow()
-    expect(spy).toHaveBeenCalled()
+    expect(spy).not.toHaveBeenCalled() // returns early before trying to take from agg if there's no nodes to take
     expect(payload).toBeUndefined()
     spy.mockRestore()
   })

--- a/tests/specs/session-trace/session-pages.e2e.js
+++ b/tests/specs/session-trace/session-pages.e2e.js
@@ -121,6 +121,76 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
     await browser.testHandle.expectTrace(10000, true)
   })
 
+  it('should not report harvest if sessionId changes', async () => {
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify({ st: 1, sts: 1, err: 1, ins: 1, spa: 1, sr: 0, loaded: 1 })
+    })
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', stConfig()))
+      .then(() => browser.waitForAgentLoad())
+
+    const { request: page1Contents } = await browser.testHandle.expectTrace(10000)
+    const { localStorage: { value: session } } = await browser.getAgentSessionInfo()
+
+    testExpectedTrace({ data: page1Contents, session })
+
+    await Promise.all([
+      browser.testHandle.expectTrace(10000, true), // should not harvest again if the session id changes mid-lifecycle
+      browser.execute(function () {
+        Object.values(NREUM.initializedAgents)[0].runtime.session.state.value = 'session_id_changed'
+      })
+    ])
+  })
+
+  it('should not report harvest if session resets', async () => {
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify({ st: 1, sts: 1, err: 1, ins: 1, spa: 1, sr: 0, loaded: 1 })
+    })
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', stConfig()))
+      .then(() => browser.waitForAgentLoad())
+
+    const { request: page1Contents } = await browser.testHandle.expectTrace(10000)
+    const { localStorage: { value: session } } = await browser.getAgentSessionInfo()
+
+    testExpectedTrace({ data: page1Contents, session })
+
+    await Promise.all([
+      browser.testHandle.expectTrace(10000, true), // should not harvest again if the session id changes mid-lifecycle
+      browser.execute(function () {
+        Object.values(NREUM.initializedAgents)[0].runtime.session.reset()
+      })
+    ])
+  })
+
+  // As of 06/26/2023 test fails in Safari, though tested behavior works in a live browser (revisit in NR-138940).
+  it.withBrowsersMatching([supportsMultipleTabs, notSafari])('should not report harvest if session resets on another page', async () => {
+    await browser.destroyAgentSession()
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify({ st: 1, sts: 1, err: 1, ins: 1, spa: 1, sr: 0, loaded: 1 })
+    })
+    let url = await browser.testHandle.assetURL('instrumented.html', stConfig())
+    await browser.url(url).then(() => browser.waitForAgentLoad())
+    await browser.testHandle.expectTrace(10000)
+    // got a payload, now open a new tab and reset the session in tab B
+    const newTab = await browser.createWindow('tab')
+    await browser.switchToWindow(newTab.handle)
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify({ st: 1, sts: 1, err: 1, ins: 1, spa: 1, sr: 0, loaded: 1 })
+    })
+    await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', stConfig()))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.resetAgentSession()
+
+    // go back to tab A and see if we get another harvest
+    await browser.closeWindow()
+    await browser.switchToWindow((await browser.getWindowHandles())[0])
+    await browser.testHandle.expectTrace(10000, true)
+  })
+
   // As of 06/26/2023 test fails in Safari, though tested behavior works in a live browser (revisit in NR-138940).
   it.withBrowsersMatching([supportsMultipleTabs, notSafari])('catches mode transition from other pages in the session', async () => {
     await browser.destroyAgentSession()


### PR DESCRIPTION
Prevent Session Traces from "final" harvesting if the session identifiers change during a page life-cycle, such as when a session becomes stale and resets.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-267346?atlOrigin=eyJpIjoiNTIyMzRjODkwYTlhNDRhY2FhNTFkYmExMGI2MjNjOGIiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New unit and e2e tests have been added to check this behavior
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
