### PR TITLE
chore: Add page url to Session Replay and Session Trace payloads

### DIFF
--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -28,6 +28,7 @@ import { deregisterDrain } from '../../../common/drain/drain'
 import { now } from '../../../common/timing/now'
 import { buildNRMetaNode } from '../shared/utils'
 import { MAX_PAYLOAD_SIZE } from '../../../common/constants/agent-constants'
+import { cleanURL } from '../../../common/url/clean-url'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -362,7 +363,8 @@ export class Aggregate extends AggregateBase {
           'rrweb.version': RRWEB_VERSION,
           'payload.type': recorderEvents.type,
           // customer-defined data should go last so that if it exceeds the query param padding limit it will be truncated instead of important attrs
-          ...(endUserId && { 'enduser.id': this.obfuscator.obfuscateString(endUserId) })
+          ...(endUserId && { 'enduser.id': this.obfuscator.obfuscateString(endUserId) }),
+          pageUrl: cleanURL(agentRuntime.origin)
           // The Query Param is being arbitrarily limited in length here.  It is also applied when estimating the size of the payload in getPayloadSize()
         }, QUERY_PARAM_PADDING).substring(1) // remove the leading '&'
       },

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -364,7 +364,7 @@ export class Aggregate extends AggregateBase {
           'payload.type': recorderEvents.type,
           // customer-defined data should go last so that if it exceeds the query param padding limit it will be truncated instead of important attrs
           ...(endUserId && { 'enduser.id': this.obfuscator.obfuscateString(endUserId) }),
-          pageUrl: cleanURL(agentRuntime.origin)
+          currentUrl: cleanURL('' + location)
           // The Query Param is being arbitrarily limited in length here.  It is also applied when estimating the size of the payload in getPayloadSize()
         }, QUERY_PARAM_PADDING).substring(1) // remove the leading '&'
       },

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -364,7 +364,7 @@ export class Aggregate extends AggregateBase {
           'payload.type': recorderEvents.type,
           // customer-defined data should go last so that if it exceeds the query param padding limit it will be truncated instead of important attrs
           ...(endUserId && { 'enduser.id': this.obfuscator.obfuscateString(endUserId) }),
-          currentUrl: cleanURL('' + location)
+          currentUrl: this.obfuscator.obfuscateString(cleanURL('' + location))
           // The Query Param is being arbitrarily limited in length here.  It is also applied when estimating the size of the payload in getPayloadSize()
         }, QUERY_PARAM_PADDING).substring(1) // remove the leading '&'
       },

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -174,7 +174,7 @@ export class Aggregate extends AggregateBase {
           session: `${this.sessionId}`,
           // customer-defined data should go last so that if it exceeds the query param padding limit it will be truncated instead of important attrs
           ...(endUserId && { 'enduser.id': this.obfuscator.obfuscateString(endUserId) }),
-          pageUrl: cleanURL(this.agentRuntime.origin)
+          currentUrl: cleanURL('' + location)
           // The Query Param is being arbitrarily limited in length here.  It is also applied when estimating the size of the payload in getPayloadSize()
         }, QUERY_PARAM_PADDING).substring(1) // remove the leading '&'
       },

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -11,6 +11,7 @@ import { deregisterDrain } from '../../../common/drain/drain'
 import { globalScope } from '../../../common/constants/runtime'
 import { MODE, SESSION_EVENTS } from '../../../common/session/constants'
 import { applyFnToProps } from '../../../common/util/traverse'
+import { cleanURL } from '../../../common/url/clean-url'
 
 const ERROR_MODE_SECONDS_WINDOW = 30 * 1000 // sliding window of nodes to track when simply monitoring (but not harvesting) in error mode
 /** Reserved room for query param attrs */
