### PR TITLE
fix: Handle Session Replay Security Policy Errors

### DIFF
--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -312,3 +312,9 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * API/log/called
 <!--- newrelic.wrapLogger() was called --->
 * API/wrapLogger/called
+
+### INTERNAL ERRORS
+<!--- an internal error relating to rrweb processing was observed -->
+* Internal/Error/Rrweb
+<!--- an uncategorized internal error was observed -->
+* Internal/Error/Other

--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -314,7 +314,9 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * API/wrapLogger/called
 
 ### INTERNAL ERRORS
-<!--- an internal error relating to rrweb processing was observed -->
+<!--- an generalized internal error relating to rrweb processing was observed, typically thrown by rrweb's error handler -->
 * Internal/Error/Rrweb
+<!--- an internal error relating to rrweb processing tied to the security policy (or disabled browser APIs that are out of our control) was observed -->
+* Internal/Error/Rrweb-Security-Policy
 <!--- an uncategorized internal error was observed -->
 * Internal/Error/Other

--- a/src/features/jserrors/aggregate/internal-errors.js
+++ b/src/features/jserrors/aggregate/internal-errors.js
@@ -1,0 +1,19 @@
+/**
+ * This function is responsible for determining if an error should be swallowed or not.
+ * @param {Object} stackInfo - The error stack information.
+ * @returns {boolean} - Whether the error should be swallowed or not.
+ */
+export function isInternalError (stackInfo, internal) {
+  let shouldSwallow = internal || false
+  let reason = 'Other'
+  // check for *specific* security policy errors from the newrelic-recorder or rrweb itself (for NPM), these are tied to browser APIs being disabled and are out of our control
+  const isNrRecorder = stackInfo.frames?.[0].match(/nr-(.*)-recorder.min.js/)
+  const isRrweb = stackInfo.frames?.[0].match(/rrweb/)
+  if ((!!isNrRecorder || !!isRrweb) && !!stackInfo.message.toLowerCase().match(/an attempt was made to break through the security policy of the user agent/)) {
+    reason = 'Rrweb'
+    shouldSwallow = true
+  }
+  // other swallow conditions could also be added here
+
+  return { shouldSwallow, reason }
+}

--- a/src/features/jserrors/aggregate/internal-errors.js
+++ b/src/features/jserrors/aggregate/internal-errors.js
@@ -3,17 +3,19 @@
  * @param {Object} stackInfo - The error stack information.
  * @returns {boolean} - Whether the error should be swallowed or not.
  */
