### PR TITLE
chore: Remove NRTime SMs

### DIFF
--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -165,16 +165,6 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * Config/SessionReplay/ErrorSamplingRate/Modified
 
 ### Features
-<!--- The time manager Failed to calculate a valid time from the Page View Event response --->
-* PVE/NRTime/Calculation/Failed
-* <!--- The time manager Failed to calculate a valid time from the Page View Event response because the Date header did not meet RFC2616 format --->
-* PVE/NRTime/Calculation/InvalidFormat
-* <!--- The time manager calculated a local user time difference of 12 hours or more --->
-* PVE/NRTime/Calculation/DiffExceed12Hrs
-* <!--- The time manager calculated a local user time difference of 6 hours or more but less than 12 hours --->
-* PVE/NRTime/Calculation/DiffExceed6Hrs
-* <!--- The time manager calculated a local user time difference of 1 hour or more but less than 6 hours --->
-* PVE/NRTime/Calculation/DiffExceed1Hrs
 <!--- SessionReplay was Enabled but the RUM response indicated it was not entitled to run --->
 * SessionReplay/EnabledNotEntitled/Detected
 <!--- SessionReplay attempted to harvest data --->

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -11,10 +11,6 @@ import { AggregateBase } from '../../utils/aggregate-base'
 import { firstContentfulPaint } from '../../../common/vitals/first-contentful-paint'
 import { firstPaint } from '../../../common/vitals/first-paint'
 import { timeToFirstByte } from '../../../common/vitals/time-to-first-byte'
-import { drain } from '../../../common/drain/drain'
-import { FEATURE_NAMES } from '../../../loaders/features/features'
-import { handle } from '../../../common/event-emitter/handle'
-import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { now } from '../../../common/timing/now'
 import { TimeKeeper } from '../../../common/timing/time-keeper'
 
