### PR TITLE
fix: Disable session tracking when missing browser API

### DIFF
--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -25,8 +25,6 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * Session/Duration/Ms
 <!--- Capture SM when session tracking (trace, replay, and manager) could not be started due to missing PerformanceNavigationTiming API. --->
 * Session/Disabled/MissingPerformanceNavigationTiming/Seen
-<!--- Capture SMs for Session trace if active (ptid is setwhen returned byReplay ingest). Retain these SMs while we are working through the Session_replay Feature --->
-* PageSession/Feature/SessionTrace/Duration/Ms
 
 ### AJAX
 <!--- Ajax Events were Excluded because they matched the Agent beacon --->

--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -23,6 +23,8 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * Session/Inactive/Seen
 <!--- Duration of Session at time of ending --->
 * Session/Duration/Ms
+<!--- Capture SM when session tracking (trace, replay, and manager) could not be started due to missing PerformanceNavigationTiming API. --->
+* Session/Disabled/MissingPerformanceNavigationTiming/Seen
 <!--- Capture SMs for Session trace if active (ptid is setwhen returned byReplay ingest). Retain these SMs while we are working through the Session_replay Feature --->
 * PageSession/Feature/SessionTrace/Duration/Ms
 

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -89,11 +89,7 @@ export class Aggregate extends AggregateBase {
     registerHandler('trace-jserror', (...args) => this.traceStorage.storeErrorAgg(...args), this.featureName, this.ee)
     registerHandler('pvtAdded', (...args) => this.traceStorage.processPVT(...args), this.featureName, this.ee)
 
-    if (typeof PerformanceNavigationTiming !== 'undefined') {
-      this.traceStorage.storeTiming(globalScope.performance?.getEntriesByType?.('navigation')[0])
-    } else {
-      this.traceStorage.storeTiming(globalScope.performance?.timing)
-    }
+    this.traceStorage.storeTiming(globalScope.performance?.getEntriesByType?.('navigation')[0])
 
     /** Only start actually harvesting if running in full mode at init time */
     if (this.mode === MODE.FULL) this.startHarvesting()

--- a/src/features/utils/feature-gates.js
+++ b/src/features/utils/feature-gates.js
@@ -7,5 +7,5 @@ import { isBrowserScope } from '../../common/constants/runtime'
  * @returns {boolean}
  */
 export const canEnableSessionTracking = (agentId) => {
-  return isBrowserScope && getConfigurationValue(agentId, 'privacy.cookies_enabled') === true
+  return isBrowserScope && getConfigurationValue(agentId, 'privacy.cookies_enabled') === true && typeof PerformanceNavigationTiming !== 'undefined'
 }

--- a/tests/components/session_trace/index.test.js
+++ b/tests/components/session_trace/index.test.js
@@ -31,17 +31,23 @@ jest.mock('../../../src/common/window/load', () => ({
   __esModule: true,
   onWindowLoad: jest.fn(cb => cb())
 }))
+jest.mock('../../../src/features/utils/feature-gates', () => ({
+  __esModule: true,
+  canEnableSessionTracking: jest.fn(() => true)
+}))
 
 const aggregator = new Aggregator({ agentIdentifier: 'abcd', ee })
 
 describe('session trace', () => {
   let traceInstrument, traceAggregate
+
   beforeAll(async () => {
     traceInstrument = new SessionTrace('abcd', aggregator)
     await traceInstrument.onAggregateImported
     traceAggregate = traceInstrument.featAggregate
     traceAggregate.ee.emit('rumresp', [{ st: 1, sts: 1 }])
   })
+
   beforeEach(() => {
     traceAggregate.traceStorage.trace = {}
     traceAggregate.sentTrace = null

--- a/tests/unit/features/utils/feature-gates.test.js
+++ b/tests/unit/features/utils/feature-gates.test.js
@@ -7,15 +7,22 @@ jest.enableAutomock()
 jest.unmock('../../../../src/features/utils/feature-gates')
 
 let agentIdentifier
+let originalPerformanceNavigationTiming
 
 beforeEach(() => {
   agentIdentifier = faker.string.uuid()
+  originalPerformanceNavigationTiming = global.PerformanceNavigationTiming
+})
+
+afterEach(() => {
+  global.PerformanceNavigationTiming = originalPerformanceNavigationTiming
 })
 
 describe('enableSessionTracking', () => {
   test('should return false when not browser scope', async () => {
     jest.replaceProperty(runtimeConstantsModule, 'isBrowserScope', false)
     jest.mocked(configModule.getConfigurationValue).mockReturnValue(true)
+    global.PerformanceNavigationTiming = jest.fn()
 
     expect(canEnableSessionTracking(agentIdentifier)).toEqual(false)
     expect(configModule.getConfigurationValue).not.toHaveBeenCalled()
@@ -24,6 +31,16 @@ describe('enableSessionTracking', () => {
   test('should return false when session tracking disabled', async () => {
     jest.replaceProperty(runtimeConstantsModule, 'isBrowserScope', true)
     jest.mocked(configModule.getConfigurationValue).mockReturnValue(false)
+    global.PerformanceNavigationTiming = jest.fn()
+
+    expect(canEnableSessionTracking(agentIdentifier)).toEqual(false)
+    expect(configModule.getConfigurationValue).toHaveBeenCalledWith(agentIdentifier, 'privacy.cookies_enabled')
+  })
+
+  test('should return false when PerformanceNavigationTiming API is undefined', () => {
+    jest.replaceProperty(runtimeConstantsModule, 'isBrowserScope', true)
+    jest.mocked(configModule.getConfigurationValue).mockReturnValue(true)
+    global.PerformanceNavigationTiming = undefined
 
     expect(canEnableSessionTracking(agentIdentifier)).toEqual(false)
     expect(configModule.getConfigurationValue).toHaveBeenCalledWith(agentIdentifier, 'privacy.cookies_enabled')
@@ -32,6 +49,7 @@ describe('enableSessionTracking', () => {
   test('should return true when stars align', () => {
     jest.replaceProperty(runtimeConstantsModule, 'isBrowserScope', true)
     jest.mocked(configModule.getConfigurationValue).mockReturnValue(true)
+    global.PerformanceNavigationTiming = jest.fn()
 
     expect(canEnableSessionTracking(agentIdentifier)).toEqual(true)
     expect(configModule.getConfigurationValue).toHaveBeenCalledWith(agentIdentifier, 'privacy.cookies_enabled')


### PR DESCRIPTION
Disable session tracking when the browser is missing the PerformanceNavigationTiming api. This only happens with unsupported browsers and results in session trace data with the timing values in the wrong format.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

If `PerformanceNavigationTiming` is not defined, in the case of old unsupported browsers, session tracking will be disabled.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-297306

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
