### PR TITLE
chore: Migrating rum specs to use network capture

### DIFF
--- a/tests/specs/rum/index.e2e.js
+++ b/tests/specs/rum/index.e2e.js
@@ -1,5 +1,5 @@
 import { checkRumBody, checkRumPerf, checkRumQuery } from '../../util/basic-checks'
-import { testAssetRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { testAssetRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
 import { detailedCheckRum } from '../../util/detailed-checks'
 import { supportsFirstContentfulPaint, supportsFirstPaint } from '../../../tools/browser-matcher/common-matchers.mjs'
 
@@ -17,67 +17,75 @@ const loader_config = {
 }
 
 describe('basic pve capturing', () => {
-  ['same-origin', 'cross-origin'].forEach(page => {
-    it(`should send rum when ${page} page loads in an iframe`, async () => {
-      const rumPromise = browser.testHandle.expectRum()
-      await browser.pause(1000)
-      await browser.url(await browser.testHandle.assetURL(`iframe/${page}.html`))
-      const rumResults = await rumPromise
+  let rumCapture
 
-      checkRumQuery(rumResults.request)
-      checkRumBody(rumResults.request)
+  beforeEach(async () => {
+    rumCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testRumRequest })
+  })
+
+  ;['same-origin', 'cross-origin'].forEach(page => {
+    it(`should send rum when ${page} page loads in an iframe`, async () => {
+      const [[rumHarvest]] = await Promise.all([
+        rumCapture.waitForResult({ totalCount: 1 }),
+        browser.url(await browser.testHandle.assetURL(`iframe/${page}.html`))
+      ])
+
+      checkRumQuery(rumHarvest.request)
+      checkRumBody(rumHarvest.request)
     })
   })
 
   it('should capture page load timings', async () => {
-    const rumPromise = browser.testHandle.expectRum()
     await browser.testHandle.scheduleReply('assetServer', {
       test: testAssetRequest,
       permanent: false,
       delay: 500
     })
-    await browser.url(await browser.testHandle.assetURL('64kb-dom.html'))
-    const rumResults = await rumPromise
 
-    checkRumQuery(rumResults.request)
-    checkRumBody(rumResults.request)
-    expect(parseInt(rumResults.request.query.be, 10)).toBeGreaterThanOrEqual(500)
-    expect(parseInt(rumResults.request.query.fe, 10)).toBeGreaterThanOrEqual(100)
-    expect(parseInt(rumResults.request.query.dc, 10)).toBeGreaterThanOrEqual(100)
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('64kb-dom.html'))
+    ])
+
+    checkRumQuery(rumHarvest.request)
+    checkRumBody(rumHarvest.request)
+    expect(parseInt(rumHarvest.request.query.be, 10)).toBeGreaterThanOrEqual(500)
+    expect(parseInt(rumHarvest.request.query.fe, 10)).toBeGreaterThanOrEqual(100)
+    expect(parseInt(rumHarvest.request.query.dc, 10)).toBeGreaterThanOrEqual(100)
   })
 
   /** equivalent to former no-body.test.js */
   it('reports RUM with no body', async () => {
-    const rumPromise = browser.testHandle.expectRum()
-    await browser.pause(500)
-    await browser.url(await browser.testHandle.assetURL('no-body.html', { config: { account: loader_config.account } }))
-    const rumResults = await rumPromise
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('no-body.html', { config: { account: loader_config.account } }))
+    ])
 
-    checkRumQuery(rumResults.request)
-    detailedCheckRum(rumResults.request, { query: { ac: 'test_account' }, body: { ja: { no: 'body' } } })
+    checkRumQuery(rumHarvest.request)
+    detailedCheckRum(rumHarvest.request, { query: { ac: 'test_account' }, body: { ja: { no: 'body' } } })
   })
 
   /** equivalent to former paint-timing.test.js */
   it.withBrowsersMatching([supportsFirstPaint, supportsFirstContentfulPaint])('reports paint timings', async () => {
-    const rumPromise = browser.testHandle.expectRum()
-    await browser.pause(500)
-    await browser.url(await browser.testHandle.assetURL('instrumented.html', { config: { account: loader_config.account } }))
-    const rumResults = await rumPromise
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', { config: { account: loader_config.account } }))
+    ])
 
