### PR TITLE
chore: add video sm

### DIFF
--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -87,6 +87,8 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * Generic/Resources/Ajax/External
 <!--- A resource timing API Non-Ajax (other assets like scripts, etc) event was observed that does NOT match the Agent beacon --->
 * Generic/Resources/Non-Ajax/External
+<!--- A <video> element was added to the DOM, should have a total count as part of the metric --->
+* Generic/VideoElement/Added
 
 ### Frameworks
 <!--- React was Detected --->

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -96,6 +96,18 @@ export class Aggregate extends AggregateBase {
     // Check if proxy for either chunks or beacon is being used
     if (proxy.assets) this.storeSupportabilityMetrics('Config/AssetsUrl/Changed')
     if (proxy.beacon) this.storeSupportabilityMetrics('Config/BeaconUrl/Changed')
+
+    if (isBrowserScope && window.MutationObserver) {
+      this.storeSupportabilityMetrics('Generic/VideoElement/Added', window.document.querySelectorAll('video').length)
+      const mo = new MutationObserver(records => {
+        records.forEach(record => {
+          record.addedNodes.forEach(addedNode => {
+            if (addedNode instanceof HTMLVideoElement) { this.storeSupportabilityMetrics('Generic/VideoElement/Added', 1) }
+          })
+        })
+      })
+      mo.observe(window.document.body, { childList: true, subtree: true })
+    }
   }
 
   eachSessionChecks () {

--- a/tests/assets/video-player.html
+++ b/tests/assets/video-player.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init} {config} {loader}
+  </head>
+  <body>
+    <video controls width="500">
+      <source src="https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm" type="video/mp4" />
+    </video>
+
+    <div id="div1">
+      <div id="div2">
+        <div id="div3">
+            <!-- inject new video player -->
+        </div>
+      </div>
+    </div>
+
+    <script>
+      function observeVideo(video){
+      video.addEventListener('play', evt => {
+        console.log("play...", Date.now(), evt)
+      })
+      video.addEventListener('pause', evt => {
+        console.log("pause...", Date.now(), evt)
+      })
+      video.addEventListener('playing', evt => {
+        console.log("resume (playing)...", Date.now(), evt)
+      })
+      video.addEventListener('ended', evt => {
+        console.log("end (ended)...", Date.now(), evt)
+      })
+      video.addEventListener('stalled', evt => {
+        console.log("stall (stalled)...", evt)
+      })
+      video.addEventListener('seeking', evt => {
+        console.log("seek (seeking)...", evt)
+      })
+      video.addEventListener('volumechange', evt => {
+        console.log("volume (volumechange)...", evt)
+      })
+      video.addEventListener('waiting', evt => {
+        console.log("buffer (waiting)...", evt)
+      })
+      console.log("observing video", video)
+    }
+     
+    observeVideo(document.querySelector('video'))
+
+      setTimeout(() => {
+        const clone = document.querySelector('video').cloneNode(true)
+        document.querySelector('#div3').appendChild(clone)
+      }, 3000)
+
+      const mo = new MutationObserver(records => {
+        records.forEach(record => {
+          record.addedNodes.forEach(addedNode => {
+            if (addedNode instanceof HTMLVideoElement){
+              console.log("video element added!", addedNode)
+              observeVideo(addedNode)
+            }
+          })
+        })
+      })
+      mo.observe(document.body, {childList: true, subtree: true})
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a SM tracking when `<video>` elements are seen, combining those observed at window load time with a DOM query with those subsequently observed with a mutation observer
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-293248
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