@@ -172,7 +173,8 @@ export class Aggregate extends AggregateBase {
           ptid: `${this.ptid}`,
           session: `${this.sessionId}`,
           // customer-defined data should go last so that if it exceeds the query param padding limit it will be truncated instead of important attrs
-          ...(endUserId && { 'enduser.id': this.obfuscator.obfuscateString(endUserId) })
+          ...(endUserId && { 'enduser.id': this.obfuscator.obfuscateString(endUserId) }),
+          pageUrl: cleanURL(this.agentRuntime.origin)
           // The Query Param is being arbitrarily limited in length here.  It is also applied when estimating the size of the payload in getPayloadSize()
         }, QUERY_PARAM_PADDING).substring(1) // remove the leading '&'
       },

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -174,7 +174,7 @@ export class Aggregate extends AggregateBase {
           session: `${this.sessionId}`,
           // customer-defined data should go last so that if it exceeds the query param padding limit it will be truncated instead of important attrs
           ...(endUserId && { 'enduser.id': this.obfuscator.obfuscateString(endUserId) }),
-          currentUrl: cleanURL('' + location)
+          currentUrl: this.obfuscator.obfuscateString(cleanURL('' + location))
           // The Query Param is being arbitrarily limited in length here.  It is also applied when estimating the size of the payload in getPayloadSize()
         }, QUERY_PARAM_PADDING).substring(1) // remove the leading '&'
       },

--- a/tests/specs/session-replay/payload.e2e.js
+++ b/tests/specs/session-replay/payload.e2e.js
@@ -82,7 +82,14 @@ describe('Session Replay Payload Validation', () => {
         .then(() => browser.getAgentSessionInfo())
     ])
 
-    testExpectedReplay({ data: sessionReplayHarvest.request, session, hasError: false, hasMeta: true, hasSnapshot: true, isFirstChunk: true })
+    testExpectedReplay({
+      data: sessionReplayHarvest.request,
+      session,
+      hasError: false,
+      hasMeta: true,
+      hasSnapshot: true,
+      isFirstChunk: true
+    })
   })
 
   it('should match expected payload - error', async () => {

--- a/tests/specs/session-replay/payload.e2e.js
+++ b/tests/specs/session-replay/payload.e2e.js
@@ -89,7 +89,7 @@ describe('Session Replay Payload Validation', () => {
       hasMeta: true,
       hasSnapshot: true,
       isFirstChunk: true,
-      pageUrl: sessionReplayHarvest.request.headers.origin + '/tests/assets/rrweb-instrumented.html'
+      currentUrl: sessionReplayHarvest.request.headers.origin + '/tests/assets/rrweb-instrumented.html'
     })
   })
 

--- a/tests/specs/session-replay/payload.e2e.js
+++ b/tests/specs/session-replay/payload.e2e.js
@@ -88,7 +88,8 @@ describe('Session Replay Payload Validation', () => {
       hasError: false,
       hasMeta: true,
       hasSnapshot: true,
-      isFirstChunk: true
+      isFirstChunk: true,
+      pageUrl: sessionReplayHarvest.request.headers.origin + '/tests/assets/rrweb-instrumented.html'
     })
   })
 

--- a/tests/specs/session-trace/payload-metadata.e2e.js
+++ b/tests/specs/session-trace/payload-metadata.e2e.js
@@ -38,7 +38,7 @@ describe('STN Payload metadata checks', () => {
       firstTimestampOffset,
       lastTimestampOffset,
       firstSessionHarvest: true,
-      pageUrl: request.headers.origin + '/tests/assets/instrumented.html'
+      currentUrl: request.headers.origin + '/tests/assets/instrumented.html'
     })
   })
 })

--- a/tests/specs/session-trace/payload-metadata.e2e.js
+++ b/tests/specs/session-trace/payload-metadata.e2e.js
@@ -37,7 +37,8 @@ describe('STN Payload metadata checks', () => {
       nodeCount: request.body.length,
       firstTimestampOffset,
       lastTimestampOffset,
-      firstSessionHarvest: true
+      firstSessionHarvest: true,
+      pageUrl: request.headers.origin + '/tests/assets/instrumented.html'
     })
   })
 })

--- a/tests/specs/session-trace/payload-metadata.e2e.js
+++ b/tests/specs/session-trace/payload-metadata.e2e.js
@@ -32,6 +32,12 @@ describe('STN Payload metadata checks', () => {
     const firstTimestampOffset = request.body.reduce((acc, next) => (next.s < acc) ? next.s : acc, Infinity)
     const lastTimestampOffset = request.body.reduce((acc, next) => (next.e > acc) ? next.e : acc, 0)
     // first session harvest is not reported if session is disabled
-    testExpectedTrace({ data: request, nodeCount: request.body.length, firstTimestampOffset, lastTimestampOffset, firstSessionHarvest: true })
+    testExpectedTrace({
+      data: request,
+      nodeCount: request.body.length,
+      firstTimestampOffset,
+      lastTimestampOffset,
+      firstSessionHarvest: true
+    })
   })
 })

