### PR TITLE
chore: migrate third party specs to network capture

### DIFF
--- a/tests/specs/third-party-compatibility/jspdf.e2e.js
+++ b/tests/specs/third-party-compatibility/jspdf.e2e.js
@@ -1,5 +1,6 @@
 import { notIOS, notSafari } from '../../../tools/browser-matcher/common-matchers.mjs'
 import runTest from './run-test'
+import { testErrorsRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 // iOS Appium hates the use of canvas
 // As of 06/26/2023 test fails in Safari, though tested behavior works in a live browser (revisit in NR-138940).
@@ -9,11 +10,12 @@ describe.withBrowsersMatching([notIOS, notSafari])('jspdf compatibility', () => 
       browser,
       testAsset: 'third-party-compatibility/jspdf/2.5.1.html',
       afterLoadCallback: async () => {
+        const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
         const [errorsResults] = await Promise.all([
-          browser.testHandle.expectErrors(10000, true),
+          errorsCapture.waitForResult({ timeout: 10000 }),
           $('body').click() // Setup expects before interacting with page
         ])
-        expect(errorsResults).not.toBeDefined()
+        expect(errorsResults.length).toEqual(0)
 
         const pdfGenerated = await browser.execute(function () {
           return !!pdfGenerated

--- a/tests/specs/third-party-compatibility/mootools.e2e.js
+++ b/tests/specs/third-party-compatibility/mootools.e2e.js
@@ -6,7 +6,14 @@ describe('mootools compatibility', () => {
       browser,
       testAsset: 'third-party-compatibility/mootools/1.6.0-nocompat.html',
       afterLoadCallback: async () => {
+        /**
+         * This starts the process of a JSONP request on the page
+         */
         await browser.execute(function () { window.run() })
+
+        /**
+         * This ensures the JSONP request resolved correctly.
+         */
         await browser.waitUntil(
           () => browser.execute(function () {
             return !!window.success

--- a/tests/specs/third-party-compatibility/run-test.js
+++ b/tests/specs/third-party-compatibility/run-test.js
@@ -1,35 +1,77 @@
+import { testAjaxTimeSlicesRequest, testBlobTraceRequest, testEventsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
+
+/**
+ * A callback to run after the page has loaded
+ * @typedef {function} AfterLoadCallback
+ * @param {object} captures
+ * @param {import('../../../tools/wdio/plugins/testing-server/network-capture-connector.mjs').NetworkCaptureConnector} captures.rumCapture
+ * @param {import('../../../tools/wdio/plugins/testing-server/network-capture-connector.mjs').NetworkCaptureConnector} captures.tracesCapture
+ * @param {import('../../../tools/wdio/plugins/testing-server/network-capture-connector.mjs').NetworkCaptureConnector} captures.eventsCapture
+ * @param {import('../../../tools/wdio/plugins/testing-server/network-capture-connector.mjs').NetworkCaptureConnector} captures.ajaxMetricsCapture
+ * @param {object} harvests
+ * @param {import('../../../tools/testing-server/network-capture.mjs').SerializedNetworkCapture[]} harvests.rumHarvests
+ * @param {import('../../../tools/testing-server/network-capture.mjs').SerializedNetworkCapture[]} harvests.tracesHarvests
+ * @param {import('../../../tools/testing-server/network-capture.mjs').SerializedNetworkCapture[]} harvests.eventsHarvests
+ * @param {import('../../../tools/testing-server/network-capture.mjs').SerializedNetworkCapture[]} harvests.ajaxMetricsHarvests
+ */
+
+/**
+ * Executes a standard set of tests for third-party compatibility.
+ * @param browser {WebdriverIO.Browser} The wdio browser instance
+ * @param testAsset {string} The path to the test asset
+ * @param afterLoadCallback {AfterLoadCallback} A callback to run after the page has loaded
+ * @returns {Promise<void>}
+ */
 export default async function runTest ({
   browser,
   testAsset,
-  afterLoadCallback = () => { /* noop */ },
-  afterUnloadCallback = () => { /* noop */ }
+  afterLoadCallback = () => { /* noop */ }
 }) {
+  const [rumCapture, tracesCapture, eventsCapture, ajaxMetricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+    { test: testRumRequest },
+    { test: testBlobTraceRequest },
+    { test: testEventsRequest },
+    { test: testAjaxTimeSlicesRequest }
+  ])
   const url = await browser.testHandle.assetURL(testAsset)
 
-  const [rumResults, resourcesResults, eventsResults, ajaxResults] = await Promise.all([
-    browser.testHandle.expectRum(),
-    browser.testHandle.expectTrace(),
-    browser.testHandle.expectEvents(),
-    browser.testHandle.expectAjaxTimeSlices(),
-    browser.url(url) // Setup expects before loading the page
+  const [rumHarvests, tracesHarvests, eventsHarvests, ajaxMetricsHarvests] = await Promise.all([
+    rumCapture.waitForResult({ totalCount: 1 }),
+    tracesCapture.waitForResult({ totalCount: 1 }),
+    eventsCapture.waitForResult({ totalCount: 1 }),
+    ajaxMetricsCapture.waitForResult({ totalCount: 1 }),
+    browser.url(url)
       .then(() => browser.waitForAgentLoad())
   ])
 
-  expect(rumResults.request.query.a).toEqual(expect.any(String))
-  expect(rumResults.request.query.a.length).toBeGreaterThan(0)
-  expect(rumResults.request.query.ref).toEqual(url.split('?')[0])
+  expect(rumHarvests[0].request.query.a).toEqual(expect.any(String))
+  expect(rumHarvests[0].request.query.a.length).toBeGreaterThan(0)
+  expect(rumHarvests[0].request.query.ref).toEqual(url.split('?')[0])
 
-  expect(Array.isArray(resourcesResults.request.body)).toEqual(true)
-  expect(resourcesResults.request.body.length).toBeGreaterThan(0)
+  expect(Array.isArray(tracesHarvests[0].request.body)).toEqual(true)
+  expect(tracesHarvests[0].request.body.length).toBeGreaterThan(0)
 
-  expect(Array.isArray(eventsResults.request.body)).toEqual(true)
-  expect(eventsResults.request.body.length).toEqual(1)
-  expect(eventsResults.request.body[0].trigger).toEqual('initialPageLoad')
+  expect(Array.isArray(eventsHarvests[0].request.body)).toEqual(true)
+  expect(eventsHarvests[0].request.body.length).toEqual(1)
+  expect(eventsHarvests[0].request.body[0].trigger).toEqual('initialPageLoad')
 
-  expect(Array.isArray(ajaxResults.request.body.xhr)).toEqual(true)
-  expect(Array.isArray(ajaxResults.request.body.err)).toEqual(false)
-  expect(ajaxResults.request.body.xhr.length).toBeGreaterThan(0)
+  expect(Array.isArray(ajaxMetricsHarvests[0].request.body.xhr)).toEqual(true)
+  expect(Array.isArray(ajaxMetricsHarvests[0].request.body.err)).toEqual(false)
+  expect(ajaxMetricsHarvests[0].request.body.xhr.length).toBeGreaterThan(0)
 
-  await afterLoadCallback({ rumResults, resourcesResults, eventsResults, ajaxResults })
+  await afterLoadCallback(
+    {
+      rumCapture,
+      tracesCapture,
+      eventsCapture,
+      ajaxMetricsCapture
+    },
+    {
+      rumHarvests,
+      tracesHarvests,
+      eventsHarvests,
+      ajaxMetricsHarvests
+    }
+  )
   await browser.collectCoverage()
 }


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Migrating the third party spec tests to use network capturing instead of network expects.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-287596

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
