### PR TITLE
fix: address call to stopTimer on undefined scheduler

### DIFF
--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -205,6 +205,6 @@ export class Aggregate extends AggregateBase {
     this.blocked = true
     this.mode = MODE.OFF
     this.agentRuntime.session.write({ sessionTraceMode: this.mode })
-    this.scheduler.stopTimer()
+    this.scheduler?.stopTimer()
   }
 }


### PR DESCRIPTION
Fixed an issue where session trace stopping on one tab while the same site was opening in another tab could result in the second tab throwing an exception when attempting to call `stopTimer()` on an undefined harvest scheduler.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Calls to `stopTimer`  from the `SESSION_EVENTS.UPDATE` ee event could result in attempting to call `stopTimer` on an undefined harvest scheduler. Added an optional chaining to the call.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-286373
#1095 

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
