### PR TITLE
chore: migrate specs to use network capture

### DIFF
--- a/.github/workflows/wdio-all-browsers.yml
+++ b/.github/workflows/wdio-all-browsers.yml
@@ -61,14 +61,6 @@ jobs:
       browser-target: ${{ inputs.latest-only == true && 'android@latest' || 'android@*' }}
     secrets: inherit
 
-  # ie:
-  #   uses: ./.github/workflows/wdio-single-browser.yml
-  #   with:
-  #     ref: ${{ inputs.ref || github.ref }}
-  #     browser-target: ie@11
-  #     additional-flags: -P
-  #   secrets: inherit
-
   ios-webview:
     uses: ./.github/workflows/wdio-single-browser.yml
     with:

--- a/.github/workflows/wdio-all-browsers.yml
+++ b/.github/workflows/wdio-all-browsers.yml
@@ -52,6 +52,7 @@ jobs:
     with:
       ref: ${{ inputs.ref || github.ref }}
       browser-target: ${{ inputs.latest-only == true && 'ios@latest' || 'ios@*' }}
+      additional-flags: --timeout 120000 --session-timeout 240000
     secrets: inherit
 
   android:
@@ -59,6 +60,7 @@ jobs:
     with:
       ref: ${{ inputs.ref || github.ref }}
       browser-target: ${{ inputs.latest-only == true && 'android@latest' || 'android@*' }}
+      additional-flags: --timeout 120000 --session-timeout 240000
     secrets: inherit
 
   ios-webview:

--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -108,3 +108,9 @@ jobs:
         with:
           name: integration-code-coverage-report
           path: coverage-e2e/
+      - name: Archive wdio tunnel logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.browser-target }}-wdio-tunnel-logs
+          path: .lambdatest

--- a/.github/workflows/wdio-single-browser.yml
+++ b/.github/workflows/wdio-single-browser.yml
@@ -108,9 +108,15 @@ jobs:
         with:
           name: integration-code-coverage-report
           path: coverage-e2e/
+      - name: Generate wdio tunnel log archive name
+        if: ${{ always() }}
+        id: wdio-tunnel-log-archive-name
+        run: |
+          browser=${{ inputs.browser-target }}
+          echo "results=${browser/\*/all}${{ inputs.coverage && '-coverage' || '' }}${{ contains(inputs.additional-flags, '--webview') && '-webview' || '' }}-wdio-tunnel-logs" >> "$GITHUB_OUTPUT"
       - name: Archive wdio tunnel logs
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.browser-target }}-wdio-tunnel-logs
+          name: ${{ steps.wdio-tunnel-log-archive-name.outputs.results }}
           path: .lambdatest

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+browser=chrome@*
+echo "results=${browser/\*/all}"

--- a/tests/specs/loaders.e2e.js
+++ b/tests/specs/loaders.e2e.js
@@ -1,8 +1,31 @@
 import { checkAjaxEvents, checkJsErrors, checkMetrics, checkPVT, checkPageAction, checkRumBody, checkRumQuery, checkSessionTrace, checkSpa } from '../util/basic-checks'
+import { testAjaxEventsRequest, testBlobTraceRequest, testErrorsRequest, testInsRequest, testInteractionEventsRequest, testMetricsRequest, testRumRequest, testTimingEventsRequest } from '../../tools/testing-server/utils/expect-tests'
 
 const scriptLoadTypes = [null, 'defer', 'async', 'injection']
 
 describe('Loaders', () => {
+  let rumCapture
+  let timingEventsCapture
+  let metricsCapture
+  let ajaxEventsCapture
+  let errorsCapture
+  let insightsCapture
+  let tracesCapture
+  let interactionEventsCapture
+
+  beforeEach(async () => {
+    [rumCapture, timingEventsCapture, metricsCapture, ajaxEventsCapture, errorsCapture, insightsCapture, tracesCapture, interactionEventsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testRumRequest },
+      { test: testTimingEventsRequest },
+      { test: testMetricsRequest },
+      { test: testAjaxEventsRequest },
+      { test: testErrorsRequest },
+      { test: testInsRequest },
+      { test: testBlobTraceRequest },
+      { test: testInteractionEventsRequest }
+    ])
+  })
+
   afterEach(async () => {
     await browser.destroyAgentSession()
   })
