### PR TITLE
chore: migrate err e2e tests to network capture

### DIFF
--- a/tests/specs/err/attributes.e2e.js
+++ b/tests/specs/err/attributes.e2e.js
@@ -1,13 +1,21 @@
 /* globals triggerError */
 
+import { testErrorsRequest } from '../../../tools/testing-server/utils/expect-tests'
+
 describe('error attributes with spa loader', () => {
+  let errorsCapture
+
+  beforeEach(async () => {
+    errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
+  })
+
   describe('custom attributes', () => {
     it('sets multiple custom attributes after page load with multiple JS errors occurring after page load', async () => {
       await browser.url(await browser.testHandle.assetURL('js-error-with-custom-attribute.html'))
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           triggerError()
           triggerError()
@@ -15,10 +23,10 @@ describe('error attributes with spa loader', () => {
         })
       ])
 
-      expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(0)
-      expect(errorResult.request.body.err[1].custom.customParamKey).toBe(1)
-      expect(errorResult.request.body.err[2].custom.customParamKey).toBe(2)
+      expect(errorResult[0].request.body.err.length).toBe(3) // exactly 3 errors in payload
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(0)
+      expect(errorResult[0].request.body.err[1].custom.customParamKey).toBe(1)
+      expect(errorResult[0].request.body.err[2].custom.customParamKey).toBe(2)
     })
 
     it('sets single custom attribute before page load with single JS error occurring before page load', async () => {
@@ -26,12 +34,12 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1)
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(0)
+      expect(errorResult[0].request.body.err.length).toBe(1)
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(0)
     })
 
     it('sets custom attribute before page load, after loader, before info', async () => {
@@ -39,11 +47,11 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(0)
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(0)
     })
 
     it('sets custom attribute with pre-existing attributes before page load, after loader, before info', async () => {
@@ -51,12 +59,12 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(0)
-      expect(errorResult.request.body.err[0].custom.hi).toBe('mom')
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(0)
+      expect(errorResult[0].request.body.err[0].custom.hi).toBe('mom')
     })
 
     it('sets custom attribute with pre-existing attributes before page load, after loader, before info precedence check', async () => {
@@ -64,11 +72,11 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(0)
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(0)
     })
 
     it('sets multiple custom attributes before page load with multiple JS errors occurring after page load', async () => {
@@ -76,7 +84,7 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           // Using setTimeout asks each command to wait for the event loop to pick it up from the message queue rather
           // than executing direcly as a synchronous frame on the stack. This plays better with our api calls, which
@@ -88,9 +96,9 @@ describe('error attributes with spa loader', () => {
         })
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(2)
-      expect(errorResult.request.body.err[0].metrics.count).toBe(3) // the one error has a count of 3
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(2)
+      expect(errorResult[0].request.body.err[0].metrics.count).toBe(3) // the one error has a count of 3
     })
 
     it('noticeError accepts custom attributes in an argument', async () => {
@@ -98,13 +106,13 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.custom1).toBe('val1')
-      expect(errorResult.request.body.err[0].custom.custom2).toBe('val2')
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.custom1).toBe('val1')
+      expect(errorResult[0].request.body.err[0].custom.custom2).toBe('val2')
     })
   })
 
@@ -114,12 +122,12 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(1)
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(1)
     })
 
     it('muliple errors - different attribute values', async () => {
@@ -127,14 +135,14 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(3)
-      expect(errorResult.request.body.err[1].custom.customParamKey).toBe(3)
-      expect(errorResult.request.body.err[2].custom.customParamKey).toBe(3)
+      expect(errorResult[0].request.body.err.length).toBe(3) // exactly 3 errors in payload
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(3)
+      expect(errorResult[0].request.body.err[1].custom.customParamKey).toBe(3)
+      expect(errorResult[0].request.body.err[2].custom.customParamKey).toBe(3)
     })
   })
 
