### PR TITLE
fix: Remove nullish coalescing inside getter

### DIFF
--- a/src/features/utils/event-buffer.js
+++ b/src/features/utils/event-buffer.js
@@ -45,7 +45,7 @@ export class EventBuffer {
    * held is another event buffer
    */
   get held () {
-    this.#held ??= new EventBuffer(this.maxPayloadSize)
+    if (!this.#held) this.#held = new EventBuffer(this.maxPayloadSize)
     return this.#held
   }
 


### PR DESCRIPTION
Removed a nullish coalescing assignment in a class getter -- which even though is claimed to be supported -- behaved badly in old versions of webkit browsers like Safari 15, some versions of Mobile Safari, and old chromium iOS browsers that use webkit.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Changed statement in `EventBuffer.js` class
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-312050
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

Fixes #1174 

### Testing
Validated manually using LambdaTest with browser outside of supported table.  Ideally, tested using an experiment build and affected customer(s)
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
