### PR TITLE
chore: Add app automation for webview tests

### DIFF
--- a/.github/workflows/wdio-all-browsers.yml
+++ b/.github/workflows/wdio-all-browsers.yml
@@ -69,18 +69,20 @@ jobs:
       additional-flags: -P
     secrets: inherit
 
-  # ios-webview:
-  #   uses: ./.github/workflows/wdio-single-browser.yml
-  #   with:
-  #     ref: ${{ inputs.ref || github.ref }}
-  #     browser-target: ${{ inputs.latest-only == true && 'ios@latest' || 'ios@*' }}
-  #     additional-flags: --webview --timeout 300000
-  #   secrets: inherit
+  ios-webview:
+    uses: ./.github/workflows/wdio-single-browser.yml
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      browser-target: 'ios@latest'
+      additional-flags: --webview --timeout 300000
+      concurrency: 2
+    secrets: inherit
 
-  # android-webview:
-  #   uses: ./.github/workflows/wdio-single-browser.yml
-  #   with:
-  #     ref: ${{ inputs.ref || github.ref }}
-  #     browser-target: ${{ inputs.latest-only == true && 'android@latest' || 'android@*' }}
-  #     additional-flags: --webview --timeout 300000
-  #   secrets: inherit
+  android-webview:
+    uses: ./.github/workflows/wdio-single-browser.yml
+    with:
+      ref: ${{ inputs.ref || github.ref }}
+      browser-target: 'android@latest'
+      additional-flags: --webview --timeout 300000
+      concurrency: 2
+    secrets: inherit

--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -35,6 +35,11 @@ on:
         description: 'Github branch ref to checkout and run tests on'
         required: false
         type: string
+      concurrency:
+        description: 'The number of test runner threads to spawn for a run'
+        required: false
+        type: number
+        default: 10
     secrets:
       LAMBDA_USERNAME:
         required: true
@@ -70,7 +75,7 @@ jobs:
           node --max-old-space-size=8192 ./tools/wdio/bin/cli.js \
             -T \
             -b '${{ inputs.browser-target }}' \
-            --concurrent 10 \
+            --concurrent ${{ inputs.concurrency }} \
             ${{ runner.debug && '-v -L -D -d' || '' }} \
             ${{ inputs.coverage && '--coverage' || '' }} \
             ${{ inputs.additional-flags || '' }}

--- a/tools/wdio/config/lambdatest.conf.mjs
+++ b/tools/wdio/config/lambdatest.conf.mjs
@@ -57,6 +57,16 @@ function lambdaTestCapabilities () {
       } else {
         capabilities['LT:Options'].deviceName = testBrowser.device_name
         capabilities['LT:Options'].platformVersion = testBrowser.version
+        if (args.webview) { // btw, LT has different capabilities array for mobile app automation!
+          // Note: Since their available devices for app differs, we'll let default pick apply.
+          // Caution: LT does not support android@9 for app; we should only be testing webview for latest ios & android.
+          capabilities['LT:Options'].deviceName = '.*'
+          capabilities['LT:Options'].isRealMobile = false
+          // Note: LT expires app every 60 days, so the .zip/.apk needs to be re-uploaded then and these url updated to point to new url.
+          // Important: ensure the uploaded apps are set to "team" visibility.
+          if (parsedBrowserName === 'android') capabilities['LT:Options'].app = 'lt://APP10160352241718733717577609'
+          else /* === 'ios' */ capabilities['LT:Options'].app = 'lt://APP10160352241718734672953481'
+        }
       }
       capabilities['LT:Options'].platformName = testBrowser.platformName
       return capabilities
@@ -64,7 +74,7 @@ function lambdaTestCapabilities () {
 }
 
 export default function config () {
-  return {
+  const config = {
     user: process.env.LT_USERNAME || process.env.LAMBDA_USERNAME,
     key: process.env.LT_ACCESS_KEY || process.env.LAMBDA_ACCESS_KEY,
     capabilities: lambdaTestCapabilities(),
@@ -82,4 +92,9 @@ export default function config () {
       ]
     ]
   }
+  if (args.webview) { // LT app automation requires these to be specified
+    config.hostname = 'mobile-hub.lambdatest.com'
+    config.path = '/wd/hub'
+  }
+  return config
 }


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Webview tests has also been limited to android & ios latest only.
* LT has connection issues with ios 16.0 on these tests
* Android 9 is not supported -- only 11 & 14 (at this point in time, could change?)
* Android web automation device list is not applicable to app automation as the capabilities array differs
* Atm, these tests only pass with plugin tunnel (enabling `-T` flag), not with underpass application for local dev ([slack thread](https://newrelic-external.slack.com/archives/C0749JVME86/p1718904970442849?thread_ts=1718733672.426799&cid=C0749JVME86))

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-280345

### Testing

Run PR checks
