### PR TITLE
fix: Reading finish of null in SPA

### DIFF
--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -574,7 +574,7 @@ export class Aggregate extends AggregateBase {
       var interaction = this.ixn
       var node = activeNodeFor(interaction)
       setCurrentNode(null)
-      node.child('customEnd', timestamp).finish(timestamp)
+      node.child('customEnd', timestamp)?.finish(timestamp)
       interaction.finish()
     }, this.featureName, baseEE)
 


### PR DESCRIPTION
Patch cases wherein SPA `.end()` can throw exception on a finished or full interaction. `.end` still force finishes an interaction.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

SPA node `.child` function can return a null value if the interaction is already finished or if there are 128+ children nodes. This caused a chained `finish()` call on it to throw in  `.end` of API. This has been fixed via optional chaining which has minimal impact on the functionality of `.end` aside from not adding a customEnd node to the ixn.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-268147

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
