### PR TITLE
chore: remove old assert import keyword

### DIFF
--- a/tools/browser-matcher/matcher-rule.mjs
+++ b/tools/browser-matcher/matcher-rule.mjs
@@ -1,5 +1,8 @@
+import module from 'node:module'
 import { parseSpecString, equationIsTrue } from './spec-parser.mjs'
-import latestBrowserVersions from '../browsers-lists/lt-desktop-latest-vers.json' assert { type: 'json' }
+
+const require = module.createRequire(import.meta.url)
+const latestBrowserVersions = require('../browsers-lists/lt-desktop-latest-vers.json')
 
 /**
  * Represents a browser matching rule of the defined type

--- a/tools/wdio/config/lambdatest.conf.mjs
+++ b/tools/wdio/config/lambdatest.conf.mjs
@@ -1,12 +1,15 @@
-import url from 'url'
-import path from 'path'
-import child_process from 'child_process'
-import desktopBrowsers from '../../browsers-lists/lt-desktop-supported.json' assert { type: 'json' }
-import mobileBrowsers from '../../browsers-lists/lt-mobile-supported.json' assert { type: 'json' }
-import browsersPolyfill from '../../browsers-lists/lt-polyfill.json' assert { type: 'json' }
+import module from 'node:module'
+import url from 'node:url'
+import path from 'node:path'
+import child_process from 'node:child_process'
 import browsersList from '../../browsers-lists/lt-browsers-list.mjs'
 import args from '../args.mjs'
 import { getBrowserName } from '../../browsers-lists/utils.mjs'
+
+const require = module.createRequire(import.meta.url)
+const desktopBrowsers = require('../../browsers-lists/lt-desktop-supported.json')
+const mobileBrowsers = require('../../browsers-lists/lt-mobile-supported.json')
+const browsersPolyfill = require('../../browsers-lists/lt-polyfill.json')
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 

--- a/tools/webpack/env.mjs
+++ b/tools/webpack/env.mjs
@@ -1,6 +1,7 @@
-/* eslint-disable no-case-declarations */
-import packageJSON from '../../package.json' assert { type: 'json' }
-import process from 'process'
+import module from 'node:module'
+import process from 'node:process'
+
+const require = module.createRequire(import.meta.url)
 
 /**
  * @typedef {import('./index.mjs').WebpackBuildOptions} WebpackBuildOptions
@@ -16,7 +17,7 @@ import process from 'process'
  */
 export default async (env) => {
   let VERSION, PATH_VERSION, SUBVERSION, PUBLIC_PATH
-  VERSION = packageJSON.version
+  VERSION = require('../../package.json').version
 
   switch ((env.mode || '').toString().toLocaleLowerCase()) {
     case 'prod':
@@ -33,6 +34,7 @@ export default async (env) => {
       VERSION = `${VERSION}-dev`
       break
     case 'experiment':
+      // eslint-disable-next-line no-case-declarations
       const branchName = env.branchName || 'experiment'
       PATH_VERSION = ''
       SUBVERSION = branchName

--- a/tools/webpack/loaders/istanbul/index.mjs
+++ b/tools/webpack/loaders/istanbul/index.mjs
@@ -1,7 +1,10 @@
+import module from 'node:module'
 import { createInstrumenter } from 'istanbul-lib-instrument'
 import { validate } from 'schema-utils'
 import convert from 'convert-source-map'
-import schema from './options.json' assert { type: 'json' }
+
+const require = module.createRequire(import.meta.url)
+const schema = require('./options.json')
 
 export default function (source, sourceMap) {
   const options = Object.assign({ produceSourceMap: true }, this.getOptions())


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

This removes the old `import ... assert ...` keyword usage in favor of `require`. The `assert` keyword was added in [Node 16](https://nodejs.org/docs/latest-v16.x/api/esm.html#json-modules) but the keyword was changed in [Node 18](https://nodejs.org/docs/latest-v18.x/api/esm.html#import-attributes) to `with`. The `assert` keyword for imports was removed in Node 22 causing builds of our project to fail when running with Node 22.

The replacement implementation creates a `require` function using `module.createRequire(import.meta.url)`. This is supported all the way back to Node 12 and is not marked `experimental` in any way within the Node docs. This should be a stable way to import a JSON file for some time.

The alternative is to use `import ... with ...` but the `with` keyword is still under development but it is a tc39 standard that has reached stage 3 and could probably be expected to be pretty stable to use now. This would limit us and ppl forking and building the project to using Node 18 or later.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-265288

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
