### PR TITLE
fix: recordReplay will restart replays on same session page loads

### DIFF
--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -28,7 +28,7 @@ export class Instrument extends InstrumentBase {
     } catch (err) { }
 
     if (hasReplayPrerequisite(agentIdentifier)) {
-      this.ee.on('recordReplay', () => this.#apiStartOrRestartReplay())
+      this.ee.on(SR_EVENT_EMITTER_TYPES.RECORD, () => this.#apiStartOrRestartReplay())
     }
 
     if (this.#canPreloadRecorder(session)) {

--- a/src/features/session_replay/shared/__mocks__/utils.js
+++ b/src/features/session_replay/shared/__mocks__/utils.js
@@ -1,1 +1,0 @@
-export const canImportReplayAgg = jest.fn()

--- a/src/features/session_replay/shared/utils.js
+++ b/src/features/session_replay/shared/utils.js
@@ -12,11 +12,6 @@ export function isPreloadAllowed (agentId) {
   return getConfigurationValue(agentId, 'session_replay.preload') === true && hasReplayPrerequisite(agentId)
 }
 
-export function canImportReplayAgg (agentId, sessionMgr) {
-  if (!hasReplayPrerequisite(agentId)) return false
-  return !!sessionMgr?.isNew || !!sessionMgr?.state.sessionReplayMode // Session Replay should only try to run if already running from a previous page, or at the beginning of a session
-}
-
 export function buildNRMetaNode (timestamp, timeKeeper) {
   const correctedTimestamp = timeKeeper.correctAbsoluteTimestamp(timestamp)
   return {

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -11,7 +11,7 @@ import { isBrowserScope } from '../../common/constants/runtime'
 import { warn } from '../../common/util/console'
 import { FEATURE_NAMES } from '../../loaders/features/features'
 import { getConfigurationValue } from '../../common/config/config'
-import { canImportReplayAgg } from '../session_replay/shared/utils'
+import { hasReplayPrerequisite } from '../session_replay/shared/utils'
 import { canEnableSessionTracking } from './feature-gates'
 import { single } from '../../common/util/invoke'
 
@@ -127,7 +127,13 @@ export class InstrumentBase extends FeatureBase {
  * @returns
  */
   #shouldImportAgg (featureName, session) {
-    if (featureName === FEATURE_NAMES.sessionReplay) return canImportReplayAgg(this.agentIdentifier, session)
-    return !(featureName === FEATURE_NAMES.sessionTrace && !session)
+    switch (featureName) {
+      case FEATURE_NAMES.sessionReplay: // the session manager must be initialized successfully for Replay & Trace features
+        return hasReplayPrerequisite(this.agentIdentifier) && !!session
+      case FEATURE_NAMES.sessionTrace:
+        return !!session
+      default:
+        return true
+    }
   }
 }

--- a/tests/specs/session-replay/mode.e2e.js
+++ b/tests/specs/session-replay/mode.e2e.js
@@ -107,31 +107,6 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
     expect(sr.mode).toEqual(1)
   })
 
-  it('Record API called before page load does not start a replay (no entitlements yet)', async () => {
-    await browser.enableSessionReplay(0, 0)
-    await browser.url(await browser.testHandle.assetURL('rrweb-api-record-before-load.html', srConfig()))
-      .then(() => browser.waitForFeatureAggregate('session_replay'))
-
-    await browser.pause(1000)
-    await expect(getSR()).resolves.toMatchObject({
-      initialized: true,
-      mode: 1
-    })
-  })
-
-  it('Pause API called before page load stops the replay', async () => {
-    await browser.enableSessionReplay(100, 0)
-    await browser.url(await browser.testHandle.assetURL('rrweb-api-pause-before-load.html', srConfig()))
-      .then(() => browser.waitForSessionReplayRecording())
-
-    await expect(getSR()).resolves.toMatchObject({
-      recording: true,
-      initialized: true,
-      events: expect.any(Array),
-      mode: 0
-    })
-  })
-
   it('ERROR (seen after init) => FULL', async () => {
     await browser.enableSessionReplay(0, 100)
     await browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', srConfig()))

--- a/tests/specs/session-replay/session-pages.e2e.js
+++ b/tests/specs/session-replay/session-pages.e2e.js
@@ -111,28 +111,6 @@ describe.withBrowsersMatching(notIE)('Session Replay Across Pages', () => {
     await browser.switchToWindow((await browser.getWindowHandles())[0])
   })
 
-  it('should not record across navigations if not active', async () => {
-    const [{ request: page1Contents }] = await Promise.all([
-      browser.testHandle.expectReplay(10000),
-      browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', srConfig()))
-        .then(() => browser.waitForAgentLoad())
-    ])
-
-    const { localStorage } = await browser.getAgentSessionInfo()
-
-    testExpectedReplay({ data: page1Contents, session: localStorage.value, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
-
-    await browser.execute(function () {
-      Object.values(NREUM.initializedAgents)[0].runtime.session.state.sessionReplayMode = 0
-    })
-
-    await browser.enableSessionReplay()
-    await browser.refresh()
-      .then(() => browser.waitForAgentLoad())
-
-    await expect(browser.waitForFeatureAggregate('session_replay', 5000)).rejects.toThrow()
-  })
-
   // As of 06/26/2023 test fails in Safari, though tested behavior works in a live browser (revisit in NR-138940).
   it.withBrowsersMatching([supportsMultipleTabs, notSafari])('should kill active tab if killed in backgrounded tab', async () => {
     const [{ request: page1Contents }] = await Promise.all([

--- a/tests/specs/session-replay/sr-api.e2e.js
+++ b/tests/specs/session-replay/sr-api.e2e.js
@@ -1,12 +1,12 @@
 import { notIE } from '../../../tools/browser-matcher/common-matchers.mjs'
 import { srConfig, getSR } from '../util/helpers'
 
-describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', () => {
+describe.withBrowsersMatching(notIE)('Replay API', () => {
   afterEach(async () => {
     await browser.destroyAgentSession()
   })
 
-  it('Record API called before page load does not start a replay (no entitlements yet)', async () => {
+  it('recordReplay called before page load does not start a replay (no entitlements yet)', async () => {
     await browser.enableSessionReplay(0, 0)
     await browser.url(await browser.testHandle.assetURL('rrweb-api-record-before-load.html', srConfig()))
       .then(() => browser.waitForFeatureAggregate('session_replay'))
@@ -18,7 +18,7 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
     })
   })
 
-  it('Pause API called before page load stops the replay', async () => {
+  it('pauseReplay called before page load stops the replay', async () => {
     await browser.enableSessionReplay(100, 0)
     await browser.url(await browser.testHandle.assetURL('rrweb-api-pause-before-load.html', srConfig()))
       .then(() => browser.waitForSessionReplayRecording())
@@ -43,13 +43,13 @@ describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', ()
     replayState = await getSR()
     expect(replayState.mode).toEqual(0)
 
-    await browser.refresh() // paused (OFF) mode should be saved to session and next page starts with OFF
+    await browser.refresh().then(() => browser.waitForFeatureAggregate('session_replay')) // paused (OFF) mode should be saved to session and next page starts with OFF
     replayState = await getSR()
     expect(replayState.mode).toEqual(0)
 
     await browser.execute(function () {
       newrelic.recordReplay()
-    })
+    }).then(() => browser.pause(500))
     replayState = await getSR() // record should be able to restart replay on this same session on a hard page load
     expect(replayState.mode).toEqual(1)
   })

--- a/tests/specs/session-replay/sr-api.e2e.js
+++ b/tests/specs/session-replay/sr-api.e2e.js
@@ -1,0 +1,56 @@
+import { notIE } from '../../../tools/browser-matcher/common-matchers.mjs'
+import { srConfig, getSR } from '../util/helpers'
+
+describe.withBrowsersMatching(notIE)('Session Replay Sample Mode Validation', () => {
+  afterEach(async () => {
+    await browser.destroyAgentSession()
+  })
+
+  it('Record API called before page load does not start a replay (no entitlements yet)', async () => {
+    await browser.enableSessionReplay(0, 0)
+    await browser.url(await browser.testHandle.assetURL('rrweb-api-record-before-load.html', srConfig()))
+      .then(() => browser.waitForFeatureAggregate('session_replay'))
+
+    await browser.pause(1000)
+    await expect(getSR()).resolves.toMatchObject({
+      initialized: true,
+      mode: 1
+    })
+  })
+
+  it('Pause API called before page load stops the replay', async () => {
+    await browser.enableSessionReplay(100, 0)
+    await browser.url(await browser.testHandle.assetURL('rrweb-api-pause-before-load.html', srConfig()))
+      .then(() => browser.waitForSessionReplayRecording())
+
+    await expect(getSR()).resolves.toMatchObject({
+      recording: true,
+      initialized: true,
+      events: expect.any(Array),
+      mode: 0
+    })
+  })
+
+  it('Paused replays can be restarted on next page load of same session', async () => {
+    const url = await browser.testHandle.assetURL('rrweb-instrumented.html', srConfig())
+    await browser.url(url).then(() => browser.waitForSessionReplayRecording())
+    let replayState = await getSR()
+    expect(replayState.mode).toEqual(1)
+
+    await browser.execute(function () {
+      newrelic.pauseReplay()
+    })
+    replayState = await getSR()
+    expect(replayState.mode).toEqual(0)
+
+    await browser.refresh() // paused (OFF) mode should be saved to session and next page starts with OFF
+    replayState = await getSR()
+    expect(replayState.mode).toEqual(0)
+
+    await browser.execute(function () {
+      newrelic.recordReplay()
+    })
+    replayState = await getSR() // record should be able to restart replay on this same session on a hard page load
+    expect(replayState.mode).toEqual(1)
+  })
+})

--- a/tests/unit/features/session_replay/shared/utils.test.js
+++ b/tests/unit/features/session_replay/shared/utils.test.js
@@ -68,55 +68,13 @@ describe('isPreloadAllowed', () => {
   })
 })
 
-describe('canImportReplayAgg', () => {
-  beforeEach(() => {
-    jest.mocked(configModule.getConfigurationValue).mockReturnValue(true)
-    jest.mocked(configModule.getConfigurationValue).mockReturnValue(true)
-  })
+test('hasReplayPrerequisite should return false when replay prerequisites are not present', async () => {
+  jest.mocked(configModule.getConfigurationValue).mockReturnValue(true)
+  jest.mocked(configModule.getConfigurationValue).mockReturnValue(true)
 
-  test('should return false when replay prerequisites are not present', async () => {
-    jest.replaceProperty(configModule, 'originals', {})
-    const sessionManager = {
-      isNew: true
-    }
+  jest.replaceProperty(configModule, 'originals', {})
 
-    expect(sessionReplaySharedUtils.canImportReplayAgg(agentIdentifier, sessionManager)).toEqual(false)
-  })
-
-  test('should return true when session is new', async () => {
-    jest.mocked(featureGatesModule.canEnableSessionTracking).mockReturnValue(true)
-    jest.replaceProperty(configModule, 'originals', { MO: jest.fn() })
-    const sessionManager = {
-      isNew: true
-    }
-
-    expect(sessionReplaySharedUtils.canImportReplayAgg(agentIdentifier, sessionManager)).toEqual(true)
-  })
-
-  test('should return true when replay already recording', async () => {
-    jest.mocked(featureGatesModule.canEnableSessionTracking).mockReturnValue(true)
-    jest.replaceProperty(configModule, 'originals', { MO: jest.fn() })
-    const sessionManager = {
-      isNew: false,
-      state: {
-        sessionReplayMode: 1
-      }
-    }
-
-    expect(sessionReplaySharedUtils.canImportReplayAgg(agentIdentifier, sessionManager)).toEqual(true)
-  })
-
-  test('should return false when session is not new and a replay is not already recording', async () => {
-    jest.replaceProperty(configModule, 'originals', { MO: jest.fn() })
-    const sessionManager = {
-      isNew: false,
-      state: {
-        sessionReplayMode: 0
-      }
-    }
-
-    expect(sessionReplaySharedUtils.canImportReplayAgg(agentIdentifier, sessionManager)).toEqual(false)
-  })
+  expect(sessionReplaySharedUtils.hasReplayPrerequisite(agentIdentifier)).toEqual(false)
 })
 
 describe('buildNRMetaNode', () => {


### PR DESCRIPTION
Patch a case of recordReplay not restarting session replay. Customers can now programatically continue the session replay after a hard page navigation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Change old smart-attempt logic to exclude SR agg from loading if existing session mode is off to always load as long as session entity itself was initialized and exists. This ensure the aggregate is around to listen for recordReplay calls which forces the start of replay regardless of existing session mode being off (as long as entitlements are valid).

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-285311

### Testing

Run new test file w/ old build; new test will fail with mode still being 0. Run it with PR build, new test passes with mode 1.
