### PR TITLE
chore: redesign network expects

### DIFF
--- a/tests/specs/api.e2e.js
+++ b/tests/specs/api.e2e.js
@@ -1,6 +1,7 @@
 import { notIE } from '../../tools/browser-matcher/common-matchers.mjs'
 import { apiMethods, asyncApiMethods } from '../../src/loaders/api/api-methods'
 import { checkAjaxEvents, checkJsErrors, checkMetrics, checkPageAction, checkPVT, checkRumBody, checkRumQuery, checkSessionTrace, checkSpa } from '../util/basic-checks'
+import { testAjaxEventsRequest, testAjaxTimeSlicesRequest, testBlobTraceRequest, testCustomMetricsRequest, testErrorsRequest, testEventsRequest, testInsRequest, testInteractionEventsRequest, testMetricsRequest, testRumRequest, testTimingEventsRequest } from '../../tools/testing-server/utils/expect-tests'
 
 describe('newrelic api', () => {
   afterEach(async () => {
@@ -51,17 +52,23 @@ describe('newrelic api', () => {
 
   describe('setPageViewName()', () => {
     it('includes the 1st argument (page name) in rum, resources, events, and ajax calls', async () => {
+      const [rumCapture, eventsCapture, ajaxCapture] = await Promise.all([
+        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testEventsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testAjaxTimeSlicesRequest })
+      ])
+
       const [rumResults, eventsResults, ajaxResults] = await Promise.all([
-        browser.testHandle.expectRum(),
-        browser.testHandle.expectEvents(),
-        browser.testHandle.expectAjaxTimeSlices(),
+        rumCapture.waitForResult({ count: 1 }),
+        eventsCapture.waitForResult({ count: 1 }),
+        ajaxCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('api.html')) // Setup expects before loading the page
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(rumResults.request.query.ct).toEqual('http://custom.transaction/foo')
-      expect(eventsResults.request.query.ct).toEqual('http://custom.transaction/foo')
-      expect(ajaxResults.request.query.ct).toEqual('http://custom.transaction/foo')
+      expect(rumResults[0].request.query.ct).toEqual('http://custom.transaction/foo')
+      expect(eventsResults[0].request.query.ct).toEqual('http://custom.transaction/foo')
+      expect(ajaxResults[0].request.query.ct).toEqual('http://custom.transaction/foo')
     })
 
     // IE does not have reliable unload support
@@ -69,16 +76,19 @@ describe('newrelic api', () => {
       await browser.url(await browser.testHandle.assetURL('api.html'))
         .then(() => browser.waitForAgentLoad())
 
+      const customMetricsCapture = await browser.testHandle.createNetworkCapture('bamServer', {
+        test: testCustomMetricsRequest
+      })
       const [unloadCustomMetricsResults] = await Promise.all([
-        browser.testHandle.expectCustomMetrics(),
-        await browser.url(await browser.testHandle.assetURL('/'))
+        customMetricsCapture.waitForResult({ count: 1 }),
+        await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
       ])
 
-      expect(unloadCustomMetricsResults.request.query.ct).toEqual('http://custom.transaction/foo')
-      expect(Array.isArray(unloadCustomMetricsResults.request.body.cm)).toEqual(true)
-      expect(unloadCustomMetricsResults.request.body.cm.length).toBeGreaterThan(0)
+      expect(unloadCustomMetricsResults[0].request.query.ct).toEqual('http://custom.transaction/foo')
+      expect(Array.isArray(unloadCustomMetricsResults[0].request.body.cm)).toEqual(true)
+      expect(unloadCustomMetricsResults[0].request.body.cm.length).toBeGreaterThan(0)
 
-      const time = unloadCustomMetricsResults.request.body.cm[0].metrics?.time?.t
+      const time = unloadCustomMetricsResults[0].request.body.cm[0].metrics?.time?.t
       expect(typeof time).toEqual('number')
       expect(time).toBeGreaterThan(0)
     })
@@ -88,16 +98,19 @@ describe('newrelic api', () => {
       await browser.url(await browser.testHandle.assetURL('api2.html'))
         .then(() => browser.waitForAgentLoad())
 
+      const customMetricsCapture = await browser.testHandle.createNetworkCapture('bamServer', {
+        test: testCustomMetricsRequest
+      })
       const [unloadCustomMetricsResults] = await Promise.all([
-        browser.testHandle.expectCustomMetrics(),
-        await browser.url(await browser.testHandle.assetURL('/'))
+        customMetricsCapture.waitForResult({ count: 1 }),
+        await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
       ])
 
-      expect(unloadCustomMetricsResults.request.query.ct).toEqual('http://bar.baz/foo')
-      expect(Array.isArray(unloadCustomMetricsResults.request.body.cm)).toEqual(true)
-      expect(unloadCustomMetricsResults.request.body.cm.length).toBeGreaterThan(0)
+      expect(unloadCustomMetricsResults[0].request.query.ct).toEqual('http://bar.baz/foo')
+      expect(Array.isArray(unloadCustomMetricsResults[0].request.body.cm)).toEqual(true)
+      expect(unloadCustomMetricsResults[0].request.body.cm.length).toBeGreaterThan(0)
 
-      const time = unloadCustomMetricsResults.request.body.cm[0].metrics?.time?.t
+      const time = unloadCustomMetricsResults[0].request.body.cm[0].metrics?.time?.t
       expect(typeof time).toEqual('number')
       expect(time).toBeGreaterThan(0)
     })
@@ -105,16 +118,18 @@ describe('newrelic api', () => {
 
   describe('noticeError()', () => {
     it('takes an error object', async () => {
+      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+
       const [errorsResults] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('api.html')) // Setup expects before loading the page
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(Array.isArray(errorsResults.request.body.err)).toEqual(true)
-      expect(errorsResults.request.body.err.length).toBeGreaterThan(0)
+      expect(Array.isArray(errorsResults[0].request.body.err)).toEqual(true)
+      expect(errorsResults[0].request.body.err.length).toBeGreaterThan(0)
 
-      const params = errorsResults.request.body.err[0].params
+      const params = errorsResults[0].request.body.err[0].params
 
       expect(params).toBeDefined()
       expect(params.exceptionClass).toEqual('Error')
@@ -122,16 +137,18 @@ describe('newrelic api', () => {
     })
 
     it('takes a string', async () => {
+      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+
       const [errorsResults] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('api/noticeError.html')) // Setup expects before loading the page
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(Array.isArray(errorsResults.request.body.err)).toEqual(true)
-      expect(errorsResults.request.body.err.length).toBeGreaterThan(0)
+      expect(Array.isArray(errorsResults[0].request.body.err)).toEqual(true)
+      expect(errorsResults[0].request.body.err.length).toBeGreaterThan(0)
 
-      const params = errorsResults.request.body.err[0].params
+      const params = errorsResults[0].request.body.err[0].params
 
       expect(params).toBeDefined()
       expect(params.exceptionClass).toEqual('Error')
@@ -141,14 +158,15 @@ describe('newrelic api', () => {
 
   describe('finished()', () => {
     it('records a PageAction when called before RUM message', async () => {
+      const insCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testInsRequest })
+
       const [insResult] = await Promise.all([
-        browser.testHandle.expectIns(),
-        browser.testHandle.expectRum(),
+        insCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('api/finished.html'))
           .then(() => browser.waitForAgentLoad())
       ])
 
-      const pageActions = insResult.request.body.ins
+      const pageActions = insResult[0].request.body.ins
       expect(pageActions).toBeDefined()
       expect(pageActions.length).toEqual(1) // exactly 1 PageAction was submitted
       expect(pageActions[0].actionName).toEqual('finished') // PageAction has actionName = finished
@@ -157,23 +175,27 @@ describe('newrelic api', () => {
 
   describe('release()', () => {
     it('adds releases to jserrors', async () => {
+      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+
       const [errorsResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('api/release.html'))
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(errorsResult.request.query.ri).toEqual('{"example":"123","other":"456"}')
+      expect(errorsResult[0].request.query.ri).toEqual('{"example":"123","other":"456"}')
     })
 
     it('limits releases to jserrors', async () => {
+      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+
       const [errorsResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('api/release-too-many.html'))
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(JSON.parse(errorsResult.request.query.ri)).toEqual({
+      expect(JSON.parse(errorsResult[0].request.query.ri)).toEqual({
         one: '1',
         two: '2',
         three: '3',
@@ -188,31 +210,36 @@ describe('newrelic api', () => {
     })
 
     it('limits size in jserrors payload', async () => {
+      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+
       const [errorsResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('api/release-too-long.html'))
           .then(() => browser.waitForAgentLoad())
       ])
 
-      const queryRi = JSON.parse(errorsResult.request.query.ri)
+      const queryRi = JSON.parse(errorsResult[0].request.query.ri)
       expect(queryRi.one).toEqual('201')
       expect(queryRi.three).toMatch(/y{99}x{100}q/)
       expect(Object.keys(queryRi).find(element => element.match(/y{99}x{100}q/))).toBeTruthy()
     })
 
     it('does not set ri query param if release() is not called', async () => {
+      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+
       const [errorsResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('api/no-release.html'))
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(errorsResult.request.query).not.toHaveProperty('ri')
+      expect(errorsResult[0].request.query).not.toHaveProperty('ri')
     })
   })
 
   describe('setCustomAttribute()', () => {
     it('persists attribute onto subsequent page loads until unset', async () => {
+      const rumCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest })
       const testUrl = await browser.testHandle.assetURL('api/custom-attribute.html', {
         init: {
           privacy: { cookies_enabled: true }
@@ -220,12 +247,12 @@ describe('newrelic api', () => {
       })
 
       const [rumResult] = await Promise.all([
-        browser.testHandle.expectRum(),
+        rumCapture.waitForResult({ count: 1 }),
         browser.url(testUrl)
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(rumResult.request.body.ja).toEqual({ testing: 123 }) // initial page load has custom attribute
+      expect(rumResult[0].request.body.ja).toEqual({ testing: 123 }) // initial page load has custom attribute
 
       const subsequentTestUrl = await browser.testHandle.assetURL('instrumented.html', {
         init: {
@@ -234,24 +261,24 @@ describe('newrelic api', () => {
       })
 
       const [rumResultAfterNavigate] = await Promise.all([
-        browser.testHandle.expectRum(),
+        rumCapture.waitForResult({ count: 2 }),
         browser.url(subsequentTestUrl)
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(rumResultAfterNavigate.request.body.ja).toEqual({ testing: 123 }) // 2nd page load still has custom attribute from storage
+      expect(rumResultAfterNavigate[1].request.body.ja).toEqual({ testing: 123 }) // 2nd page load still has custom attribute from storage
 
       await browser.execute(function () {
         newrelic.setCustomAttribute('testing', null)
       })
 
       const [rumResultAfterUnset] = await Promise.all([
-        browser.testHandle.expectRum(),
+        rumCapture.waitForResult({ count: 3 }),
         browser.url(subsequentTestUrl)
           .then(() => browser.waitForAgentLoad())
       ])
 
-      expect(rumResultAfterUnset.request.body).not.toHaveProperty('ja') // 3rd page load does not retain custom attribute after unsetting (set to null)
+      expect(rumResultAfterUnset[2].request.body).not.toHaveProperty('ja') // 3rd page load does not retain custom attribute after unsetting (set to null)
     })
   })
 
@@ -259,6 +286,10 @@ describe('newrelic api', () => {
     const ERRORS_INBOX_UID = 'enduser.id' // this key should not be changed without consulting EI team on the data flow
 
     it('adds correct (persisted) attribute to payloads', async () => {
+      const [rumCapture, errorsCapture] = await Promise.all([
+        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+      ])
       await browser.url(await browser.testHandle.assetURL('instrumented.html', {
         init: {
           privacy: { cookies_enabled: true }
@@ -267,7 +298,7 @@ describe('newrelic api', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [firstErrorsResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.execute(function () {
           newrelic.setUserId(456)
           newrelic.setUserId({ foo: 'bar' })
@@ -275,11 +306,11 @@ describe('newrelic api', () => {
         })
       ])
 
-      expect(firstErrorsResult.request.body.err[0]).toHaveProperty('custom')
-      expect(firstErrorsResult.request.body.err[0].custom[ERRORS_INBOX_UID]).not.toBeDefined() // Invalid data type (non-string) does not set user id
+      expect(firstErrorsResult[0].request.body.err[0]).toHaveProperty('custom')
+      expect(firstErrorsResult[0].request.body.err[0].custom[ERRORS_INBOX_UID]).not.toBeDefined() // Invalid data type (non-string) does not set user id
 
       const [secondErrorsResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ count: 2 }),
         browser.execute(function () {
           newrelic.setUserId('user123')
           newrelic.setUserId()
@@ -287,17 +318,17 @@ describe('newrelic api', () => {
         })
       ])
 
-      expect(secondErrorsResult.request.body.err[0]).toHaveProperty('custom')
-      expect(secondErrorsResult.request.body.err[0].custom[ERRORS_INBOX_UID]).toBeDefined()
-      expect(secondErrorsResult.request.body.err[0].custom[ERRORS_INBOX_UID]).toBe('user123') // Correct enduser.id custom attr on error
+      expect(secondErrorsResult[1].request.body.err[0]).toHaveProperty('custom')
+      expect(secondErrorsResult[1].request.body.err[0].custom[ERRORS_INBOX_UID]).toBeDefined()
+      expect(secondErrorsResult[1].request.body.err[0].custom[ERRORS_INBOX_UID]).toBe('user123') // Correct enduser.id custom attr on error
 
       const [rumResultAfterRefresh] = await Promise.all([
-        browser.testHandle.expectRum(),
+        rumCapture.waitForResult({ count: 2 }),
         browser.refresh()
       ])
 
       // We expect setUserId's attribute to be stored by the browser tab session, and retrieved on the next page load & agent init
-      expect(rumResultAfterRefresh.request.body.ja).toEqual({ [ERRORS_INBOX_UID]: 'user123' }) // setUserId affects subsequent page loads in the same storage session
+      expect(rumResultAfterRefresh[1].request.body.ja).toEqual({ [ERRORS_INBOX_UID]: 'user123' }) // setUserId affects subsequent page loads in the same storage session
     })
   })
 
@@ -309,23 +340,34 @@ describe('newrelic api', () => {
     }
 
     it('should start all features', async () => {
+      const [rumCapture, timingsCapture, ajaxEventsCapture, errorsCapture, metricsCapture, insCapture, traceCapture, interactionCapture] = await Promise.all([
+        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testTimingEventsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testAjaxEventsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testMetricsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testInsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testBlobTraceRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testInteractionEventsRequest })
+      ])
+
       const initialLoad = await Promise.all([
-        browser.testHandle.expectRum(10000, true),
+        rumCapture.waitForResult({ timeout: 10000 }),
         browser.url(await browser.testHandle.assetURL('instrumented-manual.html'), config)
           .then(() => undefined)
       ])
 
-      expect(initialLoad).toEqual(new Array(2).fill(undefined))
+      expect(initialLoad).toEqual([[], undefined])
 
       const results = await Promise.all([
-        browser.testHandle.expectRum(10000),
-        browser.testHandle.expectTimings(10000),
-        browser.testHandle.expectAjaxEvents(10000),
-        browser.testHandle.expectErrors(10000),
-        browser.testHandle.expectMetrics(10000),
-        browser.testHandle.expectIns(10000),
-        browser.testHandle.expectTrace(10000),
-        browser.testHandle.expectInteractionEvents(10000),
+        rumCapture.waitForResult({ count: 1 }),
+        timingsCapture.waitForResult({ count: 1 }),
+        ajaxEventsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ count: 1 }),
+        metricsCapture.waitForResult({ count: 1 }),
+        insCapture.waitForResult({ count: 1 }),
+        traceCapture.waitForResult({ count: 1 }),
+        interactionCapture.waitForResult({ count: 1 }),
         browser.execute(function () {
           newrelic.start()
           setTimeout(function () {
@@ -334,21 +376,26 @@ describe('newrelic api', () => {
         })
       ])
 
-      checkRumQuery(results[0].request)
-      checkRumBody(results[0].request)
-      checkPVT(results[1].request)
-      checkAjaxEvents(results[2].request)
-      checkJsErrors(results[3].request, { messages: ['test'] })
-      checkMetrics(results[4].request)
-      checkPageAction(results[5].request, { specificAction: 'test', actionContents: { test: 1 } })
-      checkSessionTrace(results[6].request)
-      checkSpa(results[7].request)
+      checkRumQuery(results[0][0].request)
+      checkRumBody(results[0][0].request)
+      checkPVT(results[1][0].request)
+      checkAjaxEvents(results[2][0].request)
+      checkJsErrors(results[3][0].request, { messages: ['test'] })
+      checkMetrics(results[4][0].request)
+      checkPageAction(results[5][0].request, { specificAction: 'test', actionContents: { test: 1 } })
+      checkSessionTrace(results[6][0].request)
+      checkSpa(results[7][0].request)
     })
 
     it('starts everything if the auto features do not include PVE, and nothing should have started', async () => {
+      const [rumCapture, errorsCapture] = await Promise.all([
+        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+      ])
+
       const initialLoad = await Promise.all([
-        browser.testHandle.expectRum(10000, true),
-        browser.testHandle.expectErrors(10000, true),
+        rumCapture.waitForResult({ timeout: 10000 }),
+        errorsCapture.waitForResult({ timeout: 10000 }),
         browser.url(await browser.testHandle.assetURL('instrumented-manual.html', {
           init: {
             ...config.init,
@@ -359,29 +406,38 @@ describe('newrelic api', () => {
         })).then(() => undefined)
       ])
 
-      expect(initialLoad).toEqual(new Array(3).fill(undefined))
+      expect(initialLoad).toEqual([[], [], undefined])
 
       const results = await Promise.all([
-        browser.testHandle.expectRum(10000),
-        browser.testHandle.expectErrors(10000),
+        rumCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.execute(function () {
           newrelic.start()
         })
       ])
 
-      checkRumQuery(results[0].request)
-      checkRumBody(results[0].request)
-      checkJsErrors(results[1].request, { messages: ['test'] })
+      checkRumQuery(results[0][0].request)
+      checkRumBody(results[0][0].request)
+      checkJsErrors(results[1][0].request, { messages: ['test'] })
     })
 
     it('starts the rest of the features if the auto features include PVE, and those should have started', async () => {
+      const [rumCapture, timingsCapture, ajaxEventsCapture, errorsCapture, traceCapture, interactionCapture] = await Promise.all([
+        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testTimingEventsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testAjaxEventsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testBlobTraceRequest }),
+        browser.testHandle.createNetworkCapture('bamServer', { test: testInteractionEventsRequest })
+      ])
+
       const results = await Promise.all([
-        browser.testHandle.expectRum(),
-        browser.testHandle.expectTimings(),
-        browser.testHandle.expectAjaxEvents(10000, true),
-        browser.testHandle.expectErrors(10000, true),
-        browser.testHandle.expectTrace(),
-        browser.testHandle.expectInteractionEvents(),
+        rumCapture.waitForResult({ count: 1 }),
+        timingsCapture.waitForResult({ count: 1 }),
+        ajaxEventsCapture.waitForResult({ timeout: 10000 }),
+        errorsCapture.waitForResult({ timeout: 10000 }),
+        traceCapture.waitForResult({ count: 1 }),
+        interactionCapture.waitForResult({ count: 1 }),
         browser.url(await browser.testHandle.assetURL('instrumented.html', {
           init: {
             ...config.init,
@@ -402,23 +458,23 @@ describe('newrelic api', () => {
         }))
       ])
 
-      checkRumQuery(results[0].request)
-      checkRumBody(results[0].request)
-      checkPVT(results[1].request)
-      checkSessionTrace(results[4].request)
-      checkSpa(results[5].request)
+      checkRumQuery(results[0][0].request)
+      checkRumBody(results[0][0].request)
+      checkPVT(results[1][0].request)
+      checkSessionTrace(results[4][0].request)
+      checkSpa(results[5][0].request)
 
       await browser.pause(5000)
       const subsequentResults = await Promise.all([
-        browser.testHandle.expectAjaxEvents(),
-        browser.testHandle.expectErrors(),
+        ajaxEventsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ count: 1 }),
         browser.execute(function () {
           newrelic.start()
         })
       ])
 
-      checkAjaxEvents(subsequentResults[0].request)
-      checkJsErrors(subsequentResults[1].request)
+      checkAjaxEvents(subsequentResults[0][0].request)
+      checkJsErrors(subsequentResults[1][0].request)
     })
   })
 })

--- a/tests/specs/api.e2e.js
+++ b/tests/specs/api.e2e.js
@@ -52,11 +52,12 @@ describe('newrelic api', () => {
 
   describe('setPageViewName()', () => {
     it('includes the 1st argument (page name) in rum, resources, events, and ajax calls', async () => {
-      const [rumCapture, eventsCapture, ajaxCapture] = await Promise.all([
-        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testEventsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testAjaxTimeSlicesRequest })
-      ])
+      const [rumCapture, eventsCapture, ajaxCapture] =
+        await browser.testHandle.createNetworkCaptures('bamServer', [
+          { test: testRumRequest },
+          { test: testEventsRequest },
+          { test: testAjaxTimeSlicesRequest }
+        ])
 
       const [rumResults, eventsResults, ajaxResults] = await Promise.all([
         rumCapture.waitForResult({ count: 1 }),
@@ -76,7 +77,7 @@ describe('newrelic api', () => {
       await browser.url(await browser.testHandle.assetURL('api.html'))
         .then(() => browser.waitForAgentLoad())
 
-      const customMetricsCapture = await browser.testHandle.createNetworkCapture('bamServer', {
+      const customMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', {
         test: testCustomMetricsRequest
       })
       const [unloadCustomMetricsResults] = await Promise.all([
@@ -95,12 +96,12 @@ describe('newrelic api', () => {
 
     // IE does not have reliable unload support
     it.withBrowsersMatching(notIE)('includes the optional 2nd argument for host in metrics call on unload', async () => {
+      const customMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', {
+        test: testCustomMetricsRequest
+      })
       await browser.url(await browser.testHandle.assetURL('api2.html'))
         .then(() => browser.waitForAgentLoad())
 
-      const customMetricsCapture = await browser.testHandle.createNetworkCapture('bamServer', {
-        test: testCustomMetricsRequest
-      })
       const [unloadCustomMetricsResults] = await Promise.all([
         customMetricsCapture.waitForResult({ count: 1 }),
         await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
@@ -118,7 +119,7 @@ describe('newrelic api', () => {
 
   describe('noticeError()', () => {
     it('takes an error object', async () => {
-      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+      const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResults] = await Promise.all([
         errorsCapture.waitForResult({ count: 1 }),
@@ -137,7 +138,7 @@ describe('newrelic api', () => {
     })
 
     it('takes a string', async () => {
-      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+      const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResults] = await Promise.all([
         errorsCapture.waitForResult({ count: 1 }),
@@ -158,7 +159,7 @@ describe('newrelic api', () => {
 
   describe('finished()', () => {
     it('records a PageAction when called before RUM message', async () => {
-      const insCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testInsRequest })
+      const insCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInsRequest })
 
       const [insResult] = await Promise.all([
         insCapture.waitForResult({ count: 1 }),
@@ -175,7 +176,7 @@ describe('newrelic api', () => {
 
   describe('release()', () => {
     it('adds releases to jserrors', async () => {
-      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+      const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResult] = await Promise.all([
         errorsCapture.waitForResult({ count: 1 }),
@@ -187,7 +188,7 @@ describe('newrelic api', () => {
     })
 
     it('limits releases to jserrors', async () => {
-      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+      const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResult] = await Promise.all([
         errorsCapture.waitForResult({ count: 1 }),
@@ -210,7 +211,7 @@ describe('newrelic api', () => {
     })
 
     it('limits size in jserrors payload', async () => {
-      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+      const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResult] = await Promise.all([
         errorsCapture.waitForResult({ count: 1 }),
@@ -225,7 +226,7 @@ describe('newrelic api', () => {
     })
 
     it('does not set ri query param if release() is not called', async () => {
-      const errorsCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+      const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResult] = await Promise.all([
         errorsCapture.waitForResult({ count: 1 }),
@@ -239,7 +240,7 @@ describe('newrelic api', () => {
 
   describe('setCustomAttribute()', () => {
     it('persists attribute onto subsequent page loads until unset', async () => {
-      const rumCapture = await browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest })
+      const rumCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testRumRequest })
       const testUrl = await browser.testHandle.assetURL('api/custom-attribute.html', {
         init: {
           privacy: { cookies_enabled: true }
@@ -286,10 +287,11 @@ describe('newrelic api', () => {
     const ERRORS_INBOX_UID = 'enduser.id' // this key should not be changed without consulting EI team on the data flow
 
     it('adds correct (persisted) attribute to payloads', async () => {
-      const [rumCapture, errorsCapture] = await Promise.all([
-        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
-      ])
+      const [rumCapture, errorsCapture] =
+        await browser.testHandle.createNetworkCaptures('bamServer', [
+          { test: testRumRequest },
+          { test: testErrorsRequest }
+        ])
       await browser.url(await browser.testHandle.assetURL('instrumented.html', {
         init: {
           privacy: { cookies_enabled: true }
@@ -340,16 +342,17 @@ describe('newrelic api', () => {
     }
 
     it('should start all features', async () => {
-      const [rumCapture, timingsCapture, ajaxEventsCapture, errorsCapture, metricsCapture, insCapture, traceCapture, interactionCapture] = await Promise.all([
-        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testTimingEventsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testAjaxEventsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testMetricsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testInsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testBlobTraceRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testInteractionEventsRequest })
-      ])
+      const [rumCapture, timingsCapture, ajaxEventsCapture, errorsCapture, metricsCapture, insCapture, traceCapture, interactionCapture] =
+        await browser.testHandle.createNetworkCaptures('bamServer', [
+          { test: testRumRequest },
+          { test: testTimingEventsRequest },
+          { test: testAjaxEventsRequest },
+          { test: testErrorsRequest },
+          { test: testMetricsRequest },
+          { test: testInsRequest },
+          { test: testBlobTraceRequest },
+          { test: testInteractionEventsRequest }
+        ])
 
       const initialLoad = await Promise.all([
         rumCapture.waitForResult({ timeout: 10000 }),
@@ -389,8 +392,8 @@ describe('newrelic api', () => {
 
     it('starts everything if the auto features do not include PVE, and nothing should have started', async () => {
       const [rumCapture, errorsCapture] = await Promise.all([
-        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest })
+        browser.testHandle.createNetworkCaptures('bamServer', { test: testRumRequest }),
+        browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
       ])
 
       const initialLoad = await Promise.all([
@@ -422,14 +425,15 @@ describe('newrelic api', () => {
     })
 
     it('starts the rest of the features if the auto features include PVE, and those should have started', async () => {
-      const [rumCapture, timingsCapture, ajaxEventsCapture, errorsCapture, traceCapture, interactionCapture] = await Promise.all([
-        browser.testHandle.createNetworkCapture('bamServer', { test: testRumRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testTimingEventsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testAjaxEventsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testErrorsRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testBlobTraceRequest }),
-        browser.testHandle.createNetworkCapture('bamServer', { test: testInteractionEventsRequest })
-      ])
+      const [rumCapture, timingsCapture, ajaxEventsCapture, errorsCapture, traceCapture, interactionCapture] =
+        await browser.testHandle.createNetworkCaptures('bamServer', [
+          { test: testRumRequest },
+          { test: testTimingEventsRequest },
+          { test: testAjaxEventsRequest },
+          { test: testErrorsRequest },
+          { test: testBlobTraceRequest },
+          { test: testInteractionEventsRequest }
+        ])
 
       const results = await Promise.all([
         rumCapture.waitForResult({ count: 1 }),

--- a/tests/specs/api.e2e.js
+++ b/tests/specs/api.e2e.js
@@ -60,9 +60,9 @@ describe('newrelic api', () => {
         ])
 
       const [rumResults, eventsResults, ajaxResults] = await Promise.all([
-        rumCapture.waitForResult({ count: 1 }),
-        eventsCapture.waitForResult({ count: 1 }),
-        ajaxCapture.waitForResult({ count: 1 }),
+        rumCapture.waitForResult({ totalCount: 1 }),
+        eventsCapture.waitForResult({ totalCount: 1 }),
+        ajaxCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api.html')) // Setup expects before loading the page
           .then(() => browser.waitForAgentLoad())
       ])
@@ -81,7 +81,7 @@ describe('newrelic api', () => {
         test: testCustomMetricsRequest
       })
       const [unloadCustomMetricsResults] = await Promise.all([
-        customMetricsCapture.waitForResult({ count: 1 }),
+        customMetricsCapture.waitForResult({ totalCount: 1 }),
         await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
       ])
 
@@ -103,7 +103,7 @@ describe('newrelic api', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [unloadCustomMetricsResults] = await Promise.all([
-        customMetricsCapture.waitForResult({ count: 1 }),
+        customMetricsCapture.waitForResult({ totalCount: 1 }),
         await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
       ])
 
@@ -122,7 +122,7 @@ describe('newrelic api', () => {
       const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResults] = await Promise.all([
-        errorsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api.html')) // Setup expects before loading the page
           .then(() => browser.waitForAgentLoad())
       ])
@@ -141,7 +141,7 @@ describe('newrelic api', () => {
       const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResults] = await Promise.all([
-        errorsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api/noticeError.html')) // Setup expects before loading the page
           .then(() => browser.waitForAgentLoad())
       ])
@@ -162,7 +162,7 @@ describe('newrelic api', () => {
       const insCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInsRequest })
 
       const [insResult] = await Promise.all([
-        insCapture.waitForResult({ count: 1 }),
+        insCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api/finished.html'))
           .then(() => browser.waitForAgentLoad())
       ])
@@ -179,7 +179,7 @@ describe('newrelic api', () => {
       const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResult] = await Promise.all([
-        errorsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api/release.html'))
           .then(() => browser.waitForAgentLoad())
       ])
@@ -191,7 +191,7 @@ describe('newrelic api', () => {
       const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResult] = await Promise.all([
-        errorsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api/release-too-many.html'))
           .then(() => browser.waitForAgentLoad())
       ])
@@ -214,7 +214,7 @@ describe('newrelic api', () => {
       const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResult] = await Promise.all([
-        errorsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api/release-too-long.html'))
           .then(() => browser.waitForAgentLoad())
       ])
@@ -229,7 +229,7 @@ describe('newrelic api', () => {
       const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
       const [errorsResult] = await Promise.all([
-        errorsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api/no-release.html'))
           .then(() => browser.waitForAgentLoad())
       ])
@@ -248,7 +248,7 @@ describe('newrelic api', () => {
       })
 
       const [rumResult] = await Promise.all([
-        rumCapture.waitForResult({ count: 1 }),
+        rumCapture.waitForResult({ totalCount: 1 }),
         browser.url(testUrl)
           .then(() => browser.waitForAgentLoad())
       ])
@@ -262,7 +262,7 @@ describe('newrelic api', () => {
       })
 
       const [rumResultAfterNavigate] = await Promise.all([
-        rumCapture.waitForResult({ count: 2 }),
+        rumCapture.waitForResult({ totalCount: 2 }),
         browser.url(subsequentTestUrl)
           .then(() => browser.waitForAgentLoad())
       ])
@@ -274,7 +274,7 @@ describe('newrelic api', () => {
       })
 
       const [rumResultAfterUnset] = await Promise.all([
-        rumCapture.waitForResult({ count: 3 }),
+        rumCapture.waitForResult({ totalCount: 3 }),
         browser.url(subsequentTestUrl)
           .then(() => browser.waitForAgentLoad())
       ])
@@ -300,7 +300,7 @@ describe('newrelic api', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [firstErrorsResult] = await Promise.all([
-        errorsCapture.waitForResult({ count: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           newrelic.setUserId(456)
           newrelic.setUserId({ foo: 'bar' })
@@ -312,7 +312,7 @@ describe('newrelic api', () => {
       expect(firstErrorsResult[0].request.body.err[0].custom[ERRORS_INBOX_UID]).not.toBeDefined() // Invalid data type (non-string) does not set user id
 
       const [secondErrorsResult] = await Promise.all([
-        errorsCapture.waitForResult({ count: 2 }),
+        errorsCapture.waitForResult({ totalCount: 2 }),
         browser.execute(function () {
           newrelic.setUserId('user123')
           newrelic.setUserId()
@@ -325,7 +325,7 @@ describe('newrelic api', () => {
       expect(secondErrorsResult[1].request.body.err[0].custom[ERRORS_INBOX_UID]).toBe('user123') // Correct enduser.id custom attr on error
 
       const [rumResultAfterRefresh] = await Promise.all([
-        rumCapture.waitForResult({ count: 2 }),
+        rumCapture.waitForResult({ totalCount: 2 }),
         browser.refresh()
       ])
 
@@ -363,14 +363,14 @@ describe('newrelic api', () => {
       expect(initialLoad).toEqual([[], undefined])
 
       const results = await Promise.all([
-        rumCapture.waitForResult({ count: 1 }),
-        timingsCapture.waitForResult({ count: 1 }),
-        ajaxEventsCapture.waitForResult({ count: 1 }),
-        errorsCapture.waitForResult({ count: 1 }),
-        metricsCapture.waitForResult({ count: 1 }),
-        insCapture.waitForResult({ count: 1 }),
-        traceCapture.waitForResult({ count: 1 }),
-        interactionCapture.waitForResult({ count: 1 }),
+        rumCapture.waitForResult({ totalCount: 1 }),
+        timingsCapture.waitForResult({ totalCount: 1 }),
+        ajaxEventsCapture.waitForResult({ totalCount: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
+        metricsCapture.waitForResult({ totalCount: 1 }),
+        insCapture.waitForResult({ totalCount: 1 }),
+        traceCapture.waitForResult({ totalCount: 1 }),
+        interactionCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           newrelic.start()
           setTimeout(function () {
@@ -412,8 +412,8 @@ describe('newrelic api', () => {
       expect(initialLoad).toEqual([[], [], undefined])
 
       const results = await Promise.all([
-        rumCapture.waitForResult({ count: 1 }),
-        errorsCapture.waitForResult({ count: 1 }),
+        rumCapture.waitForResult({ totalCount: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           newrelic.start()
         })
@@ -436,12 +436,12 @@ describe('newrelic api', () => {
         ])
 
       const results = await Promise.all([
-        rumCapture.waitForResult({ count: 1 }),
-        timingsCapture.waitForResult({ count: 1 }),
+        rumCapture.waitForResult({ totalCount: 1 }),
+        timingsCapture.waitForResult({ totalCount: 1 }),
         ajaxEventsCapture.waitForResult({ timeout: 10000 }),
         errorsCapture.waitForResult({ timeout: 10000 }),
-        traceCapture.waitForResult({ count: 1 }),
-        interactionCapture.waitForResult({ count: 1 }),
+        traceCapture.waitForResult({ totalCount: 1 }),
+        interactionCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('instrumented.html', {
           init: {
             ...config.init,
@@ -470,8 +470,8 @@ describe('newrelic api', () => {
 
       await browser.pause(5000)
       const subsequentResults = await Promise.all([
-        ajaxEventsCapture.waitForResult({ count: 1 }),
-        errorsCapture.waitForResult({ count: 1 }),
+        ajaxEventsCapture.waitForResult({ totalCount: 1 }),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           newrelic.start()
         })

--- a/tests/specs/csp.e2e.js
+++ b/tests/specs/csp.e2e.js
@@ -1,5 +1,6 @@
 import { notIE } from '../../tools/browser-matcher/common-matchers.mjs'
 import { faker } from '@faker-js/faker'
+import { testSupportMetricsRequest } from '../../tools/testing-server/utils/expect-tests'
 
 describe.withBrowsersMatching(notIE)('Content Security Policy', () => {
   afterEach(async () => {
@@ -8,11 +9,8 @@ describe.withBrowsersMatching(notIE)('Content Security Policy', () => {
 
   it('should support a nonce script element', async () => {
     const nonce = faker.string.uuid()
-    await Promise.all([
-      browser.testHandle.expectRum(),
-      browser.url(await browser.testHandle.assetURL('instrumented.html', { nonce }))
-        .then(() => browser.waitForAgentLoad())
-    ])
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', { nonce }))
+      .then(() => browser.waitForAgentLoad())
 
     const foundNonces = await browser.execute(function () {
       var scriptTags = document.querySelectorAll('script')
@@ -34,12 +32,15 @@ describe.withBrowsersMatching(notIE)('Content Security Policy', () => {
     await browser.url(await browser.testHandle.assetURL('instrumented.html', { nonce }))
       .then(() => browser.waitForAgentLoad())
 
+    const supportMetricsCapture = await browser.testHandle.createNetworkCapture('bamServer', {
+      test: testSupportMetricsRequest
+    })
     const [unloadSupportMetricsResults] = await Promise.all([
-      browser.testHandle.expectSupportMetrics(),
+      supportMetricsCapture.waitForResult({ count: 1 }),
       await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
     ])
 
-    const supportabilityMetrics = unloadSupportMetricsResults.request.body.sm || []
+    const supportabilityMetrics = unloadSupportMetricsResults[0].request.body.sm || []
     expect(supportabilityMetrics).toEqual(expect.arrayContaining([{
       params: { name: 'Generic/Runtime/Nonce/Detected' },
       stats: { c: expect.toBeWithin(1, Infinity) }
@@ -49,17 +50,12 @@ describe.withBrowsersMatching(notIE)('Content Security Policy', () => {
   it('should load async chunk with subresource integrity', async () => {
     await browser.enableSessionReplay()
 
-    const url = await browser.testHandle.assetURL('subresource-integrity-capture.html', {
+    await browser.url(await browser.testHandle.assetURL('subresource-integrity-capture.html', {
       init: {
         privacy: { cookies_enabled: true },
         session_replay: { enabled: true }
       }
-    })
-    await Promise.all([
-      browser.testHandle.expectRum(),
-      browser.url(url)
-        .then(() => browser.waitForAgentLoad())
-    ])
+    })).then(() => browser.waitForAgentLoad())
 
     await browser.waitUntil(
       () => browser.execute(function () {

--- a/tests/specs/csp.e2e.js
+++ b/tests/specs/csp.e2e.js
@@ -28,13 +28,13 @@ describe.withBrowsersMatching(notIE)('Content Security Policy', () => {
   })
 
   it.withBrowsersMatching(notIE)('should send a nonce supportability metric', async () => {
+    const supportMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', {
+      test: testSupportMetricsRequest
+    })
     const nonce = faker.string.uuid()
     await browser.url(await browser.testHandle.assetURL('instrumented.html', { nonce }))
       .then(() => browser.waitForAgentLoad())
 
-    const supportMetricsCapture = await browser.testHandle.createNetworkCapture('bamServer', {
-      test: testSupportMetricsRequest
-    })
     const [unloadSupportMetricsResults] = await Promise.all([
       supportMetricsCapture.waitForResult({ count: 1 }),
       await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating

--- a/tests/specs/csp.e2e.js
+++ b/tests/specs/csp.e2e.js
@@ -36,7 +36,7 @@ describe.withBrowsersMatching(notIE)('Content Security Policy', () => {
       .then(() => browser.waitForAgentLoad())
 
     const [unloadSupportMetricsResults] = await Promise.all([
-      supportMetricsCapture.waitForResult({ count: 1 }),
+      supportMetricsCapture.waitForResult({ totalCount: 1 }),
       await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
     ])
 

--- a/tools/browsers-lists/lt-desktop-latest-vers.json
+++ b/tools/browsers-lists/lt-desktop-latest-vers.json
@@ -1,7 +1,7 @@
 {
-  "chrome": 125,
+  "chrome": 126,
   "edge": 126,
-  "firefox": 126,
+  "firefox": 127,
   "safari": 17,
   "safari_min": 16
 }

--- a/tools/browsers-lists/lt-mobile-supported.json
+++ b/tools/browsers-lists/lt-mobile-supported.json
@@ -1,24 +1,24 @@
 {
   "ios": [
     {
-      "device_name": "iPad (9th generation)",
+      "device_name": "iPhone 15",
       "version": "17.2",
       "platformName": "ios"
     },
     {
-      "device_name": "iPhone SE (3rd generation)",
+      "device_name": "iPhone 11",
       "version": "16.0",
       "platformName": "ios"
     }
   ],
   "android": [
     {
-      "device_name": "ASUS ZenFone 8",
+      "device_name": "Pixel 7",
       "version": "14",
       "platformName": "android"
     },
     {
-      "device_name": "Galaxy S10",
+      "device_name": "Pixel 3",
       "version": "9",
       "platformName": "android"
     }

--- a/tools/browsers-lists/lt-update-supported.mjs
+++ b/tools/browsers-lists/lt-update-supported.mjs
@@ -51,7 +51,15 @@ function updateMobileVersions (mobilePlatforms) {
   const testedMobileVersionsJson = {}
 
   const iosDevices = mobilePlatforms.find(p => p.platform === 'ios')?.devices
+    .filter(device => /^iPhone \d{2,}$/.test(device.device_name))
+    .sort((deviceA, deviceB) =>
+      Number.parseInt(deviceB.device_name.match(/^iPhone (\d{2,})$/)[1]) - Number.parseInt(deviceA.device_name.match(/^iPhone (\d{2,})$/)[1])
+    )
   const androidDevices = mobilePlatforms.find(p => p.platform === 'android')?.devices
+    .filter(device => /^Pixel \d{1,}$/.test(device.device_name))
+    .sort((deviceA, deviceB) =>
+      Number.parseInt(deviceB.device_name.match(/^Pixel (\d{1,})$/)[1]) - Number.parseInt(deviceA.device_name.match(/^Pixel (\d{1,})$/)[1])
+    )
   if (!iosDevices || !androidDevices) throw new Error('iOS or Android mobile could not be found in API response.')
 
   // iOS versions should already be sorted in descending; the built list should also be in desc order.

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -30,12 +30,12 @@ module.exports.loaderConfigKeys = [
 module.exports.loaderOnlyConfigKeys = ['accountID', 'agentID', 'trustKey']
 
 module.exports.rumFlags = {
+  loaded: 1, // Used internally to signal the tests that the agent has loaded
+
   st: 1, // session trace entitlements 0|1
   err: 1, // err entitlements 0|1
   ins: 1, // ins entitlements 0|1
-  cap: 1, // ?
   spa: 1, // spa entitlements 0|1
-  loaded: 1,
   sr: 1, // session replay entitlements 0|1
   sts: 1, // session trace sampling 0|1|2 - off full error
   srs: 1, // session replay sampling 0|1|2 - off full error

--- a/tools/testing-server/index.js
+++ b/tools/testing-server/index.js
@@ -156,6 +156,7 @@ class TestServer {
   }
 
   destroyTestHandle (testId) {
+    this.#testHandles.get(testId).destroy()
     this.#testHandles.delete(testId)
   }
 

--- a/tools/testing-server/network-capture.js
+++ b/tools/testing-server/network-capture.js
@@ -33,11 +33,11 @@ const crypto = require('crypto')
  * Conditions to pause execution based on requests being captured.
  * @typedef {object} NetworkCaptureWaitConditions
  * @property {number} timeout a predefined time to wait before continuing execution
- * @property {number} count a predefined number of requests to wait on before continuing execution
- * @example If both timeout and count are supplied, when the timeout is reached, the pause will end regardless
- * of the number of network captures and the supplied count condition.
- * @example If both timeout and count are supplied, when the count of network captures reached the supplied
- * count condition, the pause will end regardless of the timeout.
+ * @property {number} totalCount a predefined number of requests to wait on before continuing execution
+ * @example If both timeout and totalCount are supplied, when the timeout is reached, the pause will end regardless
+ * of the number of network captures and the supplied totalCount condition.
+ * @example If both timeout and totalCount are supplied, when the totalCount of network captures reached the supplied
+ * totalCount condition, the pause will end regardless of the timeout.
  */
 
 /**
@@ -212,7 +212,7 @@ module.exports = class NetworkCapture {
      */
     const deferred = { promise, resolve: capturedResolve, reject: capturedReject }
     deferred.checkWaitConditions = () => {
-      if (typeof waitConditions.count === 'number' && this.#captureCache.size >= waitConditions.count) {
+      if (typeof waitConditions.totalCount === 'number' && this.#captureCache.size >= waitConditions.totalCount) {
         capturedResolve(this.captures)
       }
     }

--- a/tools/testing-server/network-capture.js
+++ b/tools/testing-server/network-capture.js
@@ -88,9 +88,6 @@ module.exports = class NetworkCapture {
       throw new Error('Options must be supplied when creating a network capture.')
     }
     if (typeof options.test !== 'function') {
-      throw new Error('A testHandle must be supplied in the network capture options.')
-    }
-    if (typeof options.test !== 'function') {
       throw new Error('A test function must be supplied in the network capture options.')
     }
 

--- a/tools/testing-server/network-capture.js
+++ b/tools/testing-server/network-capture.js
@@ -1,0 +1,240 @@
+const crypto = require('crypto')
+
+/**
+ * A function used to check if a fastify server request should be captured.
+ * @typedef {Function} NetworkCaptureTestFn
+ * @param {import('./test-handle')} this a reference to the testHandle
+ * @param {import('fastify').FastifyRequest} request a reference to the fastify request object
+ * @returns {boolean} true if the network request should be captured
+ */
+
+/**
+ * Network capture options
+ * @typedef {object} NetworkCaptureOptions
+ * @property {NetworkCaptureTestFn} test function that takes the fastify request object and returns true if the expect should
+ * be resolved
+ */
+
+/**
+ * Serialized network capture
+ * @typedef {object} SerializedNetworkCapture
+ * @property {object} request object containing data extracted from the fastify request
+ * @property {any} request.body a copy of the request body
+ * @property {object} request.query a set of K/V pairs containing all the query parameters from the URI
+ * @property {object} request.headers a set of K/V pairs containing all the headers from the request
+ * @property {string} request.method the HTTP method used to make the request
+ * @property {object} reply object containing data extracted from the fastify reply
+ * @property {number} reply.statusCode status code the server responded with for the request
+ * @property {number} reply.headers a set of K/V pairs containing all the headers from the reply
+ * @property {number} reply.body a copy of the reply body if the reply was not a static asset
+ */
+
+/**
+ * Conditions to pause execution based on requests being captured.
+ * @typedef {object} NetworkCaptureWaitConditions
+ * @property {number} timeout a predefined time to wait before continuing execution
+ * @property {number} count a predefined number of requests to wait on before continuing execution
+ * @example If both timeout and count are supplied, when the timeout is reached, the pause will end regardless
+ * of the number of network captures and the supplied count condition.
+ * @example If both timeout and count are supplied, when the count of network captures reached the supplied
+ * count condition, the pause will end regardless of the timeout.
+ */
+
+/**
+ * Deferred object
+ * @typedef {object} Deferred
+ * @property {Promise<SerializedNetworkCapture[]>} promise the underlying promise of the deferred object
+ * @property {Function} resolve the resolve function of the deferred object
+ * @property {Function} reject the reject function of the deferred object
+ * @property {number} [timeout] the pending timeout for the deferred object
+ * @property {() => void} checkWaitConditions a function used to force the wait conditions to be evaluated. If
+ * the conditions pass, the wait will be ended and execution will continue
+ */
+
+module.exports = class NetworkCapture {
+  #instanceId = crypto.randomUUID()
+
+  /**
+   * Cache of capture requests and replies
+   * @type {Set<SerializedNetworkCapture>}
+   */
+  #captureCache = new Set()
+
+  /**
+   * Cache of deferred requests waiting on some capture conditions.
+   * @type {Set<Deferred>}
+   */
+  #deferredCache = new Set()
+
+  /**
+   * The reference back to the wrapping test handle.
+   * @type {import('./test-handle')}
+   */
+  #testHandle
+
+  /**
+   * The test function for this network capture
+   * @type {NetworkCaptureTestFn}
+   */
+  #test
+
+  /**
+   * Creates a new instance of a network capture.
+   * @param {import('./test-handle')} testHandle
+   * @param {NetworkCaptureOptions} options
+   */
+  constructor (testHandle, options) {
+    if (!options) {
+      throw new Error('Options must be supplied when creating a network capture.')
+    }
+    if (typeof options.test !== 'function') {
+      throw new Error('A testHandle must be supplied in the network capture options.')
+    }
+    if (typeof options.test !== 'function') {
+      throw new Error('A test function must be supplied in the network capture options.')
+    }
+
+    this.#testHandle = testHandle
+    this.#test = options.test
+  }
+
+  /**
+   * A unique id to identify this specific network capture. This should be
+   * used when interacting with this network capture from the testing platform.
+   * @return {UUID}
+   */
+  get instanceId () {
+    return this.#instanceId
+  }
+
+  /**
+   * Exposes all the current captures this network capture has saved.
+   * @return {SerializedNetworkCapture[]}
+   */
+  get captures () {
+    return Array.from(this.#captureCache)
+  }
+
+  /**
+   * Provides the results of executing the network capture test function passing in
+   * the test server as the `this` context and the fastify request as the parameter.
+   * @param {import('fastify').FastifyRequest} request
+   * @return {boolean} True if the fastify request matches the requirements of the test
+   * function.
+   */
+  test (request) {
+    return this.#test.call(this.#testHandle, request)
+  }
+
+  /**
+   * Captured a network request and reply.
+   * @param {import('fastify').FastifyRequest} request
+   * @param {import('fastify').FastifyReply} reply
+   * @param {any} payload
+   */
+  capture (request, reply, payload) {
+    this.#captureCache.add({
+      request: {
+        body: request.body,
+        query: request.query,
+        headers: request.headers,
+        method: request.method.toUpperCase()
+      },
+      reply: {
+        statusCode: reply.statusCode,
+        headers: reply.getHeaders(),
+        body: request.url.startsWith('/tests/assets/') || request.url.startsWith('/build/')
+          ? 'Asset content'
+          : payload
+      }
+    })
+
+    for (const deferred of this.#deferredCache) {
+      deferred.checkWaitConditions()
+    }
+  }
+
+  /**
+   * Clears the cached of network captures.
+   * @returns {void}
+   */
+  clear () {
+    this.#captureCache = new Set()
+  }
+
+  /**
+   * Destroy all memory references to allow for garbage collection.
+   * @returns {void}
+   */
+  destroy () {
+    for (const deferred of this.#deferredCache) {
+      if (deferred.timeout) {
+        clearTimeout(deferred.timeout)
+      }
+      if (deferred.promise) {
+        deferred.reject('Waiting network capture destroyed before resolving')
+      }
+    }
+    this.#deferredCache.clear()
+    this.#deferredCache = null
+
+    this.#captureCache.clear()
+    this.#captureCache = null
+
+    this.#instanceId = null
+    this.#testHandle = null
+    this.#test = null
+  }
+
+  /**
+   * Returns a promise that will resolve with the current capture cache once the provided
+   * conditions have been met.
+   * @param {NetworkCaptureWaitConditions} waitConditions Conditions to pause execution
+   * @return {Promise<SerializedNetworkCapture[]>}
+   */
+  waitFor (waitConditions) {
+    return this.#createDeferred(waitConditions).promise
+  }
+
+  /**
+   * Creates a basic deferred object
+   * @param {NetworkCaptureWaitConditions} waitConditions The conditions that, once met, indicate the
+   * deferred object can be resolved.
+   * @returns {Deferred}
+   */
+  #createDeferred (waitConditions) {
+    let capturedResolve
+    let capturedReject
+    let promise = new Promise((resolve, reject) => {
+      capturedResolve = resolve
+      capturedReject = reject
+    })
+
+    /**
+     * @type {Partial<Deferred>}
+     */
+    const deferred = { promise, resolve: capturedResolve, reject: capturedReject }
+    deferred.checkWaitConditions = () => {
+      if (typeof waitConditions.count === 'number' && this.#captureCache.size >= waitConditions.count) {
+        capturedResolve(this.captures)
+      }
+    }
+
+    if (typeof waitConditions.timeout === 'number' && waitConditions.timeout > 0) {
+      deferred.timeout = setTimeout(() => {
+        capturedResolve(this.captures)
+      }, waitConditions.timeout)
+    }
+    promise.finally(() => {
+      if (deferred.timeout) {
+        clearTimeout(deferred.timeout)
+      }
+
+      this.#deferredCache?.delete(deferred)
+    })
+
+    deferred.checkWaitConditions()
+    this.#deferredCache.add(deferred)
+    return deferred
+  }
+}

--- a/tools/testing-server/plugins/test-handle/index.js
+++ b/tools/testing-server/plugins/test-handle/index.js
@@ -9,7 +9,11 @@ const { testIdFromRequest } = require('../../utils/fastify-request')
 module.exports = fp(async function (fastify, testServer) {
   fastify.decorateRequest('scheduledReply', null)
   fastify.decorateRequest('resolvingExpect', null)
+  fastify.decorateRequest('networkCaptures', null)
   fastify.decorateRequest('testHandle', null)
+  fastify.addHook('onRequest', async (request) => {
+    request.networkCaptures = new Set()
+  })
   fastify.addHook('preHandler', async (request, reply) => {
     const testId = testIdFromRequest(request)
     const testHandle = testServer.getTestHandle(testId)
@@ -62,12 +66,16 @@ module.exports = fp(async function (fastify, testServer) {
         reply: {
           statusCode: reply.statusCode,
           headers: reply.getHeaders(),
-          body: request.url.startsWith('/tests/assets')
-            ? 'HTML asset content'
+          body: request.url.startsWith('/tests/assets/') || request.url.startsWith('/build/')
+            ? 'Asset content'
             : payload
         }
       })
     }
+
+    request.networkCaptures?.forEach(networkCapture => {
+      networkCapture.capture(request, reply)
+    })
 
     if (request.scheduledReply && request.scheduledReply.delay) {
       setTimeout(() => done(null, payload), request.scheduledReply.delay)

--- a/tools/testing-server/routes/bam-apis.js
+++ b/tools/testing-server/routes/bam-apis.js
@@ -21,32 +21,17 @@ module.exports = fp(async function (fastify) {
     method: ['GET', 'POST'],
     url: '/1/:testId',
     handler: async function (request, reply) {
-      if (request.testHandle) {
-        request.testHandle.incrementRequestCount(fastify.testServerId, 'rum')
-      }
-
-      if (!request.query.jsonp) {
-        return reply
-          .header('content-type', 'application/json')
-          .header('Timing-Allow-Origin', request.headers.origin)
-          .code(200)
-          .send(JSON.stringify(rumFlags))
-      } else {
-        return reply
-          .header('content-type', 'application/javascript')
-          .header('Timing-Allow-Origin', request.headers.origin)
-          .code(200)
-          .send(`${request.query.jsonp}(${JSON.stringify(rumFlags)})`)
-      }
+      return reply
+        .header('content-type', 'application/json')
+        .header('Timing-Allow-Origin', request.headers.origin)
+        .code(200)
+        .send(JSON.stringify(rumFlags))
     }
   })
   fastify.route({
     method: ['GET', 'POST'],
     url: '/events/1/:testId',
     handler: async function (request, reply) {
-      if (request.testHandle) {
-        request.testHandle.incrementRequestCount(fastify.testServerId, 'events')
-      }
       return reply.code(200).send('')
     }
   })
@@ -54,9 +39,7 @@ module.exports = fp(async function (fastify) {
     method: ['POST'],
     url: '/browser/blobs',
     handler: async function (request, reply) {
-      if (request.testHandle) {
-        request.testHandle.incrementRequestCount(fastify.testServerId, 'blobs')
-      } else {
+      if (!request.testHandle) {
         // running without a test handle... lets buffer it so we can replay it later
         const attributes = new URLSearchParams(request.query?.attributes)
         storeReplayData(attributes.get('session'), attributes.get('replay.firstTimestamp'), request.body)
@@ -69,10 +52,6 @@ module.exports = fp(async function (fastify) {
     method: ['POST'],
     url: '/browser/logs',
     handler: async function (request, reply) {
-      if (request.testHandle) {
-        request.testHandle.incrementRequestCount(fastify.testServerId, 'logs')
-      }
-
       return reply.code(200).send('')
     }
   })
@@ -80,10 +59,6 @@ module.exports = fp(async function (fastify) {
     method: ['GET', 'POST'],
     url: '/jserrors/1/:testId',
     handler: async function (request, reply) {
-      if (request.testHandle) {
-        request.testHandle.incrementRequestCount(fastify.testServerId, 'jserrors')
-      }
-
       return reply.code(200).send('')
     }
   })
@@ -91,10 +66,6 @@ module.exports = fp(async function (fastify) {
     method: ['GET', 'POST'],
     url: '/ins/1/:testId',
     handler: async function (request, reply) {
-      if (request.testHandle) {
-        request.testHandle.incrementRequestCount(fastify.testServerId, 'ins')
-      }
-
       return reply.code(200).send('')
     }
   })
@@ -102,10 +73,6 @@ module.exports = fp(async function (fastify) {
     method: ['GET', 'POST'],
     url: '/resources/1/:testId',
     handler: async function (request, reply) {
-      if (request.testHandle) {
-        request.testHandle.incrementRequestCount(fastify.testServerId, 'resources')
-      }
-
       // This endpoint must reply with some text in the body or further resource harvests will be disabled
       return reply.code(200).send(uuidv4())
     }

--- a/tools/testing-server/routes/command-apis.js
+++ b/tools/testing-server/routes/command-apis.js
@@ -73,8 +73,8 @@ module.exports = fp(async function (fastify, testServer) {
     const testHandle = testServer.getTestHandle(request.params.testId)
 
     try {
-      const networkCapture = testHandle.createNetworkCapture(request.params.serverId, request.body)
-      reply.code(200).send({ captureId: networkCapture.instanceId })
+      const networkCaptures = testHandle.createNetworkCaptures(request.params.serverId, request.body)
+      reply.code(200).send(networkCaptures)
     } catch (e) {
       reply.code(400).send(e)
     }

--- a/tools/testing-server/routes/command-apis.js
+++ b/tools/testing-server/routes/command-apis.js
@@ -43,6 +43,9 @@ module.exports = fp(async function (fastify, testServer) {
       reply.code(400).send(e)
     }
   })
+
+  // Scheduled Replays APIs
+
   fastify.post('/test-handle/:testId/scheduleReply', async function (request, reply) {
     const testHandle = testServer.getTestHandle(request.params.testId)
 
@@ -63,13 +66,55 @@ module.exports = fp(async function (fastify, testServer) {
       reply.code(400).send(e)
     }
   })
-  fastify.post('/test-handle/:testId/requestCounts', async function (request, reply) {
+
+  // Network Captures APIs
+
+  fastify.post('/test-handle/:testId/network-capture/:serverId', async function (request, reply) {
     const testHandle = testServer.getTestHandle(request.params.testId)
 
     try {
-      reply.code(200).send(
-        testHandle.requestCounts
-      )
+      const networkCapture = testHandle.createNetworkCapture(request.params.serverId, request.body)
+      reply.code(200).send({ captureId: networkCapture.instanceId })
+    } catch (e) {
+      reply.code(400).send(e)
+    }
+  })
+  fastify.get('/test-handle/:testId/network-capture/:serverId/:captureId', async function (request, reply) {
+    const testHandle = testServer.getTestHandle(request.params.testId)
+
+    try {
+      const networkCaptureCache = testHandle.getNetworkCaptureCache(request.params.serverId, request.params.captureId)
+      reply.code(200).send(networkCaptureCache)
+    } catch (e) {
+      reply.code(400).send(e)
+    }
+  })
+  fastify.put('/test-handle/:testId/network-capture/:serverId/:captureId/clear', async function (request, reply) {
+    const testHandle = testServer.getTestHandle(request.params.testId)
+
+    try {
+      testHandle.clearNetworkCaptureCache(request.params.serverId, request.params.captureId)
+      reply.code(204).send()
+    } catch (e) {
+      reply.code(400).send(e)
+    }
+  })
+  fastify.delete('/test-handle/:testId/network-capture/:serverId/:captureId', async function (request, reply) {
+    const testHandle = testServer.getTestHandle(request.params.testId)
+
+    try {
+      testHandle.destroyNetworkCapture(request.params.serverId, request.params.captureId)
+      reply.code(204).send()
+    } catch (e) {
+      reply.code(400).send(e)
+    }
+  })
+  fastify.post('/test-handle/:testId/network-capture/:serverId/:captureId/await', async function (request, reply) {
+    const testHandle = testServer.getTestHandle(request.params.testId)
+
+    try {
+      const networkCaptureCache = await testHandle.awaitNetworkCapture(request.params.serverId, request.params.captureId, request.body)
+      reply.code(200).send(networkCaptureCache)
     } catch (e) {
       reply.code(400).send(e)
     }

--- a/tools/testing-server/test-handle.js
+++ b/tools/testing-server/test-handle.js
@@ -250,18 +250,21 @@ module.exports = class TestHandle {
    * requests allowing tests to check which BAM APIs or assets were requested, how many times, and
    * wait for some expectation within the capture to pause testing.
    * @param {'assetServer'|'bamServer'} serverId Id of the server the request will be received on
-   * @param {import('./network-capture').NetworkCaptureOptions} networkCaptureOptions The options to apply
+   * @param {import('./network-capture').NetworkCaptureOptions[]} networkCaptureOptions The options to apply
    * to the server request to verify if the request should be captured
    * @returns {import('./network-capture')} The ID of the network capture
    */
-  createNetworkCapture (serverId, networkCaptureOptions) {
+  createNetworkCaptures (serverId, networkCaptureOptions) {
     if (!this.#networkCaptures.has(serverId)) {
       this.#networkCaptures.set(serverId, new Map())
     }
 
-    const networkCapture = new NetworkCapture(this, networkCaptureOptions)
-    this.#networkCaptures.get(serverId).set(networkCapture.instanceId, networkCapture)
-    return networkCapture
+    return networkCaptureOptions
+      .map(options => {
+        const networkCapture = new NetworkCapture(this, options)
+        this.#networkCaptures.get(serverId).set(networkCapture.instanceId, networkCapture)
+        return networkCapture.instanceId
+      })
   }
 
   /**

--- a/tools/wdio/config/lambdatest.conf.mjs
+++ b/tools/wdio/config/lambdatest.conf.mjs
@@ -59,7 +59,6 @@ function lambdaTestCapabilities () {
       } else {
         capabilities['LT:Options'].deviceName = testBrowser.device_name
         capabilities['LT:Options'].platformVersion = testBrowser.version
-        capabilities['LT:Options'].appiumVersion = '2.6.0'
         if (args.webview) { // btw, LT has different capabilities array for mobile app automation!
           // Note: Since their available devices for app differs, we'll let default pick apply.
           // Caution: LT does not support android@9 for app; we should only be testing webview for latest ios & android.
@@ -76,6 +75,12 @@ function lambdaTestCapabilities () {
           }
         } else {
           capabilities['appium:platformName'] = testBrowser.device_name
+
+          if (parsedBrowserName === 'android') {
+            capabilities['LT:Options'].appiumVersion = '1.22.3'
+          } else /* === ios */ {
+            capabilities['LT:Options'].appiumVersion = '2.6.0'
+          }
         }
       }
       return capabilities

--- a/tools/wdio/config/lambdatest.conf.mjs
+++ b/tools/wdio/config/lambdatest.conf.mjs
@@ -59,6 +59,7 @@ function lambdaTestCapabilities () {
       } else {
         capabilities['LT:Options'].deviceName = testBrowser.device_name
         capabilities['LT:Options'].platformVersion = testBrowser.version
+        capabilities['LT:Options'].appiumVersion = '2.6.0'
         if (args.webview) { // btw, LT has different capabilities array for mobile app automation!
           // Note: Since their available devices for app differs, we'll let default pick apply.
           // Caution: LT does not support android@9 for app; we should only be testing webview for latest ios & android.
@@ -66,8 +67,15 @@ function lambdaTestCapabilities () {
           capabilities['LT:Options'].isRealMobile = false
           // Note: LT expires app every 60 days, so the .zip/.apk needs to be re-uploaded then and these url updated to point to new url.
           // Important: ensure the uploaded apps are set to "team" visibility.
-          if (parsedBrowserName === 'android') capabilities['LT:Options'].app = 'lt://APP10160352241718733717577609'
-          else /* === 'ios' */ capabilities['LT:Options'].app = 'lt://APP10160352241718734672953481'
+          if (parsedBrowserName === 'android') {
+            capabilities['appium:platformName'] = 'android'
+            capabilities['LT:Options'].app = 'lt://APP10160352241718733717577609'
+          } else /* === 'ios' */ {
+            capabilities['appium:platformName'] = 'ios'
+            capabilities['LT:Options'].app = 'lt://APP10160352241718734672953481'
+          }
+        } else {
+          capabilities['appium:platformName'] = testBrowser.device_name
         }
       }
       return capabilities
@@ -86,7 +94,7 @@ export default function config () {
           tunnel: args.tunnel,
           sessionNameFormat: (config, capabilities, suiteTitle, testTitle) => suiteTitle,
           lambdatestOpts: {
-            // allowHosts: args.host || 'bam-test-1.nr-local.net',
+            allowHosts: args.host || 'bam-test-1.nr-local.net',
             logFile: path.resolve(__dirname, '../../../.lambdatest')
           }
         }

--- a/tools/wdio/plugins/testing-server/network-capture-connector.mjs
+++ b/tools/wdio/plugins/testing-server/network-capture-connector.mjs
@@ -1,0 +1,106 @@
+import logger from '@wdio/logger'
+import fetch from 'node-fetch'
+import { serialize } from '../../../shared/serializer.js'
+
+const log = logger('network-capture-connector')
+
+export class NetworkCaptureConnector {
+  /**
+   * Base URL for network capture API calls.
+   */
+  #networkCaptureBase
+
+  /**
+   * Id of the server this network capture connector instance is related to.
+   * This is used to execute additional APIs for the specific network capture
+   * instance.
+   * @type {'assetServer'|'bamServer'}
+   */
+  #serverId
+
+  /**
+   * The options to apply to the server request to verify if the request should
+   * be captured.
+   * @type {import('../../../testing-server/network-capture.js').NetworkCaptureOptions}
+   */
+  #networkCaptureOptions
+
+  /**
+   * The unique id of the network capture that was created in the test server.
+   * This is used to execute additional APIs for the specific network capture
+   * instance.
+   * @type {string}
+   */
+  #captureId
+
+  /**
+   * Creates a new instance of a network capture connector.
+   * @param {import('./test-handle-connector.mjs').TestHandleConnector} testHandleConnector
+   * @param {'assetServer'|'bamServer'} serverId
+   */
+  constructor (testHandleConnector, serverId, networkCaptureOptions) {
+    this.#serverId = serverId
+    this.#networkCaptureBase = `${testHandleConnector.commandServerBase}/test-handle/${testHandleConnector.testId}/network-capture`
+    this.#networkCaptureOptions = networkCaptureOptions
+  }
+
+  async ready () {
+    if (!this.#captureId) {
+      const result = await fetch(`${this.#networkCaptureBase}/${this.#serverId}`, {
+        method: 'POST',
+        body: serialize(this.#networkCaptureOptions),
+        headers: { 'content-type': 'application/serialized+json' }
+      })
+      this.#captureId = (await result.json()).captureId
+      log.info(`Network Capture ID: ${this.#captureId}`)
+    }
+  }
+
+  /**
+   * Gets and returns the current data for this network capture
+   * @returns {Promise<import('../../../testing-server/network-capture.mjs').SerializedNetworkCapture[]>} Array of serialized network captures
+   */
+  async getCurrentResults () {
+    const result = await fetch(`${this.#networkCaptureBase}/${this.#serverId}/${this.#captureId}`)
+    return await result.json()
+  }
+
+  /**
+   * Clears any stored data for this network capture
+   * @returns {Promise<void>}
+   */
+  async clearResults () {
+    await fetch(`${this.#networkCaptureBase}/${this.#serverId}/${this.#captureId}/clear`, {
+      method: 'PUT'
+    })
+  }
+
+  /**
+   * Destroys this network capture on the testing server to release memory for garbage collection
+   * @returns {Promise<void>}
+   */
+  async destroy () {
+    await fetch(`${this.#networkCaptureBase}/${this.#serverId}/${this.#captureId}`, {
+      method: 'DELETE'
+    })
+
+    this.#captureId = null
+    this.#networkCaptureOptions = null
+    this.#serverId = null
+    this.#networkCaptureBase = null
+  }
+
+  /**
+   * Pauses test execution until the network condition on the testing server meets the supplied conditions
+   * @param {import('../../../testing-server/network-capture.mjs').NetworkCaptureWaitConditions} waitConditions Conditions to pause execution
+   * @returns {Promise<import('../../../testing-server/network-capture.mjs').SerializedNetworkCapture[]>} Array of serialized network captures
+   */
+  async waitForResult (waitConditions) {
+    const result = await fetch(`${this.#networkCaptureBase}/${this.#serverId}/${this.#captureId}/await`, {
+      method: 'POST',
+      body: serialize(waitConditions),
+      headers: { 'content-type': 'application/serialized+json' }
+    })
+    return await result.json()
+  }
+}

--- a/tools/wdio/plugins/testing-server/network-capture-connector.mjs
+++ b/tools/wdio/plugins/testing-server/network-capture-connector.mjs
@@ -1,8 +1,5 @@
-import logger from '@wdio/logger'
 import fetch from 'node-fetch'
 import { serialize } from '../../../shared/serializer.js'
-
-const log = logger('network-capture-connector')
 
 export class NetworkCaptureConnector {
   /**
@@ -11,49 +8,12 @@ export class NetworkCaptureConnector {
   #networkCaptureBase
 
   /**
-   * Id of the server this network capture connector instance is related to.
-   * This is used to execute additional APIs for the specific network capture
-   * instance.
-   * @type {'assetServer'|'bamServer'}
-   */
-  #serverId
-
-  /**
-   * The options to apply to the server request to verify if the request should
-   * be captured.
-   * @type {import('../../../testing-server/network-capture.js').NetworkCaptureOptions}
-   */
-  #networkCaptureOptions
-
-  /**
-   * The unique id of the network capture that was created in the test server.
-   * This is used to execute additional APIs for the specific network capture
-   * instance.
-   * @type {string}
-   */
-  #captureId
-
-  /**
    * Creates a new instance of a network capture connector.
    * @param {import('./test-handle-connector.mjs').TestHandleConnector} testHandleConnector
    * @param {'assetServer'|'bamServer'} serverId
    */
-  constructor (testHandleConnector, serverId, networkCaptureOptions) {
-    this.#serverId = serverId
-    this.#networkCaptureBase = `${testHandleConnector.commandServerBase}/test-handle/${testHandleConnector.testId}/network-capture`
-    this.#networkCaptureOptions = networkCaptureOptions
-  }
-
-  async ready () {
-    if (!this.#captureId) {
-      const result = await fetch(`${this.#networkCaptureBase}/${this.#serverId}`, {
-        method: 'POST',
-        body: serialize(this.#networkCaptureOptions),
-        headers: { 'content-type': 'application/serialized+json' }
-      })
-      this.#captureId = (await result.json()).captureId
-      log.info(`Network Capture ID: ${this.#captureId}`)
-    }
+  constructor (testHandleConnector, serverId, captureId) {
+    this.#networkCaptureBase = `${testHandleConnector.commandServerBase}/test-handle/${testHandleConnector.testId}/network-capture/${serverId}/${captureId}`
   }
 
   /**
@@ -61,7 +21,7 @@ export class NetworkCaptureConnector {
    * @returns {Promise<import('../../../testing-server/network-capture.mjs').SerializedNetworkCapture[]>} Array of serialized network captures
    */
   async getCurrentResults () {
-    const result = await fetch(`${this.#networkCaptureBase}/${this.#serverId}/${this.#captureId}`)
+    const result = await fetch(this.#networkCaptureBase)
     return await result.json()
   }
 
@@ -70,7 +30,7 @@ export class NetworkCaptureConnector {
    * @returns {Promise<void>}
    */
   async clearResults () {
-    await fetch(`${this.#networkCaptureBase}/${this.#serverId}/${this.#captureId}/clear`, {
+    await fetch(`${this.#networkCaptureBase}/clear`, {
       method: 'PUT'
     })
   }
@@ -80,13 +40,10 @@ export class NetworkCaptureConnector {
    * @returns {Promise<void>}
    */
   async destroy () {
-    await fetch(`${this.#networkCaptureBase}/${this.#serverId}/${this.#captureId}`, {
+    await fetch(this.#networkCaptureBase, {
       method: 'DELETE'
     })
 
-    this.#captureId = null
-    this.#networkCaptureOptions = null
-    this.#serverId = null
     this.#networkCaptureBase = null
   }
 
@@ -96,7 +53,7 @@ export class NetworkCaptureConnector {
    * @returns {Promise<import('../../../testing-server/network-capture.mjs').SerializedNetworkCapture[]>} Array of serialized network captures
    */
   async waitForResult (waitConditions) {
-    const result = await fetch(`${this.#networkCaptureBase}/${this.#serverId}/${this.#captureId}/await`, {
+    const result = await fetch(`${this.#networkCaptureBase}/await`, {
       method: 'POST',
       body: serialize(waitConditions),
       headers: { 'content-type': 'application/serialized+json' }


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Redesigned the network expects in our integration tests. Tests can now setup network captures before executing any browser commands. The network capture instances will capture all network traffic for the specific test allowing us to verify how many times a BAM api is called, check for calls to BAM apis happened, and wait for BAM api calls to happen. This resolves the race condition we were seeing with the existing network expects logic and ensures the capture is setup prior to loading the test page.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-283311

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

Two spec files have been updated in this PR to use the new network capture feature in place of the old network expect. You can run those on LT to verify it is working.

Local test results:

```
> npm run wdio -- tests/specs/api.e2e.js --no-retry --concurrent 30 -b 'safar@*,chrome@*,firefox@*,edge@*'
Spec Files:      6 passed, 6 total (100% completed) in 00:02:31

> npm run wdio -- tests/specs/api.e2e.js --no-retry --concurrent 30 -b 'ios@*'
Spec Files:      2 passed, 2 total (100% completed) in 00:04:19

> npm run wdio -- tests/specs/api.e2e.js --no-retry --concurrent 30 -b 'android@*'
Spec Files:      2 passed, 2 total (100% completed) in 00:03:06

> npm run wdio -- --webview --no-retry --concurrent 30 -b 'android@latest'
Spec Files:      1 passed, 1 skipped, 2 total (100% completed) in 00:01:12

> npm run wdio -- --webview --no-retry --concurrent 30 -b 'ios@latest'
Spec Files:      1 passed, 1 skipped, 2 total (100% completed) in 00:01:14
```