@@ -144,15 +152,15 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           document.getElementById('trigger').click()
           setTimeout(function () { location.reload() }, 100) // IE needs a little time before the refresh.
         })
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(1)
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(1)
     })
 
     it('multiple errors - different attribute values', async () => {
@@ -160,17 +168,17 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           document.getElementById('trigger').click()
           setTimeout(function () { location.reload() }, 100) // IE needs a little time before the refresh.
         })
       ])
 
-      expect(errorResult.request.body.err.length).toBe(3) // exactly 3 errors in payload
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(3)
-      expect(errorResult.request.body.err[1].custom.customParamKey).toBe(3)
-      expect(errorResult.request.body.err[2].custom.customParamKey).toBe(3)
+      expect(errorResult[0].request.body.err.length).toBe(3) // exactly 3 errors in payload
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(3)
+      expect(errorResult[0].request.body.err[1].custom.customParamKey).toBe(3)
+      expect(errorResult[0].request.body.err[2].custom.customParamKey).toBe(3)
     })
 
     it('attributes captured in discarded interaction are still collected', async () => {
@@ -178,15 +186,15 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           document.getElementById('trigger').click()
           setTimeout(function () { location.reload() }, 100) // IE needs a little time before the refresh.
         })
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.customParamKey).toBe(1)
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.customParamKey).toBe(1)
     })
   })
 
@@ -196,13 +204,13 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.globalKey).toBe(1)
-      expect(errorResult.request.body.err[0].custom.localKey).toBe(2)
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.globalKey).toBe(1)
+      expect(errorResult[0].request.body.err[0].custom.localKey).toBe(2)
     })
   })
 
@@ -212,12 +220,12 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.localKey).toBe(2) // first error should have value from setAttribute
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.localKey).toBe(2) // first error should have value from setAttribute
     })
 
     it('noticeError takes precedence over setAttribute', async () => {
@@ -225,12 +233,12 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.refresh()
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.custom1).toBe('val2') // error should have value from noticeError
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.custom1).toBe('val2') // error should have value from noticeError
     })
 
     it('noticeError takes precedence over setAttribute in discarded interactions', async () => {
@@ -238,15 +246,15 @@ describe('error attributes with spa loader', () => {
         .then(() => browser.waitForAgentLoad())
 
       const [errorResult] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.execute(function () {
           document.getElementById('trigger').click()
           setTimeout(function () { location.reload() }, 100) // IE needs a little time before the refresh.
         })
       ])
 
-      expect(errorResult.request.body.err.length).toBe(1) // exactly 1 error in payload
-      expect(errorResult.request.body.err[0].custom.custom1).toBe('val1') // error should have value from noticeError
+      expect(errorResult[0].request.body.err.length).toBe(1) // exactly 1 error in payload
+      expect(errorResult[0].request.body.err[0].custom.custom1).toBe('val1') // error should have value from noticeError
     })
   })
 })

