### PR TITLE
chore: Post release repo updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8090,9 +8090,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001637",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001637.tgz",
-      "integrity": "sha512-1x0qRI1mD1o9e+7mBI7XtzFAP4XszbHaVWsMiGbSPLYekKTJF7K+FNk6AsXH4sUpc+qrsI3pVgf1Jdl/uGkuSQ==",
+      "version": "1.0.30001639",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz",
+      "integrity": "sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==",
       "dev": true,
       "funding": [
         {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Jun 26 2024 18:29:16 GMT+0000 (Coordinated Universal Time)",
+  "lastUpdated": "Tue Jul 02 2024 15:00:02 GMT+0000 (Coordinated Universal Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,

--- a/tools/browsers-lists/lt-mobile-supported.json
+++ b/tools/browsers-lists/lt-mobile-supported.json
@@ -2,7 +2,7 @@
   "ios": [
     {
       "device_name": "iPhone 15",
-      "version": "17.2",
+      "version": "17.5",
       "platformName": "ios"
     },
     {

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.1.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.2.tgz"
   }
 }

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/client": "^3.8.8",
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.1.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.2.tgz",
     "graphql": "^16.8.1"
   }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.1.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.2.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.1.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.261.2.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/tools/wdio/config/lambdatest.conf.mjs
+++ b/tools/wdio/config/lambdatest.conf.mjs
@@ -76,11 +76,12 @@ function lambdaTestCapabilities () {
         } else {
           capabilities['appium:platformName'] = testBrowser.device_name
 
-          if (parsedBrowserName === 'android') {
-            capabilities['LT:Options'].appiumVersion = '1.22.3'
-          } else /* === ios */ {
-            capabilities['LT:Options'].appiumVersion = '2.6.0'
-          }
+          // Feature request open with LT to support appium 2.x on android and ios
+          // if (parsedBrowserName === 'android') {
+          //   capabilities['LT:Options'].appiumVersion = '1.22.3'
+          // } else /* === ios */ {
+          //   capabilities['LT:Options'].appiumVersion = '2.6.0'
+          // }
         }
       }
       return capabilities


### PR DESCRIPTION
When this PR is merged, caniuse-lite database is updated, latest browserslist for SauceLabs is retrieved, and third-party dependencies docs are updates.
---

This PR was generated with post-release-updates GitHub action.