--- a/tests/specs/util/helpers.js
+++ b/tests/specs/util/helpers.js
@@ -14,7 +14,7 @@ export const RRWEB_EVENT_TYPES = {
   Custom: 5
 }
 
-export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes, appId, entityGuid, harvestId, pageUrl }) {
+export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes, appId, entityGuid, harvestId, currentUrl }) {
   expect(data.query).toMatchObject({
     browser_monitoring_key: expect.any(String),
     type: 'SessionReplay',
@@ -42,7 +42,7 @@ export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasEr
     decompressedBytes: decompressedBytes || expect.any(Number),
     'rrweb.version': expect.any(String),
     inlinedAllStylesheets: expect.any(Boolean),
-    ...(pageUrl && { pageUrl })
+    ...(currentUrl && { currentUrl })
   })
 
   expect(data.body).toEqual(expect.any(Array))
@@ -59,7 +59,7 @@ export function testExpectedTrace ({
   ptid,
   harvestId,
   entityGuid,
-  pageUrl
+  currentUrl
 }) {
   expect(data.query).toMatchObject({
     browser_monitoring_key: expect.any(String),
@@ -79,7 +79,7 @@ export function testExpectedTrace ({
     'trace.nodes': nodeCount || expect.any(Number),
     ptid: ptid || expect.anything(),
     session: session || expect.any(String),
-    ...(pageUrl && { pageUrl }),
+    ...(currentUrl && { currentUrl }),
     // optional attrs here
     ...(firstSessionHarvest && { firstSessionHarvest }),
     ...(hasReplay && { hasReplay })

--- a/tests/specs/util/helpers.js
+++ b/tests/specs/util/helpers.js
@@ -58,7 +58,8 @@ export function testExpectedTrace ({
   session,
   ptid,
   harvestId,
-  entityGuid
+  entityGuid,
+  pageUrl
 }) {
   expect(data.query).toMatchObject({
     browser_monitoring_key: expect.any(String),
@@ -78,6 +79,7 @@ export function testExpectedTrace ({
     'trace.nodes': nodeCount || expect.any(Number),
     ptid: ptid || expect.anything(),
     session: session || expect.any(String),
+    ...(pageUrl && { pageUrl }),
     // optional attrs here
     ...(firstSessionHarvest && { firstSessionHarvest }),
     ...(hasReplay && { hasReplay })

--- a/tests/specs/util/helpers.js
+++ b/tests/specs/util/helpers.js
@@ -14,7 +14,7 @@ export const RRWEB_EVENT_TYPES = {
   Custom: 5
 }
 
-export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes, appId, entityGuid, harvestId }) {
+export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes, appId, entityGuid, harvestId, pageUrl }) {
   expect(data.query).toMatchObject({
     browser_monitoring_key: expect.any(String),
     type: 'SessionReplay',
@@ -41,7 +41,8 @@ export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasEr
     isFirstChunk: isFirstChunk || expect.any(Boolean),
     decompressedBytes: decompressedBytes || expect.any(Number),
     'rrweb.version': expect.any(String),
-    inlinedAllStylesheets: expect.any(Boolean)
+    inlinedAllStylesheets: expect.any(Boolean),
+    ...(pageUrl && { pageUrl })
   })
 
   expect(data.body).toEqual(expect.any(Array))


### PR DESCRIPTION
To aid with troubleshooting Session Replay and Session Trace, page url will be included in the respective payload's query string under `attributes.pageUrl`.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

In this PR, we are adding the page URL to the query string of the corresponding Session Replay and Session Trace payloads under `attributes.pageUrl`.  The page URL will be added last, so if the total payload size exceeds current limit (5000), then truncation may occur.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-268394

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
- Added a test condition to the Session Replay standard payload unit test
- Manually tested and confirmed presence of URL in payload:
  
Session Replay
(screenshot - to be added)

Session Trace
(screenshot - to be added)