-    expect(Number(rumResults.request.query.fp)).toBeGreaterThan(0)
-    expect(Number(rumResults.request.query.fcp)).toBeGreaterThan(0)
+    expect(Number(rumHarvest.request.query.fp)).toBeGreaterThan(0)
+    expect(Number(rumHarvest.request.query.fcp)).toBeGreaterThan(0)
   })
 
   /** equivalent to former unconfigured-on-load.test.js */
   it('should not receive RUM call if not configured', async () => {
-    const rumPromise = browser.testHandle.expectRum(10000, true)
-    await browser.pause(500)
-    await browser.url(await browser.testHandle.assetURL('unconfigured-on-load.html'))
-    await rumPromise
-  })
-})
+    const [rumHarvests] = await Promise.all([
+      rumCapture.waitForResult({ timeout: 10000 }),
+      browser.url(await browser.testHandle.assetURL('unconfigured-on-load.html'))
+    ])
 
-describe('APM Decorations', () => {
+    expect(rumHarvests.length).toEqual(0)
+  })
+
   // equivalent to former data.test.js
   it('should capture detailed APM decorations', async () => {
     const expected = {
@@ -95,46 +103,48 @@ describe('APM Decorations', () => {
       },
       body: { ja: { foo: 'bar' } }
     }
-    const rumPromise = browser.testHandle.expectRum()
-    await browser.pause(500)
-    await browser.url(await browser.testHandle.assetURL('rum-data.html', { config: loader_config }))
-    const rumResults = await rumPromise
-    detailedCheckRum(rumResults.request, expected) // equivalent to former data.test.js
-    checkRumPerf(rumResults.request) // equivalent to former nav-timing.test.js, former perf.test.js
-    expect(+rumResults.request.query.dc).toBeGreaterThanOrEqual(0)
-    expect(+rumResults.request.query.fe).toBeGreaterThanOrEqual(+rumResults.request.query.dc)
+
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('rum-data.html', { config: loader_config }))
+    ])
+
+    detailedCheckRum(rumHarvest.request, expected) // equivalent to former data.test.js
+    checkRumPerf(rumHarvest.request) // equivalent to former nav-timing.test.js, former perf.test.js
+    expect(+rumHarvest.request.query.dc).toBeGreaterThanOrEqual(0)
+    expect(+rumHarvest.request.query.fe).toBeGreaterThanOrEqual(+rumHarvest.request.query.dc)
   })
 
   /** equivalent to former transaction-name.test.js */
   it('should report a transactionName without a tNamePlain', async () => {
-    const rumPromise = browser.testHandle.expectRum()
-    await browser.pause(500)
-    await browser.url(await browser.testHandle.assetURL('instrumented.html', { config: { transactionName: 'abc' } }))
-    const rumResults = await rumPromise
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', { config: { transactionName: 'abc' } }))
+    ])
 
-    expect(rumResults.request.query.to).toEqual('abc') // has correct obfuscated transactionName
-    expect(rumResults.request.query.t).toBeUndefined() // tNamePlain excluded
+    expect(rumHarvest.request.query.to).toEqual('abc') // has correct obfuscated transactionName
+    expect(rumHarvest.request.query.t).toBeUndefined() // tNamePlain excluded
   })
 
   /** equivalent to former transaction-name.test.js */
   it('should report a tNamePlain without a transactionName', async () => {
-    const rumPromise = browser.testHandle.expectRum()
-    await browser.pause(500)
-    await browser.url(await browser.testHandle.assetURL('instrumented.html', { config: { tNamePlain: 'abc' } }))
-    const rumResults = await rumPromise
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', { config: { tNamePlain: 'abc' } }))
+    ])
 
-    expect(rumResults.request.query.t).toEqual('abc') // has correct tNamePlain
-    expect(rumResults.request.query.to).toBeUndefined() // transactionName excluded
+    expect(rumHarvest.request.query.t).toEqual('abc') // has correct tNamePlain
+    expect(rumHarvest.request.query.to).toBeUndefined() // transactionName excluded
   })
 
   /** equivalent to former transaction-name.test.js */
   it('should honor transactionName if both tNamePlain and transactionName are supplied', async () => {
-    const rumPromise = browser.testHandle.expectRum()
-    await browser.pause(500)
-    await browser.url(await browser.testHandle.assetURL('instrumented.html', { config: { transactionName: 'abc', tNamePlain: 'def' } }))
-    const rumResults = await rumPromise
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', { config: { transactionName: 'abc', tNamePlain: 'def' } }))
+    ])
 
