### PR TITLE
fix: Ensure drain target is a valid event emitter before subscribing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,7 @@ module.exports = {
         sourceType: 'module'
       },
       rules: {
-        'no-console': ['error', { allow: ['debug'] }],
+        'no-console': ['error'],
         'n/no-callback-literal': 'off' // This is not NodeJS code and should not be forced to adhere to NodeJS callback parameter pattern
       }
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,7 @@ module.exports = {
         sourceType: 'module'
       },
       rules: {
+        'no-console': ['error', { allow: ['debug'] }],
         'n/no-callback-literal': 'off' // This is not NodeJS code and should not be forced to adhere to NodeJS callback parameter pattern
       }
     },

--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -107,7 +107,6 @@ function drainGroup (agentIdentifier, group, activateGroup = true) {
           // registration *should* be an array of: [targetEE, eventHandler]
           // certain browser polyfills of .values and .entries pass the prototype methods into the callback,
           // which breaks this assumption and throws errors. So we make sure here that we only call .on() if its an actual NR EE
-          console.log(registration[0])
           if (registration[0]?.on && registration[0]?.context() instanceof EventContext) registration[0].on(eventType, registration[1])
         })
       })

--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -6,6 +6,7 @@
 import { ee } from '../event-emitter/contextual-ee'
 import { registerHandler as defaultRegister } from '../event-emitter/register-handler'
 import { featurePriority } from '../../loaders/features/features'
+import { EventContext } from '../event-emitter/event-context'
 
 const registry = {}
 
@@ -103,8 +104,11 @@ function drainGroup (agentIdentifier, group, activateGroup = true) {
 
       Object.entries(groupHandlers).forEach(([eventType, handlerRegistrationList]) => {
         Object.values(handlerRegistrationList || {}).forEach((registration) => {
-          // registration is an array of: [targetEE, eventHandler]
-          registration[0].on(eventType, registration[1])
+          // registration *should* be an array of: [targetEE, eventHandler]
+          // certain browser polyfills of .values and .entries pass the prototype methods into the callback,
+          // which breaks this assumption and throws errors. So we make sure here that we only call .on() if its an actual NR EE
+          console.log(registration[0])
+          if (registration[0]?.on && registration[0]?.context() instanceof EventContext) registration[0].on(eventType, registration[1])
         })
       })
     }

--- a/src/common/util/console.js
+++ b/src/common/util/console.js
@@ -1,3 +1,5 @@
+/* eslint no-console: ["error", { allow: ["debug"] }] */
+
 /**
  * A helper method to warn to the console with New Relic: decoration
  * @param {string} message The primary message to warn

--- a/tests/unit/common/drain/drain.test.js
+++ b/tests/unit/common/drain/drain.test.js
@@ -14,6 +14,16 @@ test('can register a feat and drain it', () => {
   expect(emitSpy).toHaveBeenCalledWith('drain-page_view_event', expect.anything())
 })
 
+test('will not execute .on if the object is not an EE', () => {
+  registerHandler('tusks', () => {}, 'page_view_event', ee.get('abcd'))
+  registerDrain('abcd', 'page_view_event')
+  let valuesSpy = jest.spyOn(Object, 'values').mockImplementation(() => [[{ foo: 'bar' }]])
+  let emitSpy = jest.spyOn(ee.get('abcd'), 'on')
+  drain('abcd', 'page_view_event')
+  expect(valuesSpy).toHaveBeenCalled()
+  expect(emitSpy).not.toHaveBeenCalled()
+})
+
 test('other unregistered drains do not affect feat reg & drain', () => {
   registerDrain('abcd', 'page_view_event')
 


### PR DESCRIPTION
Ensure that the drain target is a valid event emitter to ensure that the `.on` method exists and will not throw errors.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://newrelic.slack.com/archives/C0193KAHHAS/p1724879485394419
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New unit test has been added to validate the behavior 
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