--- a/tests/specs/err/bucketing.e2e.js
+++ b/tests/specs/err/bucketing.e2e.js
@@ -4,15 +4,21 @@ import { testErrorsRequest } from '../../../tools/testing-server/utils/expect-te
 // IE11 actually does bucket these cases, so these tests will fail. Because the cases are niche, we exclude IE11.
 
 describe.withBrowsersMatching(notIE)('error bucketing', () => {
+  let errorsCapture
+
+  beforeEach(async () => {
+    errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
+  })
+
   it('NR-40043: Multiple errors with noticeError and unique messages should not bucket', async () => {
     const [errorResult] = await Promise.all([
-      browser.testHandle.expectErrors(),
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('js-errors-noticeerror-bucketing.html'))
         .then(() => browser.waitForAgentLoad())
     ])
 
-    expect(errorResult.request.body.err.length).toBe(8) // should honor unique messages and not group and count at all
-    errorResult.request.body.err.forEach((error, i) => {
+    expect(errorResult[0].request.body.err.length).toBe(8) // should honor unique messages and not group and count at all
+    errorResult[0].request.body.err.forEach((error, i) => {
       expect(error.params.message).toBe(`Error message ${i + 1}`) // all eight unique messages expected
     })
   })
@@ -24,30 +30,30 @@ describe.withBrowsersMatching(notIE)('error bucketing', () => {
     })
 
     const [firstErrorResult] = await Promise.all([
-      browser.testHandle.expectErrors(),
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('js-errors-noticeerror-bucketing.html'))
         .then(() => browser.waitForAgentLoad())
     ])
 
-    expect(firstErrorResult.reply.statusCode).toBe(429)
+    expect(firstErrorResult[0].reply.statusCode).toBe(429)
 
-    const secondErrorResult = await browser.testHandle.expectErrors()
+    const secondErrorResult = await errorsCapture.waitForResult({ totalCount: 2 })
 
-    expect(secondErrorResult.reply.statusCode).toBe(200)
-    expect(firstErrorResult.request.body.err).toEqual(secondErrorResult.request.body.err) // same because it's a retry
+    expect(secondErrorResult[1].reply.statusCode).toBe(200)
+    expect(firstErrorResult[0].request.body.err).toEqual(secondErrorResult[1].request.body.err) // same because it's a retry
   })
 
   it('NEWRELIC-3788: Multiple identical errors from the same line but different columns should not be bucketed', async () => {
     const [errorResult] = await Promise.all([
-      browser.testHandle.expectErrors(),
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('js-error-column-bucketing.html'))
         .then(() => browser.waitForAgentLoad())
     ])
 
-    expect(errorResult.request.body.err).toBeDefined() // has errors
-    expect(errorResult.request.body.err.length).toBe(2) // both errors reported, not bucketed
-    expect(typeof errorResult.request.body.err[0].params.stack_trace === 'string').toBeTruthy() // first error has a stack trace
-    expect(typeof errorResult.request.body.err[1].params.stack_trace === 'string').toBeTruthy() // second error has a stack trace
+    expect(errorResult[0].request.body.err).toBeDefined() // has errors
+    expect(errorResult[0].request.body.err.length).toBe(2) // both errors reported, not bucketed
+    expect(typeof errorResult[0].request.body.err[0].params.stack_trace === 'string').toBeTruthy() // first error has a stack trace
+    expect(typeof errorResult[0].request.body.err[1].params.stack_trace === 'string').toBeTruthy() // second error has a stack trace
   })
 
   it('NEWRELIC-3788: Multiple identical errors from the same line but different columns should not be bucketed when retrying due to 429', async () => {
@@ -57,18 +63,18 @@ describe.withBrowsersMatching(notIE)('error bucketing', () => {
     })
 
     const [firstErrorResult] = await Promise.all([
-      browser.testHandle.expectErrors(),
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('js-error-column-bucketing.html'))
         .then(() => browser.waitForAgentLoad())
     ])
 
-    expect(firstErrorResult.reply.statusCode).toBe(429)
+    expect(firstErrorResult[0].reply.statusCode).toBe(429)
 
-    const secondErrorResult = await browser.testHandle.expectErrors()
+    const secondErrorResult = await errorsCapture.waitForResult({ totalCount: 2 })
 
-    expect(secondErrorResult.reply.statusCode).toBe(200)
-    expect(secondErrorResult.request.body.err).toBeDefined() // has errors
-    expect(secondErrorResult.request.body.err).toEqual(firstErrorResult.request.body.err) // same because it's a retry
-    expect(secondErrorResult.request.body.err.length).toBe(2) // both errors reported, not bucketed
+    expect(secondErrorResult[1].reply.statusCode).toBe(200)
+    expect(secondErrorResult[1].request.body.err).toBeDefined() // has errors
+    expect(secondErrorResult[1].request.body.err).toEqual(firstErrorResult[0].request.body.err) // same because it's a retry
+    expect(secondErrorResult[1].request.body.err.length).toBe(2) // both errors reported, not bucketed
   })
 })