@@ -10,80 +33,88 @@ describe('Loaders', () => {
   scriptLoadTypes.forEach(scriptLoadType => {
     it(`should report data for the lite agent when using ${!scriptLoadType ? 'embedded' : scriptLoadType}`, async () => {
       const url = await browser.testHandle.assetURL('all-events.html', { loader: 'rum', script: scriptLoadType })
-      const [rum, pvt, metrics] = await Promise.all([
-        browser.testHandle.expectRum(),
-        browser.testHandle.expectTimings(),
-        browser.testHandle.expectMetrics(),
-        browser.testHandle.expectAjaxEvents(10000, true),
-        browser.testHandle.expectErrors(10000, true),
-        browser.testHandle.expectIns(10000, true),
-        browser.testHandle.expectTrace(10000, true),
-        browser.testHandle.expectInteractionEvents(10000, true),
+      const [rumHarvests, timingEventsHarvests, metricsHarvests, ajaxEventsHarvests, errorsHarvests, insightsHarvests, tracesHarvests, interactionEventsHarvests] = await Promise.all([
+        rumCapture.waitForResult({ timeout: 10000 }),
+        timingEventsCapture.waitForResult({ timeout: 10000 }),
+        metricsCapture.waitForResult({ timeout: 10000 }),
+        ajaxEventsCapture.waitForResult({ timeout: 10000 }),
+        errorsCapture.waitForResult({ timeout: 10000 }),
+        insightsCapture.waitForResult({ timeout: 10000 }),
+        tracesCapture.waitForResult({ timeout: 10000 }),
+        interactionEventsCapture.waitForResult({ timeout: 10000 }),
         browser.url(url)
           .then(() => browser.waitForAgentLoad())
           .then(() => browser.pause(5000))
           .then(() => browser.refresh())
       ])
 
-      checkRumQuery(rum.request, { liteAgent: true })
-      checkRumBody(rum.request, { liteAgent: true })
-      checkPVT(pvt.request)
-      checkMetrics(metrics.request)
+      rumHarvests.forEach(harvest => checkRumQuery(harvest.request, { liteAgent: true }))
+      rumHarvests.forEach(harvest => checkRumBody(harvest.request, { liteAgent: true }))
+      timingEventsHarvests.forEach(harvest => checkPVT(harvest.request))
+      metricsHarvests.forEach(harvest => checkMetrics(harvest.request))
+
+      expect(ajaxEventsHarvests.length).toEqual(0)
+      expect(errorsHarvests.length).toEqual(0)
+      expect(insightsHarvests.length).toEqual(0)
+      expect(tracesHarvests.length).toEqual(0)
+      expect(interactionEventsHarvests.length).toEqual(0)
     })
 
     it(`should report data for the pro agent when using ${!scriptLoadType ? 'embedded' : scriptLoadType}`, async () => {
       const url = await browser.testHandle.assetURL('all-events.html', { loader: 'full', script: scriptLoadType })
-      const [rum, pvt, metrics, ajax, jserrors, pa, st] = await Promise.all([
-        browser.testHandle.expectRum(),
-        browser.testHandle.expectTimings(),
-        browser.testHandle.expectMetrics(),
-        browser.testHandle.expectAjaxEvents(),
-        browser.testHandle.expectErrors(),
-        browser.testHandle.expectIns(),
-        browser.testHandle.expectTrace(),
-        browser.testHandle.expectInteractionEvents(10000, true),
+      const [rumHarvests, timingEventsHarvests, metricsHarvests, ajaxEventsHarvests, errorsHarvests, insightsHarvests, tracesHarvests, interactionEventsHarvests] = await Promise.all([
+        rumCapture.waitForResult({ timeout: 10000 }),
+        timingEventsCapture.waitForResult({ timeout: 10000 }),
+        metricsCapture.waitForResult({ timeout: 10000 }),
+        ajaxEventsCapture.waitForResult({ timeout: 10000 }),
+        errorsCapture.waitForResult({ timeout: 10000 }),
+        insightsCapture.waitForResult({ timeout: 10000 }),
+        tracesCapture.waitForResult({ timeout: 10000 }),
+        interactionEventsCapture.waitForResult({ timeout: 10000 }),
         browser.url(url)
           .then(() => browser.waitForAgentLoad())
           .then(() => browser.pause(5000))
           .then(() => browser.refresh())
       ])
 
-      checkRumQuery(rum.request)
-      checkRumBody(rum.request)
-      checkPVT(pvt.request)
-      checkMetrics(metrics.request)
-      checkAjaxEvents(ajax.request)
-      checkJsErrors(jserrors.request)
-      checkPageAction(pa.request)
-      checkSessionTrace(st.request)
+      rumHarvests.forEach(harvest => checkRumQuery(harvest.request))
+      rumHarvests.forEach(harvest => checkRumBody(harvest.request))
+      timingEventsHarvests.forEach(harvest => checkPVT(harvest.request))
+      metricsHarvests.forEach(harvest => checkMetrics(harvest.request))
+      ajaxEventsHarvests.forEach(harvest => checkAjaxEvents(harvest.request))
+      errorsHarvests.forEach(harvest => checkJsErrors(harvest.request))
+      insightsHarvests.forEach(harvest => checkPageAction(harvest.request))
+      tracesHarvests.forEach(harvest => checkSessionTrace(harvest.request))
+
+      expect(interactionEventsHarvests.length).toEqual(0)
     })
 
     it(`should report data for the spa agent when using ${!scriptLoadType ? 'embedded' : scriptLoadType}`, async () => {
       const url = await browser.testHandle.assetURL('all-events.html', { loader: 'spa', script: scriptLoadType })
-      const [rum, pvt, metrics, ajax, jserrors, pa, st, spa] = await Promise.all([
-        browser.testHandle.expectRum(),
-        browser.testHandle.expectTimings(),
-        browser.testHandle.expectMetrics(),
-        browser.testHandle.expectAjaxEvents(),
-        browser.testHandle.expectErrors(),
-        browser.testHandle.expectIns(),
-        browser.testHandle.expectTrace(10000),
-        browser.testHandle.expectInteractionEvents(),
+      const [rumHarvests, timingEventsHarvests, metricsHarvests, ajaxEventsHarvests, errorsHarvests, insightsHarvests, tracesHarvests, interactionEventsHarvests] = await Promise.all([
+        rumCapture.waitForResult({ timeout: 10000 }),
+        timingEventsCapture.waitForResult({ timeout: 10000 }),
+        metricsCapture.waitForResult({ timeout: 10000 }),
+        ajaxEventsCapture.waitForResult({ timeout: 10000 }),
+        errorsCapture.waitForResult({ timeout: 10000 }),
+        insightsCapture.waitForResult({ timeout: 10000 }),
+        tracesCapture.waitForResult({ timeout: 10000 }),
+        interactionEventsCapture.waitForResult({ timeout: 10000 }),
         browser.url(url)
           .then(() => browser.waitForAgentLoad())
           .then(() => browser.pause(5000))
           .then(() => browser.refresh())
       ])
 
-      checkRumQuery(rum.request)
-      checkRumBody(rum.request)
-      checkPVT(pvt.request)
-      checkMetrics(metrics.request)
-      checkAjaxEvents(ajax.request)
-      checkJsErrors(jserrors.request)
-      checkPageAction(pa.request)
-      checkSessionTrace(st.request)
-      checkSpa(spa.request)
+      rumHarvests.forEach(harvest => checkRumQuery(harvest.request))
+      rumHarvests.forEach(harvest => checkRumBody(harvest.request))
+      timingEventsHarvests.forEach(harvest => checkPVT(harvest.request))
+      metricsHarvests.forEach(harvest => checkMetrics(harvest.request))
+      ajaxEventsHarvests.forEach(harvest => checkAjaxEvents(harvest.request))
+      errorsHarvests.forEach(harvest => checkJsErrors(harvest.request))
+      insightsHarvests.forEach(harvest => checkPageAction(harvest.request))
+      tracesHarvests.forEach(harvest => checkSessionTrace(harvest.request))
+      interactionEventsHarvests.forEach(harvest => checkSpa(harvest.request))
     })
   })
 })

--- a/tests/specs/proxy.e2e.js
+++ b/tests/specs/proxy.e2e.js
@@ -1,11 +1,23 @@
+import { testRumRequest, testSupportMetricsRequest } from '../../tools/testing-server/utils/expect-tests'
+
 describe('Using proxy servers -', () => {
+  let rumCapture
+  let supportabilityMetricsCapture
+
+  beforeEach(async () => {
+    [rumCapture, supportabilityMetricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testRumRequest },
+      { test: testSupportMetricsRequest }
+    ])
+  })
+
   it('setting an assets url changes where agent fetches its chunks from', async () => {
     const { host, port } = browser.testHandle.assetServerConfig
     const assetServerChangedUrl = `http://${host}:${port}/assets`
     const url = await browser.testHandle.assetURL('instrumented.html', { init: { proxy: { assets: assetServerChangedUrl } } })
 
-    const [rumResults] = await Promise.all([
-      browser.testHandle.expectRum(),
+    const [[rumResults]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
       browser.url(url)
         .then(() => browser.waitForAgentLoad())
     ])
@@ -24,13 +36,21 @@ describe('Using proxy servers -', () => {
       })
     ]))
 
-    const [unloadSupportMetricsResults] = await Promise.all([
-      browser.testHandle.expectSupportMetrics(),
+    const [supportabilityMetricsHarvests] = await Promise.all([
+      supportabilityMetricsCapture.waitForResult({ timeout: 5000 }),
       browser.url(await browser.testHandle.assetURL('/'))
     ])
 
-    expect(unloadSupportMetricsResults.request.body.sm).toEqual(expect.arrayContaining([
-      { params: { name: 'Config/AssetsUrl/Changed' }, stats: { c: 1 } }
+    expect(supportabilityMetricsHarvests).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        request: expect.objectContaining({
+          body: expect.objectContaining({
+            sm: expect.arrayContaining([
+              { params: { name: 'Config/AssetsUrl/Changed' }, stats: { c: 1 } }
+            ])
+          })
+        })
+      })
     ]))
   })
 
@@ -39,8 +59,8 @@ describe('Using proxy servers -', () => {
     const beaconServerChangedUrl = `${host}:${port}/beacon`
     const url = await browser.testHandle.assetURL('instrumented.html', { init: { proxy: { beacon: beaconServerChangedUrl } } })
 
-    const [rumResults] = await Promise.all([
-      browser.testHandle.expectRum(),
+    const [[rumResults]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
       browser.url(url)
         .then(() => browser.waitForAgentLoad())
     ])
@@ -59,13 +79,21 @@ describe('Using proxy servers -', () => {
       })
     ]))
 
-    const [unloadSupportMetricsResults] = await Promise.all([
-      browser.testHandle.expectSupportMetrics(),
+    const [supportabilityMetricsHarvests] = await Promise.all([
+      supportabilityMetricsCapture.waitForResult({ timeout: 5000 }),
       browser.url(await browser.testHandle.assetURL('/'))
     ])
 
-    expect(unloadSupportMetricsResults.request.body.sm).toEqual(expect.arrayContaining([
-      { params: { name: 'Config/BeaconUrl/Changed' }, stats: { c: 1 } }
+    expect(supportabilityMetricsHarvests).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        request: expect.objectContaining({
+          body: expect.objectContaining({
+            sm: expect.arrayContaining([
+              { params: { name: 'Config/BeaconUrl/Changed' }, stats: { c: 1 } }
+            ])
+          })
+        })
+      })
     ]))
   })
 })

