### PR TITLE
fix: Disable websocket wrapping

### DIFF
--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -2,7 +2,7 @@ import { getConfiguration } from '../../../common/config/init'
 import { getRuntime } from '../../../common/config/runtime'
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
-import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL, WATCHABLE_WEB_SOCKET_EVENTS } from '../constants'
+import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL/*, WATCHABLE_WEB_SOCKET_EVENTS */ } from '../constants'
 import { getFrameworks } from './framework-detection'
 import { isFileProtocol } from '../../../common/url/protocol'
 import { onDOMContentLoaded } from '../../../common/window/load'
@@ -10,8 +10,8 @@ import { windowAddEventListener } from '../../../common/event-listener/event-lis
 import { isBrowserScope, isWorkerScope } from '../../../common/constants/runtime'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { deregisterDrain } from '../../../common/drain/drain'
-import { WEBSOCKET_TAG } from '../../../common/wrap/wrap-websocket'
-import { handleWebsocketEvents } from './websocket-detection'
+// import { WEBSOCKET_TAG } from '../../../common/wrap/wrap-websocket'
+// import { handleWebsocketEvents } from './websocket-detection'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -118,11 +118,11 @@ export class Aggregate extends AggregateBase {
       mo.observe(window.document.body, { childList: true, subtree: true })
     }
 
-    WATCHABLE_WEB_SOCKET_EVENTS.forEach(tag => {
-      registerHandler('buffered-' + WEBSOCKET_TAG + tag, (...args) => {
-        handleWebsocketEvents(this.storeSupportabilityMetrics.bind(this), tag, ...args)
-      }, this.featureName, this.ee)
-    })
+    // WATCHABLE_WEB_SOCKET_EVENTS.forEach(tag => {
+    //   registerHandler('buffered-' + WEBSOCKET_TAG + tag, (...args) => {
+    //     handleWebsocketEvents(this.storeSupportabilityMetrics.bind(this), tag, ...args)
+    //   }, this.featureName, this.ee)
+    // })
   }
 
   eachSessionChecks () {

--- a/src/features/metrics/constants.js
+++ b/src/features/metrics/constants.js
@@ -1,4 +1,4 @@
-import { ADD_EVENT_LISTENER_TAG } from '../../common/wrap/wrap-websocket'
+// import { ADD_EVENT_LISTENER_TAG } from '../../common/wrap/wrap-websocket'
 import { FEATURE_NAMES } from '../../loaders/features/features'
 
 export const FEATURE_NAME = FEATURE_NAMES.metrics
@@ -7,4 +7,4 @@ export const CUSTOM_METRIC = 'cm'
 export const SUPPORTABILITY_METRIC_CHANNEL = 'storeSupportabilityMetrics'
 export const CUSTOM_METRIC_CHANNEL = 'storeEventMetrics'
 
-export const WATCHABLE_WEB_SOCKET_EVENTS = ['new', 'send', 'close', ADD_EVENT_LISTENER_TAG]
+// export const WATCHABLE_WEB_SOCKET_EVENTS = ['new', 'send', 'close', ADD_EVENT_LISTENER_TAG]

--- a/src/features/metrics/instrument/index.js
+++ b/src/features/metrics/instrument/index.js
@@ -1,19 +1,19 @@
-import { handle } from '../../../common/event-emitter/handle'
-import { WEBSOCKET_TAG, wrapWebSocket } from '../../../common/wrap/wrap-websocket'
+// import { handle } from '../../../common/event-emitter/handle'
+// import { WEBSOCKET_TAG, wrapWebSocket } from '../../../common/wrap/wrap-websocket'
 import { InstrumentBase } from '../../utils/instrument-base'
-import { FEATURE_NAME, WATCHABLE_WEB_SOCKET_EVENTS } from '../constants'
+import { FEATURE_NAME/*, WATCHABLE_WEB_SOCKET_EVENTS */ } from '../constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator, auto = true) {
     super(agentIdentifier, aggregator, FEATURE_NAME, auto)
-    wrapWebSocket(this.ee)
+    // wrapWebSocket(this.ee)
 
-    WATCHABLE_WEB_SOCKET_EVENTS.forEach((suffix) => {
-      this.ee.on(WEBSOCKET_TAG + suffix, (...args) => {
-        handle('buffered-' + WEBSOCKET_TAG + suffix, [...args], undefined, this.featureName, this.ee)
-      })
-    })
+    // WATCHABLE_WEB_SOCKET_EVENTS.forEach((suffix) => {
+    //   this.ee.on(WEBSOCKET_TAG + suffix, (...args) => {
+    //     handle('buffered-' + WEBSOCKET_TAG + suffix, [...args], undefined, this.featureName, this.ee)
+    //   })
+    // })
 
     this.importAggregator()
   }