--- a/tests/specs/err/circular.e2e.js
+++ b/tests/specs/err/circular.e2e.js
@@ -1,12 +1,20 @@
+import { testErrorsRequest } from '../../../tools/testing-server/utils/expect-tests'
+
 describe('circular references', () => {
+  let errorsCapture
+
+  beforeEach(async () => {
+    errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
+  })
+
   it('are encoded properly when error message contains a circular reference', async () => {
     const [errorsResults] = await Promise.all([
-      browser.testHandle.expectErrors(),
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('circular.html'))
         .then(() => browser.waitForAgentLoad())
     ])
 
-    expect(errorsResults.request.body.err.length).toBe(1) // exactly one error
-    expect(errorsResults.request.body.err[0].params.message).toBe('[object Object]')
+    expect(errorsResults[0].request.body.err.length).toBe(1) // exactly one error
+    expect(errorsResults[0].request.body.err[0].params.message).toBe('[object Object]')
   })
 })

--- a/tests/specs/err/retry-harvesting.e2e.js
+++ b/tests/specs/err/retry-harvesting.e2e.js
@@ -1,7 +1,13 @@
 import { testErrorsRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('err retry harvesting', () => {
-  [408, 429, 500, 503].forEach(statusCode =>
+  let errorsCapture
+
+  beforeEach(async () => {
+    errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
+  })
+
+  ;[408, 429, 500, 503].forEach(statusCode =>
     it(`should send the error on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testErrorsRequest,
@@ -10,7 +16,7 @@ describe('err retry harvesting', () => {
       })
 
       const [firstErrorsHarvest] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('instrumented.html'))
           .then(() => browser.waitForAgentLoad())
           .then(() => browser.execute(function () {
@@ -23,18 +29,18 @@ describe('err retry harvesting', () => {
       await browser.testHandle.clearScheduledReplies('bamServer')
 
       const [secondErrorsHarvest] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 2 }),
         browser.execute(function () {
           newrelic.noticeError(new Error('hippo hangry 2'))
         })
       ])
 
-      expect(firstErrorsHarvest.reply.statusCode).toEqual(statusCode)
-      expect(secondErrorsHarvest.request.body.err).toEqual(expect.arrayContaining(firstErrorsHarvest.request.body.err))
+      expect(firstErrorsHarvest[0].reply.statusCode).toEqual(statusCode)
+      expect(secondErrorsHarvest[1].request.body.err).toEqual(expect.arrayContaining(firstErrorsHarvest[0].request.body.err))
     })
-  );
+  )
 
-  [400, 404, 502, 504, 512].forEach(statusCode =>
+  ;[400, 404, 502, 504, 512].forEach(statusCode =>
     it(`should not send the error on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testErrorsRequest,
@@ -43,7 +49,7 @@ describe('err retry harvesting', () => {
       })
 
       const [firstErrorsHarvest] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('instrumented.html'))
           .then(() => browser.waitForAgentLoad())
           .then(() => browser.execute(function () {
@@ -56,14 +62,14 @@ describe('err retry harvesting', () => {
       await browser.testHandle.clearScheduledReplies('bamServer')
 
       const [secondErrorsHarvest] = await Promise.all([
-        browser.testHandle.expectErrors(),
+        errorsCapture.waitForResult({ totalCount: 2 }),
         browser.execute(function () {
           newrelic.noticeError(new Error('hippo hangry 2'))
         })
       ])
 
-      expect(firstErrorsHarvest.reply.statusCode).toEqual(statusCode)
-      expect(secondErrorsHarvest.request.body.err).not.toEqual(expect.arrayContaining(firstErrorsHarvest.request.body.err))
+      expect(firstErrorsHarvest[0].reply.statusCode).toEqual(statusCode)
+      expect(secondErrorsHarvest[1].request.body.err).not.toEqual(expect.arrayContaining(firstErrorsHarvest[0].request.body.err))
     })
   )
 })

--- a/tests/specs/err/scripts-and-callbacks.e2e.js
+++ b/tests/specs/err/scripts-and-callbacks.e2e.js
@@ -1,11 +1,18 @@
 const { onlyIE, notIE } = require('../../../tools/browser-matcher/common-matchers.mjs')
 const { assertExpectedErrors, assertErrorAttributes } = require('./assertion-helper')
+const { testErrorsRequest } = require('../../../tools/testing-server/utils/expect-tests')
 
 describe('JSE Error detection in various callbacks', () => {
+  let errorsCapture
+
+  beforeEach(async () => {
+    errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
+  })
+
   it('should report errors from event listener callbacks', async () => {
     const eventListenersURL = await browser.testHandle.assetURL('event-listener-error.html')
-    const [{ request: { body: errorBody } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(eventListenersURL)
         .then(() => browser.waitForAgentLoad())
     ])
@@ -39,8 +46,8 @@ describe('JSE Error detection in various callbacks', () => {
 
   it('should report uncaught errors from external scripts', async () => {
     const pageUrl = await browser.testHandle.assetURL('external-uncaught-error.html')
-    const [{ request: { body: errorBody, query: errorQuery } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody, query: errorQuery } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(pageUrl)
         .then(() => browser.waitForAgentLoad())
     ])
@@ -51,8 +58,8 @@ describe('JSE Error detection in various callbacks', () => {
 
   it('should report uncaught errors from inline scripts', async () => {
     const pageUrl = await browser.testHandle.assetURL('inline-uncaught-error.html')
-    const [{ request: { body: errorBody, query: errorQuery } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody, query: errorQuery } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(pageUrl)
         .then(() => browser.waitForAgentLoad())
     ])
@@ -63,8 +70,8 @@ describe('JSE Error detection in various callbacks', () => {
 
   it.withBrowsersMatching(onlyIE)('should report errors from setImmediate callbacks', async () => {
     const pageUrl = await browser.testHandle.assetURL('set-immediate-error.html')
-    const [{ request: { body: errorBody } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(pageUrl)
         .then(() => browser.waitForAgentLoad())
         .then(() => browser.waitUntil(
@@ -92,8 +99,8 @@ describe('JSE Error detection in various callbacks', () => {
 
   it('should report errors from setInterval callbacks', async () => {
     const pageUrl = await browser.testHandle.assetURL('set-interval-error.html')
-    const [{ request: { body: errorBody } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(pageUrl)
         .then(() => browser.waitForAgentLoad())
         .then(() => browser.waitUntil(
@@ -121,8 +128,8 @@ describe('JSE Error detection in various callbacks', () => {
 
   it('should report errors from setTimeout callbacks', async () => {
     const pageUrl = await browser.testHandle.assetURL('set-timeout-error.html')
-    const [{ request: { body: errorBody } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(pageUrl)
         .then(() => browser.waitForAgentLoad())
         .then(() => browser.waitUntil(
@@ -151,8 +158,8 @@ describe('JSE Error detection in various callbacks', () => {
 
   it('should report uncaught errors in callbacks', async () => {
     const pageUrl = await browser.testHandle.assetURL('uncaught.html')
-    const [{ request: { body: errorBody } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(pageUrl)
         .then(() => browser.waitForAgentLoad())
     ])
@@ -177,8 +184,8 @@ describe('JSE Error detection in various callbacks', () => {
 
   it.withBrowsersMatching(notIE)('should report unhandledPromiseRejections that are readable', async () => {
     const pageUrl = await browser.testHandle.assetURL('unhandled-promise-rejection-readable.html')
-    const [{ request: { body: errorBody, query: errorQuery } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody, query: errorQuery } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(pageUrl)
         .then(() => browser.waitForAgentLoad())
     ])
@@ -211,8 +218,8 @@ describe('JSE Error detection in various callbacks', () => {
 
   it('should report errors from XHR callbacks', async () => {
     const pageUrl = await browser.testHandle.assetURL('xhr-error.html')
-    const [{ request: { body: errorBody, query: errorQuery } }] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[{ request: { body: errorBody, query: errorQuery } }]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(pageUrl)
         .then(() => browser.waitForAgentLoad())
     ])


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Migrating the e2e tests in `tests/specs/err` to use the network capturing functionality.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-287578

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