-export function isInternalError (stackInfo, internal) {
-  let shouldSwallow = internal || false
-  let reason = 'Other'
+export function evaluateInternalError (stackInfo, internal) {
+  const output = { shouldSwallow: internal || false, reason: 'Other' }
+  const leadingFrame = stackInfo.frames?.[0]
+  /** If we cant otherwise determine from the frames and message, the default of internal + reason will be the fallback */
+  if (!leadingFrame || !stackInfo.message) return output
   // check for *specific* security policy errors from the newrelic-recorder or rrweb itself (for NPM), these are tied to browser APIs being disabled and are out of our control
-  const isNrRecorder = stackInfo.frames?.[0].match(/nr-(.*)-recorder.min.js/)
-  const isRrweb = stackInfo.frames?.[0].match(/rrweb/)
-  if ((!!isNrRecorder || !!isRrweb) && !!stackInfo.message.toLowerCase().match(/an attempt was made to break through the security policy of the user agent/)) {
-    reason = 'Rrweb'
-    shouldSwallow = true
+  const isNrRecorder = leadingFrame?.url?.match(/nr-(.*)-recorder.min.js/)
+  const isRrweb = leadingFrame?.url?.match(/rrweb/)
+  if (!!isNrRecorder || !!isRrweb) {
+    output.shouldSwallow = true
+    output.reason = 'Rrweb'
+    if (stackInfo.message.toLowerCase().match(/an attempt was made to break through the security policy of the user agent/)) output.reason += '-Security-Policy'
   }
   // other swallow conditions could also be added here
-
-  return { shouldSwallow, reason }
+  return output
 }

--- a/tests/specs/err/error-payload.e2e.js
+++ b/tests/specs/err/error-payload.e2e.js
@@ -3,8 +3,7 @@
 const { Key } = require('webdriverio')
 const { notSafari, notIOS, notAndroid } = require('../../../tools/browser-matcher/common-matchers.mjs')
 const { srConfig } = require('../util/helpers')
-const { checkJsErrors } = require('../../util/basic-checks')
-const { testErrorsRequest, testAnyJseXhrRequest } = require('../../../tools/testing-server/utils/expect-tests')
+const { testErrorsRequest, testSupportMetricsRequest } = require('../../../tools/testing-server/utils/expect-tests')
 
 describe('error payloads', () => {
   let errorsCapture
@@ -138,19 +137,23 @@ describe('error payloads', () => {
    * This is a specific bug observed in rrweb for specific browsers tied to contenteditable divs.
    * This serves a purpose of checking that rrweb errors are not reported as `err`
    * **/
-  it.withBrowsersMatching([notSafari, notAndroid, notIOS])('should collect rrweb errors only as internal errors', async () => {
-    const anyJseXhrCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testAnyJseXhrRequest })
+  it.withBrowsersMatching([notSafari, notAndroid, notIOS])('should collect rrweb errors only as internal error supportability metric', async () => {
+    const jsErrCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
+    const smCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
     await browser.enableSessionReplay()
-    const [[{ request }]] = await Promise.all([
-      anyJseXhrCapture.waitForResult({ timeout: 10000 }),
+    const [jseCaptureResults, smCaptureResults] = await Promise.all([
+      jsErrCapture.waitForResult({ timeout: 10000 }),
+      smCapture.waitForResult({ totalCount: 1 }),
       browser.url(await browser.testHandle.assetURL('rrweb-instrumented.html', srConfig()))
         .then(() => browser.waitForSessionReplayRecording())
         .then(() => $('#content-editable-div'))
         .then((elem) => elem.click())
         .then(() => browser.keys([Key.Ctrl, Key.Backspace]))
+        .then(() => browser.refresh())
     ])
 
-    checkJsErrors(request, ['Cannot read properties of null (reading \'tagName\')'], 'ierr')
-    expect(request.body.err).toBeUndefined()
+    const sms = smCaptureResults[0].request.body.sm
+    expect(sms.find(sm => sm.params.name === 'Internal/Error/Rrweb')).toBeTruthy()
+    expect(jseCaptureResults).toEqual([])
   })
 })

--- a/tests/unit/features/jserrors/aggregate/internal-errors.test.js
+++ b/tests/unit/features/jserrors/aggregate/internal-errors.test.js
@@ -1,0 +1,57 @@
+import { isInternalError } from '../../../../../src/features/jserrors/aggregate/internal-errors'
+
+describe('isInternalError', () => {
+  it('should not swallow and reason "Other" when no internal flag and no specific error', () => {
+    const stackInfo = {
+      frames: ['some-other-script.js'],
+      message: 'Some error message'
+    }
+    const result = isInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: false, reason: 'Other' })
+  })
+
+  it('should swallow and reason "Rrweb" for nr-recorder security policy error', () => {
+    const stackInfo = {
+      frames: ['nr-123-recorder.min.js'],
+      message: 'An attempt was made to break through the security policy of the user agent'
+    }
+    const result = isInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb' })
+  })
+
+  it('should swallow and reason "Rrweb" for rrweb security policy error', () => {
+    const stackInfo = {
+      frames: ['rrweb'],
+      message: 'An attempt was made to break through the security policy of the user agent'
+    }
+    const result = isInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb' })
+  })
+
+  it('should swallow and reason "Other" for any error when internal flag is true', () => {
+    const stackInfo = {
+      frames: ['some-other-script.js'],
+      message: 'Some error message'
+    }
+    const result = isInternalError(stackInfo, true)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Other' })
+  })
+
+  it('should not swallow and reason "Other" for non-security policy error in nr-recorder', () => {
+    const stackInfo = {
+      frames: ['nr-123-recorder.min.js'],
+      message: 'Some other error message'
+    }
+    const result = isInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: false, reason: 'Other' })
+  })
+
+  it('should not swallow and reason "Other" for non-security policy error in rrweb', () => {
+    const stackInfo = {
+      frames: ['rrweb'],
+      message: 'Some other error message'
+    }
+    const result = isInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: false, reason: 'Other' })
+  })
+})

