### PR TITLE
chore: default tests to lambdatest

### DIFF
--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run WDIO Tests
         run: |
           node --max-old-space-size=8192 ./tools/wdio/bin/cli.js \
-            --lt -T \
+            -T \
             -b '${{ inputs.browser-target }}' \
             --concurrent 10 \
             ${{ runner.debug && '-v -L -D -d' || '' }} \

--- a/tools/wdio/args.mjs
+++ b/tools/wdio/args.mjs
@@ -98,9 +98,9 @@ const args = yargs(hideBin(process.argv))
   .default('webview', false)
   .describe('webview', 'Run webview tests')
 
-  .boolean('lt')
-  .default('lt', false)
-  .describe('lt', 'Run with lambda test')
+  .boolean('sl')
+  .default('sl', false)
+  .describe('sl', 'Run with sauce labs')
 
   .middleware(argv => {
     if (argv.webview && (!argv.browsers || argv.browsers === 'chrome@latest')) {

--- a/tools/wdio/config/lambdatest.conf.mjs
+++ b/tools/wdio/config/lambdatest.conf.mjs
@@ -38,7 +38,6 @@ function lambdaTestCapabilities () {
     .map(testBrowser => {
       const capabilities = {
         'LT:Options': {
-          tunnel: true,
           w3c: true,
           build: `Browser Agent: ${testBrowser.browserName || testBrowser.device_name} ${testBrowser.browserVersion || testBrowser.version} ${testBrowser.platformName} [${revision}]`,
           ...(args.extendedDebugging

--- a/tools/wdio/runner.mjs
+++ b/tools/wdio/runner.mjs
@@ -23,7 +23,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const wdioConfig = deepmerge(
   baseConfig(),
   specsConfig(),
-  args.lt ? lambdaTestConfig() : sauceConfig()
+  args.sl ? sauceConfig() : lambdaTestConfig()
 )
 const configFilePath = path.join(
   path.resolve(__dirname, '../../node_modules/.cache/wdio'),


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Defaulting wdio to run against LambdaTest while still supporting SauceLabs with a cli flag.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-254321

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
