### PR TITLE
fix: Release backlog memory when features are blocked by RUM

### DIFF
--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -113,7 +113,7 @@ function drainGroup (agentIdentifier, group, activateGroup = true) {
 
   if (!baseEE.isolatedBacklog) delete handlers[group]
   baseEE.backlog[group] = null
-  baseEE.emit('drain-' + group, []) // exists purely for a unit test
+  baseEE.emit('drain-' + group, []) // TODO: Code exists purely for a unit test and needs to be refined
 }
 
 /**

--- a/tests/specs/cleanup-on-halt.e2e.js
+++ b/tests/specs/cleanup-on-halt.e2e.js
@@ -1,0 +1,32 @@
+import { testRumRequest } from '../../tools/testing-server/utils/expect-tests'
+
+describe('Memory leaks', () => {
+  it('does not occur on ee backlog when RUM flags are 0', async () => {
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify({ st: 0, sr: 0, err: 0, ins: 0, spa: 0, loaded: 1 })
+    })
+    // This test relies on features to call deregisterDrain when not enabled by flags which in turn should clear their backlogs.
+
+    await browser.url(await browser.testHandle.assetURL('obfuscate-pii.html')).then(() => browser.waitForAgentLoad())
+    const backlog = await browser.execute(function () {
+      const backlog = {}
+      for (const key in newrelic.ee.backlog) {
+        const array = newrelic.ee.backlog[key]
+        backlog[key] = array === null ? 0 : array.length
+      }
+      return backlog
+    })
+
+    expect(backlog).toEqual(expect.objectContaining({
+      ajax: 0, // ajax does not rely on any flags anyways so it's always drained
+      jserrors: 0,
+      metrics: 0,
+      page_action: 0,
+      page_view_event: 0, // no handler
+      page_view_timing: 0, // does not rely on any flags
+      session_trace: 0,
+      spa: 0
+    }))
+  })
+})

--- a/tests/specs/harvesting/disable-harvesting.e2e.js
+++ b/tests/specs/harvesting/disable-harvesting.e2e.js
@@ -8,7 +8,6 @@ describe('disable harvesting', () => {
         st: 1,
         err: 0,
         ins: 1,
-        cap: 1,
         spa: 1,
         loaded: 1
       })
@@ -32,7 +31,6 @@ describe('disable harvesting', () => {
         st: 1,
         err: 1,
         ins: 1,
-        cap: 1,
         spa: 0,
         loaded: 1
       })
@@ -59,7 +57,6 @@ describe('disable harvesting', () => {
         st: 1,
         err: 1,
         ins: 0,
-        cap: 1,
         spa: 1,
         loaded: 1
       })
@@ -81,7 +78,6 @@ describe('disable harvesting', () => {
         st: 0,
         err: 1,
         ins: 1,
-        cap: 1,
         spa: 1,
         loaded: 1
       })

--- a/tests/specs/session-replay/initialization.e2e.js
+++ b/tests/specs/session-replay/initialization.e2e.js
@@ -12,7 +12,6 @@ async function disqualifySR () {
       sts: 1,
       err: 1,
       ins: 1,
-      cap: 1,
       spa: 1,
       loaded: 1,
       sr: 0,

--- a/tests/specs/session-replay/session-state.e2e.js
+++ b/tests/specs/session-replay/session-state.e2e.js
@@ -85,6 +85,9 @@ describe.withBrowsersMatching(notIE)('session manager state behavior', () => {
       await browser.enableSessionReplay()
       await browser.url(await browser.testHandle.assetURL('instrumented.html', srConfig()))
         .then(() => browser.waitForSessionReplayRecording())
+
+      await browser.closeWindow()
+      await browser.switchToWindow((await browser.getWindowHandles())[0])
     })
   })
 

--- a/tests/specs/session-trace/trace-nodes.e2e.js
+++ b/tests/specs/session-trace/trace-nodes.e2e.js
@@ -33,7 +33,7 @@ describe('Trace nodes', () => {
     await browser.testHandle.clearScheduledReplies('bamServer')
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
-      body: JSON.stringify({ st: 0, sts: 0, sr: 0, err: 1, ins: 1, cap: 1, spa: 0, loaded: 1 })
+      body: JSON.stringify({ st: 0, sts: 0, sr: 0, err: 1, ins: 1, spa: 0, loaded: 1 })
     })
 
     const url = await browser.testHandle.assetURL('pagehide.html', stConfig())

--- a/tests/specs/soft_navigations/integration.e2e.js
+++ b/tests/specs/soft_navigations/integration.e2e.js
@@ -32,7 +32,7 @@ describe('Soft navigations', () => {
   it('does not harvest when spa is blocked by rum response', async () => {
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
-      body: `${JSON.stringify({ st: 1, err: 1, ins: 1, cap: 1, spa: 0, loaded: 1 })}`
+      body: `${JSON.stringify({ st: 1, err: 1, ins: 1, spa: 0, loaded: 1 })}`
     })
 
     let url = await browser.testHandle.assetURL('instrumented.html', config)

--- a/tests/unit/common/drain/drain.test.js
+++ b/tests/unit/common/drain/drain.test.js
@@ -1,8 +1,9 @@
-let registerDrain, drain, ee
+let registerDrain, drain, deregisterDrain, ee, registerHandler
 beforeEach(async () => {
   jest.resetModules()
-  ;({ registerDrain, drain } = await import('../../../../src/common/drain/drain'))
+  ;({ registerDrain, drain, deregisterDrain } = await import('../../../../src/common/drain/drain'))
   ;({ ee } = await import('../../../../src/common/event-emitter/contextual-ee'))
+  ;({ registerHandler } = await import('../../../../src/common/event-emitter/register-handler'))
 })
 
 test('can register a feat and drain it', () => {
@@ -23,6 +24,15 @@ test('other unregistered drains do not affect feat reg & drain', () => {
 
   drain('abcd', 'page_view_event')
   expect(emitSpy).toHaveBeenCalledWith('drain-page_view_event', expect.anything())
+})
+
+test('unregistering groups clears their handlers from the buffering system', () => {
+  registerDrain('abcd', 'pumbaa')
+  registerHandler('tusks', () => {}, 'pumbaa', ee)
+  expect(registerHandler.handlers.pumbaa).toEqual({ tusks: expect.anything() })
+
+  deregisterDrain('abcd', 'pumbaa')
+  expect(registerHandler.handlers.pumbaa).toBeUndefined()
 })
 
 describe('drain', () => {


### PR DESCRIPTION
Plug a memory leak in Session Trace and other features. When entitlement or enable flag from RUM request returns a 0 for a feature, the agent will now release the reference to the events buffer under that feature so it can be garbage collected.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

The pre-load cycle of the agent sets up listeners and buffers events in a backlog and an internal handlers object to be flushed and processed after the page loads. It was discovered that if the RUM call getting made post-load returns a `0` for an applicable feature, those things are never cleared for such feature. This caused the backlog for instance to indefinitely hold onto events awaiting processing, consuming memory. This fix will flush those events in such cases when the features are not activated via the `deregisterDrain` call made by each.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-284960
This issue was also seen in other features and have been addressed together.

### Testing

New e2e on `-b *`: 
<img width="494" alt="image" src="https://github.com/newrelic/newrelic-browser-agent/assets/28714891/441ae51f-971b-43a8-87d1-94e4b804ac52">

