### PR TITLE
fix: safeguard api calls

### DIFF
--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -29,7 +29,9 @@ export function setTopLevelCallers () {
   function caller (fnName, ...args) {
     let returnVals = []
     Object.values(nr.initializedAgents).forEach(val => {
-      if (val.exposed && val.api[fnName]) {
+      if (!val || !val.api) {
+        warn(`Call to api '${fnName}' made before agent fully initialized.`)
+      } else if (val.exposed && val.api[fnName]) {
         returnVals.push(val.api[fnName](...args))
       }
     })


### PR DESCRIPTION
Adding a safeguard to prevent an exception from being thrown when browser agent APIs are called before the agent is fully initialized.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Adding a safeguard to prevent an exception from being thrown when browser agent APIs are called before the agent is fully initialized.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-276448
#1057 

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->

The issue cannot be reproduced.