### PR TITLE
chore: Add createTracer and SPA deprecation notices to browser agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ A lot of new frameworks support the concept of server-side rendering the pages o
 
 ## Disclaimers
 
-The session replay library shipping as part of the browser agent is not turned on by default. For information on the use of this feature, see [Session Replay](#session-replay)
+* The session replay feature is not turned on by default. For information on the use of this feature, see [Session Replay](#session-replay)
+* As part of the improvement efforts around our SPA capabilities, the `createTracer` API has been [deprecated](https://docs.newrelic.com/eol/2024/04/eol-04-24-24-createtracer/). Please engage in removing usage of that library. If tracking task duration, we recommend utilizing the generic browser performance mark and measure APIs, which will gain native detection support from the agent in a future update.
 
 ## Support
 

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -20,6 +20,9 @@ const {
   FEATURE_NAME, START, END, BODY, CB_END, JS_TIME, FETCH, FN_START, CB_START, FN_END
 } = CONSTANTS
 
+/**
+ * @deprecated This feature has been deprecated, in favor of `soft_navigations`, which is in limited preview. Consider using/importing `SoftNavigations` instead. To gain access to the limited preview, please see https://docs.newrelic.com/docs/browser/single-page-app-monitoring/get-started/browser-spa-v2/ for more information. This feature will be removed in a future release.
+ */
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   constructor (agentIdentifier, aggregator, auto = true) {

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -173,6 +173,7 @@ export class AgentBase {
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/interaction/}
    * @returns {InteractionInstance} An API object that is bound to a specific BrowserInteraction event. Each time this method is called for the same BrowserInteraction, a new object is created, but it still references the same interaction.
    *  - Note: Does not apply to MicroAgent
+   *  - Deprecation Notice: interaction.createTracer is deprecated.  See https://docs.newrelic.com/eol/2024/04/eol-04-24-24-createtracer/ for more information.
   */
   interaction () {
     return this.#callMethod('interaction')


### PR DESCRIPTION
Added documentation to readme, typings, and JSDOC in the agent source code to document the deprecation of the SPA v1 feature and the `createTracer` API tied to it.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-224097
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests should be unaffected
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