--- a/tests/specs/websockets/metrics.e2e.js
+++ b/tests/specs/websockets/metrics.e2e.js
@@ -1,40 +1,40 @@
-const { notIOS, notSafari } = require('../../../tools/browser-matcher/common-matchers.mjs')
-const { testSupportMetricsRequest } = require('../../../tools/testing-server/utils/expect-tests')
+// const { notIOS, notSafari } = require('../../../tools/browser-matcher/common-matchers.mjs')
+// const { testSupportMetricsRequest } = require('../../../tools/testing-server/utils/expect-tests')
 
 describe('WebSocket supportability metrics', () => {
   /** Safari and iOS safari are blocked from connecting to the websocket protocol on LT, which throws socket errors instead of connecting and capturing the expected payloads.
    *  validated that this works locally for these envs */
-  it.withBrowsersMatching([notSafari, notIOS])('should capture expected SMs', async () => {
-    const supportabilityMetricsRequest = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
-    const url = await browser.testHandle.assetURL('websockets.html')
+  // it.withBrowsersMatching([notSafari, notIOS])('should capture expected SMs', async () => {
+  //   const supportabilityMetricsRequest = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
+  //   const url = await browser.testHandle.assetURL('websockets.html')
 
-    await browser.url(url)
-      .then(() => browser.waitForAgentLoad())
-      .then(() => browser.refresh())
+  //   await browser.url(url)
+  //     .then(() => browser.waitForAgentLoad())
+  //     .then(() => browser.refresh())
 
-    const [sms] = await supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
-    const smPayload = sms.request.body.sm
-    const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
+  //   const [sms] = await supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
+  //   const smPayload = sms.request.body.sm
+  //   const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
 
-    smTags.forEach(expectedSm => {
-      const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
-      const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
-      const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
+  //   smTags.forEach(expectedSm => {
+  //     const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
+  //     const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
+  //     const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
 
-      expect(ms).toBeTruthy()
-      expect(ms.stats.t).toBeGreaterThan(0)
-      expect(ms.stats.c).toEqual(2)
+  //     expect(ms).toBeTruthy()
+  //     expect(ms.stats.t).toBeGreaterThan(0)
+  //     expect(ms.stats.c).toEqual(2)
 
-      expect(msSinceClassInit).toBeTruthy()
-      if (expectedSm === 'New') expect(msSinceClassInit.stats.t).toBeLessThanOrEqual(1)
-      else expect(msSinceClassInit.stats.t).toBeGreaterThan(0)
-      expect(msSinceClassInit.stats.c).toEqual(2)
+  //     expect(msSinceClassInit).toBeTruthy()
+  //     if (expectedSm === 'New') expect(msSinceClassInit.stats.t).toBeLessThanOrEqual(1)
+  //     else expect(msSinceClassInit.stats.t).toBeGreaterThan(0)
+  //     expect(msSinceClassInit.stats.c).toEqual(2)
 
-      if (['Send', 'Message'].includes(expectedSm)) {
-        expect(bytes).toBeTruthy()
-        if (expectedSm === 'Send') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(8) // we are sending about 8 bytes from client to server
-        if (expectedSm === 'Message') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(40) // we are sending about 40 bytes from server to client
-      } else expect(bytes).toBeFalsy()
-    })
-  })
+  //     if (['Send', 'Message'].includes(expectedSm)) {
+  //       expect(bytes).toBeTruthy()
+  //       if (expectedSm === 'Send') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(8) // we are sending about 8 bytes from client to server
+  //       if (expectedSm === 'Message') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(40) // we are sending about 40 bytes from server to client
+  //     } else expect(bytes).toBeFalsy()
+  //   })
+  // })
 })


### PR DESCRIPTION
Fix websocket problems and breakage in application using other third party libraries dealing with sockets by removing the wrapping introduced in version 1.265.0.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Removing websocket wrapping for now to resolve integration issues (incomplete interface or bad wrapping) in 1.265.0.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-310559

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
