### PR TITLE
feat: Configure Session Replay to wait for DOMContentLoaded

### DIFF
--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -93,7 +93,8 @@ export class Recorder {
         this.parent.ee.emit('internal-error', [err])
         /** returning true informs rrweb to swallow the error instead of throwing it to the window */
         return true
-      }
+      },
+      recordAfter: 'DOMContentLoaded'
     })
 
     this.stopRecording = () => {


### PR DESCRIPTION
Decrease the time spent waiting by triggering Session Replay mutation observer wrapping on the DOMContentLoaded event instead of the previously used window load event. This ensures wrapping is completed before the load chain.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-300929
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