--- a/tests/unit/features/jserrors/aggregate/internal-errors.test.js
+++ b/tests/unit/features/jserrors/aggregate/internal-errors.test.js
@@ -1,57 +1,81 @@
-import { isInternalError } from '../../../../../src/features/jserrors/aggregate/internal-errors'
+import { evaluateInternalError } from '../../../../../src/features/jserrors/aggregate/internal-errors'
 
 describe('isInternalError', () => {
   it('should not swallow and reason "Other" when no internal flag and no specific error', () => {
     const stackInfo = {
-      frames: ['some-other-script.js'],
+      frames: [{ url: 'some-other-script.js' }],
       message: 'Some error message'
     }
-    const result = isInternalError(stackInfo, false)
+    const result = evaluateInternalError(stackInfo, false)
     expect(result).toEqual({ shouldSwallow: false, reason: 'Other' })
   })
 
-  it('should swallow and reason "Rrweb" for nr-recorder security policy error', () => {
+  it('should swallow and reason "Rrweb-Security-Policy" for nr-recorder security policy error', () => {
     const stackInfo = {
-      frames: ['nr-123-recorder.min.js'],
+      frames: [{ url: 'nr-123-recorder.min.js' }],
       message: 'An attempt was made to break through the security policy of the user agent'
     }
-    const result = isInternalError(stackInfo, false)
-    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb' })
+    const result = evaluateInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb-Security-Policy' })
   })
 
-  it('should swallow and reason "Rrweb" for rrweb security policy error', () => {
+  it('should swallow and reason "Rrweb-Security-Policy" for rrweb security policy error', () => {
     const stackInfo = {
-      frames: ['rrweb'],
+      frames: [{ url: 'fake/rrweb/file.js' }],
       message: 'An attempt was made to break through the security policy of the user agent'
     }
-    const result = isInternalError(stackInfo, false)
-    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb' })
+    const result = evaluateInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb-Security-Policy' })
   })
 
   it('should swallow and reason "Other" for any error when internal flag is true', () => {
     const stackInfo = {
-      frames: ['some-other-script.js'],
+      frames: [{ url: 'some-other-script.js' }],
       message: 'Some error message'
     }
-    const result = isInternalError(stackInfo, true)
+    const result = evaluateInternalError(stackInfo, true)
     expect(result).toEqual({ shouldSwallow: true, reason: 'Other' })
   })
 
-  it('should not swallow and reason "Other" for non-security policy error in nr-recorder', () => {
+  it('should swallow and reason "Other" for any error when internal flag is true and no frames', () => {
     const stackInfo = {
-      frames: ['nr-123-recorder.min.js'],
-      message: 'Some other error message'
+      message: 'Some error message'
     }
-    const result = isInternalError(stackInfo, false)
+    const result = evaluateInternalError(stackInfo, true)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Other' })
+  })
+
+  it('should swallow and reason "Other" for any error when internal flag is true and no message', () => {
+    const stackInfo = {
+      frames: [{ url: 'some-other-script.js' }]
+    }
+    const result = evaluateInternalError(stackInfo, true)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Other' })
+  })
+
+  it('should not swallow and reason "Other" for recorder errors that are incomplete', () => {
+    const stackInfo = {
+      frames: [{ url: 'fake/rrweb/file.js' }]
+    }
+    const result = evaluateInternalError(stackInfo)
     expect(result).toEqual({ shouldSwallow: false, reason: 'Other' })
   })
 
-  it('should not swallow and reason "Other" for non-security policy error in rrweb', () => {
+  it('should swallow and reason "Rrweb" for non-security policy error in nr-recorder', () => {
     const stackInfo = {
-      frames: ['rrweb'],
+      frames: [{ url: 'nr-123-recorder.min.js' }],
       message: 'Some other error message'
     }
-    const result = isInternalError(stackInfo, false)
-    expect(result).toEqual({ shouldSwallow: false, reason: 'Other' })
+    const result = evaluateInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb' })
+  })
+
+  it('should swallow and reason "Rrweb" for non-security policy error in rrweb', () => {
+    const stackInfo = {
+      frames: [{ url: 'fake/rrweb/file.js' }],
+      message: 'Some other error message'
+    }
+    const result = evaluateInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb' })
   })
 })

--- a/tests/unit/features/jserrors/aggregate/internal-errors.test.js
+++ b/tests/unit/features/jserrors/aggregate/internal-errors.test.js
@@ -28,6 +28,15 @@ describe('isInternalError', () => {
     expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb-Security-Policy' })
   })
 
+  it('should swallow and reason "Rrweb-Security-Policy" for security policy error in generic recorder module (npm custom build)', () => {
+    const stackInfo = {
+      frames: [{ url: 'custom/npm/build/recorder.1a2b3c4d.js' }],
+      message: 'An attempt was made to break through the security policy of the user agent'
+    }
+    const result = evaluateInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: true, reason: 'Rrweb-Security-Policy' })
+  })
+
   it('should swallow and reason "Other" for any error when internal flag is true', () => {
     const stackInfo = {
       frames: [{ url: 'some-other-script.js' }],


### PR DESCRIPTION
Handle Security Policy Errors encountered by session replay when browser APIs have been natively disabled.  This was also observed to happen in Chromium browsers that completely disabled cookie storage.  Supportability metrics about agent internal errors are now captured as a biproduct of this work to help facilitate future improvements.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
All errors thrown from either the `rrweb` library directly or the wrapping `nr-recorder` module will be handled through the new internal handler.
All instances of internal errors will now generate a supportability metric instead of an unused `ierr` harvest.  There are a few basic categories added as part of this pr.  More categories can be added later as needs arise
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-316093
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been updated to evaluate the new behavior
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
