### PR TITLE
fix: Improve reliability of customMasker

### DIFF
--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -241,7 +241,7 @@ export class Aggregate extends AggregateBase {
   }
 
   prepareHarvest ({ opts } = {}) {
-    if (!this.recorder || !this.timeKeeper?.ready) return
+    if (!this.recorder || !this.timeKeeper?.ready || !this.recorder.hasSeenSnapshot) return
     const recorderEvents = this.recorder.getEvents()
     // get the event type and use that to trigger another harvest if needed
     if (!recorderEvents.events.length || (this.mode !== MODE.FULL) || this.blocked) return

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -29,6 +29,8 @@ export class Recorder {
     this.recording = false
     /** The pointer to the current bucket holding rrweb events */
     this.currentBufferTarget = this.#events
+    /** Only set to true once a snapshot node has been processed.  Used to block preload harvests from sending before we know we have a snapshot */
+    this.hasSeenSnapshot = false
     /** Hold on to the last meta node, so that it can be re-inserted if the meta and snapshot nodes are broken up due to harvesting */
     this.lastMeta = false
     /** The parent class that instantiated the recorder */
@@ -190,6 +192,7 @@ export class Recorder {
     // snapshot event
     if (event.type === RRWEB_EVENT_TYPES.FullSnapshot) {
       this.currentBufferTarget.hasSnapshot = true
+      this.hasSeenSnapshot = true
     }
     this.currentBufferTarget.add(event)
 


### PR DESCRIPTION
The customMasker method of the Session Replay feature has been fixed to be more reliable with DOM elements that do not fit web-standards, as to not throw errors when processing.  Initial Replay harvests will now be gated until a valid snapshot is taken.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR has been named the way it has to encapsulate SR bug fix changes that span across this PR and some that were rolled into #1190.  It has been named this way to aid with the release notes.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-314446
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests should continue to pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