--- a/tests/specs/session-manager.e2e.js
+++ b/tests/specs/session-manager.e2e.js
@@ -1,4 +1,5 @@
 import { notSafari, supportsMultipleTabs } from '../../tools/browser-matcher/common-matchers.mjs'
+import { testErrorsRequest } from '../../tools/testing-server/utils/expect-tests'
 
 const config = {
   init: {
@@ -91,10 +92,14 @@ describe('newrelic session ID', () => {
     })
 
     it('Session exists when config is set after loader', async () => {
-      await browser.url(await browser.testHandle.assetURL('custom-attribute-race-condition.html', config))
-        .then(() => browser.waitForAgentLoad())
+      const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
 
-      const { request: { query } } = await browser.testHandle.expectErrors()
+      const [[{ request: { query } }]] = await Promise.all([
+        errorsCapture.waitForResult({ totalCount: 1 }),
+        browser.url(await browser.testHandle.assetURL('custom-attribute-race-condition.html', config))
+          .then(() => browser.waitForAgentLoad())
+      ])
+
       expect(query.s).not.toEqual('0')
       expect(query.s).toBeTruthy()
     })

--- a/tests/specs/web-worker-scope.e2e.js
+++ b/tests/specs/web-worker-scope.e2e.js
@@ -1,7 +1,15 @@
+import { testAjaxEventsRequest, testAjaxTimeSlicesRequest, testInsRequest } from '../../tools/testing-server/utils/expect-tests'
+
 describe('web worker scope', () => {
   it('should capture XHR events and metrics', async () => {
-    const [events, metrics] = await Promise.all([
-      browser.testHandle.expectAjaxEvents(),
+    const [ajaxEventsCapture, ajaxMetricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testAjaxEventsRequest },
+      { test: testAjaxTimeSlicesRequest }
+    ])
+
+    const [[events], [metrics]] = await Promise.all([
+      ajaxEventsCapture.waitForResult({ totalCount: 1 }),
+      ajaxMetricsCapture.waitForResult({ totalCount: 1 }),
       browser.testHandle.expectAjaxTimeSlices(),
       browser.url(
         await browser.testHandle.assetURL(
@@ -39,9 +47,14 @@ describe('web worker scope', () => {
   })
 
   it('should capture fetch events', async () => {
-    const [events, metrics] = await Promise.all([
-      browser.testHandle.expectAjaxEvents(),
-      browser.testHandle.expectAjaxTimeSlices(),
+    const [ajaxEventsCapture, ajaxMetricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testAjaxEventsRequest },
+      { test: testAjaxTimeSlicesRequest }
+    ])
+
+    const [[events], [metrics]] = await Promise.all([
+      ajaxEventsCapture.waitForResult({ totalCount: 1 }),
+      ajaxMetricsCapture.waitForResult({ totalCount: 1 }),
       browser.url(
         await browser.testHandle.assetURL(
           'test-builds/browser-agent-wrapper/worker-agent.html',
@@ -76,8 +89,10 @@ describe('web worker scope', () => {
   })
 
   it('should capture error metrics', async () => {
-    const [metrics] = await Promise.all([
-      browser.testHandle.expectErrors(),
+    const ajaxMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testAjaxTimeSlicesRequest })
+
+    const [[metrics]] = await Promise.all([
+      ajaxMetricsCapture.waitForResult({ totalCount: 1 }),
       browser.url(
         await browser.testHandle.assetURL(
           'test-builds/browser-agent-wrapper/worker-agent.html',
@@ -106,8 +121,10 @@ describe('web worker scope', () => {
   })
 
   it('should capture page action events', async () => {
-    const [events] = await Promise.all([
-      browser.testHandle.expectIns(),
+    const insightsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInsRequest })
+
+    const [[events]] = await Promise.all([
+      insightsCapture.waitForResult({ totalCount: 1 }),
       browser.url(
         await browser.testHandle.assetURL(
           'test-builds/browser-agent-wrapper/worker-agent.html',

--- a/tests/util/basic-checks.js
+++ b/tests/util/basic-checks.js
@@ -258,7 +258,7 @@ export function checkSessionTrace ({ query, body }) {
         s: expect.any(Number),
         e: expect.any(Number),
         o: expect.any(String),
-        t: expect.any(String)
+        t: expect.any(Number)
       })
     } else if (res.n === 'Ajax') {
       expect(res).toMatchObject({

--- a/tools/wdio/config/lambdatest.conf.mjs
+++ b/tools/wdio/config/lambdatest.conf.mjs
@@ -90,7 +90,6 @@ export default function config () {
           tunnel: args.tunnel,
           sessionNameFormat: (config, capabilities, suiteTitle, testTitle) => suiteTitle,
           lambdatestOpts: {
-            // allowHosts: args.host || 'bam-test-1.nr-local.net', // @phousley LT `allowHost` has issues with CORs in firefox
             logFile: path.resolve(__dirname, '../../../.lambdatest'),
             verbose: true
           }


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Migrate `specs/*.e2e.js` specs to use network capture.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-287597

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
