### PR TITLE
fix: Prevent agent using invalid date header

### DIFF
--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -163,6 +163,14 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 ### Features
 <!--- The time manager Failed to calculate a valid time from the Page View Event response --->
 * PVE/NRTime/Calculation/Failed
+* <!--- The time manager Failed to calculate a valid time from the Page View Event response because the Date header did not meet RFC2616 format --->
+* PVE/NRTime/Calculation/InvalidFormat
+* <!--- The time manager calculated a local user time difference of 12 hours or more --->
+* PVE/NRTime/Calculation/DiffExceed12Hrs
+* <!--- The time manager calculated a local user time difference of 6 hours or more but less than 12 hours --->
+* PVE/NRTime/Calculation/DiffExceed6Hrs
+* <!--- The time manager calculated a local user time difference of 1 hour or more but less than 6 hours --->
+* PVE/NRTime/Calculation/DiffExceed1Hrs
 <!--- SessionReplay was Enabled but the RUM response indicated it was not entitled to run --->
 * SessionReplay/EnabledNotEntitled/Detected
 <!--- SessionReplay attempted to harvest data --->

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { srConfig, decodeAttributes } from './util/helpers'
 import { notIE, supportsFetch } from '../../tools/browser-matcher/common-matchers.mjs'
+import { testAjaxEventsRequest, testBlobReplayRequest, testErrorsRequest, testInsRequest, testInteractionEventsRequest, testRumRequest, testSupportMetricsRequest } from '../../tools/testing-server/utils/expect-tests'
 
 let serverTime
 describe('NR Server Time', () => {
@@ -13,70 +14,76 @@ describe('NR Server Time', () => {
   })
 
   it('should send page view event wth rst parameter and no timestamp when nr server time unknown', async () => {
-    const [rum] = await Promise.all([
-      browser.testHandle.expectRum(),
+    const rumCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testRumRequest })
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('instrumented.html'))
         .then(() => browser.waitForAgentLoad())
     ])
 
-    expect(parseInt(rum.request.query.rst, 10)).toBeGreaterThan(0)
-    expect(rum.request.query.timestamp).toBeUndefined()
+    expect(parseInt(rumHarvest.request.query.rst, 10)).toBeGreaterThan(0)
+    expect(rumHarvest.request.query.timestamp).toBeUndefined()
   })
 
   it('should send page view event wth rst and timestamp parameter when nr server time is known', async () => {
+    const rumCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testRumRequest })
     await browser.url(await browser.testHandle.assetURL('instrumented.html'))
       .then(() => browser.waitForAgentLoad())
 
-    const [rum, timeKeeper] = await Promise.all([
-      browser.testHandle.expectRum(),
+    const [[, rumHarvest], timeKeeper] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 2 }),
       browser.url(await browser.testHandle.assetURL('instrumented.html'))
         .then(() => browser.waitForAgentLoad())
         .then(() => browser.getPageTime())
     ])
 
-    const rumTimestamp = parseInt(rum.request.query.timestamp, 10)
-    expect(parseInt(rum.request.query.rst, 10)).toBeGreaterThan(0)
+    const rumTimestamp = parseInt(rumHarvest.request.query.timestamp, 10)
+    expect(parseInt(rumHarvest.request.query.rst, 10)).toBeGreaterThan(0)
     expect(rumTimestamp).toBeGreaterThan(serverTime)
     testTimeExpectations(rumTimestamp, timeKeeper, false)
   })
 
   it('should send jserror with timestamp prior to rum date header', async () => {
-    const [errors, timeKeeper] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
+    const [[errorsHarvest], timeKeeper] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('nr-server-time/error-before-load.html'))
         .then(() => browser.waitForAgentLoad())
         .then(() => browser.getPageTime())
     ])
 
-    const error = errors.request.body.err[0]
+    const error = errorsHarvest.request.body.err[0]
     expect(error.params.firstOccurrenceTimestamp).toEqual(error.params.timestamp)
     testTimeExpectations(error.params.timestamp, timeKeeper, true)
   })
 
   it('should send jserror with timestamp after rum date header', async () => {
+    const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
     const timeKeeper = await browser.url(await browser.testHandle.assetURL('instrumented.html'))
       .then(() => browser.waitForAgentLoad())
       .then(() => browser.getPageTime())
 
-    const [errors] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const [[errorsHarvest]] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }),
       browser.getPageTime(),
       browser.execute(function () {
         newrelic.noticeError(new Error('test error'))
       })
     ])
 
