### PR TITLE
feat: Shut down agent if improperly configured

### DIFF
--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -85,3 +85,5 @@
 `Failed to execute setUserId. Non-null value must be a string type.`
 ### 42
 `Failed to execute setApplicationVersion. Expected <String | null>`
+### 43
+`Agent not configured properly.`

--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -90,7 +90,7 @@ function checkCanDrainAll (agentIdentifier) {
 function drainGroup (agentIdentifier, group, activateGroup = true) {
   const baseEE = agentIdentifier ? ee.get(agentIdentifier) : ee
   const handlers = defaultRegister.handlers // other storage in registerHandler
-  if (!baseEE.backlog || !handlers) return
+  if (baseEE.aborted || !baseEE.backlog || !handlers) return
 
   // Only activated features being drained should run queued listeners on buffered events. Deactivated features only need to release memory.
   if (activateGroup) {

--- a/src/common/util/console.js
+++ b/src/common/util/console.js
@@ -6,5 +6,5 @@
  */
 export function warn (code, secondary) {
   if (typeof console.debug !== 'function') return
-  console.debug(`New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/warning-codes.md#${code}`, secondary)
+  console.debug(`New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#${code}`, secondary)
 }

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -1,7 +1,7 @@
 import { globalScope, isBrowserScope, originTime } from '../../../common/constants/runtime'
 import { addPT, addPN } from '../../../common/timing/nav-timing'
 import { stringify } from '../../../common/util/stringify'
-import { getInfo, getRuntime } from '../../../common/config/config'
+import { getInfo, getRuntime, isConfigured } from '../../../common/config/config'
 import { Harvest } from '../../../common/harvest/harvest'
 import * as CONSTANTS from '../constants'
 import { getActivatedFeaturesFlags } from './initialized-features'
@@ -28,6 +28,11 @@ export class Aggregate extends AggregateBase {
     this.firstByteToDomContent = 0 // our "dom processing" duration
     this.timeKeeper = new TimeKeeper(this.agentIdentifier)
 
+    if (!isConfigured(agentIdentifier)) {
+      this.ee.abort()
+      return warn(43)
+    }
+
     if (isBrowserScope) {
       timeToFirstByte.subscribe(({ value, attrs }) => {
         const navEntry = attrs.navigationEntry
@@ -48,7 +53,6 @@ export class Aggregate extends AggregateBase {
     const agentRuntime = getRuntime(this.agentIdentifier)
     const harvester = new Harvest(this)
 
-    if (!info.beacon) return
     if (info.queueTime) this.aggregator.store('measures', 'qt', { value: info.queueTime })
     if (info.applicationTime) this.aggregator.store('measures', 'ap', { value: info.applicationTime })
 

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -4,7 +4,6 @@ import { configure } from '../../loaders/configure/configure'
 import { gosCDN } from '../../common/window/nreum'
 import { drain } from '../../common/drain/drain'
 import { activatedFeatures } from '../../common/util/feature-flags'
-import { warn } from '../../common/util/console'
 
 export class AggregateBase extends FeatureBase {
   constructor (...args) {
@@ -51,10 +50,6 @@ export class AggregateBase extends FeatureBase {
     // NOTE: This check has to happen at aggregator load time
     if (!isConfigured(this.agentIdentifier)) {
       const cdn = gosCDN()
-      if (!cdn.info?.licenseKey || !cdn.info?.applicationID) {
-        this.ee.abort()
-        return warn(43)
-      }
       let jsAttributes = { ...cdn.info?.jsAttributes }
       try {
         jsAttributes = {

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -4,6 +4,7 @@ import { configure } from '../../loaders/configure/configure'
 import { gosCDN } from '../../common/window/nreum'
 import { drain } from '../../common/drain/drain'
 import { activatedFeatures } from '../../common/util/feature-flags'
+import { warn } from '../../common/util/console'
 
 export class AggregateBase extends FeatureBase {
   constructor (...args) {
@@ -49,7 +50,9 @@ export class AggregateBase extends FeatureBase {
   checkConfiguration () {
     // NOTE: This check has to happen at aggregator load time
     if (!isConfigured(this.agentIdentifier)) {
-      let jsAttributes = { ...gosCDN().info?.jsAttributes }
+      const cdn = gosCDN()
+      if (!cdn.info?.licenseKey || !cdn.info?.applicationID) return warn(43)
+      let jsAttributes = { ...cdn.info?.jsAttributes }
       try {
         jsAttributes = {
           ...jsAttributes,
@@ -59,9 +62,9 @@ export class AggregateBase extends FeatureBase {
         // do nothing
       }
       configure({ agentIdentifier: this.agentIdentifier }, {
-        ...gosCDN(),
+        ...cdn,
         info: {
-          ...gosCDN().info,
+          ...cdn.info,
           jsAttributes
         },
         runtime: getRuntime(this.agentIdentifier)

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -51,7 +51,10 @@ export class AggregateBase extends FeatureBase {
     // NOTE: This check has to happen at aggregator load time
     if (!isConfigured(this.agentIdentifier)) {
       const cdn = gosCDN()
-      if (!cdn.info?.licenseKey || !cdn.info?.applicationID) return warn(43)
+      if (!cdn.info?.licenseKey || !cdn.info?.applicationID) {
+        this.ee.abort()
+        return warn(43)
+      }
       let jsAttributes = { ...cdn.info?.jsAttributes }
       try {
         jsAttributes = {

--- a/tests/assets/no-app-id-after.html
+++ b/tests/assets/no-app-id-after.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init}
+    {loader}
+    {config}
+    <script>
+      delete NREUM.info.applicationID
+    </script>
+  </head>
+  <body>Instrumented</body>
+</html>

--- a/tests/assets/no-app-id-before.html
+++ b/tests/assets/no-app-id-before.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init} {config}
+    <script>
+      delete NREUM.info.applicationID
+    </script>
+    {loader}
+  </head>
+  <body>Instrumented</body>
+</html>

--- a/tests/assets/no-license-key-after.html
+++ b/tests/assets/no-license-key-after.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init}
+    {loader}
+    {config}
+    <script>
+      delete NREUM.info.licenseKey
+    </script>
+  </head>
+  <body>Instrumented</body>
+</html>

--- a/tests/assets/no-license-key-before.html
+++ b/tests/assets/no-license-key-before.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init} {config}
+    <script>
+      delete NREUM.info.licenseKey
+    </script>
+    {loader}
+  </head>
+  <body>Instrumented</body>
+</html>

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -276,7 +276,7 @@ describe('setAPI', () => {
       apiInterface.setCustomAttribute(...args)
 
       expect(console.debug).toHaveBeenCalledTimes(1)
-      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/warning-codes.md#39'), typeof name)
+      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#39'), typeof name)
     })
 
     test.each([undefined, {}, [], Symbol('foobar')])('should return early and warn when value is not a string, number, or null (%s)', (value) => {
@@ -284,7 +284,7 @@ describe('setAPI', () => {
       apiInterface.setCustomAttribute(...args)
 
       expect(console.debug).toHaveBeenCalledTimes(1)
-      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/warning-codes.md#40'), typeof value)
+      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#40'), typeof value)
     })
 
     test('should set a custom attribute with a string value', () => {
@@ -387,7 +387,7 @@ describe('setAPI', () => {
       apiInterface.setUserId(...args)
 
       expect(console.debug).toHaveBeenCalledTimes(1)
-      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/warning-codes.md#41'), typeof value)
+      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#41'), typeof value)
     })
 
     test('should set a custom attribute with name enduser.id', () => {
@@ -438,7 +438,7 @@ describe('setAPI', () => {
       apiInterface.setApplicationVersion(...args)
 
       expect(console.debug).toHaveBeenCalledTimes(1)
-      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/warning-codes.md#42'), typeof value)
+      expect(console.debug).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#42'), typeof value)
     })
 
     test('should set a custom attribute with name application.version', () => {

--- a/tests/components/page_view_timing/index.test.js
+++ b/tests/components/page_view_timing/index.test.js
@@ -1,6 +1,6 @@
 import { Aggregator } from '../../../src/common/aggregate/aggregator'
 import { ee } from '../../../src/common/event-emitter/contextual-ee'
-import { setRuntime } from '../../../src/common/config/config'
+import { setConfiguration, setInfo, setRuntime } from '../../../src/common/config/config'
 import { VITAL_NAMES } from '../../../src/common/vitals/constants'
 
 // Note: these callbacks fire right away unlike the real web-vitals API which are async-on-trigger
@@ -52,11 +52,9 @@ describe('pvt aggregate tests', () => {
       __esModule: true,
       activatedFeatures: { [agentId]: { pvt: 1 } }
     }))
-    // jest.doMock('../../../common/harvest/harvest', () => ({
-    //   __esModule: true,
-    //   send: jest.fn()
-    // }))
 
+    setInfo(agentId, { licenseKey: 'licenseKey', applicationID: 'applicationID' })
+    setConfiguration(agentId, {})
     setRuntime(agentId, {})
     const { Aggregate } = await import('../../../src/features/page_view_timing/aggregate')
 

--- a/tests/specs/harvesting/disable-harvesting.e2e.js
+++ b/tests/specs/harvesting/disable-harvesting.e2e.js
@@ -91,4 +91,21 @@ describe('disable harvesting', () => {
 
     await expect(stnPromise).resolves.toEqual(undefined)
   })
+
+  ;['app-id', 'license-key'].forEach(name => {
+    ;['before', 'after'].forEach(loadState => {
+      it(`should disable all harvesting and abort if ${name} is absent (${loadState})`, async () => {
+        const rumPromise = browser.testHandle.expectRum(10000, true)
+
+        await browser.url(await browser.testHandle.assetURL(`no-${name}-${loadState}.html`))
+
+        await expect(rumPromise).resolves.toEqual(undefined)
+
+        const eeBacklog = await browser.execute(function () {
+          return newrelic.ee.backlog
+        })
+        expect(eeBacklog).toEqual({})
+      })
+    })
+  })
 })

--- a/tests/unit/common/util/console.test.js
+++ b/tests/unit/common/util/console.test.js
@@ -18,13 +18,13 @@ describe('warn', () => {
 
   test('should call console.debug with a prefixed message', () => {
     warn(1000)
-    expect(console.debug).toHaveBeenCalledWith('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/warning-codes.md#1000', undefined)
+    expect(console.debug).toHaveBeenCalledWith('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#1000', undefined)
   })
 
   test('should call console.debug with secondary argument if provided', () => {
     const secondary = 'secondary value'
     warn(123, secondary)
-    expect(console.debug).toHaveBeenCalledWith('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/warning-codes.md#123', secondary)
+    expect(console.debug).toHaveBeenCalledWith('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#123', secondary)
   })
 
   test('should not call console.debug with secondary argument if not provided', () => {

--- a/tests/unit/features/utils/aggregate-base.test.js
+++ b/tests/unit/features/utils/aggregate-base.test.js
@@ -114,10 +114,13 @@ test('should early return with warning if missing global info props', () => {
   jest.mocked(isConfigured).mockReturnValue(false)
 
   jest.mocked(gosCDN).mockReturnValue({})
-  new AggregateBase(agentIdentifier, aggregator, featureName)
+  const aggBase = new AggregateBase(agentIdentifier, aggregator, featureName)
 
   expect(warn).toHaveBeenCalledWith(43)
   expect(configure).not.toHaveBeenCalled()
+
+  expect(aggBase.ee.aborted).toEqual(true)
+  expect(aggBase.ee.backlog).toEqual({})
 })
 
 test('should resolve waitForFlags correctly based on flags with real vals', async () => {

--- a/tests/unit/features/utils/aggregate-base.test.js
+++ b/tests/unit/features/utils/aggregate-base.test.js
@@ -3,7 +3,6 @@ import { AggregateBase } from '../../../../src/features/utils/aggregate-base'
 import { getInfo, isConfigured, getRuntime } from '../../../../src/common/config/config'
 import { configure } from '../../../../src/loaders/configure/configure'
 import { gosCDN } from '../../../../src/common/window/nreum'
-import { warn } from '../../../../src/common/util/console'
 
 jest.enableAutomock()
 jest.unmock('../../../../src/features/utils/aggregate-base')
@@ -108,19 +107,6 @@ test('should only configure the agent once', () => {
   expect(getInfo).not.toHaveBeenCalled()
   expect(getRuntime).not.toHaveBeenCalled()
   expect(configure).not.toHaveBeenCalled()
-})
-
-test('should early return with warning if missing global info props', () => {
-  jest.mocked(isConfigured).mockReturnValue(false)
-
-  jest.mocked(gosCDN).mockReturnValue({})
-  const aggBase = new AggregateBase(agentIdentifier, aggregator, featureName)
-
-  expect(warn).toHaveBeenCalledWith(43)
-  expect(configure).not.toHaveBeenCalled()
-
-  expect(aggBase.ee.aborted).toEqual(true)
-  expect(aggBase.ee.backlog).toEqual({})
 })
 
 test('should resolve waitForFlags correctly based on flags with real vals', async () => {


### PR DESCRIPTION
Shut down initialization of the agent if improperly configured. Agents must be provided a valid licenseKey and applicationID at runtime.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Shut down the agent with a new warning code if invalid licenseKey or App ID are provided.  Also fixed an issue where the warning code did not link correctly.

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-257211
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been updated to reflect the new behavior
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
