### PR TITLE
fix: Force generic events feature to clear buffer when unloading

### DIFF
--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -132,6 +132,8 @@ export class Aggregate extends AggregateBase {
     })
 
     if (options.retry) this.events.hold()
+    else this.events.clear()
+
     return payload
   }
 


### PR DESCRIPTION
Fixed an issue where the generic events buffer was not clearing when unloading. This affected a small portion of experiences where the agent was "unloading" due to the page losing focus, but not actually closing.  Subsequent harvests when the page was re-focused would have the potential for duplicated data.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-319565
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Existing tests should continue to pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
