### PR TITLE
feat: Upgrade to web-vitals v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "fflate": "0.7.4",
         "rrweb": "2.0.0-alpha.12",
-        "web-vitals": "3.5.2"
+        "web-vitals": "4.2.3"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.4",
@@ -24225,10 +24225,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
-      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
-      "license": "Apache-2.0"
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.3.tgz",
+      "integrity": "sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q=="
     },
     "node_modules/webdriver": {
       "version": "8.40.3",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
   "dependencies": {
     "fflate": "0.7.4",
     "rrweb": "2.0.0-alpha.12",
-    "web-vitals": "3.5.2"
+    "web-vitals": "4.2.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.4",

--- a/src/common/vitals/interaction-to-next-paint.js
+++ b/src/common/vitals/interaction-to-next-paint.js
@@ -15,6 +15,10 @@ if (isBrowserScope) {
       interactionTarget: attribution.interactionTarget,
       interactionTime: attribution.interactionTime,
       interactionType: attribution.interactionType,
+      inputDelay: attribution.inputDelay,
+      nextPaintTime: attribution.nextPaintTime,
+      processingDuration: attribution.processingDuration,
+      presentationDelay: attribution.presentationDelay,
       loadState: attribution.loadState
     }
     interactionToNextPaint.update({ value, attrs })

--- a/src/common/vitals/interaction-to-next-paint.js
+++ b/src/common/vitals/interaction-to-next-paint.js
@@ -10,9 +10,11 @@ if (isBrowserScope) {
   onINP(({ value, attribution, id }) => {
     const attrs = {
       metricId: id,
-      eventTarget: attribution.eventTarget,
-      eventType: attribution.eventType,
-      eventTime: attribution.eventTime,
+      eventTarget: attribution.interactionTarget, // event* attrs deprecated in v4, kept for NR backwards compatibility
+      eventTime: attribution.interactionTime, // event* attrs deprecated in v4, kept for NR backwards compatibility
+      interactionTarget: attribution.interactionTarget,
+      interactionTime: attribution.interactionTime,
+      interactionType: attribution.interactionType,
       loadState: attribution.loadState
     }
     interactionToNextPaint.update({ value, attrs })

--- a/src/common/vitals/largest-contentful-paint.js
+++ b/src/common/vitals/largest-contentful-paint.js
@@ -20,7 +20,8 @@ if (isBrowserScope) {
         element: attribution.element,
         timeToFirstByte: attribution.timeToFirstByte,
         resourceLoadDelay: attribution.resourceLoadDelay,
-        resourceLoadTime: attribution.resourceLoadTime,
+        resourceLoadDuration: attribution.resourceLoadDuration,
+        resourceLoadTime: attribution.resourceLoadDuration, // kept for NR backwards compatibility
         elementRenderDelay: attribution.elementRenderDelay
       }
       if (attribution.url) attrs.elUrl = cleanURL(attribution.url)

--- a/src/common/vitals/largest-contentful-paint.js
+++ b/src/common/vitals/largest-contentful-paint.js
@@ -21,7 +21,7 @@ if (isBrowserScope) {
         timeToFirstByte: attribution.timeToFirstByte,
         resourceLoadDelay: attribution.resourceLoadDelay,
         resourceLoadDuration: attribution.resourceLoadDuration,
-        resourceLoadTime: attribution.resourceLoadDuration, // kept for NR backwards compatibility
+        resourceLoadTime: attribution.resourceLoadDuration, // kept for NR backwards compatibility, deprecated in v3->v4
         elementRenderDelay: attribution.elementRenderDelay
       }
       if (attribution.url) attrs.elUrl = cleanURL(attribution.url)

--- a/tests/unit/common/vitals/interaction-to-next-paint.test.js
+++ b/tests/unit/common/vitals/interaction-to-next-paint.test.js
@@ -5,9 +5,9 @@ beforeEach(() => {
 })
 
 const inpAttribution = {
-  eventTarget: 'html',
-  eventType: 'keydown',
-  eventTime: 100,
+  interactionType: 'keydown',
+  interactionTarget: 'html',
+  interactionTime: 100,
   loadState: 'complete'
 }
 const getFreshINPImport = async (codeToRun) => {
@@ -22,7 +22,12 @@ describe('inp', () => {
   test('reports fcp from web-vitals', (done) => {
     getFreshINPImport(metric => metric.subscribe(({ value, attrs }) => {
       expect(value).toEqual(8)
-      expect(attrs).toEqual({ ...inpAttribution, metricId: 'ruhroh' })
+      expect(attrs).toEqual({
+        ...inpAttribution,
+        eventTarget: inpAttribution.interactionTarget,
+        eventTime: inpAttribution.interactionTime,
+        metricId: 'ruhroh'
+      })
       done()
     }))
   })

--- a/tests/unit/common/vitals/interaction-to-next-paint.test.js
+++ b/tests/unit/common/vitals/interaction-to-next-paint.test.js
@@ -8,6 +8,10 @@ const inpAttribution = {
   interactionType: 'keydown',
   interactionTarget: 'html',
   interactionTime: 100,
+  inputDelay: 0,
+  nextPaintTime: 200,
+  processingDuration: 0,
+  presentationDelay: 0,
   loadState: 'complete'
 }
 const getFreshINPImport = async (codeToRun) => {
@@ -19,7 +23,7 @@ const getFreshINPImport = async (codeToRun) => {
 }
 
 describe('inp', () => {
-  test('reports fcp from web-vitals', (done) => {
+  test('reports inp from web-vitals', (done) => {
     getFreshINPImport(metric => metric.subscribe(({ value, attrs }) => {
       expect(value).toEqual(8)
       expect(attrs).toEqual({

--- a/tests/unit/common/vitals/interaction-to-next-paint.test.js
+++ b/tests/unit/common/vitals/interaction-to-next-paint.test.js
@@ -26,10 +26,17 @@ describe('inp', () => {
   test('reports inp from web-vitals', (done) => {
     getFreshINPImport(metric => metric.subscribe(({ value, attrs }) => {
       expect(value).toEqual(8)
-      expect(attrs).toEqual({
-        ...inpAttribution,
+      expect(attrs).toStrictEqual({
         eventTarget: inpAttribution.interactionTarget,
         eventTime: inpAttribution.interactionTime,
+        interactionTarget: inpAttribution.interactionTarget,
+        interactionTime: inpAttribution.interactionTime,
+        interactionType: inpAttribution.interactionType,
+        inputDelay: inpAttribution.inputDelay,
+        nextPaintTime: inpAttribution.nextPaintTime,
+        processingDuration: inpAttribution.processingDuration,
+        presentationDelay: inpAttribution.presentationDelay,
+        loadState: inpAttribution.loadState,
         metricId: 'ruhroh'
       })
       done()

--- a/tests/unit/common/vitals/interaction-to-next-paint.test.js
+++ b/tests/unit/common/vitals/interaction-to-next-paint.test.js
@@ -5,7 +5,7 @@ beforeEach(() => {
 })
 
 const inpAttribution = {
-  interactionType: 'keydown',
+  interactionType: 'keyboard',
   interactionTarget: 'html',
   interactionTime: 100,
   inputDelay: 0,

--- a/tests/unit/common/vitals/largest-contentful-paint.test.js
+++ b/tests/unit/common/vitals/largest-contentful-paint.test.js
@@ -13,7 +13,7 @@ const lcpAttribution = {
   element: '#someid',
   timeToFirstByte: 1,
   resourceLoadDelay: 2,
-  resourceLoadTime: 3,
+  resourceLoadDuration: 3,
   elementRenderDelay: 4,
   url: 'http://domain.com/page?k1=v1#hash'
 }
@@ -38,7 +38,8 @@ describe('lcp', () => {
         element: lcpAttribution.element,
         timeToFirstByte: lcpAttribution.timeToFirstByte,
         resourceLoadDelay: lcpAttribution.resourceLoadDelay,
-        resourceLoadTime: lcpAttribution.resourceLoadTime,
+        resourceLoadDuration: lcpAttribution.resourceLoadDuration,
+        resourceLoadTime: lcpAttribution.resourceLoadDuration,
         elementRenderDelay: lcpAttribution.elementRenderDelay
       })
       done()


### PR DESCRIPTION
Upgrade to web-vitals v4.  For more info, please see https://github.com/GoogleChrome/web-vitals/blob/main/docs/upgrading-to-v4.md.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

In this PR, we are upgrading to current latest web-vitals lib (v4.2.3) following the web-vitals upgrade [doc](https://github.com/GoogleChrome/web-vitals/blob/main/docs/upgrading-to-v4.md).

Notable changes:

**INP**
- `eventType` is renamed to `interactionType` to avoid keyword conflict within NR
- Add `interaction*` equivalents for other `event*` attrs in use
    - `event*` attrs are preserved for backwards compatibility to be EOL'd at a later time

**LCP**
- Add `resourceLoadTime` as replacement for `resourceLoadDuration`
    - `resourceLoadDuration` is preserved for backwards compatibility to be EOL'd at a later time


### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->
https://new-relic.atlassian.net/browse/NR-296095

### Testing
Relevant web-vital unit tests + PVT integration tests
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
