### PR TITLE
fix: Unhandled promise rejection for session import

### DIFF
--- a/src/features/utils/__mocks__/agent-session.js
+++ b/src/features/utils/__mocks__/agent-session.js
@@ -1,1 +1,3 @@
-export const setupAgentSession = jest.fn()
+export const setupAgentSession = jest.fn(() => {
+  return {}
+})

--- a/src/features/utils/__mocks__/feature-base.js
+++ b/src/features/utils/__mocks__/feature-base.js
@@ -5,7 +5,8 @@ export const FeatureBase = jest.fn(function (agentIdentifier, aggregator, featur
 
   this.ee = {
     abort: jest.fn(),
-    on: jest.fn()
+    on: jest.fn(),
+    emit: jest.fn()
   }
   this.blocked = false
 })

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -17,7 +17,7 @@ export class AggregateBase extends FeatureBase {
    * @returns {Promise}
    */
   waitForFlags (flagNames = []) {
-    return new Promise((resolve, reject) => {
+    const flagsPromise = new Promise((resolve, reject) => {
       if (activatedFeatures[this.agentIdentifier]) {
         resolve(buildOutput(activatedFeatures[this.agentIdentifier]))
       } else {
@@ -31,6 +31,9 @@ export class AggregateBase extends FeatureBase {
           return ref[flag]
         })
       }
+    })
+    return flagsPromise.catch(err => {
+      this.ee.emit('internal-error', [err])
     })
   }
 

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -86,6 +86,7 @@ export class InstrumentBase extends FeatureBase {
         }
       } catch (e) {
         warn('A problem occurred when starting up session manager. This page will not start or extend any session.', e)
+        this.ee.emit('internal-error', [e])
         if (this.featureName === FEATURE_NAMES.sessionReplay) this.abortHandler?.() // SR should stop recording if session DNE
       }
 
@@ -127,6 +128,6 @@ export class InstrumentBase extends FeatureBase {
  */
   #shouldImportAgg (featureName, session) {
     if (featureName === FEATURE_NAMES.sessionReplay) return canImportReplayAgg(this.agentIdentifier, session)
-    return true
+    return !(featureName === FEATURE_NAMES.sessionTrace && !session)
   }
 }

--- a/tools/testing-server/plugins/test-handle/index.js
+++ b/tools/testing-server/plugins/test-handle/index.js
@@ -19,6 +19,7 @@ module.exports = fp(async function (fastify, testServer) {
     }
     if (!!testId && request.url.startsWith('/tests/assets') && request.url.includes('.html')) {
       reply.header('set-cookie', `test-id=${testId};path=/build/`)
+      reply.header('set-cookie', `test-id=${testId};path=/tests/assets/`)
     }
 
     if (request.query.nonce) {

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -68,7 +68,11 @@ export default class CustomCommands {
       const agentSessionsJSON = await browser.execute(function () {
         return JSON.stringify(Object.entries(newrelic.initializedAgents)
           .reduce(function (aggregate, agentEntry) {
-            aggregate[agentEntry[0]] = agentEntry[1].runtime.session.state
+            if (agentEntry[1].runtime.session) {
+              aggregate[agentEntry[0]] = agentEntry[1].runtime.session.state
+            } else {
+              aggregate[agentEntry[0]] = {}
+            }
             return aggregate
           }, {}))
       })
@@ -76,10 +80,14 @@ export default class CustomCommands {
       const agentSessionInstances = await browser.execute(function () {
         return Object.entries(newrelic.initializedAgents)
           .reduce(function (aggregate, agentEntry) {
-            aggregate[agentEntry[0]] = {
-              key: agentEntry[1].runtime.session.key,
-              isNew: agentEntry[1].runtime.session.isNew,
-              initialized: agentEntry[1].runtime.session.initialized
+            if (agentEntry[1].runtime.session) {
+              aggregate[agentEntry[0]] = {
+                key: agentEntry[1].runtime.session.key,
+                isNew: agentEntry[1].runtime.session.isNew,
+                initialized: agentEntry[1].runtime.session.initialized
+              }
+            } else {
+              aggregate[agentEntry[0]] = {}
             }
             return aggregate
           }, {})


### PR DESCRIPTION
Fixing an issue where an unhandled promise rejection could be thrown from the agent when using the npm package if the session manager async chunk get blocked or fails to setup a session.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

If the session manager chunk is blocked, the agent was throwing an unhandled promise rejection error and the agent was failing to harvest a lot of other data. To fix the issue, a check has been added to prevent the session trace aggregate `initialize` function from running.

This issue could also happen if the session entity or the session initialization code threw an exception. I have added an `ierr` for those scenarios so we and customers can get better clarity on if/when/why the session manager is failing.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-281861
#1075

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

To test locally, use the vite-react-wrapper and block only the session manager chunk using browser dev tools. Before this change, you should see an unhandled promise rejection in the console logs and the agent will stop harvesting data for anything except page view, page timings, and supportability metrics. With this change, the agent should continue functioning normally but without an session trace harvests. There should also be an ierr reported in the first timeslice payload.