@@ -130,22 +126,7 @@ export class Aggregate extends AggregateBase {
           if (!this.timeKeeper.ready) throw new Error('TimeKeeper not ready')
 
           agentRuntime.timeKeeper = this.timeKeeper
-
-          // Check if the time diff is such that we need to capture a supportability metric
-          if (this.timeKeeper.localTimeDiff >= 12 * 60 * 60 * 1000) {
-            handle(SUPPORTABILITY_METRIC_CHANNEL, ['PVE/NRTime/Calculation/DiffExceed12Hrs'], undefined, FEATURE_NAMES.metrics, this.ee)
-          } else if (this.timeKeeper.localTimeDiff >= 6 * 60 * 60 * 1000) {
-            handle(SUPPORTABILITY_METRIC_CHANNEL, ['PVE/NRTime/Calculation/DiffExceed6Hrs'], undefined, FEATURE_NAMES.metrics, this.ee)
-          } else if (this.timeKeeper.localTimeDiff >= 60 * 60 * 1000) {
-            handle(SUPPORTABILITY_METRIC_CHANNEL, ['PVE/NRTime/Calculation/DiffExceed1Hrs'], undefined, FEATURE_NAMES.metrics, this.ee)
-          }
         } catch (error) {
-          if (error?.message?.indexOf('invalid format') > 0) {
-            handle(SUPPORTABILITY_METRIC_CHANNEL, ['PVE/NRTime/Calculation/InvalidFormat'], undefined, FEATURE_NAMES.metrics, this.ee)
-          } else {
-            handle(SUPPORTABILITY_METRIC_CHANNEL, ['PVE/NRTime/Calculation/Failed'], undefined, FEATURE_NAMES.metrics, this.ee)
-          }
-          drain(this.agentIdentifier, FEATURE_NAMES.metrics, true)
           this.ee.abort()
           warn(17, error)
           return

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker'
 import { srConfig, decodeAttributes } from './util/helpers'
 import { supportsFetch } from '../../tools/browser-matcher/common-matchers.mjs'
-import { testAjaxEventsRequest, testBlobReplayRequest, testErrorsRequest, testInsRequest, testInteractionEventsRequest, testRumRequest, testSupportMetricsRequest } from '../../tools/testing-server/utils/expect-tests'
+import { testAjaxEventsRequest, testBlobReplayRequest, testErrorsRequest, testInsRequest, testInteractionEventsRequest, testRumRequest } from '../../tools/testing-server/utils/expect-tests'
 
 let serverTime
 describe('NR Server Time', () => {
@@ -341,77 +341,6 @@ describe('NR Server Time', () => {
 
       expect(subsequentServerTimeDiff).toEqual(initialServerTimeDiff)
       expect(subsequentSession.localStorage.serverTimeDiff).toEqual(initialSession.localStorage.serverTimeDiff)
-    })
-  })
-
-  describe('supportability metrics', () => {
-    it('should send a supportability metric when time diff is >= 1 hour and < 6 hours', async () => {
-      const supportMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
-      await browser.destroyAgentSession()
-      await browser.testHandle.clearScheduledReplies('bamServer')
-
-      serverTime = await browser.mockDateResponse(Date.now() - (61 * 60 * 1000))
-      const [supportMetricsHarvest] = await Promise.all([
-        supportMetricsCapture.waitForResult({ timeout: 10000 }),
-        browser.url(await browser.testHandle.assetURL('instrumented.html'))
-          .then(() => browser.waitForAgentLoad())
-          .then(() => browser.pause(1000))
-          .then(() => browser.refresh())
-      ])
-
-      const sm = supportMetricsHarvest
-        .flatMap(harvest => harvest.request.body.sm)
-        .find(metric => metric.params.name === 'PVE/NRTime/Calculation/DiffExceed1Hrs')
-      expect(sm).toBeDefined()
-      expect(sm.stats.c).toEqual(1)
-
-      await browser.destroyAgentSession()
-    })
-
-    it('should send a supportability metric when time diff is >= 6 hour and < 12 hours', async () => {
-      const supportMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
-      await browser.destroyAgentSession()
-      await browser.testHandle.clearScheduledReplies('bamServer')
-
-      serverTime = await browser.mockDateResponse(Date.now() - (6 * 61 * 60 * 1000))
-      const [supportMetricsHarvest] = await Promise.all([
-        supportMetricsCapture.waitForResult({ timeout: 10000 }),
-        browser.url(await browser.testHandle.assetURL('instrumented.html'))
-          .then(() => browser.waitForAgentLoad())
-          .then(() => browser.pause(1000))
-          .then(() => browser.refresh())
-      ])
-
-      const sm = supportMetricsHarvest
-        .flatMap(harvest => harvest.request.body.sm)
-        .find(metric => metric.params.name === 'PVE/NRTime/Calculation/DiffExceed6Hrs')
-      expect(sm).toBeDefined()
-      expect(sm.stats.c).toEqual(1)
-
-      await browser.destroyAgentSession()
-    })
-
-    it('should send a supportability metric when time diff is >= 12 hours', async () => {
-      const supportMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
-      await browser.destroyAgentSession()
-      await browser.testHandle.clearScheduledReplies('bamServer')
-
-      serverTime = await browser.mockDateResponse(Date.now() - (12 * 61 * 60 * 1000))
-      const [supportMetricsHarvest] = await Promise.all([
-        supportMetricsCapture.waitForResult({ timeout: 10000 }),
-        browser.url(await browser.testHandle.assetURL('instrumented.html'))
-          .then(() => browser.waitForAgentLoad())
-          .then(() => browser.pause(1000))
-          .then(() => browser.refresh())
-      ])
-
-      const sm = supportMetricsHarvest
-        .flatMap(harvest => harvest.request.body.sm)
-        .find(metric => metric.params.name === 'PVE/NRTime/Calculation/DiffExceed12Hrs')
-      expect(sm).toBeDefined()
-      expect(sm.stats.c).toEqual(1)
-
-      await browser.destroyAgentSession()
     })
   })
 })


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Removing the NRTime supportability metrics that are no longer needed and/or could not be harvested when the agent shuts down.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
