### PR TITLE
chore: Post release repo updates

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -132,7 +132,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### web-vitals
 
-This product includes source derived from [web-vitals](https://github.com/GoogleChrome/web-vitals) ([v3.5.2](https://github.com/GoogleChrome/web-vitals/tree/v3.5.2)), distributed under the [Apache-2.0 License](https://github.com/GoogleChrome/web-vitals/blob/v3.5.2/LICENSE):
+This product includes source derived from [web-vitals](https://github.com/GoogleChrome/web-vitals) ([v4.2.3](https://github.com/GoogleChrome/web-vitals/tree/v4.2.3)), distributed under the [Apache-2.0 License](https://github.com/GoogleChrome/web-vitals/blob/v4.2.3/LICENSE):
 
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9362,9 +9362,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001660",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
-      "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
       "dev": true,
       "funding": [
         {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Sep 17 2024 14:19:25 GMT+0000 (Coordinated Universal Time)",
+  "lastUpdated": "Wed Sep 25 2024 17:09:22 GMT+0000 (Coordinated Universal Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,
@@ -31,15 +31,15 @@
       "licenseTextSource": "spdx",
       "publisher": "yanzhen@smartx.com"
     },
-    "web-vitals@3.5.2": {
+    "web-vitals@4.2.3": {
       "name": "web-vitals",
-      "version": "3.5.2",
-      "range": "^3.1.0",
+      "version": "4.2.3",
+      "range": "4.2.3",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/GoogleChrome/web-vitals",
-      "versionedRepoUrl": "https://github.com/GoogleChrome/web-vitals/tree/v3.5.2",
+      "versionedRepoUrl": "https://github.com/GoogleChrome/web-vitals/tree/v4.2.3",
       "licenseFile": "node_modules/web-vitals/LICENSE",
-      "licenseUrl": "https://github.com/GoogleChrome/web-vitals/blob/v3.5.2/LICENSE",
+      "licenseUrl": "https://github.com/GoogleChrome/web-vitals/blob/v4.2.3/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Philip Walton",
       "email": "philip@philipwalton.com",

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.266.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.267.0.tgz"
   }
 }

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/client": "^3.8.8",
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.266.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.267.0.tgz",
     "graphql": "^16.8.1"
   }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.266.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.267.0.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.266.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.267.0.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
When this PR is merged, caniuse-lite database is updated, latest browserslist for SauceLabs is retrieved, and third-party dependencies docs are updates.
---

This PR was generated with post-release-updates GitHub action.