-    expect(rumResults.request.query.to).toEqual('abc') // should honor obfuscated if both are defined
-    expect(rumResults.request.query.t).toBeUndefined() // tNamePlain excluded
+    expect(rumHarvest.request.query.to).toEqual('abc') // should honor obfuscated if both are defined
+    expect(rumHarvest.request.query.t).toBeUndefined() // tNamePlain excluded
   })
 })

--- a/tests/specs/rum/retry-harvesting.e2e.js
+++ b/tests/specs/rum/retry-harvesting.e2e.js
@@ -1,7 +1,35 @@
-import { testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { testAjaxEventsRequest, testAjaxTimeSlicesRequest, testBlobReplayRequest, testBlobTraceRequest, testErrorsRequest, testInsRequest, testInteractionEventsRequest, testRumRequest, testTimingEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('rum retry harvesting', () => {
-  [400, 404, 408, 429, 500, 502, 503, 504, 512].forEach(statusCode => {
+  let rumCapture
+  let timingEventsCapture
+  let ajaxEventsCapture
+  let ajaxMetricsCapture
+  let traceCapture
+  let insightsCapture
+  let interactionEventsCapture
+  let errorMetricsCapture
+  let replaysCapture
+
+  beforeEach(async () => {
+    [rumCapture, timingEventsCapture, ajaxEventsCapture, ajaxMetricsCapture, traceCapture, insightsCapture, interactionEventsCapture, errorMetricsCapture, replaysCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testRumRequest },
+      { test: testTimingEventsRequest },
+      { test: testAjaxEventsRequest },
+      { test: testAjaxTimeSlicesRequest },
+      { test: testBlobTraceRequest },
+      { test: testInsRequest },
+      { test: testInteractionEventsRequest },
+      { test: testErrorsRequest },
+      { test: testBlobReplayRequest }
+    ])
+  })
+
+  afterEach(async () => {
+    await browser.destroyAgentSession(browser.testHandle)
+  })
+
+  ;[400, 404, 408, 429, 500, 502, 503, 504, 512].forEach(statusCode => {
     it(`should not retry rum and should not continue harvesting when request statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testRumRequest,
@@ -10,52 +38,89 @@ describe('rum retry harvesting', () => {
         body: ''
       })
 
-      const allPayloads = Promise.all([
-        browser.testHandle.expectTrace(10000, true),
-        browser.testHandle.expectInteractionEvents(10000, true),
-        browser.testHandle.expectTimings(10000, true),
-        browser.testHandle.expectAjaxTimeSlices(10000, true),
-        browser.testHandle.expectAjaxEvents(10000, true),
-        browser.testHandle.expectIns(10000, true),
-        browser.testHandle.expectRum()
+      let [
+        rumHarvests,
+        timingEventsHarvests,
+        ajaxEventsHarvests,
+        ajaxMetricsHarvests,
+        insightsHarvests,
+        interactionEventsHarvests,
+        traceHarvests,
+        errorMetricsHarvests,
+        replaysHarvests
+      ] = await Promise.all([
+        rumCapture.waitForResult({ timeout: 10000 }),
+        timingEventsCapture.waitForResult({ timeout: 10000 }),
+        ajaxEventsCapture.waitForResult({ timeout: 10000 }),
+        ajaxMetricsCapture.waitForResult({ timeout: 10000 }),
+        insightsCapture.waitForResult({ timeout: 10000 }),
+        interactionEventsCapture.waitForResult({ timeout: 10000 }),
+        traceCapture.waitForResult({ timeout: 10000 }),
+        errorMetricsCapture.waitForResult({ timeout: 10000 }),
+        replaysCapture.waitForResult({ timeout: 10000 }),
+        browser.url(await browser.testHandle.assetURL('obfuscate-pii.html'))
+          .then(() => $('a').click())
+          .then(() => browser.execute(function () {
+            newrelic.noticeError(new Error('hippo hangry'))
+            newrelic.addPageAction('DummyEvent', { free: 'tacos' })
+          }))
       ])
-      await browser.pause(500)
-      await browser.url(await browser.testHandle.assetURL('obfuscate-pii.html')).then(() => $('a').click())
-      const [
-        resourcesResults,
-        interactionResults,
-        timingsResults,
-        ajaxSliceResults,
-        ajaxEventsResults,
-        insResults,
-        rumResults
-      ] = await allPayloads
 
-      // Uncomment this code to reproduce the issue described in https://issues.newrelic.com/browse/NEWRELIC-9348
-      // Leave uncommented once that ticket is worked
-      // await browser.pause(500)
+      if (statusCode === 408) {
+        // Browsers automatically retry requests with status code 408
+        expect(rumHarvests.length).toBeLessThan(5)
+      } else {
+        expect(rumHarvests.length).toEqual(1)
+      }
+      expect(rumHarvests[0].reply.statusCode).toEqual(statusCode)
 
-      // await browser.execute(function () {
-      //   newrelic.noticeError(new Error('hippo hangry'))
-      //   newrelic.addPageAction('DummyEvent', { free: 'tacos' })
-      // })
+      expect(timingEventsHarvests.length).toEqual(0)
+      expect(ajaxEventsHarvests.length).toEqual(0)
+      expect(ajaxMetricsHarvests.length).toEqual(0)
+      expect(insightsHarvests.length).toEqual(0)
+      expect(interactionEventsHarvests.length).toEqual(0)
+      expect(traceHarvests.length).toEqual(0)
+      expect(errorMetricsHarvests.length).toEqual(0)
+      expect(replaysHarvests.length).toEqual(0)
 
-      // await Promise.all([
-      //   browser.testHandle.expectTimings(10000, true),
-      //   browser.testHandle.expectAjaxEvents(10000, true),
-      //   browser.testHandle.expectMetrics(10000, true),
-      //   browser.testHandle.expectErrors(10000, true),
-      //   browser.testHandle.expectTrace(10000, true),
-      //   browser.url(await browser.testHandle.assetURL('/'))
-      // ])
+      ;[
+        rumHarvests,
+        timingEventsHarvests,
+        ajaxEventsHarvests,
+        ajaxMetricsHarvests,
+        insightsHarvests,
+        interactionEventsHarvests,
+        traceHarvests,
+        errorMetricsHarvests,
+        replaysHarvests
+      ] = await Promise.all([
+        rumCapture.waitForResult({ timeout: 10000 }),
+        timingEventsCapture.waitForResult({ timeout: 10000 }),
+        ajaxEventsCapture.waitForResult({ timeout: 10000 }),
+        ajaxMetricsCapture.waitForResult({ timeout: 10000 }),
+        insightsCapture.waitForResult({ timeout: 10000 }),
+        interactionEventsCapture.waitForResult({ timeout: 10000 }),
+        traceCapture.waitForResult({ timeout: 10000 }),
+        errorMetricsCapture.waitForResult({ timeout: 10000 }),
+        replaysCapture.waitForResult({ timeout: 10000 }),
+        browser.url(await browser.testHandle.assetURL('/'))
+      ])
 
-      expect(rumResults.reply.statusCode).toEqual(statusCode)
-      expect(resourcesResults).toBeUndefined()
-      expect(interactionResults).toBeUndefined()
-      expect(timingsResults).toBeUndefined()
-      expect(ajaxSliceResults).toBeUndefined()
-      expect(ajaxEventsResults).toBeUndefined()
-      expect(insResults).toBeUndefined()
+      if (statusCode === 408) {
+        // Browsers automatically retry requests with status code 408
+        expect(rumHarvests.length).toBeLessThan(5)
+      } else {
+        expect(rumHarvests.length).toEqual(1)
+      }
+
+      expect(timingEventsHarvests.length).toEqual(0)
+      expect(ajaxEventsHarvests.length).toEqual(0)
+      expect(ajaxMetricsHarvests.length).toEqual(0)
+      expect(insightsHarvests.length).toEqual(0)
+      expect(interactionEventsHarvests.length).toEqual(0)
+      expect(traceHarvests.length).toEqual(0)
+      expect(errorMetricsHarvests.length).toEqual(0)
+      expect(replaysHarvests.length).toEqual(0)
     })
   })
 })


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Migrating the rum spec tests to use network capturing instead of network expects.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-287587

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
