### PR TITLE
fix: Updated Logging API function

### DIFF
--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -180,12 +180,12 @@ export class AgentBase {
 
   /**
    * Capture a single log.
-   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/loginfo/}
+   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/log/}
    * @param {string} message String to be captured as log message
    * @param {{customAttributes?: object, level?: 'ERROR'|'TRACE'|'DEBUG'|'INFO'|'WARN'}} [options] customAttributes defaults to `{}` if not assigned, level defaults to `info` if not assigned.
   */
   log (message, options) {
-    return this.#callMethod('logInfo', message, options)
+    return this.#callMethod('log', message, options)
   }
 
   /**


### PR DESCRIPTION
Fix an issue where the logging API method would always result in an uninitialized agent warning and would not capture the log.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
When configuring and using the new Logging feature it always warns that it's not initialized. I am able to get it to work if I change logInfo to log.

### Related Issue(s)

[<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->](https://github.com/newrelic/newrelic-browser-agent/issues/1146)

### Testing
Tested it locally and now I am seeing logging in my NR dashboard
![Screenshot 2024-08-13 at 1 34 14 PM](https://github.com/user-attachments/assets/60bbb61a-c9a1-49e7-b678-70152ce352cd)

