### PR TITLE
chore: Post release repo updates

### DIFF
--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Fri Jun 21 2024 09:58:59 GMT-0500 (Central Daylight Time)",
+  "lastUpdated": "Wed Jun 26 2024 01:38:29 GMT+0000 (Coordinated Universal Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,

--- a/tools/browsers-lists/lt-desktop-latest-vers.json
+++ b/tools/browsers-lists/lt-desktop-latest-vers.json
@@ -1,6 +1,6 @@
 {
   "chrome": 125,
-  "edge": 125,
+  "edge": 126,
   "firefox": 126,
   "safari": 17
 }

--- a/tools/browsers-lists/lt-mobile-supported.json
+++ b/tools/browsers-lists/lt-mobile-supported.json
@@ -6,19 +6,19 @@
       "platformName": "ios"
     },
     {
-      "device_name": "iPhone 14 Pro Max",
+      "device_name": "iPhone SE (3rd generation)",
       "version": "16.0",
       "platformName": "ios"
     }
   ],
   "android": [
     {
-      "device_name": "Pixel 4",
+      "device_name": "ASUS ZenFone 8",
       "version": "14",
       "platformName": "android"
     },
     {
-      "device_name": "Oppo A9",
+      "device_name": "Galaxy S10",
       "version": "9",
       "platformName": "android"
     }

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.0.tgz"
   }
 }

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/client": "^3.8.8",
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.0.tgz",
     "graphql": "^16.8.1"
   }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.0.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.260.1.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.0.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
When this PR is merged, caniuse-lite database is updated, latest browserslist for SauceLabs is retrieved, and third-party dependencies docs are updates.
---

This PR was generated with post-release-updates GitHub action.