### PR TITLE
chore: migrate soft-nav tests to use network capturing

### DIFF
--- a/tools/wdio/config/lambdatest.conf.mjs
+++ b/tools/wdio/config/lambdatest.conf.mjs
@@ -79,6 +79,10 @@ function lambdaTestCapabilities () {
 
 export default function config () {
   const config = {
+    protocol: 'https',
+    hostname: 'hub.lambdatest.com',
+    path: '/wd/hub',
+    port: 443,
     user: process.env.LT_USERNAME || process.env.LAMBDA_USERNAME,
     key: process.env.LT_ACCESS_KEY || process.env.LAMBDA_ACCESS_KEY,
     capabilities: lambdaTestCapabilities(),
@@ -97,9 +101,9 @@ export default function config () {
       ]
     ]
   }
-  if (args.webview) { // LT app automation requires these to be specified
+  if (args.webview) {
+    // LT app automation requires a different hostname
     config.hostname = 'mobile-hub.lambdatest.com'
-    config.path = '/wd/hub'
   }
   return config
 }


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

Migrating the soft-nav integration tests to use network capturing instead of network expects. This PR also includes a minor change to force wdio to connect to LT via https. Starbucks likes to block http calls to LT when trying to execute remote JS.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

https://new-relic.atlassian.net/browse/NR-287592

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
