### PR TITLE
fix: Stringify now returns an empty string if failed to transform

### DIFF
--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -89,3 +89,5 @@
 `Agent not configured properly.`
 ### 44
 `Invalid object passed to generic event aggregate. Missing "eventType".`
+### 45
+`An internal agent process failed to execute.`

--- a/src/common/util/stringify.js
+++ b/src/common/util/stringify.js
@@ -38,8 +38,9 @@ export function stringify (val) {
       ee.emit('internal-error', [e])
       warn(45, 'Could not stringify the value: ' + val)
     } catch (err) {
-      // return a string so that downstream users of the method do not throw errors
-      return ''
+      // do nothing
     }
+    // return a string so that downstream users of the method do not throw errors
+    return ''
   }
 }

--- a/src/common/util/stringify.js
+++ b/src/common/util/stringify.js
@@ -4,7 +4,6 @@
  */
 
 import { ee } from '../event-emitter/contextual-ee'
-import { warn } from './console'
 
 /**
  * Returns a function for use as a replacer parameter in JSON.stringify() to handle circular references.
@@ -36,7 +35,6 @@ export function stringify (val) {
   } catch (e) {
     try {
       ee.emit('internal-error', [e])
-      warn(45, 'Could not stringify the value: ' + val)
     } catch (err) {
       // do nothing
     }

--- a/src/common/util/stringify.js
+++ b/src/common/util/stringify.js
@@ -4,6 +4,7 @@
  */
 
 import { ee } from '../event-emitter/contextual-ee'
+import { warn } from './console'
 
 /**
  * Returns a function for use as a replacer parameter in JSON.stringify() to handle circular references.
@@ -35,8 +36,10 @@ export function stringify (val) {
   } catch (e) {
     try {
       ee.emit('internal-error', [e])
+      warn(45, 'Could not stringify the value: ' + val)
     } catch (err) {
-      // do nothing
+      // return a string so that downstream users of the method do not throw errors
+      return ''
     }
   }
 }

--- a/src/features/utils/event-buffer.js
+++ b/src/features/utils/event-buffer.js
@@ -58,13 +58,14 @@ export class EventBuffer {
   }
 
   /**
-   * Adds an event object to the buffer while tallying size
+   * Adds an event object to the buffer while tallying size. Only adds the event if it is valid
+   * and would not make the event buffer exceed the maxPayloadSize.
    * @param {Object} event the event object to add to the buffer
    * @returns {EventBuffer} returns the event buffer for chaining
    */
   add (event) {
     const size = stringify(event).length
-    if (!this.canMerge(size)) return this
+    if (!size || !this.canMerge(size)) return this
     this.#buffer.push(event)
     this.#bytes += size
     return this

--- a/src/features/utils/event-buffer.js
+++ b/src/features/utils/event-buffer.js
@@ -122,7 +122,6 @@ export class EventBuffer {
    * @returns {boolean}
    */
   canMerge (size) {
-    if (!size) return false
     return this.bytes + (size || Infinity) < this.maxPayloadSize
   }
 }

--- a/src/features/utils/event-buffer.js
+++ b/src/features/utils/event-buffer.js
@@ -65,7 +65,7 @@ export class EventBuffer {
    */
   add (event) {
     const size = stringify(event).length
-    if (!size || !this.canMerge(size)) return this
+    if (!this.canMerge(size)) return this
     this.#buffer.push(event)
     this.#bytes += size
     return this
@@ -122,6 +122,7 @@ export class EventBuffer {
    * @returns {boolean}
    */
   canMerge (size) {
+    if (!size) return false
     return this.bytes + (size || Infinity) < this.maxPayloadSize
   }
 }

--- a/tests/unit/common/util/stringify.test.js
+++ b/tests/unit/common/util/stringify.test.js
@@ -37,13 +37,14 @@ test('should support serializing circular references by omitting the circular re
   expect(stringify(input)).toEqual('{"a":1,"arr":["foo",null]}')
 })
 
-test('should emit an "internal-error" event if an error occurs during JSON.stringify', () => {
+test('should emit an "internal-error" event and still return a string if an error occurs during JSON.stringify', () => {
   jest.spyOn(eventEmitterModule.ee, 'emit')
   jest.spyOn(JSON, 'stringify').mockImplementation(() => {
     throw new Error('message')
   })
 
-  stringify('foo')
+  const output = stringify('foo')
 
   expect(eventEmitterModule.ee.emit).toHaveBeenCalledWith('internal-error', expect.any(Array))
+  expect(output).toEqual('')
 })

--- a/tests/unit/features/utils/event-buffer.test.js
+++ b/tests/unit/features/utils/event-buffer.test.js
@@ -158,6 +158,10 @@ describe('EventBuffer', () => {
       eventBuffer.add({ test: 1 })
       expect(eventBuffer.canMerge()).toEqual(false)
     })
+    it('should return false if 0 size provided', () => {
+      eventBuffer.add({ test: 1 })
+      expect(eventBuffer.canMerge(0)).toEqual(false)
+    })
     it('should return false if size is not a number', () => {
       eventBuffer.add({ test: 1 })
       expect(eventBuffer.canMerge('test')).toEqual(false)


### PR DESCRIPTION
An internal mechanism used to convert objects to strings would return undefined if an exception was thrown during the process. This could lead downstream users of that method to throw errors if they expected the output to be a string. The utility method now always returns a string.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This utility method now always returns a string, empty if failed, and the string output of the object if successful. 
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-316691
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Existing tests should continue to pass.  A new unit test is added to check for exception value.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
