### PR TITLE
chore: Enforce no re-wrapping with log wrappers

### DIFF
--- a/src/common/wrap/wrap-function.js
+++ b/src/common/wrap/wrap-function.js
@@ -118,7 +118,7 @@ export function createWrapperWithEmitter (emitter, always) {
    * @param {boolean} [bubble=false] If `true`, emitted events should also bubble up to the old emitter upon which
    * the `emitter` in the current scope was based (if it defines one).
    */
-  function inPlace (obj, methods, prefix, getContext, bubble, unwrapPrevious) {
+  function inPlace (obj, methods, prefix, getContext, bubble) {
     if (!prefix) prefix = ''
 
     // If prefix starts with '-' set this boolean to add the method name to the prefix before passing each one to wrap.
@@ -126,9 +126,6 @@ export function createWrapperWithEmitter (emitter, always) {
 
     for (let i = 0; i < methods.length; i++) {
       const method = methods[i]
-
-      if (unwrapPrevious && obj[method][flag] && typeof obj[method][flag] === 'function') obj[method] = obj[method][flag]
-
       const fn = obj[method]
 
       // Unless fn is both wrappable and unwrapped, bail so we don't add extra properties with undefined values.

--- a/src/common/wrap/wrap-function.js
+++ b/src/common/wrap/wrap-function.js
@@ -118,7 +118,7 @@ export function createWrapperWithEmitter (emitter, always) {
    * @param {boolean} [bubble=false] If `true`, emitted events should also bubble up to the old emitter upon which
    * the `emitter` in the current scope was based (if it defines one).
    */
-  function inPlace (obj, methods, prefix, getContext, bubble) {
+  function inPlace (obj, methods, prefix, getContext, bubble, unwrapPrevious) {
     if (!prefix) prefix = ''
 
     // If prefix starts with '-' set this boolean to add the method name to the prefix before passing each one to wrap.
@@ -126,6 +126,9 @@ export function createWrapperWithEmitter (emitter, always) {
 
     for (let i = 0; i < methods.length; i++) {
       const method = methods[i]
+
+      if (unwrapPrevious && obj[method][flag] && typeof obj[method][flag] === 'function') obj[method] = obj[method][flag]
+
       const fn = obj[method]
 
       // Unless fn is both wrappable and unwrapped, bail so we don't add extra properties with undefined values.

--- a/src/common/wrap/wrap-logger.js
+++ b/src/common/wrap/wrap-logger.js
@@ -33,7 +33,7 @@ export function wrapLogger(sharedEE, parent, loggerFn, context) {
   ctx.customAttributes = context.customAttributes
 
   /** observe calls to <loggerFn> and emit events prefixed with `wrap-logger-` */
-  wrapFn.inPlace(parent, [loggerFn], 'wrap-logger-', ctx, undefined, true)
+  wrapFn.inPlace(parent, [loggerFn], 'wrap-logger-', ctx)
 
   return ee
 }

--- a/src/common/wrap/wrap-logger.js
+++ b/src/common/wrap/wrap-logger.js
@@ -24,9 +24,8 @@ export function wrapLogger(sharedEE, parent, loggerFn, context) {
   const wrapFn = wfn(ee)
 
   /**
-   * This section allows us to pass an over-writable context along through the event emitter
-   * so that subsequent calls to `newrelic.wrapLogger` `WILL NOT` re-wrap (emit twice), but `WILL` overwrite the
-   * context object which contains the custom attributes and log level
+   * This section contains the context that will be shared across all invoked calls of the wrapped function,
+   * which will be used to decorate the log data later at agg time
   */
   const ctx = new EventContext(contextId)
   ctx.level = context.level

--- a/src/common/wrap/wrap-logger.js
+++ b/src/common/wrap/wrap-logger.js
@@ -31,10 +31,9 @@ export function wrapLogger(sharedEE, parent, loggerFn, context) {
   const ctx = new EventContext(contextId)
   ctx.level = context.level
   ctx.customAttributes = context.customAttributes
-  parent[loggerFn].__nrContext = ctx
 
   /** observe calls to <loggerFn> and emit events prefixed with `wrap-logger-` */
-  wrapFn.inPlace(parent, [loggerFn], 'wrap-logger-', () => parent[loggerFn].__nrContext)
+  wrapFn.inPlace(parent, [loggerFn], 'wrap-logger-', ctx, undefined, true)
 
   return ee
 }

--- a/tests/assets/logs-api-wrap-logger-rewrapped.html
+++ b/tests/assets/logs-api-wrap-logger-rewrapped.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>Logs API Error Object</title>
+    {init} {config} {loader}
+    <script>
+      var loggers = {
+        log: function(message, attr){}
+      }
+      
+      newrelic.wrapLogger(loggers, 'log', { level: "info" })
+      loggers.log('test1')
+      // should capture event with `info` level
+
+      newrelic.wrapLogger(loggers, 'log', { level: "warn" })
+      loggers.log('test2')
+      // should capture another event, but now with `warn` level
+
+      var orig = loggers.log
+      loggers.log = (...args) => {console.log('wrapped again by 3rd party'); orig(...args)} 
+      loggers.log('test3')
+      // should capture another event, and still have the `warn` level even though the parent context was changed
+    </script>
+  </head>
+  <body>Logs API Error Object</body>
+</html>

--- a/tests/assets/logs-api-wrap-logger-rewrapped.html
+++ b/tests/assets/logs-api-wrap-logger-rewrapped.html
@@ -12,13 +12,14 @@
         log: function(message, attr){}
       }
       
-      newrelic.wrapLogger(loggers, 'log', { level: "info" })
-      loggers.log('test1')
-      // should capture event with `info` level
-
       newrelic.wrapLogger(loggers, 'log', { level: "warn" })
+      loggers.log('test1')
+      // should capture event with `warn` level
+
+      newrelic.wrapLogger(loggers, 'log', { level: "debug" })
       loggers.log('test2')
-      // should capture another event, but now with `warn` level
+      // should capture another event, ignoring the `debug` level and harvesting with `warn`
+      // should NOT duplicate the log events (ie, capture 2 logs for this one call)
 
       var orig = loggers.log
       loggers.log = (...args) => {console.log('wrapped again by 3rd party'); orig(...args)} 

--- a/tests/components/logging/instrument.test.js
+++ b/tests/components/logging/instrument.test.js
@@ -43,7 +43,7 @@ describe('logging instrument component tests', () => {
     expect(utils.bufferLog).toHaveBeenCalledWith(loggingInstrument.ee, 'message', { args: 1 }, 'error')
   })
 
-  it('should get latest context from wrapLogger', async () => {
+  it('wrapLogger should not re-wrap or overwrite context if called more than once', async () => {
     const onCalls = instanceEE.on.mock.calls.length
     const loggingInstrument = new LoggingInstrument(agentIdentifier, new Aggregator({}))
     expect(instanceEE.on).toHaveBeenCalledTimes(onCalls + 1)
@@ -56,10 +56,10 @@ describe('logging instrument component tests', () => {
     expect(utils.bufferLog).toHaveBeenCalledTimes(0)
     myLoggerSuite.myTestLogger('message', { args: 2 })
     expect(utils.bufferLog).toHaveBeenCalledWith(loggingInstrument.ee, 'message', { args: 1 }, 'error') // ignores args: 2
-    /** re-wrap the logger with a NEW context, new events should get that context now */
+    /** re-wrap the logger with a NEW context, new events should NOT get that context because the wrapper should early-exit */
     wrapLogger(loggingInstrument.ee, myLoggerSuite, 'myTestLogger', { customAttributes: { args: 'abc' }, level: 'info' })
     myLoggerSuite.myTestLogger('message', { args: 2 })
-    expect(utils.bufferLog).toHaveBeenCalledWith(loggingInstrument.ee, 'message', { args: 'abc' }, 'info')
+    expect(utils.bufferLog).toHaveBeenCalledWith(loggingInstrument.ee, 'message', { args: 1 }, 'error')
   })
 })
 

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -74,20 +74,20 @@ describe('logging harvesting', () => {
       expect(JSON.parse(body)[0].logs[0].message).toEqual('Error: test')
     })
 
-    it('should allow for re-wrapping and 3rd party wrapping', async () => {
+    it.withBrowsersMatching(notIE)('should allow for re-wrapping and 3rd party wrapping', async () => {
       const [{ request: { body } }] = await Promise.all([
         browser.testHandle.expectLogs(10000),
         browser.url(await browser.testHandle.assetURL('logs-api-wrap-logger-rewrapped.html'))
       ])
       const logs = JSON.parse(body)[0].logs
       // should not duplicate after re-wrapping,
-      // if it did we would see 1 + 2 + 3 = 6 logs here
+      // if it did we would see 1 + 2 + 2 = 5 logs here
       // we would also see multiple test2 or test3 messages show up
       expect(logs.length).toEqual(3)
-      // original wrapping context (info)
+      // original wrapping context (warn)
       expect(logs[0].message).toEqual('test1')
-      expect(logs[0].logType).toEqual('info')
-      // should allow re-wrapping to change the context (warn)
+      expect(logs[0].logType).toEqual('warn')
+      // should not re-wrap, meaning the logType should not change, but the message should here
       expect(logs[1].message).toEqual('test2')
       expect(logs[1].logType).toEqual('warn')
       // should allow a 3rd party to wrap the function and not affect the context (warn)

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -73,6 +73,27 @@ describe('logging harvesting', () => {
 
       expect(JSON.parse(body)[0].logs[0].message).toEqual('Error: test')
     })
+
+    it('should allow for re-wrapping and 3rd party wrapping', async () => {
+      const [{ request: { body } }] = await Promise.all([
+        browser.testHandle.expectLogs(10000),
+        browser.url(await browser.testHandle.assetURL('logs-api-wrap-logger-rewrapped.html'))
+      ])
+      const logs = JSON.parse(body)[0].logs
+      // should not duplicate after re-wrapping,
+      // if it did we would see 1 + 2 + 3 = 6 logs here
+      // we would also see multiple test2 or test3 messages show up
+      expect(logs.length).toEqual(3)
+      // original wrapping context (info)
+      expect(logs[0].message).toEqual('test1')
+      expect(logs[0].logType).toEqual('info')
+      // should allow re-wrapping to change the context (warn)
+      expect(logs[1].message).toEqual('test2')
+      expect(logs[1].logType).toEqual('warn')
+      // should allow a 3rd party to wrap the function and not affect the context (warn)
+      expect(logs[2].message).toEqual('test3')
+      expect(logs[2].logType).toEqual('warn')
+    })
   })
 
   describe('logging retry harvests', () => {


### PR DESCRIPTION
Adding a fix after observing an issue internally where re-wrapping a logging function after the agent has already wrapped it will break the scoped context.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new test has been added to confirm this behavior
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