-    const error = errors.request.body.err[0]
+    const error = errorsHarvest.request.body.err[0]
     expect(error.params.firstOccurrenceTimestamp).toEqual(error.params.timestamp)
     testTimeExpectations(error.params.timestamp, timeKeeper, false)
   })
 
   it.withBrowsersMatching(notIE)('should send session replay with timestamp prior to rum date header', async () => {
+    const sessionReplayCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testBlobReplayRequest })
     await browser.destroyAgentSession()
     await browser.testHandle.clearScheduledReplies('bamServer')
+
     serverTime = await browser.mockDateResponse(undefined, { flags: { sr: 1, srs: 1 } })
-    const [{ request: replayData }, timeKeeper] = await Promise.all([
-      browser.testHandle.expectReplay(),
+    const [[{ request: replayData }], timeKeeper] = await Promise.all([
+      sessionReplayCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', srConfig({ session_replay: { preload: true } })))
         .then(() => browser.waitForSessionReplayRecording())
         .then(() => browser.getPageTime())
@@ -105,11 +112,13 @@ describe('NR Server Time', () => {
   })
 
   it.withBrowsersMatching(notIE)('should send session replay with timestamp after rum date header', async () => {
+    const sessionReplayCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testBlobReplayRequest })
     await browser.destroyAgentSession()
     await browser.testHandle.clearScheduledReplies('bamServer')
+
     serverTime = await browser.mockDateResponse(undefined, { flags: { sr: 1, srs: 1 } })
-    const [{ request: replayData }, timeKeeper] = await Promise.all([
-      browser.testHandle.expectReplay(),
+    const [[{ request: replayData }], timeKeeper] = await Promise.all([
+      sessionReplayCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', srConfig({ session_replay: { sampling_rate: 100, preload: false } })))
         .then(() => browser.waitForSessionReplayRecording())
         .then(() => browser.getPageTime())
@@ -137,34 +146,37 @@ describe('NR Server Time', () => {
   })
 
   it('should send page action with timestamp before rum date header', async () => {
-    const [pageActions, timeKeeper] = await Promise.all([
-      browser.testHandle.expectIns(),
+    const insightsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInsRequest })
+    const [[insightsHarvest], timeKeeper] = await Promise.all([
+      insightsCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('nr-server-time/page-action-before-load.html'))
         .then(() => browser.waitForAgentLoad())
         .then(() => browser.getPageTime())
     ])
 
-    const pageAction = pageActions.request.body.ins[0]
+    const pageAction = insightsHarvest.request.body.ins[0]
     testTimeExpectations(pageAction.timestamp, timeKeeper, true)
   })
 
   it('should send page action with timestamp after rum date header', async () => {
+    const insightsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInsRequest })
     const timeKeeper = await browser.url(await browser.testHandle.assetURL('instrumented.html'))
       .then(() => browser.waitForAgentLoad())
       .then(() => browser.getPageTime())
 
-    const [pageActions] = await Promise.all([
-      browser.testHandle.expectIns(),
+    const [[insightsHarvest]] = await Promise.all([
+      insightsCapture.waitForResult({ totalCount: 1 }),
       browser.execute(function () {
         newrelic.addPageAction('bizbaz')
       })
     ])
 
-    const pageAction = pageActions.request.body.ins[0]
+    const pageAction = insightsHarvest.request.body.ins[0]
     testTimeExpectations(pageAction.timestamp, timeKeeper, false)
   })
 
   it('should send xhr with distributed tracing timestamp before rum date header', async () => {
+    const interactionsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInteractionEventsRequest })
     const url = await browser.testHandle.assetURL('nr-server-time/xhr-before-load.html', {
       config: {
         accountID: faker.string.hexadecimal({ length: 16, prefix: '' }),
@@ -182,23 +194,24 @@ describe('NR Server Time', () => {
       }
     })
 
-    const [interactionEvents, timeKeeper] = await Promise.all([
-      browser.testHandle.expectInteractionEvents(),
+    const [[interactionsHarvest], timeKeeper] = await Promise.all([
+      interactionsCapture.waitForResult({ totalCount: 1 }),
       browser.url(url)
         .then(() => browser.waitForAgentLoad())
         .then(() => browser.getPageTime())
     ])
 
-    const ajaxEvent = interactionEvents.request.body[0].children.find(r => r.path === '/json' && r.requestedWith === 'XMLHttpRequest')
+    const ajaxEvent = interactionsHarvest.request.body[0].children.find(r => r.path === '/json' && r.requestedWith === 'XMLHttpRequest')
     testTimeExpectations(ajaxEvent.timestamp, timeKeeper, true)
 
     if (browserMatch(supportsFetch)) {
-      const fetchEvent = interactionEvents.request.body[0].children.find(r => r.path === '/json' && r.requestedWith === 'fetch')
+      const fetchEvent = interactionsHarvest.request.body[0].children.find(r => r.path === '/json' && r.requestedWith === 'fetch')
       testTimeExpectations(fetchEvent.timestamp, timeKeeper, true)
     }
   })
 
   it('should send xhr with distributed tracing timestamp after rum date header', async () => {
+    const ajaxEventsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testAjaxEventsRequest })
     const url = await browser.testHandle.assetURL('instrumented.html', {
       config: {
         accountID: faker.string.hexadecimal({ length: 16, prefix: '' }),
@@ -220,8 +233,8 @@ describe('NR Server Time', () => {
       .then(() => browser.waitForAgentLoad())
       .then(() => browser.getPageTime())
 
-    const [ajaxEvents] = await Promise.all([
-      browser.testHandle.expectAjaxEvents(),
+    const [[ajaxEventsHarvest]] = await Promise.all([
+      ajaxEventsCapture.waitForResult({ totalCount: 1 }),
       browser.execute(function () {
         var xhr = new XMLHttpRequest()
         xhr.open('GET', '/json')
@@ -233,31 +246,28 @@ describe('NR Server Time', () => {
       })
     ])
 
-    const ajaxEvent = ajaxEvents.request.body.find(r => r.path === '/json' && r.requestedWith === 'XMLHttpRequest')
+    const ajaxEvent = ajaxEventsHarvest.request.body.find(r => r.path === '/json' && r.requestedWith === 'XMLHttpRequest')
     testTimeExpectations(ajaxEvent.timestamp, timeKeeper, false)
 
     if (browserMatch(supportsFetch)) {
-      const fetchEvent = ajaxEvents.request.body.find(r => r.path === '/json' && r.requestedWith === 'fetch')
+      const fetchEvent = ajaxEventsHarvest.request.body.find(r => r.path === '/json' && r.requestedWith === 'fetch')
       testTimeExpectations(fetchEvent.timestamp, timeKeeper, false)
     }
   })
 
   describe('session integration', () => {
     it('should not re-use the server time diff when session tracking is disabled', async () => {
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      const url = await browser.testHandle.assetURL('instrumented.html', {
         init: {
           privacy: { cookies_enabled: false }
         }
-      })).then(() => browser.waitForAgentLoad())
+      })
+      await browser.url(url).then(() => browser.waitForAgentLoad())
 
       const initialServerTime = await browser.getPageTime()
       const initialServerTimeDiff = initialServerTime.originTime - initialServerTime.correctedOriginTime
 
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', {
-        init: {
-          privacy: { cookies_enabled: false }
-        }
-      })).then(() => browser.waitForAgentLoad())
+      await browser.url(url).then(() => browser.waitForAgentLoad())
 
       const subsequentServerTime = await browser.getPageTime()
       const subsequentServerTimeDiff = subsequentServerTime.originTime - subsequentServerTime.correctedOriginTime
@@ -266,21 +276,18 @@ describe('NR Server Time', () => {
     })
 
     it('should re-use the server time diff stored in the session', async () => {
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      const url = await browser.testHandle.assetURL('instrumented.html', {
         init: {
           privacy: { cookies_enabled: true }
         }
-      })).then(() => browser.waitForAgentLoad())
+      })
+      await browser.url(url).then(() => browser.waitForAgentLoad())
 
       const initialSession = await browser.getAgentSessionInfo()
       const initialServerTime = await browser.getPageTime()
       const initialServerTimeDiff = initialServerTime.originTime - initialServerTime.correctedOriginTime
 
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', {
-        init: {
-          privacy: { cookies_enabled: true }
-        }
-      })).then(() => browser.waitForAgentLoad())
+      await browser.url(url).then(() => browser.waitForAgentLoad())
 
       const subsequentSession = await browser.getAgentSessionInfo()
       const subsequentServerTime = await browser.getPageTime()
@@ -291,12 +298,13 @@ describe('NR Server Time', () => {
     })
 
     it('should re-use the server time diff already calculated when session times out - inactivity', async () => {
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      const url = await browser.testHandle.assetURL('instrumented.html', {
         init: {
           privacy: { cookies_enabled: true },
           session: { inactiveMs: 10000 }
         }
-      })).then(() => browser.waitForAgentLoad())
+      })
+      await browser.url(url).then(() => browser.waitForAgentLoad())
 
       const initialSession = await browser.getAgentSessionInfo()
       const initialServerTime = await browser.getPageTime()
@@ -313,12 +321,13 @@ describe('NR Server Time', () => {
     })
 
     it('should re-use the server time diff already calculated when session times out - expires', async () => {
-      await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      const url = await browser.testHandle.assetURL('instrumented.html', {
         init: {
           privacy: { cookies_enabled: true },
           session: { expiresMs: 10000 }
         }
-      })).then(() => browser.waitForAgentLoad())
+      })
+      await browser.url(url).then(() => browser.waitForAgentLoad())
 
       const initialSession = await browser.getAgentSessionInfo()
       const initialServerTime = await browser.getPageTime()
@@ -332,6 +341,77 @@ describe('NR Server Time', () => {
 
       expect(subsequentServerTimeDiff).toEqual(initialServerTimeDiff)
       expect(subsequentSession.localStorage.serverTimeDiff).toEqual(initialSession.localStorage.serverTimeDiff)
+    })
+  })
+
+  describe('supportability metrics', () => {
+    it('should send a supportability metric when time diff is >= 1 hour and < 6 hours', async () => {
+      const supportMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
+      await browser.destroyAgentSession()
+      await browser.testHandle.clearScheduledReplies('bamServer')
+
+      serverTime = await browser.mockDateResponse(Date.now() - (61 * 60 * 1000))
+      const [supportMetricsHarvest] = await Promise.all([
+        supportMetricsCapture.waitForResult({ timeout: 10000 }),
+        browser.url(await browser.testHandle.assetURL('instrumented.html'))
+          .then(() => browser.waitForAgentLoad())
+          .then(() => browser.pause(1000))
+          .then(() => browser.refresh())
+      ])
+
+      const sm = supportMetricsHarvest
+        .flatMap(harvest => harvest.request.body.sm)
+        .find(metric => metric.params.name === 'PVE/NRTime/Calculation/DiffExceed1Hrs')
+      expect(sm).toBeDefined()
+      expect(sm.stats.c).toEqual(1)
+
+      await browser.destroyAgentSession()
+    })
+
+    it('should send a supportability metric when time diff is >= 6 hour and < 12 hours', async () => {
+      const supportMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
+      await browser.destroyAgentSession()
+      await browser.testHandle.clearScheduledReplies('bamServer')
+
+      serverTime = await browser.mockDateResponse(Date.now() - (6 * 61 * 60 * 1000))
+      const [supportMetricsHarvest] = await Promise.all([
+        supportMetricsCapture.waitForResult({ timeout: 10000 }),
+        browser.url(await browser.testHandle.assetURL('instrumented.html'))
+          .then(() => browser.waitForAgentLoad())
+          .then(() => browser.pause(1000))
+          .then(() => browser.refresh())
+      ])
+
+      const sm = supportMetricsHarvest
+        .flatMap(harvest => harvest.request.body.sm)
+        .find(metric => metric.params.name === 'PVE/NRTime/Calculation/DiffExceed6Hrs')
+      expect(sm).toBeDefined()
+      expect(sm.stats.c).toEqual(1)
+
+      await browser.destroyAgentSession()
+    })
+
+    it('should send a supportability metric when time diff is >= 12 hours', async () => {
+      const supportMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
+      await browser.destroyAgentSession()
+      await browser.testHandle.clearScheduledReplies('bamServer')
+
+      serverTime = await browser.mockDateResponse(Date.now() - (12 * 61 * 60 * 1000))
+      const [supportMetricsHarvest] = await Promise.all([
+        supportMetricsCapture.waitForResult({ timeout: 10000 }),
+        browser.url(await browser.testHandle.assetURL('instrumented.html'))
+          .then(() => browser.waitForAgentLoad())
+          .then(() => browser.pause(1000))
+          .then(() => browser.refresh())
+      ])
+
+      const sm = supportMetricsHarvest
+        .flatMap(harvest => harvest.request.body.sm)
+        .find(metric => metric.params.name === 'PVE/NRTime/Calculation/DiffExceed12Hrs')
+      expect(sm).toBeDefined()
+      expect(sm.stats.c).toEqual(1)
+
+      await browser.destroyAgentSession()
     })
   })
 })

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -115,8 +115,8 @@ export default class CustomCommands {
     })
 
     /**
-     * Sets a permanent scheduled reply for the rum call to include the session
-     * replay flag with a value of 1 enabling the feature.
+     * Sets a permanent scheduled reply for the rum call to define the Date header
+     * to a specific value. Default is to set the header to one hour in the past.
      */
     browser.addCommand('mockDateResponse', async function (serverTime = Date.now() - (60 * 60 * 1000), opts = {}) {
       const { flags } = opts


### PR DESCRIPTION
Shut down the agent when unable to read a correctly formatted date header for the page view event harvest. This prevents harvesting data with wildly inaccurate timestamps. This should only happen with third-party or non-agent code has tampered with the ajax response headers.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Adding supportability metrics to track when the calculated time diff is >= 12 hours, >= 6 hours, or >= 1 hour.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://new-relic.atlassian.net/browse/NR-295258
https://source.datanerd.us/agents/angler/pull/600

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
