### PR TITLE
feat: Add wrapLogger API method for wrapping 3rd party loggers

### DIFF
--- a/src/common/wrap/wrap-logger.js
+++ b/src/common/wrap/wrap-logger.js
@@ -11,11 +11,11 @@ import { ee as baseEE } from '../event-emitter/contextual-ee'
 import { createWrapperWithEmitter as wfn } from './wrap-function'
 
 /**
- * Wraps the global `setTimeout`, `setImmediate`, `setInterval`, `clearTimeout`, and `clearImmediate` functions to emit
- * events on start, end, and error, in the context of a new event emitter scoped only to timer functions. Also wraps
- * the callbacks of `setTimeout` and `setInterval`.
+ * Wraps a supplied function and adds emitter events under the `-wrap-logger-` prefix
  * @param {Object} sharedEE - The shared event emitter on which a new scoped event emitter will be based.
- * @returns {Object} Scoped event emitter with a debug ID of `timer`.
+ * @param {Object} parent - The parent object housing the logger function
+ * @param {string} loggerFn - The name of the function in the parent object to wrap
+ * @returns {Object} Scoped event emitter with a debug ID of `logger`.
  */
 // eslint-disable-next-line
 export function wrapLogger(sharedEE, parent, loggerFn) {
@@ -31,7 +31,7 @@ export function wrapLogger(sharedEE, parent, loggerFn) {
  * features shared the same group in the event, to isolate events between features. It will likely be revisited.
  * @param {Object} sharedEE - Optional event emitter on which to base the scoped emitter.
  *     Uses `ee` on the global scope if undefined).
- * @returns {Object} Scoped event emitter with a debug ID of 'timer'.
+ * @returns {Object} Scoped event emitter with a debug ID of 'logger'.
  */
 export function scopedEE (sharedEE) {
   return (sharedEE || baseEE).get('logger')

--- a/src/loaders/api/api-methods.js
+++ b/src/loaders/api/api-methods.js
@@ -1,10 +1,14 @@
 import { SR_EVENT_EMITTER_TYPES } from '../../features/session_replay/constants'
 
+export const logApiMethods = [
+  'logError', 'logWarn', 'logInfo', 'logDebug', 'logTrace'
+]
+
 export const apiMethods = [
   'setErrorHandler', 'finished', 'addToTrace', 'addRelease',
   'addPageAction', 'setCurrentRouteName', 'setPageViewName', 'setCustomAttribute',
   'interaction', 'noticeError', 'setUserId', 'setApplicationVersion', 'start',
-  SR_EVENT_EMITTER_TYPES.RECORD, SR_EVENT_EMITTER_TYPES.PAUSE
+  SR_EVENT_EMITTER_TYPES.RECORD, SR_EVENT_EMITTER_TYPES.PAUSE, ...logApiMethods
 ]
 
 export const asyncApiMethods = [

--- a/src/loaders/api/api-methods.js
+++ b/src/loaders/api/api-methods.js
@@ -1,5 +1,6 @@
 import { SR_EVENT_EMITTER_TYPES } from '../../features/session_replay/constants'
 
+/** These will get moved to feature constants once the feature exists */
 export const logApiMethods = [
   'logError', 'logWarn', 'logInfo', 'logDebug', 'logTrace'
 ]
@@ -8,7 +9,7 @@ export const apiMethods = [
   'setErrorHandler', 'finished', 'addToTrace', 'addRelease',
   'addPageAction', 'setCurrentRouteName', 'setPageViewName', 'setCustomAttribute',
   'interaction', 'noticeError', 'setUserId', 'setApplicationVersion', 'start',
-  SR_EVENT_EMITTER_TYPES.RECORD, SR_EVENT_EMITTER_TYPES.PAUSE, ...logApiMethods
+  SR_EVENT_EMITTER_TYPES.RECORD, SR_EVENT_EMITTER_TYPES.PAUSE, ...logApiMethods, 'wrapLogger'
 ]
 
 export const asyncApiMethods = [

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -73,8 +73,8 @@ export function setAPI (agentIdentifier, forceDrain, runSoftNavOverSpa = false) 
 
   apiInterface.wrapLogger = (parent, functionName, level = 'info', customAttributes = {}) => {
     wrapLogger(instanceEE, parent, functionName)
-    if (!wrappedLoggers.has({ parent, functionName })) {
-      wrappedLoggers.add({ parent, functionName })
+    if (!wrappedLoggers.has(parent[functionName])) {
+      wrappedLoggers.add(parent[functionName])
       instanceEE.on(`${functionName}-wrap-logger-end`, ([message, ...args]) => {
         log(message, {
           ...(!!args.length && { 'wrappedFn.args': stringify(args) }),

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -72,6 +72,7 @@ export function setAPI (agentIdentifier, forceDrain, runSoftNavOverSpa = false) 
   })
 
   apiInterface.wrapLogger = (parent, functionName, level = 'info', customAttributes = {}) => {
+    if (!(typeof parent === 'object' && typeof functionName === 'string')) return
     wrapLogger(instanceEE, parent, functionName)
     if (!wrappedLoggers.has(parent[functionName])) {
       wrappedLoggers.add(parent[functionName])

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -16,6 +16,8 @@ import { apiMethods, asyncApiMethods, logApiMethods } from './api-methods'
 import { SR_EVENT_EMITTER_TYPES } from '../../features/session_replay/constants'
 import { now } from '../../common/timing/now'
 import { MODE } from '../../common/session/constants'
+import { wrapLogger } from '../../common/wrap/wrap-logger'
+import { stringify } from '../../common/util/stringify'
 
 export function setTopLevelCallers () {
   const nr = gosCDN()
@@ -57,16 +59,24 @@ export function setAPI (agentIdentifier, forceDrain, runSoftNavOverSpa = false) 
    * @param {{[key: string]: *}} context
    * @param {string} level
    */
-  function log (message, context, level = 'info') {
-    handle(SUPPORTABILITY_METRIC_CHANNEL, [`API/log${level}/called`], undefined, FEATURE_NAMES.metrics, instanceEE)
-    handle('log', [now(), message, context, level], undefined, FEATURE_NAMES.logging, instanceEE)
+  function log (message, customAttributes, level = 'info') {
+    handle(SUPPORTABILITY_METRIC_CHANNEL, [`API/logging/${level}/called`], undefined, FEATURE_NAMES.metrics, instanceEE)
+    handle('log', [now(), message, customAttributes, level], undefined, FEATURE_NAMES.logging, instanceEE)
   }
 
   logApiMethods.forEach((method) => {
-    apiInterface[method] = function (message, context) {
-      log(message, context, method.toLowerCase().replace('log', ''))
+    apiInterface[method] = function (message, customAttributes = {}) {
+      log(message, customAttributes, method.toLowerCase().replace('log', ''))
     }
   })
+
+  apiInterface.wrapLogger = (parent, functionName, level = 'info', customAttributes = {}) => {
+    wrapLogger(instanceEE, parent, functionName)
+
+    instanceEE.on(`${functionName}-wrap-logger-end`, (args) => {
+      log(args.map(arg => typeof arg === 'string' ? arg : stringify(arg)).join(' '), customAttributes, level)
+    })
+  }
 
   // Setup stub functions that queue calls for later processing.
   asyncApiMethods.forEach(fnName => { apiInterface[fnName] = apiCall(prefix, fnName, true, 'api') })

--- a/tests/specs/api.e2e.js
+++ b/tests/specs/api.e2e.js
@@ -25,7 +25,7 @@ describe('newrelic api', () => {
         }
         return Array.from(result)
       }
-      return getAllPropertyNames(Object.values(newrelic.initializedAgents)[0])
+      return getAllPropertyNames(Object.values(newrelic.initializedAgents)[0].api)
     })
 
     expect(globalApiMethods).toEqual(expect.arrayContaining([

--- a/tests/specs/npm/index.e2e.js
+++ b/tests/specs/npm/index.e2e.js
@@ -54,38 +54,21 @@ describe.withBrowsersMatching(es2022Support)('basic npm agent', () => {
     })
 
     if (testBuild !== 'worker-agent') {
-      it(`dist/${testBuild} exposes the correct API methods`, async () => {
-        await browser.url(await browser.testHandle.assetURL(`test-builds/browser-agent-wrapper/${testBuild}.html`))
+      ;[['dist', 'browser-agent-wrapper'], ['src', 'raw-src-wrapper']].forEach(([type, wrapper]) => {
+        it(`${type}/${testBuild} exposes the correct API methods`, async () => {
+          await browser.url(await browser.testHandle.assetURL(`test-builds/${wrapper}/${testBuild}.html`))
 
-        const agentProps = await getAgentProps('window.agent')
-        const agentApiProps = await getAgentProps('window.agent.api')
+          const NREUMProps = await getAgentProps('NREUM')
+          const newrelicProps = await getAgentProps('newrelic')
+          const agentApiProps = await getAgentProps('window.agent.api')
 
-        expect(agentProps).toEqual(expect.arrayContaining([
-          ...apiMethods,
-          ...asyncApiMethods
-        ]))
-
-        expect(agentApiProps).toEqual(expect.arrayContaining([
-          ...apiMethods,
-          ...asyncApiMethods
-        ]))
-      })
-
-      it(`src/${testBuild} exposes the correct API methods`, async () => {
-        await browser.url(await browser.testHandle.assetURL(`test-builds/raw-src-wrapper/${testBuild}.html`))
-
-        const agentProps = await getAgentProps('window.agent')
-        const agentApiProps = await getAgentProps('window.agent.api')
-
-        expect(agentProps).toEqual(expect.arrayContaining([
-          ...apiMethods,
-          ...asyncApiMethods
-        ]))
-
-        expect(agentApiProps).toEqual(expect.arrayContaining([
-          ...apiMethods,
-          ...asyncApiMethods
-        ]))
+          ;[NREUMProps, newrelicProps, agentApiProps].forEach(keys => {
+            expect(keys).toEqual(expect.arrayContaining([
+              ...apiMethods,
+              ...asyncApiMethods
+            ]))
+          })
+        })
       })
     }
   })

--- a/tests/unit/loaders/api/api.test.js
+++ b/tests/unit/loaders/api/api.test.js
@@ -11,7 +11,7 @@ describe('setTopLevelCallers', () => {
     setTopLevelCallers()
 
     const nreum = gosCDN()
-    expect(Object.keys(nreum).length).toEqual(20)
+    expect(Object.keys(nreum).length).toEqual(21)
     expect(typeof nreum.setErrorHandler).toEqual('function')
     expect(typeof nreum.finished).toEqual('function')
     expect(typeof nreum.addToTrace).toEqual('function')
@@ -32,6 +32,7 @@ describe('setTopLevelCallers', () => {
     expect(typeof nreum.logDebug).toEqual('function')
     expect(typeof nreum.logWarn).toEqual('function')
     expect(typeof nreum.logTrace).toEqual('function')
+    expect(typeof nreum.wrapLogger).toEqual('function')
   })
 
   test('should forward calls to initialized and exposed agents', () => {

--- a/tests/unit/loaders/api/api.test.js
+++ b/tests/unit/loaders/api/api.test.js
@@ -11,7 +11,7 @@ describe('setTopLevelCallers', () => {
     setTopLevelCallers()
 
     const nreum = gosCDN()
-    expect(Object.keys(nreum).length).toEqual(15)
+    expect(Object.keys(nreum).length).toEqual(20)
     expect(typeof nreum.setErrorHandler).toEqual('function')
     expect(typeof nreum.finished).toEqual('function')
     expect(typeof nreum.addToTrace).toEqual('function')
@@ -27,6 +27,11 @@ describe('setTopLevelCallers', () => {
     expect(typeof nreum.start).toEqual('function')
     expect(typeof nreum.recordReplay).toEqual('function')
     expect(typeof nreum.pauseReplay).toEqual('function')
+    expect(typeof nreum.logError).toEqual('function')
+    expect(typeof nreum.logInfo).toEqual('function')
+    expect(typeof nreum.logDebug).toEqual('function')
+    expect(typeof nreum.logWarn).toEqual('function')
+    expect(typeof nreum.logTrace).toEqual('function')
   })
 
   test('should forward calls to initialized and exposed agents', () => {


### PR DESCRIPTION
Observe existing logging functions and report through event emitter for later processing when capturing log events.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
** NOTE ** please review #1052 first, as this PR is branched from that.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-251149
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New jest tests have been added
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
