### PR TITLE
feat: Relocate aggregator from loader and improve agent internals

### DIFF
--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -19,11 +19,11 @@ import { EventBuffer } from '../../utils/event-buffer'
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
 
-  constructor (thisAgent) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, FEATURE_NAME)
 
-    const harvestTimeSeconds = thisAgent.init.ajax.harvestTimeSeconds || 10
-    setDenyList(thisAgent.runtime.denyList)
+    const harvestTimeSeconds = agentRef.init.ajax.harvestTimeSeconds || 10
+    setDenyList(agentRef.runtime.denyList)
 
     this.ajaxEvents = new EventBuffer()
     this.spaAjaxEvents = {}

--- a/src/features/ajax/instrument/index.js
+++ b/src/features/ajax/instrument/index.js
@@ -28,10 +28,10 @@ var origXHR = gosNREUMOriginals().o.XHR
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
 
-    this.dt = new DT(thisAgent.agentIdentifier)
+    this.dt = new DT(agentRef.agentIdentifier)
 
     this.handler = (type, args, ctx, group) => handle(type, args, ctx, group, this.ee)
 
@@ -59,13 +59,13 @@ export class Instrument extends InstrumentBase {
 
     wrapFetch(this.ee)
     wrapXhr(this.ee)
-    subscribeToEvents(thisAgent, this.ee, this.handler, this.dt)
+    subscribeToEvents(agentRef, this.ee, this.handler, this.dt)
 
-    this.importAggregator(thisAgent)
+    this.importAggregator(agentRef)
   }
 }
 
-function subscribeToEvents (thisAgent, ee, handler, dt) {
+function subscribeToEvents (agentRef, ee, handler, dt) {
   ee.on('new-xhr', onNewXhr)
   ee.on('open-xhr-start', onOpenXhrStart)
   ee.on('open-xhr-end', onOpenXhrEnd)
@@ -120,8 +120,8 @@ function subscribeToEvents (thisAgent, ee, handler, dt) {
   }
 
   function onOpenXhrEnd (args, xhr) {
-    if (thisAgent.loader_config.xpid && this.sameOrigin) {
-      xhr.setRequestHeader('X-NewRelic-ID', thisAgent.loader_config.xpid)
+    if (agentRef.loader_config.xpid && this.sameOrigin) {
+      xhr.setRequestHeader('X-NewRelic-ID', agentRef.loader_config.xpid)
     }
 
     var payload = dt.generateTracePayload(this.parsedOrigin)

--- a/src/features/ajax/instrument/index.js
+++ b/src/features/ajax/instrument/index.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { gosNREUMOriginals } from '../../../common/window/nreum'
-import { getLoaderConfig } from '../../../common/config/loader-config'
 import { handle } from '../../../common/event-emitter/handle'
 import { id } from '../../../common/ids/id'
 import { ffVersion, globalScope, isBrowserScope } from '../../../common/constants/runtime'
@@ -29,10 +28,10 @@ var origXHR = gosNREUMOriginals().o.XHR
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
 
-    this.dt = new DT(agentIdentifier)
+    this.dt = new DT(thisAgent.agentIdentifier)
 
     this.handler = (type, args, ctx, group) => handle(type, args, ctx, group, this.ee)
 
@@ -60,13 +59,13 @@ export class Instrument extends InstrumentBase {
 
     wrapFetch(this.ee)
     wrapXhr(this.ee)
-    subscribeToEvents(agentIdentifier, this.ee, this.handler, this.dt)
+    subscribeToEvents(thisAgent, this.ee, this.handler, this.dt)
 
-    this.importAggregator()
+    this.importAggregator(thisAgent)
   }
 }
 
-function subscribeToEvents (agentIdentifier, ee, handler, dt) {
+function subscribeToEvents (thisAgent, ee, handler, dt) {
   ee.on('new-xhr', onNewXhr)
   ee.on('open-xhr-start', onOpenXhrStart)
   ee.on('open-xhr-end', onOpenXhrEnd)
@@ -121,9 +120,8 @@ function subscribeToEvents (agentIdentifier, ee, handler, dt) {
   }
 
   function onOpenXhrEnd (args, xhr) {
-    var loaderConfig = getLoaderConfig(agentIdentifier)
-    if (loaderConfig.xpid && this.sameOrigin) {
-      xhr.setRequestHeader('X-NewRelic-ID', loaderConfig.xpid)
+    if (thisAgent.loader_config.xpid && this.sameOrigin) {
+      xhr.setRequestHeader('X-NewRelic-ID', thisAgent.loader_config.xpid)
     }
 
     var payload = dt.generateTracePayload(this.parsedOrigin)

--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -21,11 +21,11 @@ import { isIFrameWindow } from '../../../common/dom/iframe'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, FEATURE_NAME)
 
     this.eventsPerHarvest = 1000
-    this.harvestTimeSeconds = thisAgent.init.generic_events.harvestTimeSeconds
+    this.harvestTimeSeconds = agentRef.init.generic_events.harvestTimeSeconds
 
     this.referrerUrl = (isBrowserScope && document.referrer) ? cleanURL(document.referrer) : undefined
     this.events = new EventBuffer()
@@ -39,7 +39,7 @@ export class Aggregate extends AggregateBase {
 
       const preHarvestMethods = []
 
-      if (thisAgent.init.page_action.enabled) {
+      if (agentRef.init.page_action.enabled) {
         registerHandler('api-addPageAction', (timestamp, name, attributes) => {
           this.addEvent({
             ...attributes,
@@ -56,7 +56,7 @@ export class Aggregate extends AggregateBase {
         }, this.featureName, this.ee)
       }
 
-      if (isBrowserScope && thisAgent.init.user_actions.enabled) {
+      if (isBrowserScope && agentRef.init.user_actions.enabled) {
         this.userActionAggregator = new UserActionsAggregator()
 
         this.addUserAction = (aggregatedUserAction) => {

--- a/src/features/generic_events/instrument/index.js
+++ b/src/features/generic_events/instrument/index.js
@@ -2,7 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getConfiguration } from '../../../common/config/init'
 import { isBrowserScope } from '../../../common/constants/runtime'
 import { deregisterDrain } from '../../../common/drain/drain'
 import { handle } from '../../../common/event-emitter/handle'
@@ -12,16 +11,15 @@ import { FEATURE_NAME, OBSERVED_EVENTS, OBSERVED_WINDOW_EVENTS } from '../consta
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
-    const agentInit = getConfiguration(this.agentIdentifier)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
     const genericEventSourceConfigs = [
-      agentInit.page_action.enabled,
-      agentInit.user_actions.enabled
+      thisAgent.init.page_action.enabled,
+      thisAgent.init.user_actions.enabled
       // other future generic event source configs to go here, like M&Ms, PageResouce, etc.
     ]
 
-    if (isBrowserScope && agentInit.user_actions.enabled) {
+    if (isBrowserScope && thisAgent.init.user_actions.enabled) {
       OBSERVED_EVENTS.forEach(eventType =>
         windowAddEventListener(eventType, (evt) => handle('ua', [evt], undefined, this.featureName, this.ee), true)
       )
@@ -32,8 +30,8 @@ export class Instrument extends InstrumentBase {
     }
 
     /** If any of the sources are active, import the aggregator. otherwise deregister */
-    if (genericEventSourceConfigs.some(x => x)) this.importAggregator()
-    else deregisterDrain(this.agentIdentifier, this.featureName)
+    if (genericEventSourceConfigs.some(x => x)) this.importAggregator(thisAgent)
+    else deregisterDrain(thisAgent.agentIdentifier, this.featureName)
   }
 }
 

--- a/src/features/generic_events/instrument/index.js
+++ b/src/features/generic_events/instrument/index.js
@@ -11,15 +11,15 @@ import { FEATURE_NAME, OBSERVED_EVENTS, OBSERVED_WINDOW_EVENTS } from '../consta
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
     const genericEventSourceConfigs = [
-      thisAgent.init.page_action.enabled,
-      thisAgent.init.user_actions.enabled
+      agentRef.init.page_action.enabled,
+      agentRef.init.user_actions.enabled
       // other future generic event source configs to go here, like M&Ms, PageResouce, etc.
     ]
 
-    if (isBrowserScope && thisAgent.init.user_actions.enabled) {
+    if (isBrowserScope && agentRef.init.user_actions.enabled) {
       OBSERVED_EVENTS.forEach(eventType =>
         windowAddEventListener(eventType, (evt) => handle('ua', [evt], undefined, this.featureName, this.ee), true)
       )
@@ -30,8 +30,8 @@ export class Instrument extends InstrumentBase {
     }
 
     /** If any of the sources are active, import the aggregator. otherwise deregister */
-    if (genericEventSourceConfigs.some(x => x)) this.importAggregator(thisAgent)
-    else deregisterDrain(thisAgent.agentIdentifier, this.featureName)
+    if (genericEventSourceConfigs.some(x => x)) this.importAggregator(agentRef)
+    else deregisterDrain(agentRef.agentIdentifier, this.featureName)
   }
 }
 

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -12,9 +12,6 @@ import { registerHandler as register } from '../../../common/event-emitter/regis
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { stringify } from '../../../common/util/stringify'
 import { handle } from '../../../common/event-emitter/handle'
-import { getInfo } from '../../../common/config/info'
-import { getConfigurationValue } from '../../../common/config/init'
-import { getRuntime } from '../../../common/config/runtime'
 import { globalScope } from '../../../common/constants/runtime'
 
 import { FEATURE_NAME } from '../constants'
@@ -31,8 +28,8 @@ import { applyFnToProps } from '../../../common/util/traverse'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
+  constructor (thisAgent) {
+    super(thisAgent, FEATURE_NAME)
 
     this.stackReported = {}
     this.observedAt = {}
@@ -49,7 +46,7 @@ export class Aggregate extends AggregateBase {
     register('softNavFlush', (interactionId, wasFinished, softNavAttrs) =>
       this.onSoftNavNotification(interactionId, wasFinished, softNavAttrs), this.featureName, this.ee) // when an ixn is done or cancelled
 
-    const harvestTimeSeconds = getConfigurationValue(this.agentIdentifier, 'jserrors.harvestTimeSeconds') || 10
+    const harvestTimeSeconds = thisAgent.init.jserrors.harvestTimeSeconds || 10
 
     // 0 == off, 1 == on
     this.waitForFlags(['err']).then(([errFlag]) => {
@@ -68,7 +65,7 @@ export class Aggregate extends AggregateBase {
   onHarvestStarted (options) {
     // this gets rid of dependency in AJAX module
     var body = applyFnToProps(
-      this.aggregator.take(['err', 'ierr', 'xhr']),
+      this.agentRef.sharedAggregator.take(['err', 'ierr', 'xhr']),
       this.obfuscator.obfuscateString.bind(this.obfuscator), 'string'
     )
 
@@ -77,7 +74,7 @@ export class Aggregate extends AggregateBase {
     }
 
     var payload = { body, qs: {} }
-    var releaseIds = stringify(getRuntime(this.agentIdentifier).releaseIds)
+    var releaseIds = stringify(this.agentRef.runtime.releaseIds)
 
     if (releaseIds !== '{}') {
       payload.qs.ri = releaseIds
@@ -100,7 +97,7 @@ export class Aggregate extends AggregateBase {
         for (var i = 0; i < value.length; i++) {
           var bucket = value[i]
           var name = this.getBucketName(key, bucket.params, bucket.custom)
-          this.aggregator.merge(key, name, bucket.metrics, bucket.params, bucket.custom)
+          this.agentRef.sharedAggregator.merge(key, name, bucket.metrics, bucket.params, bucket.custom)
         }
       })
       this.currentBody = null
@@ -146,11 +143,10 @@ export class Aggregate extends AggregateBase {
     if (!err) return
     // are we in an interaction
     time = time || now()
-    const agentRuntime = getRuntime(this.agentIdentifier)
     let filterOutput
 
-    if (!internal && agentRuntime.onerror) {
-      filterOutput = agentRuntime.onerror(err)
+    if (!internal && this.agentRef.runtime.onerror) {
+      filterOutput = this.agentRef.runtime.onerror(err)
       if (filterOutput && !(typeof filterOutput.group === 'string' && filterOutput.group.length)) {
         // All truthy values mean don't report (store) the error, per backwards-compatible usage,
         // - EXCEPT if a fingerprinting label is returned, via an object with key of 'group' and value of non-empty string
@@ -184,11 +180,11 @@ export class Aggregate extends AggregateBase {
     if (!this.stackReported[bucketHash]) {
       this.stackReported[bucketHash] = true
       params.stack_trace = truncateSize(stackInfo.stackString)
-      this.observedAt[bucketHash] = Math.floor(agentRuntime.timeKeeper.correctRelativeTimestamp(time))
+      this.observedAt[bucketHash] = Math.floor(this.agentRef.runtime.timeKeeper.correctRelativeTimestamp(time))
     } else {
       params.browser_stack_hash = stringHashCode(stackInfo.stackString)
     }
-    params.releaseIds = stringify(agentRuntime.releaseIds)
+    params.releaseIds = stringify(this.agentRef.runtime.releaseIds)
 
     // When debugging stack canonicalization/hashing, uncomment these lines for
     // more output in the test logs
@@ -201,7 +197,7 @@ export class Aggregate extends AggregateBase {
     }
 
     params.firstOccurrenceTimestamp = this.observedAt[bucketHash]
-    params.timestamp = Math.floor(agentRuntime.timeKeeper.correctRelativeTimestamp(time))
+    params.timestamp = Math.floor(this.agentRef.runtime.timeKeeper.correctRelativeTimestamp(time))
 
     var type = internal ? 'ierr' : 'err'
     var newMetrics = { time }
@@ -247,14 +243,14 @@ export class Aggregate extends AggregateBase {
       delete params._softNavAttributes // cleanup temp properties from synchronous evaluation; this is harmless when async from soft nav (properties DNE)
       delete params._softNavFinished
     } else { // interaction was cancelled -> error should not be associated OR there was no interaction
-      Object.entries(getInfo(this.agentIdentifier).jsAttributes).forEach(([k, v]) => setCustom(k, v))
+      Object.entries(this.agentRef.info.jsAttributes).forEach(([k, v]) => setCustom(k, v))
       delete params.browserInteractionId
     }
     if (localAttrs) Object.entries(localAttrs).forEach(([k, v]) => setCustom(k, v)) // local custom attrs are applied in either case with the highest precedence
 
     const jsAttributesHash = stringHashCode(stringify(allCustomAttrs))
     const aggregateHash = bucketHash + ':' + jsAttributesHash
-    this.aggregator.store(type, aggregateHash, params, newMetrics, allCustomAttrs)
+    this.agentRef.sharedAggregator.store(type, aggregateHash, params, newMetrics, allCustomAttrs)
 
     function setCustom (key, val) {
       allCustomAttrs[key] = (val && typeof val === 'object' ? stringify(val) : val)
@@ -284,7 +280,7 @@ export class Aggregate extends AggregateBase {
       var jsAttributesHash = stringHashCode(stringify(allCustomAttrs))
       var aggregateHash = hash + ':' + jsAttributesHash
 
-      this.aggregator.store(item[0], aggregateHash, params, item[3], allCustomAttrs)
+      this.agentRef.sharedAggregator.store(item[0], aggregateHash, params, item[3], allCustomAttrs)
 
       function setCustom ([key, val]) {
         allCustomAttrs[key] = (val && typeof val === 'object' ? stringify(val) : val)

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -28,8 +28,8 @@ import { applyFnToProps } from '../../../common/util/traverse'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, FEATURE_NAME)
 
     this.stackReported = {}
     this.observedAt = {}
@@ -46,7 +46,7 @@ export class Aggregate extends AggregateBase {
     register('softNavFlush', (interactionId, wasFinished, softNavAttrs) =>
       this.onSoftNavNotification(interactionId, wasFinished, softNavAttrs), this.featureName, this.ee) // when an ixn is done or cancelled
 
-    const harvestTimeSeconds = thisAgent.init.jserrors.harvestTimeSeconds || 10
+    const harvestTimeSeconds = agentRef.init.jserrors.harvestTimeSeconds || 10
 
     // 0 == off, 1 == on
     this.waitForFlags(['err']).then(([errFlag]) => {

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -14,11 +14,10 @@ import { castError, castErrorEvent, castPromiseRejectionEvent } from '../shared/
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-
   #replayRunning = false
 
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
 
     try {
       // this try-catch can be removed when IE11 is completely unsupported & gone
@@ -45,7 +44,7 @@ export class Instrument extends InstrumentBase {
     }, eventListenerOpts(false, this.removeOnAbort?.signal))
 
     this.abortHandler = this.#abort // we also use this as a flag to denote that the feature is active or on and handling errors
-    this.importAggregator()
+    this.importAggregator(thisAgent)
   }
 
   /** Restoration and resource release tasks to be done if JS error loader is being aborted. Unwind changes to globals. */

--- a/src/features/jserrors/instrument/index.js
+++ b/src/features/jserrors/instrument/index.js
@@ -16,8 +16,8 @@ export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   #replayRunning = false
 
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
 
     try {
       // this try-catch can be removed when IE11 is completely unsupported & gone
@@ -44,7 +44,7 @@ export class Instrument extends InstrumentBase {
     }, eventListenerOpts(false, this.removeOnAbort?.signal))
 
     this.abortHandler = this.#abort // we also use this as a flag to denote that the feature is active or on and handling errors
-    this.importAggregator(thisAgent)
+    this.importAggregator(agentRef)
   }
 
   /** Restoration and resource release tasks to be done if JS error loader is being aborted. Unwind changes to globals. */

--- a/src/features/logging/aggregate/index.js
+++ b/src/features/logging/aggregate/index.js
@@ -14,13 +14,13 @@ import { EventBuffer } from '../../utils/event-buffer'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, FEATURE_NAME)
 
     /** held logs before sending */
     this.bufferedLogs = new EventBuffer()
 
-    this.harvestTimeSeconds = thisAgent.init.logging.harvestTimeSeconds
+    this.harvestTimeSeconds = agentRef.init.logging.harvestTimeSeconds
 
     this.waitForFlags([]).then(() => {
       this.scheduler = new HarvestScheduler('browser/logs', {

--- a/src/features/logging/instrument/index.js
+++ b/src/features/logging/instrument/index.js
@@ -4,8 +4,8 @@ import { bufferLog } from '../shared/utils'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
 
     const instanceEE = this.ee
     /** emitted by wrap-logger function */
@@ -13,7 +13,7 @@ export class Instrument extends InstrumentBase {
       const { level, customAttributes } = this
       bufferLog(instanceEE, message, customAttributes, level)
     })
-    this.importAggregator()
+    this.importAggregator(thisAgent)
   }
 }
 

--- a/src/features/logging/instrument/index.js
+++ b/src/features/logging/instrument/index.js
@@ -4,8 +4,8 @@ import { bufferLog } from '../shared/utils'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
 
     const instanceEE = this.ee
     /** emitted by wrap-logger function */
@@ -13,7 +13,7 @@ export class Instrument extends InstrumentBase {
       const { level, customAttributes } = this
       bufferLog(instanceEE, message, customAttributes, level)
     })
-    this.importAggregator(thisAgent)
+    this.importAggregator(agentRef)
   }
 }
 

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -1,5 +1,3 @@
-import { getConfiguration } from '../../../common/config/init'
-import { getRuntime } from '../../../common/config/runtime'
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL/*, WATCHABLE_WEB_SOCKET_EVENTS */ } from '../constants'
@@ -16,15 +14,15 @@ import { isIFrameWindow } from '../../../common/dom/iframe'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
+  constructor (thisAgent) {
+    super(thisAgent, FEATURE_NAME)
 
     this.waitForFlags(['err']).then(([errFlag]) => {
       if (errFlag) {
         // *cli, Mar 23 - Per NR-94597, this feature should only harvest ONCE at the (potential) EoL time of the page.
         const scheduler = new HarvestScheduler('jserrors', { onUnload: () => this.unload() }, this)
         // this is needed to ensure EoL is "on" and sent
-        scheduler.harvest.on('jserrors', () => ({ body: this.aggregator.take(['cm', 'sm']) }))
+        scheduler.harvest.on('jserrors', () => ({ body: this.agentRef.sharedAggregator.take(['cm', 'sm']) }))
         this.drain()
       } else {
         this.blocked = true // if rum response determines that customer lacks entitlements for spa endpoint, this feature shouldn't harvest
@@ -44,20 +42,20 @@ export class Aggregate extends AggregateBase {
     if (this.blocked) return
     const type = SUPPORTABILITY_METRIC
     const params = { name }
-    this.aggregator.storeMetric(type, name, params, value)
+    this.agentRef.sharedAggregator.storeMetric(type, name, params, value)
   }
 
   storeEventMetrics (name, metrics) {
     if (this.blocked) return
     const type = CUSTOM_METRIC
     const params = { name }
-    this.aggregator.store(type, name, params, metrics)
+    this.agentRef.sharedAggregator.store(type, name, params, metrics)
   }
 
   singleChecks () {
     // report loaderType
-    const { distMethod, loaderType } = getRuntime(this.agentIdentifier)
-    const { proxy, privacy } = getConfiguration(this.agentIdentifier)
+    const { distMethod, loaderType } = this.agentRef.runtime
+    const { proxy, privacy } = this.agentRef.init
 
     if (loaderType) this.storeSupportabilityMetrics(`Generic/LoaderType/${loaderType}/Detected`)
     if (distMethod) this.storeSupportabilityMetrics(`Generic/DistMethod/${distMethod}/Detected`)

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -14,8 +14,8 @@ import { isIFrameWindow } from '../../../common/dom/iframe'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, FEATURE_NAME)
 
     this.waitForFlags(['err']).then(([errFlag]) => {
       if (errFlag) {

--- a/src/features/metrics/instrument/index.js
+++ b/src/features/metrics/instrument/index.js
@@ -5,8 +5,8 @@ import { FEATURE_NAME/*, WATCHABLE_WEB_SOCKET_EVENTS */ } from '../constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
     // wrapWebSocket(this.ee)
 
     // WATCHABLE_WEB_SOCKET_EVENTS.forEach((suffix) => {
@@ -15,7 +15,7 @@ export class Instrument extends InstrumentBase {
     //   })
     // })
 
-    this.importAggregator(thisAgent)
+    this.importAggregator(agentRef)
   }
 }
 

--- a/src/features/metrics/instrument/index.js
+++ b/src/features/metrics/instrument/index.js
@@ -5,8 +5,8 @@ import { FEATURE_NAME/*, WATCHABLE_WEB_SOCKET_EVENTS */ } from '../constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
     // wrapWebSocket(this.ee)
 
     // WATCHABLE_WEB_SOCKET_EVENTS.forEach((suffix) => {
@@ -15,7 +15,7 @@ export class Instrument extends InstrumentBase {
     //   })
     // })
 
-    this.importAggregator()
+    this.importAggregator(thisAgent)
   }
 }
 

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -1,8 +1,7 @@
 import { globalScope, isBrowserScope, originTime } from '../../../common/constants/runtime'
 import { addPT, addPN } from '../../../common/timing/nav-timing'
 import { stringify } from '../../../common/util/stringify'
-import { getInfo, isValid } from '../../../common/config/info'
-import { getRuntime } from '../../../common/config/runtime'
+import { isValid } from '../../../common/config/info'
 import { Harvest } from '../../../common/harvest/harvest'
 import * as CONSTANTS from '../constants'
 import { getActivatedFeaturesFlags } from './initialized-features'
@@ -18,15 +17,15 @@ import { applyFnToProps } from '../../../common/util/traverse'
 
 export class Aggregate extends AggregateBase {
   static featureName = CONSTANTS.FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, CONSTANTS.FEATURE_NAME)
+  constructor (thisAgent) {
+    super(thisAgent, CONSTANTS.FEATURE_NAME)
 
     this.timeToFirstByte = 0
     this.firstByteToWindowLoad = 0 // our "frontend" duration
     this.firstByteToDomContent = 0 // our "dom processing" duration
-    this.timeKeeper = new TimeKeeper(this.agentIdentifier)
+    this.timeKeeper = new TimeKeeper(thisAgent.agentIdentifier)
 
-    if (!isValid(agentIdentifier)) {
+    if (!isValid(thisAgent.agentIdentifier)) {
       this.ee.abort()
       return warn(43)
     }
@@ -47,8 +46,7 @@ export class Aggregate extends AggregateBase {
   }
 
   sendRum () {
-    const info = getInfo(this.agentIdentifier)
-    const agentRuntime = getRuntime(this.agentIdentifier)
+    const info = this.agentRef.info
     const harvester = new Harvest(this)
 
     if (info.queueTime) this.aggregator.store('measures', 'qt', { value: info.queueTime })
@@ -78,7 +76,7 @@ export class Aggregate extends AggregateBase {
       at: info.atts
     }
 
-    if (agentRuntime.session) queryParameters.fsh = Number(agentRuntime.session.isNew) // "first session harvest" aka RUM request or PageView event of a session
+    if (this.agentRef.runtime.session) queryParameters.fsh = Number(this.agentRef.runtime.session.isNew) // "first session harvest" aka RUM request or PageView event of a session
 
     let body
     if (typeof info.jsAttributes === 'object' && Object.keys(info.jsAttributes).length > 0) {
@@ -128,13 +126,13 @@ export class Aggregate extends AggregateBase {
           try {
             this.timeKeeper.processRumRequest(xhr, rumStartTime, rumEndTime, app.nrServerTime)
             if (!this.timeKeeper.ready) throw new Error('TimeKeeper not ready')
-            agentRuntime.timeKeeper = this.timeKeeper
+            this.agentRef.runtime.timeKeeper = this.timeKeeper
           } catch (error) {
             this.ee.abort()
             warn(17, error)
             return
           }
-          agentRuntime.appMetadata = app
+          this.agentRef.runtime.appMetadata = app
           activateFeatures(flags, this.agentIdentifier)
           this.drain()
         } catch (err) {

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -17,15 +17,15 @@ import { applyFnToProps } from '../../../common/util/traverse'
 
 export class Aggregate extends AggregateBase {
   static featureName = CONSTANTS.FEATURE_NAME
-  constructor (thisAgent) {
-    super(thisAgent, CONSTANTS.FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, CONSTANTS.FEATURE_NAME)
 
     this.timeToFirstByte = 0
     this.firstByteToWindowLoad = 0 // our "frontend" duration
     this.firstByteToDomContent = 0 // our "dom processing" duration
-    this.timeKeeper = new TimeKeeper(thisAgent.agentIdentifier)
+    this.timeKeeper = new TimeKeeper(agentRef.agentIdentifier)
 
-    if (!isValid(thisAgent.agentIdentifier)) {
+    if (!isValid(agentRef.agentIdentifier)) {
       this.ee.abort()
       return warn(43)
     }

--- a/src/features/page_view_event/instrument/index.js
+++ b/src/features/page_view_event/instrument/index.js
@@ -3,10 +3,10 @@ import * as CONSTANTS from '../constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = CONSTANTS.FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, CONSTANTS.FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, CONSTANTS.FEATURE_NAME, auto)
 
-    this.importAggregator()
+    this.importAggregator(thisAgent)
   }
 }
 

--- a/src/features/page_view_event/instrument/index.js
+++ b/src/features/page_view_event/instrument/index.js
@@ -3,10 +3,10 @@ import * as CONSTANTS from '../constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = CONSTANTS.FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, CONSTANTS.FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, CONSTANTS.FEATURE_NAME, auto)
 
-    this.importAggregator(thisAgent)
+    this.importAggregator(agentRef)
   }
 }
 

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -28,8 +28,8 @@ export class Aggregate extends AggregateBase {
     this.addTiming(name, value, attrs)
   }
 
-  constructor (thisAgent) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, FEATURE_NAME)
 
     this.timings = new EventBuffer()
     this.curSessEndRecorded = false
@@ -37,7 +37,7 @@ export class Aggregate extends AggregateBase {
     registerHandler('docHidden', msTimestamp => this.endCurrentSession(msTimestamp), this.featureName, this.ee)
     registerHandler('winPagehide', msTimestamp => this.recordPageUnload(msTimestamp), this.featureName, this.ee)
 
-    const harvestTimeSeconds = thisAgent.init.page_view_timing.harvestTimeSeconds || 30
+    const harvestTimeSeconds = agentRef.init.page_view_timing.harvestTimeSeconds || 30
 
     this.waitForFlags(([])).then(() => {
       /* It's important that CWV api, like "onLCP", is called before the **scheduler** is initialized. The reason is because they listen to the same

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -7,8 +7,6 @@ import { nullable, numeric, getAddStringContext, addCustomAttributes } from '../
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { handle } from '../../../common/event-emitter/handle'
-import { getInfo } from '../../../common/config/info'
-import { getConfigurationValue } from '../../../common/config/init'
 import { FEATURE_NAME } from '../constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { AggregateBase } from '../../utils/aggregate-base'
@@ -30,8 +28,8 @@ export class Aggregate extends AggregateBase {
     this.addTiming(name, value, attrs)
   }
 
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
+  constructor (thisAgent) {
+    super(thisAgent, FEATURE_NAME)
 
     this.timings = new EventBuffer()
     this.curSessEndRecorded = false
@@ -39,7 +37,7 @@ export class Aggregate extends AggregateBase {
     registerHandler('docHidden', msTimestamp => this.endCurrentSession(msTimestamp), this.featureName, this.ee)
     registerHandler('winPagehide', msTimestamp => this.recordPageUnload(msTimestamp), this.featureName, this.ee)
 
-    const harvestTimeSeconds = getConfigurationValue(this.agentIdentifier, 'page_view_timing.harvestTimeSeconds') || 30
+    const harvestTimeSeconds = thisAgent.init.page_view_timing.harvestTimeSeconds || 30
 
     this.waitForFlags(([])).then(() => {
       /* It's important that CWV api, like "onLCP", is called before the **scheduler** is initialized. The reason is because they listen to the same
@@ -129,11 +127,10 @@ export class Aggregate extends AggregateBase {
 
   appendGlobalCustomAttributes (timing) {
     var timingAttributes = timing.attrs || {}
-    var customAttributes = getInfo(this.agentIdentifier).jsAttributes || {}
 
     var reservedAttributes = ['size', 'eid', 'cls', 'type', 'fid', 'elTag', 'elUrl', 'net-type',
       'net-etype', 'net-rtt', 'net-dlink']
-    Object.entries(customAttributes || {}).forEach(([key, val]) => {
+    Object.entries(this.agentRef.info.jsAttributes || {}).forEach(([key, val]) => {
       if (reservedAttributes.indexOf(key) < 0) {
         timingAttributes[key] = val
       }

--- a/src/features/page_view_timing/instrument/index.js
+++ b/src/features/page_view_timing/instrument/index.js
@@ -12,8 +12,8 @@ import { now } from '../../../common/timing/now'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
     if (!isBrowserScope) return // CWV is irrelevant outside web context
 
     // While we try to replicate web-vital's visibilitywatcher logic in an effort to defer that library to post-pageload, this isn't perfect and doesn't consider prerendering.
@@ -22,7 +22,7 @@ export class Instrument extends InstrumentBase {
     // Window fires its pagehide event (typically on navigation--this occurrence is a *subset* of vis change); don't defer this unless it's guarantee it cannot happen before load(?)
     windowAddEventListener('pagehide', () => handle('winPagehide', [now()], undefined, FEATURE_NAME, this.ee))
 
-    this.importAggregator()
+    this.importAggregator(thisAgent)
   }
 }
 

--- a/src/features/page_view_timing/instrument/index.js
+++ b/src/features/page_view_timing/instrument/index.js
@@ -12,8 +12,8 @@ import { now } from '../../../common/timing/now'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
     if (!isBrowserScope) return // CWV is irrelevant outside web context
 
     // While we try to replicate web-vital's visibilitywatcher logic in an effort to defer that library to post-pageload, this isn't perfect and doesn't consider prerendering.
@@ -22,7 +22,7 @@ export class Instrument extends InstrumentBase {
     // Window fires its pagehide event (typically on navigation--this occurrence is a *subset* of vis change); don't defer this unless it's guarantee it cannot happen before load(?)
     windowAddEventListener('pagehide', () => handle('winPagehide', [now()], undefined, FEATURE_NAME, this.ee))
 
-    this.importAggregator(thisAgent)
+    this.importAggregator(agentRef)
   }
 }
 

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -32,10 +32,10 @@ export class Aggregate extends AggregateBase {
   mode = MODE.OFF
 
   // pass the recorder into the aggregator
-  constructor (thisAgent, args) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef, args) {
+    super(agentRef, FEATURE_NAME)
     /** The interval to harvest at.  This gets overridden if the size of the payload exceeds certain thresholds */
-    this.harvestTimeSeconds = thisAgent.init.session_replay.harvestTimeSeconds || 60
+    this.harvestTimeSeconds = agentRef.init.session_replay.harvestTimeSeconds || 60
     /** Set once the recorder has fully initialized after flag checks and sampling */
     this.initialized = false
     /** Set once the feature has been "aborted" to prevent other side-effects from continuing */
@@ -74,7 +74,7 @@ export class Aggregate extends AggregateBase {
     this.ee.on(SESSION_EVENTS.RESUME, () => {
       if (!this.recorder) return
       // if the mode changed on a different tab, it needs to update this instance to match
-      this.mode = thisAgent.runtime.session.state.sessionReplayMode
+      this.mode = agentRef.runtime.session.state.sessionReplayMode
       if (!this.initialized || this.mode === MODE.OFF) return
       this.recorder?.startRecording()
     })
@@ -101,7 +101,7 @@ export class Aggregate extends AggregateBase {
       this.handleError(e)
     }, this.featureName, this.ee)
 
-    const { error_sampling_rate, sampling_rate, autoStart, block_selector, mask_text_selector, mask_all_inputs, inline_images, collect_fonts } = thisAgent.init.session_replay
+    const { error_sampling_rate, sampling_rate, autoStart, block_selector, mask_text_selector, mask_all_inputs, inline_images, collect_fonts } = agentRef.init.session_replay
 
     this.waitForFlags(['srs', 'sr']).then(([srMode, entitled]) => {
       this.entitled = !!entitled

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -9,9 +9,6 @@
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { ABORT_REASONS, FEATURE_NAME, QUERY_PARAM_PADDING, RRWEB_EVENT_TYPES, SR_EVENT_EMITTER_TYPES, TRIGGERS } from '../constants'
-import { getInfo } from '../../../common/config/info'
-import { getConfigurationValue } from '../../../common/config/init'
-import { getRuntime } from '../../../common/config/runtime'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { sharedChannel } from '../../../common/constants/shared-channel'
 import { obj as encodeObj } from '../../../common/url/encode'
@@ -35,10 +32,10 @@ export class Aggregate extends AggregateBase {
   mode = MODE.OFF
 
   // pass the recorder into the aggregator
-  constructor (agentIdentifier, aggregator, args) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
+  constructor (thisAgent, args) {
+    super(thisAgent, FEATURE_NAME)
     /** The interval to harvest at.  This gets overridden if the size of the payload exceeds certain thresholds */
-    this.harvestTimeSeconds = getConfigurationValue(this.agentIdentifier, 'session_replay.harvestTimeSeconds') || 60
+    this.harvestTimeSeconds = thisAgent.init.session_replay.harvestTimeSeconds || 60
     /** Set once the recorder has fully initialized after flag checks and sampling */
     this.initialized = false
     /** Set once the feature has been "aborted" to prevent other side-effects from continuing */
@@ -77,8 +74,7 @@ export class Aggregate extends AggregateBase {
     this.ee.on(SESSION_EVENTS.RESUME, () => {
       if (!this.recorder) return
       // if the mode changed on a different tab, it needs to update this instance to match
-      const { session } = getRuntime(this.agentIdentifier)
-      this.mode = session.state.sessionReplayMode
+      this.mode = thisAgent.runtime.session.state.sessionReplayMode
       if (!this.initialized || this.mode === MODE.OFF) return
       this.recorder?.startRecording()
     })
@@ -105,7 +101,7 @@ export class Aggregate extends AggregateBase {
       this.handleError(e)
     }, this.featureName, this.ee)
 
-    const { error_sampling_rate, sampling_rate, autoStart, block_selector, mask_text_selector, mask_all_inputs, inline_images, collect_fonts } = getConfigurationValue(this.agentIdentifier, 'session_replay')
+    const { error_sampling_rate, sampling_rate, autoStart, block_selector, mask_text_selector, mask_all_inputs, inline_images, collect_fonts } = thisAgent.init.session_replay
 
     this.waitForFlags(['srs', 'sr']).then(([srMode, entitled]) => {
       this.entitled = !!entitled
@@ -178,7 +174,7 @@ export class Aggregate extends AggregateBase {
     // we are not actively recording SR... DO NOT import or run the recording library
     // session replay samples can only be decided on the first load of a session
     // session replays can continue if already in progress
-    const { session, timeKeeper } = getRuntime(this.agentIdentifier)
+    const { session, timeKeeper } = this.agentRef.runtime
     this.timeKeeper = timeKeeper
     if (this.recorder?.parent.trigger === TRIGGERS.API && this.recorder?.recording) {
       this.mode = MODE.FULL
@@ -285,8 +281,7 @@ export class Aggregate extends AggregateBase {
       return
     }
     // TODO -- Gracefully handle the buffer for retries.
-    const { session } = getRuntime(this.agentIdentifier)
-    if (!session.state.sessionReplaySentFirstChunk) this.syncWithSessionManager({ sessionReplaySentFirstChunk: true })
+    if (!this.agentRef.runtime.session.state.sessionReplaySentFirstChunk) this.syncWithSessionManager({ sessionReplaySentFirstChunk: true })
     this.recorder.clearBuffer()
     if (recorderEvents.type === 'preloaded') this.scheduler.runHarvest(opts)
     return [payload]
@@ -301,9 +296,8 @@ export class Aggregate extends AggregateBase {
   getHarvestContents (recorderEvents) {
     recorderEvents ??= this.recorder.getEvents()
     let events = recorderEvents.events
-    const agentRuntime = getRuntime(this.agentIdentifier)
-    const info = getInfo(this.agentIdentifier)
-    const endUserId = info.jsAttributes?.['enduser.id']
+    const agentRuntime = this.agentRef.runtime
+    const endUserId = this.agentRef.info.jsAttributes?.['enduser.id']
 
     // do not let the first node be a full snapshot node, since this NEEDS to be preceded by a meta node
     // we will manually inject it if this happens
@@ -335,9 +329,9 @@ export class Aggregate extends AggregateBase {
 
     return {
       qs: {
-        browser_monitoring_key: info.licenseKey,
+        browser_monitoring_key: this.agentRef.info.licenseKey,
         type: 'SessionReplay',
-        app_id: info.applicationID,
+        app_id: this.agentRef.info.applicationID,
         protocol_version: '0',
         timestamp: firstTimestamp,
         attributes: encodeObj({
@@ -407,7 +401,6 @@ export class Aggregate extends AggregateBase {
   }
 
   syncWithSessionManager (state = {}) {
-    const { session } = getRuntime(this.agentIdentifier)
-    session.write(state)
+    this.agentRef.runtime.session.write(state)
   }
 }

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -17,16 +17,16 @@ export class Instrument extends InstrumentBase {
 
   #mode
   #agentRef
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
     let session
     this.replayRunning = false
-    this.#agentRef = thisAgent
+    this.#agentRef = agentRef
     try {
       session = JSON.parse(localStorage.getItem(`${PREFIX}_${DEFAULT_KEY}`))
     } catch (err) { }
 
-    if (hasReplayPrerequisite(thisAgent.agentIdentifier)) {
+    if (hasReplayPrerequisite(agentRef.agentIdentifier)) {
       this.ee.on(SR_EVENT_EMITTER_TYPES.RECORD, () => this.#apiStartOrRestartReplay())
     }
 
@@ -34,7 +34,7 @@ export class Instrument extends InstrumentBase {
       this.#mode = session?.sessionReplayMode
       this.#preloadStartRecording()
     } else {
-      this.importAggregator(thisAgent)
+      this.importAggregator(agentRef)
     }
 
     /** If the recorder is running, we can pass error events on to the agg to help it switch to full mode later */

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -16,15 +16,17 @@ export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
 
   #mode
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  #agentRef
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
     let session
     this.replayRunning = false
+    this.#agentRef = thisAgent
     try {
       session = JSON.parse(localStorage.getItem(`${PREFIX}_${DEFAULT_KEY}`))
     } catch (err) { }
 
-    if (hasReplayPrerequisite(agentIdentifier)) {
+    if (hasReplayPrerequisite(thisAgent.agentIdentifier)) {
       this.ee.on(SR_EVENT_EMITTER_TYPES.RECORD, () => this.#apiStartOrRestartReplay())
     }
 
@@ -32,7 +34,7 @@ export class Instrument extends InstrumentBase {
       this.#mode = session?.sessionReplayMode
       this.#preloadStartRecording()
     } else {
-      this.importAggregator()
+      this.importAggregator(thisAgent)
     }
 
     /** If the recorder is running, we can pass error events on to the agg to help it switch to full mode later */
@@ -79,7 +81,7 @@ export class Instrument extends InstrumentBase {
       this.recorder.startRecording()
       this.abortHandler = this.recorder.stopRecording
     } catch (e) {}
-    this.importAggregator({ recorder: this.recorder, errorNoticed: this.errorNoticed })
+    this.importAggregator(this.#agentRef, { recorder: this.recorder, errorNoticed: this.errorNoticed })
   }
 
   /**

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -16,12 +16,12 @@ const QUERY_PARAM_PADDING = 5000
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
 
-  constructor (thisAgent) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, FEATURE_NAME)
 
     /** A buffer to hold on to harvested traces in the case that a retry must be made later */
     this.sentTrace = null
-    this.harvestTimeSeconds = thisAgent.init.session_trace.harvestTimeSeconds || 30
+    this.harvestTimeSeconds = agentRef.init.session_trace.harvestTimeSeconds || 30
     /** Tied to the entitlement flag response from BCS.  Will short circuit operations of the agg if false  */
     this.entitled = undefined
     /** A flag used to decide if the 30 node threshold should be ignored on the first harvest to ensure sending on the first payload */

--- a/src/features/session_trace/aggregate/index.js
+++ b/src/features/session_trace/aggregate/index.js
@@ -1,8 +1,5 @@
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
-import { getInfo } from '../../../common/config/info'
-import { getConfigurationValue } from '../../../common/config/init'
-import { getRuntime } from '../../../common/config/runtime'
 import { FEATURE_NAME } from '../constants'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { TraceStorage } from './trace/storage'
@@ -19,14 +16,12 @@ const QUERY_PARAM_PADDING = 5000
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
 
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
-    this.agentRuntime = getRuntime(agentIdentifier)
-    this.agentInfo = getInfo(agentIdentifier)
+  constructor (thisAgent) {
+    super(thisAgent, FEATURE_NAME)
 
     /** A buffer to hold on to harvested traces in the case that a retry must be made later */
     this.sentTrace = null
-    this.harvestTimeSeconds = getConfigurationValue(agentIdentifier, 'session_trace.harvestTimeSeconds') || 30
+    this.harvestTimeSeconds = thisAgent.init.session_trace.harvestTimeSeconds || 30
     /** Tied to the entitlement flag response from BCS.  Will short circuit operations of the agg if false  */
     this.entitled = undefined
     /** A flag used to decide if the 30 node threshold should be ignored on the first harvest to ensure sending on the first payload */
@@ -48,8 +43,8 @@ export class Aggregate extends AggregateBase {
     if (!this.initialized) {
       this.initialized = true
       /** Store session identifiers at initialization time to be cross-checked later at harvest time for session changes that are subject to race conditions */
-      this.ptid = this.agentRuntime.ptid
-      this.sessionId = this.agentRuntime.session?.state.value
+      this.ptid = this.agentRef.runtime.ptid
+      this.sessionId = this.agentRef.runtime.session?.state.value
       // The SessionEntity class can emit a message indicating the session was cleared and reset (expiry, inactivity). This feature must abort and never resume if that occurs.
       this.ee.on(SESSION_EVENTS.RESET, () => {
         if (this.blocked) return
@@ -68,14 +63,14 @@ export class Aggregate extends AggregateBase {
 
     /** ST/SR sampling flow in BCS - https://drive.google.com/file/d/19hwt2oft-8Hh4RrjpLqEXfpP_9wYBLcq/view?usp=sharing */
     /** ST will run in the mode provided by BCS if the session IS NEW.  If not... it will use the state of the session entity to determine what mode to run in */
-    if (!this.agentRuntime.session.isNew && !ignoreSession) this.mode = this.agentRuntime.session.state.sessionTraceMode
+    if (!this.agentRef.runtime.session.isNew && !ignoreSession) this.mode = this.agentRef.runtime.session.state.sessionTraceMode
     else this.mode = stMode
 
     /** If the mode is off, we do not want to hold up draining for other features, so we deregister the feature for now.
      * If it drains later (due to a mode change), data and handlers will instantly drain instead of waiting for the registry. */
     if (this.mode === MODE.OFF) return deregisterDrain(this.agentIdentifier, this.featureName)
 
-    this.timeKeeper ??= this.agentRuntime.timeKeeper
+    this.timeKeeper ??= this.agentRef.runtime.timeKeeper
 
     this.scheduler = new HarvestScheduler('browser/blobs', {
       onFinished: this.onHarvestFinished.bind(this),
@@ -107,7 +102,7 @@ export class Aggregate extends AggregateBase {
         if (this.mode === MODE.ERROR) this.switchToFull()
       }, this.featureName, this.ee)
     }
-    this.agentRuntime.session.write({ sessionTraceMode: this.mode })
+    this.agentRef.runtime.session.write({ sessionTraceMode: this.mode })
     this.drain()
   }
 
@@ -123,7 +118,7 @@ export class Aggregate extends AggregateBase {
     this.traceStorage.prevStoredEvents.clear() // release references to past events for GC
     if (!this.timeKeeper?.ready) return // this should likely never happen, but just to be safe, we should never harvest if we cant correct time
     if (this.blocked || this.mode !== MODE.FULL || this.traceStorage.nodeCount === 0) return
-    if (this.sessionId !== this.agentRuntime.session?.state.value || this.ptid !== this.agentRuntime.ptid) return this.abort(3) // if something unexpected happened and we somehow still got to the point of harvesting after a session identifier changed, we should force-exit instead of harvesting
+    if (this.sessionId !== this.agentRef.runtime.session?.state.value || this.ptid !== this.agentRef.runtime.ptid) return this.abort(3) // if something unexpected happened and we somehow still got to the point of harvesting after a session identifier changed, we should force-exit instead of harvesting
     /** Get the ST nodes from the traceStorage buffer.  This also returns helpful metadata about the payload. */
     const { stns, earliestTimeStamp, latestTimeStamp } = this.traceStorage.takeSTNs()
     if (!stns) return // there are no trace nodes
@@ -131,11 +126,11 @@ export class Aggregate extends AggregateBase {
       this.sentTrace = stns
     }
 
-    const firstSessionHarvest = !this.agentRuntime.session.state.traceHarvestStarted
-    if (firstSessionHarvest) this.agentRuntime.session.write({ traceHarvestStarted: true })
+    const firstSessionHarvest = !this.agentRef.runtime.session.state.traceHarvestStarted
+    if (firstSessionHarvest) this.agentRef.runtime.session.write({ traceHarvestStarted: true })
 
-    const hasReplay = this.agentRuntime.session?.state.sessionReplayMode === 1
-    const endUserId = this.agentInfo?.jsAttributes?.['enduser.id']
+    const hasReplay = this.agentRef.runtime.session?.state.sessionReplayMode === 1
+    const endUserId = this.agentRef.info?.jsAttributes?.['enduser.id']
 
     this.everHarvested = true
 
@@ -148,17 +143,17 @@ export class Aggregate extends AggregateBase {
      *
      * For data that does not fit the schema of the above, it should be url-encoded and placed into `attributes`
      */
-    const agentMetadata = this.agentRuntime.appMetadata?.agents?.[0] || {}
+    const agentMetadata = this.agentRef.runtime.appMetadata?.agents?.[0] || {}
     return {
       qs: {
-        browser_monitoring_key: this.agentInfo.licenseKey,
+        browser_monitoring_key: this.agentRef.info.licenseKey,
         type: 'BrowserSessionChunk',
-        app_id: this.agentInfo.applicationID,
+        app_id: this.agentRef.info.applicationID,
         protocol_version: '0',
         timestamp: Math.floor(this.timeKeeper.correctRelativeTimestamp(earliestTimeStamp)),
         attributes: encodeObj({
           ...(agentMetadata.entityGuid && { entityGuid: agentMetadata.entityGuid }),
-          harvestId: `${this.agentRuntime.session?.state.value}_${this.agentRuntime.ptid}_${this.agentRuntime.harvestCount}`,
+          harvestId: `${this.agentRef.runtime.session?.state.value}_${this.agentRef.runtime.ptid}_${this.agentRef.runtime.harvestCount}`,
           // this section of attributes must be controllable and stay below the query param padding limit -- see QUERY_PARAM_PADDING
           // if not, data could be lost to truncation at time of sending, potentially breaking parsing / API behavior in NR1
           // trace payload metadata
@@ -167,7 +162,7 @@ export class Aggregate extends AggregateBase {
           'trace.nodes': stns.length,
           'trace.originTimestamp': this.timeKeeper.correctedOriginTime,
           // other payload metadata
-          agentVersion: this.agentRuntime.version,
+          agentVersion: this.agentRef.runtime.version,
           ...(firstSessionHarvest && { firstSessionHarvest }),
           ...(hasReplay && { hasReplay }),
           ptid: `${this.ptid}`,
@@ -197,7 +192,7 @@ export class Aggregate extends AggregateBase {
     if (this.mode === MODE.FULL || !this.entitled || this.blocked) return
     const prevMode = this.mode
     this.mode = MODE.FULL
-    this.agentRuntime.session.write({ sessionTraceMode: this.mode })
+    this.agentRef.runtime.session.write({ sessionTraceMode: this.mode })
     if (prevMode === MODE.OFF || !this.initialized) return this.initialize(this.mode, this.entitled)
     if (this.initialized) {
       this.traceStorage.trimSTNs(ERROR_MODE_SECONDS_WINDOW) // up until now, Trace would've been just buffering nodes up to max, which needs to be trimmed to last X seconds
@@ -209,7 +204,7 @@ export class Aggregate extends AggregateBase {
   abort (reason) {
     this.blocked = true
     this.mode = MODE.OFF
-    this.agentRuntime.session.write({ sessionTraceMode: this.mode })
+    this.agentRef.runtime.session.write({ sessionTraceMode: this.mode })
     this.scheduler?.stopTimer()
   }
 }

--- a/src/features/session_trace/instrument/index.js
+++ b/src/features/session_trace/instrument/index.js
@@ -18,8 +18,8 @@ const {
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
     const canTrackSession = canEnableSessionTracking(this.agentIdentifier)
     if (!canTrackSession) {
       deregisterDrain(this.agentIdentifier, this.featureName)
@@ -59,7 +59,7 @@ export class Instrument extends InstrumentBase {
       // Per NEWRELIC-8525, we don't have a fallback for capturing resources for older versions that don't support PO at this time.
     }
 
-    this.importAggregator(thisAgent, { resourceObserver: observer })
+    this.importAggregator(agentRef, { resourceObserver: observer })
   }
 }
 

--- a/src/features/session_trace/instrument/index.js
+++ b/src/features/session_trace/instrument/index.js
@@ -18,8 +18,8 @@ const {
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
     const canTrackSession = canEnableSessionTracking(this.agentIdentifier)
     if (!canTrackSession) {
       deregisterDrain(this.agentIdentifier, this.featureName)
@@ -59,7 +59,7 @@ export class Instrument extends InstrumentBase {
       // Per NEWRELIC-8525, we don't have a fallback for capturing resources for older versions that don't support PO at this time.
     }
 
-    this.importAggregator({ resourceObserver: observer })
+    this.importAggregator(thisAgent, { resourceObserver: observer })
   }
 }
 

--- a/src/features/soft_navigations/aggregate/index.js
+++ b/src/features/soft_navigations/aggregate/index.js
@@ -15,14 +15,14 @@ import { Interaction } from './interaction'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, { domObserver }) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef, { domObserver }) {
+    super(agentRef, FEATURE_NAME)
 
-    const harvestTimeSeconds = thisAgent.init.soft_navigations.harvestTimeSeconds || 10
+    const harvestTimeSeconds = agentRef.init.soft_navigations.harvestTimeSeconds || 10
     this.interactionsToHarvest = new EventBuffer()
     this.domObserver = domObserver
 
-    this.initialPageLoadInteraction = new InitialPageLoadInteraction(thisAgent.agentIdentifier)
+    this.initialPageLoadInteraction = new InitialPageLoadInteraction(agentRef.agentIdentifier)
     timeToFirstByte.subscribe(({ attrs }) => {
       const loadEventTime = attrs.navigationEntry.loadEventEnd
       this.initialPageLoadInteraction.forceSave = true

--- a/src/features/soft_navigations/instrument/index.js
+++ b/src/features/soft_navigations/instrument/index.js
@@ -18,8 +18,8 @@ const UI_WAIT_INTERVAL = 1 / 10 * 1000 // assume 10 fps
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
     if (!isBrowserScope || !gosNREUMOriginals().o.MO) return // soft navigations is not supported outside web env or browsers without the mutation observer API
 
     const historyEE = wrapHistory(this.ee)
@@ -58,7 +58,7 @@ export class Instrument extends InstrumentBase {
     for (let eventType of INTERACTION_TRIGGERS) document.addEventListener(eventType, () => { /* no-op, this ensures the UI events are monitored by our callback above */ })
 
     this.abortHandler = abort
-    this.importAggregator({ domObserver })
+    this.importAggregator(thisAgent, { domObserver })
 
     function abort () {
       this.removeOnAbort?.abort()

--- a/src/features/soft_navigations/instrument/index.js
+++ b/src/features/soft_navigations/instrument/index.js
@@ -18,8 +18,8 @@ const UI_WAIT_INTERVAL = 1 / 10 * 1000 // assume 10 fps
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
     if (!isBrowserScope || !gosNREUMOriginals().o.MO) return // soft navigations is not supported outside web env or browsers without the mutation observer API
 
     const historyEE = wrapHistory(this.ee)
@@ -58,7 +58,7 @@ export class Instrument extends InstrumentBase {
     for (let eventType of INTERACTION_TRIGGERS) document.addEventListener(eventType, () => { /* no-op, this ensures the UI events are monitored by our callback above */ })
 
     this.abortHandler = abort
-    this.importAggregator(thisAgent, { domObserver })
+    this.importAggregator(agentRef, { domObserver })
 
     function abort () {
       this.removeOnAbort?.abort()

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -32,12 +32,12 @@ const {
 } = CONSTANTS
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent) {
-    super(thisAgent, FEATURE_NAME)
+  constructor (agentRef) {
+    super(agentRef, FEATURE_NAME)
 
     this.state = {
-      initialPageURL: thisAgent.runtime.origin,
-      lastSeenUrl: thisAgent.runtime.origin,
+      initialPageURL: agentRef.runtime.origin,
+      lastSeenUrl: agentRef.runtime.origin,
       lastSeenRouteName: null,
       timerMap: {},
       timerBudget: MAX_TIMER_BUDGET,
@@ -48,10 +48,10 @@ export class Aggregate extends AggregateBase {
       pageLoaded: false,
       childTime: 0,
       depth: 0,
-      harvestTimeSeconds: thisAgent.init.spa.harvestTimeSeconds || 10,
+      harvestTimeSeconds: agentRef.init.spa.harvestTimeSeconds || 10,
       interactionsToHarvest: new EventBuffer(),
       // The below feature flag is used to disable the SPA ajax fix for specific customers, see https://new-relic.atlassian.net/browse/NR-172169
-      disableSpaFix: (thisAgent.init.feature_flags || []).indexOf('disable-spa-fix') > -1
+      disableSpaFix: (agentRef.init.feature_flags || []).indexOf('disable-spa-fix') > -1
     }
 
     let scheduler
@@ -59,7 +59,7 @@ export class Aggregate extends AggregateBase {
 
     const { state, serializer } = this
 
-    const baseEE = ee.get(thisAgent.agentIdentifier) // <-- parent baseEE
+    const baseEE = ee.get(agentRef.agentIdentifier) // <-- parent baseEE
     const mutationEE = baseEE.get('mutation')
     const promiseEE = baseEE.get('promise')
     const historyEE = baseEE.get('history')
@@ -112,13 +112,13 @@ export class Aggregate extends AggregateBase {
         this.drain()
       } else {
         this.blocked = true
-        deregisterDrain(thisAgent.agentIdentifier, this.featureName)
+        deregisterDrain(agentRef.agentIdentifier, this.featureName)
       }
     })
 
-    if (thisAgent.init.spa.enabled !== true) return
+    if (agentRef.init.spa.enabled !== true) return
 
-    state.initialPageLoad = new Interaction('initialPageLoad', 0, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, thisAgent.agentIdentifier)
+    state.initialPageLoad = new Interaction('initialPageLoad', 0, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentRef.agentIdentifier)
     state.initialPageLoad.save = true
     state.prevInteraction = state.initialPageLoad
     state.currentNode = state.initialPageLoad.root // hint
@@ -209,7 +209,7 @@ export class Aggregate extends AggregateBase {
         // Otherwise, if no interaction is currently active, create a new node ID,
         // and let the aggregator know that we entered a new event handler callback
         // so that it has a chance to possibly start an interaction.
-        var ixn = new Interaction(evName, this[FN_START], state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, thisAgent.agentIdentifier)
+        var ixn = new Interaction(evName, this[FN_START], state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentRef.agentIdentifier)
 
         // Store the interaction as prevInteraction in case it is prematurely discarded
         state.prevInteraction = ixn
@@ -307,7 +307,7 @@ export class Aggregate extends AggregateBase {
         this.sent = true
         node.dt = this.dt
         if (node.dt?.timestamp) {
-          node.dt.timestamp = thisAgent.runtime.timeKeeper.correctAbsoluteTimestamp(node.dt.timestamp)
+          node.dt.timestamp = agentRef.runtime.timeKeeper.correctAbsoluteTimestamp(node.dt.timestamp)
         }
         node.jsEnd = node.start = this.startTime
         node[INTERACTION][REMAINING]++
@@ -407,7 +407,7 @@ export class Aggregate extends AggregateBase {
           if (dtPayload && this[SPA_NODE]) {
             this[SPA_NODE].dt = dtPayload
             if (this[SPA_NODE].dt?.timestamp) {
-              this[SPA_NODE].dt.timestamp = thisAgent.runtime.timeKeeper.correctAbsoluteTimestamp(this[SPA_NODE].dt.timestamp)
+              this[SPA_NODE].dt.timestamp = agentRef.runtime.timeKeeper.correctAbsoluteTimestamp(this[SPA_NODE].dt.timestamp)
             }
           }
         }
@@ -545,7 +545,7 @@ export class Aggregate extends AggregateBase {
       var interaction
       if (state?.currentNode?.[INTERACTION]) interaction = this.ixn = state.currentNode[INTERACTION]
       else if (state?.prevNode?.end === null && state?.prevNode?.[INTERACTION]?.root?.[INTERACTION]?.eventName !== 'initialPageLoad') interaction = this.ixn = state.prevNode[INTERACTION]
-      else interaction = this.ixn = new Interaction('api', t, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, thisAgent.agentIdentifier)
+      else interaction = this.ixn = new Interaction('api', t, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentRef.agentIdentifier)
       if (!state.currentNode) {
         interaction.checkFinish()
         if (state.depth) setCurrentNode(interaction.root)
@@ -699,9 +699,9 @@ export class Aggregate extends AggregateBase {
     register('function-err', function (args, obj, error) {
       if (!state.currentNode) return
       error.__newrelic ??= {}
-      error.__newrelic[thisAgent.agentIdentifier] = { interactionId: state.currentNode.interaction.id }
+      error.__newrelic[agentRef.agentIdentifier] = { interactionId: state.currentNode.interaction.id }
       if (state.currentNode.type && state.currentNode.type !== 'interaction') {
-        error.__newrelic[thisAgent.agentIdentifier].interactionNodeId = state.currentNode.id
+        error.__newrelic[agentRef.agentIdentifier].interactionNodeId = state.currentNode.id
       }
     }, this.featureName, baseEE)
 

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -9,8 +9,6 @@ import { shouldCollectEvent } from '../../../common/deny-list/deny-list'
 import { navTimingValues as navTiming } from '../../../common/timing/nav-timing'
 import { generateUuid } from '../../../common/ids/unique-id'
 import { Interaction } from './interaction'
-import { getConfigurationValue } from '../../../common/config/init'
-import { getRuntime } from '../../../common/config/runtime'
 import { eventListenerOpts } from '../../../common/event-listener/event-listener-opts'
 import { HarvestScheduler } from '../../../common/harvest/harvest-scheduler'
 import { Serializer } from './serializer'
@@ -34,13 +32,12 @@ const {
 } = CONSTANTS
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator) {
-    super(agentIdentifier, aggregator, FEATURE_NAME)
+  constructor (thisAgent) {
+    super(thisAgent, FEATURE_NAME)
 
-    const agentRuntime = getRuntime(agentIdentifier)
     this.state = {
-      initialPageURL: agentRuntime.origin,
-      lastSeenUrl: agentRuntime.origin,
+      initialPageURL: thisAgent.runtime.origin,
+      lastSeenUrl: thisAgent.runtime.origin,
       lastSeenRouteName: null,
       timerMap: {},
       timerBudget: MAX_TIMER_BUDGET,
@@ -51,10 +48,10 @@ export class Aggregate extends AggregateBase {
       pageLoaded: false,
       childTime: 0,
       depth: 0,
-      harvestTimeSeconds: getConfigurationValue(agentIdentifier, 'spa.harvestTimeSeconds') || 10,
+      harvestTimeSeconds: thisAgent.init.spa.harvestTimeSeconds || 10,
       interactionsToHarvest: new EventBuffer(),
       // The below feature flag is used to disable the SPA ajax fix for specific customers, see https://new-relic.atlassian.net/browse/NR-172169
-      disableSpaFix: (getConfigurationValue(agentIdentifier, 'feature_flags') || []).indexOf('disable-spa-fix') > -1
+      disableSpaFix: (thisAgent.init.feature_flags || []).indexOf('disable-spa-fix') > -1
     }
 
     let scheduler
@@ -62,7 +59,7 @@ export class Aggregate extends AggregateBase {
 
     const { state, serializer } = this
 
-    const baseEE = ee.get(agentIdentifier) // <-- parent baseEE
+    const baseEE = ee.get(thisAgent.agentIdentifier) // <-- parent baseEE
     const mutationEE = baseEE.get('mutation')
     const promiseEE = baseEE.get('promise')
     const historyEE = baseEE.get('history')
@@ -110,18 +107,18 @@ export class Aggregate extends AggregateBase {
         scheduler = new HarvestScheduler('events', {
           onFinished: onHarvestFinished,
           retryDelay: state.harvestTimeSeconds
-        }, { agentIdentifier, ee: baseEE })
+        }, this)
         scheduler.harvest.on('events', onHarvestStarted)
         this.drain()
       } else {
         this.blocked = true
-        deregisterDrain(this.agentIdentifier, this.featureName)
+        deregisterDrain(thisAgent.agentIdentifier, this.featureName)
       }
     })
 
-    if (!isEnabled()) return
+    if (thisAgent.init.spa.enabled !== true) return
 
-    state.initialPageLoad = new Interaction('initialPageLoad', 0, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentIdentifier)
+    state.initialPageLoad = new Interaction('initialPageLoad', 0, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, thisAgent.agentIdentifier)
     state.initialPageLoad.save = true
     state.prevInteraction = state.initialPageLoad
     state.currentNode = state.initialPageLoad.root // hint
@@ -212,7 +209,7 @@ export class Aggregate extends AggregateBase {
         // Otherwise, if no interaction is currently active, create a new node ID,
         // and let the aggregator know that we entered a new event handler callback
         // so that it has a chance to possibly start an interaction.
-        var ixn = new Interaction(evName, this[FN_START], state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentIdentifier)
+        var ixn = new Interaction(evName, this[FN_START], state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, thisAgent.agentIdentifier)
 
         // Store the interaction as prevInteraction in case it is prematurely discarded
         state.prevInteraction = ixn
@@ -310,7 +307,7 @@ export class Aggregate extends AggregateBase {
         this.sent = true
         node.dt = this.dt
         if (node.dt?.timestamp) {
-          node.dt.timestamp = agentRuntime.timeKeeper.correctAbsoluteTimestamp(node.dt.timestamp)
+          node.dt.timestamp = thisAgent.runtime.timeKeeper.correctAbsoluteTimestamp(node.dt.timestamp)
         }
         node.jsEnd = node.start = this.startTime
         node[INTERACTION][REMAINING]++
@@ -410,7 +407,7 @@ export class Aggregate extends AggregateBase {
           if (dtPayload && this[SPA_NODE]) {
             this[SPA_NODE].dt = dtPayload
             if (this[SPA_NODE].dt?.timestamp) {
-              this[SPA_NODE].dt.timestamp = agentRuntime.timeKeeper.correctAbsoluteTimestamp(this[SPA_NODE].dt.timestamp)
+              this[SPA_NODE].dt.timestamp = thisAgent.runtime.timeKeeper.correctAbsoluteTimestamp(this[SPA_NODE].dt.timestamp)
             }
           }
         }
@@ -548,7 +545,7 @@ export class Aggregate extends AggregateBase {
       var interaction
       if (state?.currentNode?.[INTERACTION]) interaction = this.ixn = state.currentNode[INTERACTION]
       else if (state?.prevNode?.end === null && state?.prevNode?.[INTERACTION]?.root?.[INTERACTION]?.eventName !== 'initialPageLoad') interaction = this.ixn = state.prevNode[INTERACTION]
-      else interaction = this.ixn = new Interaction('api', t, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentIdentifier)
+      else interaction = this.ixn = new Interaction('api', t, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, thisAgent.agentIdentifier)
       if (!state.currentNode) {
         interaction.checkFinish()
         if (state.depth) setCurrentNode(interaction.root)
@@ -702,9 +699,9 @@ export class Aggregate extends AggregateBase {
     register('function-err', function (args, obj, error) {
       if (!state.currentNode) return
       error.__newrelic ??= {}
-      error.__newrelic[agentIdentifier] = { interactionId: state.currentNode.interaction.id }
+      error.__newrelic[thisAgent.agentIdentifier] = { interactionId: state.currentNode.interaction.id }
       if (state.currentNode.type && state.currentNode.type !== 'interaction') {
-        error.__newrelic[agentIdentifier].interactionNodeId = state.currentNode.id
+        error.__newrelic[thisAgent.agentIdentifier].interactionNodeId = state.currentNode.id
       }
     }, this.featureName, baseEE)
 
@@ -750,11 +747,6 @@ export class Aggregate extends AggregateBase {
 
       scheduler?.scheduleHarvest(0)
       if (!scheduler) warn(19)
-    }
-
-    function isEnabled () {
-      var enabled = getConfigurationValue(agentIdentifier, 'spa.enabled')
-      return enabled !== false
     }
   }
 }

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -22,8 +22,8 @@ const {
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (agentIdentifier, aggregator, auto = true) {
-    super(agentIdentifier, aggregator, FEATURE_NAME, auto)
+  constructor (thisAgent, auto = true) {
+    super(thisAgent, FEATURE_NAME, auto)
     if (!isBrowserScope) return // SPA not supported outside web env
 
     try {
@@ -51,7 +51,7 @@ export class Instrument extends InstrumentBase {
     promiseEE.on(CB_END, endTimestamp)
     jsonpEE.on(CB_END, endTimestamp)
 
-    this.ee.on('fn-err', (...args) => { if (!args[2]?.__newrelic?.[agentIdentifier]) handle('function-err', [...args], undefined, this.featureName, this.ee) })
+    this.ee.on('fn-err', (...args) => { if (!args[2]?.__newrelic?.[thisAgent.agentIdentifier]) handle('function-err', [...args], undefined, this.featureName, this.ee) })
 
     this.ee.buffer([FN_START, FN_END, 'xhr-resolved'], this.featureName)
     eventsEE.buffer([FN_START], this.featureName)
@@ -107,7 +107,7 @@ export class Instrument extends InstrumentBase {
     }
 
     this.abortHandler = this.#abort
-    this.importAggregator()
+    this.importAggregator(thisAgent)
   }
 
   /** Restoration and resource release tasks to be done if SPA loader is being aborted. Unwind changes to globals and subscription to DOM events. */

--- a/src/features/spa/instrument/index.js
+++ b/src/features/spa/instrument/index.js
@@ -25,8 +25,8 @@ const {
  */
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
-  constructor (thisAgent, auto = true) {
-    super(thisAgent, FEATURE_NAME, auto)
+  constructor (agentRef, auto = true) {
+    super(agentRef, FEATURE_NAME, auto)
     if (!isBrowserScope) return // SPA not supported outside web env
 
     try {
@@ -54,7 +54,7 @@ export class Instrument extends InstrumentBase {
     promiseEE.on(CB_END, endTimestamp)
     jsonpEE.on(CB_END, endTimestamp)
 
-    this.ee.on('fn-err', (...args) => { if (!args[2]?.__newrelic?.[thisAgent.agentIdentifier]) handle('function-err', [...args], undefined, this.featureName, this.ee) })
+    this.ee.on('fn-err', (...args) => { if (!args[2]?.__newrelic?.[agentRef.agentIdentifier]) handle('function-err', [...args], undefined, this.featureName, this.ee) })
 
     this.ee.buffer([FN_START, FN_END, 'xhr-resolved'], this.featureName)
     eventsEE.buffer([FN_START], this.featureName)
@@ -110,7 +110,7 @@ export class Instrument extends InstrumentBase {
     }
 
     this.abortHandler = this.#abort
-    this.importAggregator(thisAgent)
+    this.importAggregator(agentRef)
   }
 
   /** Restoration and resource release tasks to be done if SPA loader is being aborted. Unwind changes to globals and subscription to DOM events. */

--- a/src/features/utils/__mocks__/feature-base.js
+++ b/src/features/utils/__mocks__/feature-base.js
@@ -1,6 +1,5 @@
-export const FeatureBase = jest.fn(function (agentIdentifier, aggregator, featureName) {
+export const FeatureBase = jest.fn(function (agentIdentifier, featureName) {
   this.agentIdentifier = agentIdentifier
-  this.aggregator = aggregator
   this.featureName = featureName
 
   this.ee = {

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -7,11 +7,11 @@ import { activatedFeatures } from '../../common/util/feature-flags'
 import { Obfuscator } from '../../common/util/obfuscate'
 
 export class AggregateBase extends FeatureBase {
-  constructor (thisAgentRef, featureName) {
-    super(thisAgentRef.agentIdentifier, featureName)
-    this.agentRef = thisAgentRef
-    this.checkConfiguration(thisAgentRef)
-    this.obfuscator = thisAgentRef.runtime.obfuscator
+  constructor (agentRef, featureName) {
+    super(agentRef.agentIdentifier, featureName)
+    this.agentRef = agentRef
+    this.checkConfiguration(agentRef)
+    this.obfuscator = agentRef.runtime.obfuscator
   }
 
   /**

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -1,6 +1,5 @@
 import { FeatureBase } from './feature-base'
-import { getInfo, isValid } from '../../common/config/info'
-import { getRuntime } from '../../common/config/runtime'
+import { isValid } from '../../common/config/info'
 import { configure } from '../../loaders/configure/configure'
 import { gosCDN } from '../../common/window/nreum'
 import { deregisterDrain, drain } from '../../common/drain/drain'
@@ -8,10 +7,11 @@ import { activatedFeatures } from '../../common/util/feature-flags'
 import { Obfuscator } from '../../common/util/obfuscate'
 
 export class AggregateBase extends FeatureBase {
-  constructor (...args) {
-    super(...args)
-    this.checkConfiguration()
-    this.obfuscator = getRuntime(this.agentIdentifier).obfuscator
+  constructor (thisAgentRef, featureName) {
+    super(thisAgentRef.agentIdentifier, featureName)
+    this.agentRef = thisAgentRef
+    this.checkConfiguration(thisAgentRef)
+    this.obfuscator = thisAgentRef.runtime.obfuscator
   }
 
   /**
@@ -51,7 +51,7 @@ export class AggregateBase extends FeatureBase {
    * Checks for additional `jsAttributes` items to support backward compatibility with implementations of the agent where
    * loader configurations may appear after the loader code is executed.
    */
-  checkConfiguration () {
+  checkConfiguration (existingAgent) {
     // NOTE: This check has to happen at aggregator load time
     if (!isValid(this.agentIdentifier)) {
       const cdn = gosCDN()
@@ -59,7 +59,7 @@ export class AggregateBase extends FeatureBase {
       try {
         jsAttributes = {
           ...jsAttributes,
-          ...getInfo(this.agentIdentifier)?.jsAttributes
+          ...existingAgent.info?.jsAttributes
         }
       } catch (err) {
         // do nothing
@@ -70,13 +70,12 @@ export class AggregateBase extends FeatureBase {
           ...cdn.info,
           jsAttributes
         },
-        runtime: getRuntime(this.agentIdentifier)
+        runtime: existingAgent.runtime
       })
     }
 
-    const runtime = getRuntime(this.agentIdentifier)
-    if (!runtime.obfuscator) {
-      runtime.obfuscator = new Obfuscator(this.agentIdentifier)
+    if (!existingAgent.runtime.obfuscator) {
+      existingAgent.runtime.obfuscator = new Obfuscator(this.agentIdentifier)
     }
   }
 }

--- a/src/features/utils/feature-base.js
+++ b/src/features/utils/feature-base.js
@@ -1,11 +1,9 @@
 import { ee } from '../../common/event-emitter/contextual-ee'
 
 export class FeatureBase {
-  constructor (agentIdentifier, aggregator, featureName) {
+  constructor (agentIdentifier, featureName) {
     /** @type {string} */
     this.agentIdentifier = agentIdentifier
-    /** @type {import('../../common/aggregate/aggregator').Aggregator} */
-    this.aggregator = aggregator
     /** @type {import('../../common/event-emitter/contextual-ee').ee} */
     this.ee = ee.get(agentIdentifier)
     /** @type {string} */

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -65,7 +65,7 @@ export class InstrumentBase extends FeatureBase {
   /**
    * Lazy-load the latter part of the feature: its aggregator. This method is called by the first part of the feature
    * (the instrumentation) when instrumentation is complete.
-   * @param {BrowserAgent} thisAgentRef - reference to the base agent ancestor that this feature belongs to
+   * @param thisAgentRef - reference to the base agent ancestor that this feature belongs to
    * @param {Object} [argsObjFromInstrument] - any values or references to pass down to aggregate
    * @returns void
    */

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -28,8 +28,8 @@ export class InstrumentBase extends FeatureBase {
    *     of its pooled instrumentation data handled by the agent's centralized drain functionality, rather than draining
    *     immediately. Primarily useful for fine-grained control in tests.
    */
-  constructor (thisAgentRef, featureName, auto = true) {
-    super(thisAgentRef.agentIdentifier, featureName)
+  constructor (agentRef, featureName, auto = true) {
+    super(agentRef.agentIdentifier, featureName)
     this.auto = auto
 
     /** @type {Function | undefined} This should be set by any derived Instrument class if it has things to do when feature fails or is killed. */
@@ -49,16 +49,16 @@ export class InstrumentBase extends FeatureBase {
     this.onAggregateImported = undefined
 
     /** used in conjunction with newrelic.start() to defer harvesting in features */
-    if (thisAgentRef.init[this.featureName].autoStart === false) this.auto = false
+    if (agentRef.init[this.featureName].autoStart === false) this.auto = false
     /** if the feature requires opt-in (!auto-start), it will get registered once the api has been called */
-    if (this.auto) registerDrain(thisAgentRef.agentIdentifier, featureName)
+    if (this.auto) registerDrain(agentRef.agentIdentifier, featureName)
     else {
       this.ee.on('manual-start-all', single(() => {
         // register the feature to drain only once the API has been called, it will drain when importAggregator finishes for all the features
         // called by the api in that cycle
-        registerDrain(thisAgentRef.agentIdentifier, this.featureName)
+        registerDrain(agentRef.agentIdentifier, this.featureName)
         this.auto = true
-        this.importAggregator(thisAgentRef)
+        this.importAggregator(agentRef)
       }))
     }
   }
@@ -66,11 +66,11 @@ export class InstrumentBase extends FeatureBase {
   /**
    * Lazy-load the latter part of the feature: its aggregator. This method is called by the first part of the feature
    * (the instrumentation) when instrumentation is complete.
-   * @param thisAgentRef - reference to the base agent ancestor that this feature belongs to
+   * @param agentRef - reference to the base agent ancestor that this feature belongs to
    * @param {Object} [argsObjFromInstrument] - any values or references to pass down to aggregate
    * @returns void
    */
-  importAggregator (thisAgentRef, argsObjFromInstrument = {}) {
+  importAggregator (agentRef, argsObjFromInstrument = {}) {
     if (this.featAggregate || !this.auto) return
 
     let loadedSuccessfully
@@ -95,7 +95,7 @@ export class InstrumentBase extends FeatureBase {
       if (!InstrumentBase.getAggregator) {
         InstrumentBase.getAggregator = import(/* webpackChunkName: "shared-aggregator" */ '../../common/aggregate/aggregator')
         const { Aggregator } = await InstrumentBase.getAggregator
-        thisAgentRef.sharedAggregator = new Aggregator()
+        agentRef.sharedAggregator = new Aggregator()
       } else await InstrumentBase.getAggregator // if another feature is already importing the aggregator, wait for it to finish
 
       /**
@@ -110,7 +110,7 @@ export class InstrumentBase extends FeatureBase {
         }
         const { lazyFeatureLoader } = await import(/* webpackChunkName: "lazy-feature-loader" */ './lazy-feature-loader')
         const { Aggregate } = await lazyFeatureLoader(this.featureName, 'aggregate')
-        this.featAggregate = new Aggregate(thisAgentRef, argsObjFromInstrument)
+        this.featAggregate = new Aggregate(agentRef, argsObjFromInstrument)
         loadedSuccessfully(true)
       } catch (e) {
         warn(34, e)

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -19,6 +19,7 @@ import { single } from '../../common/util/invoke'
  * @extends FeatureBase
  */
 export class InstrumentBase extends FeatureBase {
+  static getAggregator
   /**
    * Instantiate InstrumentBase.
    * @param {string} agentIdentifier - The unique ID of the instantiated agent (relative to global scope).
@@ -91,10 +92,11 @@ export class InstrumentBase extends FeatureBase {
       }
 
       // Create a single Aggregator for this agent if DNE yet; to be used by jserror endpoint features.
-      if (!thisAgentRef.sharedAggregator) {
-        const { Aggregator } = await import(/* webpackChunkName: "shared-aggregator" */ '../../common/aggregate/aggregator')
+      if (!InstrumentBase.getAggregator) {
+        InstrumentBase.getAggregator = import(/* webpackChunkName: "shared-aggregator" */ '../../common/aggregate/aggregator')
+        const { Aggregator } = await InstrumentBase.getAggregator
         thisAgentRef.sharedAggregator = new Aggregator()
-      }
+      } else await InstrumentBase.getAggregator // if another feature is already importing the aggregator, wait for it to finish
 
       /**
        * Note this try-catch differs from the one in Agent.run() in that it's placed later in a page's lifecycle and

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -19,7 +19,6 @@ import { single } from '../../common/util/invoke'
  * @extends FeatureBase
  */
 export class InstrumentBase extends FeatureBase {
-  static getAggregator
   /**
    * Instantiate InstrumentBase.
    * @param {string} agentIdentifier - The unique ID of the instantiated agent (relative to global scope).
@@ -92,11 +91,11 @@ export class InstrumentBase extends FeatureBase {
       }
 
       // Create a single Aggregator for this agent if DNE yet; to be used by jserror endpoint features.
-      if (!InstrumentBase.getAggregator) {
-        InstrumentBase.getAggregator = import(/* webpackChunkName: "shared-aggregator" */ '../../common/aggregate/aggregator')
-        const { Aggregator } = await InstrumentBase.getAggregator
+      if (!agentRef.sharedAggregator) {
+        agentRef.sharedAggregator = import(/* webpackChunkName: "shared-aggregator" */ '../../common/aggregate/aggregator')
+        const { Aggregator } = await agentRef.sharedAggregator
         agentRef.sharedAggregator = new Aggregator()
-      } else await InstrumentBase.getAggregator // if another feature is already importing the aggregator, wait for it to finish
+      } else await agentRef.sharedAggregator // if another feature is already importing the aggregator, wait for it to finish
 
       /**
        * Note this try-catch differs from the one in Agent.run() in that it's placed later in a page's lifecycle and

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -10,7 +10,6 @@ import { featurePriority, FEATURE_NAMES } from './features/features'
 // required features
 import { Instrument as PageViewEvent } from '../features/page_view_event/instrument'
 // common files
-import { Aggregator } from '../common/aggregate/aggregator'
 import { gosNREUM, setNREUMInitializedAgent } from '../common/window/nreum'
 import { warn } from '../common/util/console'
 import { globalScope } from '../common/constants/runtime'
@@ -34,7 +33,6 @@ export class Agent extends AgentBase {
       return
     }
 
-    this.sharedAggregator = new Aggregator({ agentIdentifier: this.agentIdentifier })
     this.features = {}
     setNREUMInitializedAgent(this.agentIdentifier, this) // append this agent onto the global NREUM.initializedAgents
 
@@ -80,7 +78,7 @@ export class Agent extends AgentBase {
           })
         }
 
-        this.features[InstrumentCtor.featureName] = new InstrumentCtor(this.agentIdentifier, this.sharedAggregator)
+        this.features[InstrumentCtor.featureName] = new InstrumentCtor(this)
       })
     } catch (err) {
       warn(22, err)

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -10,7 +10,6 @@ import { getLoaderConfig } from '../common/config/loader-config'
 import { getRuntime } from '../common/config/runtime'
 import { FEATURE_NAMES } from './features/features'
 import { warn } from '../common/util/console'
-import { onWindowLoad } from '../common/window/load'
 import { AgentBase } from './agent-base'
 
 const nonAutoFeatures = [
@@ -80,16 +79,17 @@ export class MicroAgent extends AgentBase {
         warn(24, err)
       }
 
-      onWindowLoad(() => {
-        // these features do not import an "instrument" file, meaning they are only hooked up to the API.
+      this.features.page_view_event.onAggregateImported.then(() => {
+        /* The following features do not import an "instrument" file, meaning they are only hooked up to the API.
+        Since the missing instrument-base class handles drain-gating (racing behavior) and PVE handles some setup, these are chained until after PVE has finished initializing
+        so as to avoid the race condition of things like session and sharedAggregator not being ready by features that uses them right away. */
         nonAutoFeatures.forEach(f => {
           if (enabledFeatures[f] && features.includes(f)) {
             import(/* webpackChunkName: "lazy-feature-loader" */ '../features/utils/lazy-feature-loader').then(({ lazyFeatureLoader }) => {
               return lazyFeatureLoader(f, 'aggregate')
             }).then(({ Aggregate }) => {
               this.features[f] = new Aggregate(this)
-            }).catch(err =>
-              warn(25, err))
+            }).catch(err => warn(25, err))
           }
         })
       })

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -3,7 +3,6 @@ import { Instrument as PVE } from '../features/page_view_event/instrument'
 import { getEnabledFeatures } from './features/enabled-features'
 import { configure } from './configure/configure'
 // core files
-import { Aggregator } from '../common/aggregate/aggregator'
 import { setNREUMInitializedAgent } from '../common/window/nreum'
 import { getInfo } from '../common/config/info'
 import { getConfiguration, getConfigurationValue } from '../common/config/init'
@@ -33,7 +32,6 @@ export class MicroAgent extends AgentBase {
   constructor (options, agentIdentifier) {
     super(agentIdentifier)
 
-    this.sharedAggregator = new Aggregator({ agentIdentifier: this.agentIdentifier })
     this.features = {}
     setNREUMInitializedAgent(this.agentIdentifier, this)
 
@@ -76,7 +74,7 @@ export class MicroAgent extends AgentBase {
 
       try {
         // a biproduct of doing this is that the "session manager" is automatically handled through importing this feature
-        this.features.page_view_event = new PVE(this.agentIdentifier, this.sharedAggregator)
+        this.features.page_view_event = new PVE(this)
       } catch (err) {
         warn(24, err)
       }
@@ -88,7 +86,7 @@ export class MicroAgent extends AgentBase {
             import(/* webpackChunkName: "lazy-feature-loader" */ '../features/utils/lazy-feature-loader').then(({ lazyFeatureLoader }) => {
               return lazyFeatureLoader(f, 'aggregate')
             }).then(({ Aggregate }) => {
-              this.features[f] = new Aggregate(this.agentIdentifier, this.sharedAggregator)
+              this.features[f] = new Aggregate(this)
             }).catch(err =>
               warn(25, err))
           }

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -37,7 +37,7 @@ let ajaxAggregate, context
 beforeEach(async () => {
   jest.spyOn(handleModule, 'handle')
 
-  const ajaxInstrument = new Ajax(agentSetup.agentIdentifier, agentSetup.aggregator)
+  const ajaxInstrument = new Ajax(agentSetup)
   await new Promise(process.nextTick)
   ajaxAggregate = ajaxInstrument.featAggregate
   ajaxAggregate.drain()

--- a/tests/components/ajax/instrument.test.js
+++ b/tests/components/ajax/instrument.test.js
@@ -3,12 +3,12 @@ import { setupAgent } from '../setup-agent'
 import { Instrument as Ajax } from '../../../src/features/ajax/instrument'
 import { FEATURE_NAMES } from '../../../src/loaders/features/features'
 
-let agentSetup
+let mainAgent
 
 beforeAll(async () => {
   jest.spyOn(handleModule, 'handle')
 
-  agentSetup = setupAgent()
+  mainAgent = setupAgent()
 })
 
 let ajaxInstrument
@@ -16,7 +16,7 @@ let ajaxInstrument
 beforeEach(async () => {
   jest.spyOn(handleModule, 'handle')
 
-  ajaxInstrument = new Ajax(agentSetup.agentIdentifier, agentSetup.aggregator)
+  ajaxInstrument = new Ajax(mainAgent)
   jest.spyOn(ajaxInstrument.ee, 'emit')
 })
 

--- a/tests/components/generic_events/aggregate/index.test.js
+++ b/tests/components/generic_events/aggregate/index.test.js
@@ -15,7 +15,7 @@ beforeAll(() => {
 })
 
 beforeEach(async () => {
-  const genericEventsInstrument = new GenericEvents(agentSetup.agentIdentifier, agentSetup.aggregator)
+  const genericEventsInstrument = new GenericEvents(agentSetup)
   await new Promise(process.nextTick)
   genericEventsAggregate = genericEventsInstrument.featAggregate
 })
@@ -140,7 +140,7 @@ describe('sub-features', () => {
     getConfiguration(agentSetup.agentIdentifier).page_action = { enabled: false }
 
     const { Aggregate } = await import('../../../../src/features/generic_events/aggregate')
-    genericEventsAggregate = new Aggregate(agentSetup.agentIdentifier, agentSetup.aggregator)
+    genericEventsAggregate = new Aggregate(agentSetup)
     genericEventsAggregate.ee.emit('api-addPageAction', [relativeTimestamp, name, {}])
     expect(genericEventsAggregate.events[0]).toBeUndefined()
   })

--- a/tests/components/generic_events/instrument/index.test.js
+++ b/tests/components/generic_events/instrument/index.test.js
@@ -1,45 +1,41 @@
 import { Instrument as GenericEvents } from '../../../../src/features/generic_events/instrument'
 import * as handleModule from '../../../../src/common/event-emitter/handle'
 import { setupAgent } from '../../setup-agent'
-import { getConfiguration } from '../../../../src/common/config/init'
 import { OBSERVED_EVENTS } from '../../../../src/features/generic_events/constants'
 
-let agentSetup
+let mainAgent
 
 beforeAll(() => {
-  agentSetup = setupAgent()
+  mainAgent = setupAgent()
 })
 
 describe('pageActions sub-feature', () => {
   test('should import if at least one child feature is enabled', async () => {
-    const config = getConfiguration(agentSetup.agentIdentifier)
-    config.page_action.enabled = true
-    config.user_actions.enabled = false
+    mainAgent.init.page_action.enabled = true
+    mainAgent.init.user_actions.enabled = false
 
-    const genericEventsInstrument = new GenericEvents(agentSetup.agentIdentifier, agentSetup.aggregator)
+    const genericEventsInstrument = new GenericEvents(mainAgent)
     await new Promise(process.nextTick)
 
     expect(genericEventsInstrument.featAggregate).toBeDefined()
   })
 
   test('should not import if no child features are enabled', async () => {
-    const config = getConfiguration(agentSetup.agentIdentifier)
-    config.page_action.enabled = false
-    config.user_actions.enabled = false
+    mainAgent.init.page_action.enabled = false
+    mainAgent.init.user_actions.enabled = false
 
-    const genericEventsInstrument = new GenericEvents(agentSetup.agentIdentifier, agentSetup.aggregator)
+    const genericEventsInstrument = new GenericEvents(mainAgent)
     await new Promise(process.nextTick)
 
     expect(genericEventsInstrument.featAggregate).toBeUndefined()
   })
 
   test('user actions should be observed if enabled', () => {
-    const config = getConfiguration(agentSetup.agentIdentifier)
-    config.page_action.enabled = false
-    config.user_actions.enabled = true
+    mainAgent.init.page_action.enabled = false
+    mainAgent.init.user_actions.enabled = true
     const handleSpy = jest.spyOn(handleModule, 'handle')
 
-    const genericEventsInstrument = new GenericEvents(agentSetup.agentIdentifier, agentSetup.aggregator)
+    const genericEventsInstrument = new GenericEvents(mainAgent)
     OBSERVED_EVENTS.forEach(eventType => {
       const event = new Event(eventType)
       window.dispatchEvent(event)

--- a/tests/components/logging/aggregate.test.js
+++ b/tests/components/logging/aggregate.test.js
@@ -7,12 +7,12 @@ import * as handleModule from '../../../src/common/event-emitter/handle'
 import { resetAgent, setupAgent } from '../setup-agent'
 import { getInfo } from '../../../src/common/config/info'
 
-let agentSetup, info, runtime
+let mainAgent, info, runtime
 
 beforeAll(async () => {
-  agentSetup = setupAgent()
-  info = getInfo(agentSetup.agentIdentifier)
-  runtime = getRuntime(agentSetup.agentIdentifier)
+  mainAgent = setupAgent()
+  info = getInfo(mainAgent.agentIdentifier)
+  runtime = getRuntime(mainAgent.agentIdentifier)
 })
 
 let loggingAggregate
@@ -21,13 +21,13 @@ beforeEach(async () => {
   jest.spyOn(handleModule, 'handle')
   jest.spyOn(consoleModule, 'warn').mockImplementation(() => {})
 
-  const loggingInstrument = new Logging(agentSetup.agentIdentifier, agentSetup.aggregator)
+  const loggingInstrument = new Logging(mainAgent)
   await new Promise(process.nextTick)
   loggingAggregate = loggingInstrument.featAggregate
 })
 
 afterEach(() => {
-  resetAgent(agentSetup.agentIdentifier)
+  resetAgent(mainAgent.agentIdentifier)
   jest.clearAllMocks()
 })
 
@@ -35,7 +35,6 @@ describe('class setup', () => {
   test('should have expected public properties', () => {
     expect(Object.keys(loggingAggregate)).toEqual(expect.arrayContaining([
       'agentIdentifier',
-      'aggregator',
       'ee',
       'featureName',
       'blocked',
@@ -61,7 +60,7 @@ describe('payloads', () => {
   test('fills buffered logs with event emitter messages and prepares matching payload', async () => {
     loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [1234, 'test message', { myAttributes: 1 }, 'error'])
 
-    const timeKeeper = getRuntime(agentSetup.agentIdentifier).timeKeeper
+    const timeKeeper = getRuntime(mainAgent.agentIdentifier).timeKeeper
     const expectedLog = new Log(
       Math.floor(timeKeeper.correctAbsoluteTimestamp(
         timeKeeper.convertRelativeTimestamp(1234)
@@ -81,7 +80,7 @@ describe('payloads', () => {
             session: runtime.session.state.value,
             hasReplay: false,
             hasTrace: false,
-            ptid: agentSetup.agentIdentifier,
+            ptid: mainAgent.agentIdentifier,
             appId: info.applicationID,
             standalone: false,
             agentVersion: expect.any(String)

--- a/tests/components/logging/instrument.test.js
+++ b/tests/components/logging/instrument.test.js
@@ -5,10 +5,10 @@ import * as loggingUtilsModule from '../../../src/features/logging/shared/utils'
 import { Instrument as Logging } from '../../../src/features/logging/instrument'
 import { faker } from '@faker-js/faker'
 
-let agentSetup
+let mainAgent
 
 beforeAll(async () => {
-  agentSetup = setupAgent()
+  mainAgent = setupAgent()
 })
 
 let loggingInstrument
@@ -16,11 +16,11 @@ let loggingInstrument
 beforeEach(async () => {
   jest.spyOn(loggingUtilsModule, 'bufferLog')
 
-  loggingInstrument = new Logging(agentSetup.agentIdentifier, agentSetup.aggregator)
+  loggingInstrument = new Logging(mainAgent)
 })
 
 test('should subscribe to wrap-logger events and buffer them', async () => {
-  const instanceEE = ee.get(agentSetup.agentIdentifier)
+  const instanceEE = ee.get(mainAgent.agentIdentifier)
   expect(instanceEE.on).toHaveBeenCalledWith('wrap-logger-end', expect.any(Function))
 
   const myLoggerSuite = {

--- a/tests/components/metrics/aggregate.test.js
+++ b/tests/components/metrics/aggregate.test.js
@@ -3,16 +3,16 @@ import { resetAgent, setupAgent } from '../setup-agent'
 import { Instrument as Metrics } from '../../../src/features/metrics/instrument'
 import { faker } from '@faker-js/faker'
 
-let agentSetup
+let mainAgent
 
 beforeAll(async () => {
-  agentSetup = setupAgent()
+  mainAgent = setupAgent()
 })
 
 let metricsAggregate, metricName
 
 beforeEach(async () => {
-  const metricsInstrument = new Metrics(agentSetup.agentIdentifier, agentSetup.aggregator)
+  const metricsInstrument = new Metrics(mainAgent)
   await new Promise(process.nextTick)
   metricsAggregate = metricsInstrument.featAggregate
 
@@ -20,7 +20,7 @@ beforeEach(async () => {
 })
 
 afterEach(() => {
-  resetAgent(agentSetup.agentIdentifier)
+  resetAgent(mainAgent.agentIdentifier)
 })
 
 ;[
@@ -30,7 +30,7 @@ afterEach(() => {
   test(`${name} with no value creates a metric with just a count`, () => {
     createAndStoreMetric(undefined, isSupportability)
 
-    const records = agentSetup.aggregator.take([type])[type]
+    const records = mainAgent.sharedAggregator.take([type])[type]
       .filter(x => x?.params?.name === metricName)
     expect(records.length).toEqual(1)
 
@@ -47,7 +47,7 @@ afterEach(() => {
     createAndStoreMetric(undefined, isSupportability)
     createAndStoreMetric(undefined, isSupportability)
 
-    const records = agentSetup.aggregator.take([type])[type]
+    const records = mainAgent.sharedAggregator.take([type])[type]
       .filter(x => x?.params?.name === metricName)
     expect(records.length).toEqual(1)
 
@@ -62,7 +62,7 @@ afterEach(() => {
   test(`${name} with a value ${auxDescription}`, () => {
     createAndStoreMetric(isSupportability ? 500 : { time: 500 }, isSupportability)
 
-    const records = agentSetup.aggregator.take([type])[type]
+    const records = mainAgent.sharedAggregator.take([type])[type]
       .filter(x => x?.params?.name === metricName)
     expect(records.length).toEqual(1)
 
@@ -80,7 +80,7 @@ afterEach(() => {
       .fill(null).map(() => faker.number.int({ min: 100, max: 1000 }))
     values.forEach(v => createAndStoreMetric(isSupportability ? v : { time: v }, isSupportability))
 
-    const records = agentSetup.aggregator.take([type])[type]
+    const records = mainAgent.sharedAggregator.take([type])[type]
       .filter(x => x?.params?.name === metricName)
     expect(records.length).toEqual(1)
 
@@ -99,7 +99,7 @@ afterEach(() => {
   test(`${name} does not create a ${otherType} item`, () => {
     createAndStoreMetric(faker.number.float(), isSupportability)
 
-    const records = agentSetup.aggregator.take([otherType])?.[otherType]
+    const records = mainAgent.sharedAggregator.take([otherType])?.[otherType]
       ?.filter(x => x?.params?.name === metricName) || []
     expect(records).toEqual([])
   })
@@ -108,7 +108,7 @@ afterEach(() => {
     test('storeEvent (custom) with an invalid value type does not create a named metric object in metrics section', () => {
       createAndStoreMetric(faker.number.float(), false)
 
-      const records = agentSetup.aggregator.take([CUSTOM_METRIC])[CUSTOM_METRIC]
+      const records = mainAgent.sharedAggregator.take([CUSTOM_METRIC])[CUSTOM_METRIC]
         .filter(x => x?.params?.name === metricName)
       expect(records.length).toEqual(1)
 

--- a/tests/components/page_view_timing/aggregate.test.js
+++ b/tests/components/page_view_timing/aggregate.test.js
@@ -32,7 +32,7 @@ jest.mock('web-vitals/attribution', () => ({
   }))
 }))
 
-let agentSetup
+let mainAgent
 
 beforeAll(async () => {
   global.navigator.connection = {
@@ -42,7 +42,7 @@ beforeAll(async () => {
     downlink: 700
   }
 
-  agentSetup = setupAgent()
+  mainAgent = setupAgent()
 })
 
 let timingsAggregate
@@ -50,14 +50,14 @@ let timingsAggregate
 beforeEach(async () => {
   jest.spyOn(pageVisibilityModule, 'subscribeToVisibilityChange')
 
-  const timingsInstrument = new Timings(agentSetup.agentIdentifier, agentSetup.aggregator)
+  const timingsInstrument = new Timings(mainAgent)
   await new Promise(process.nextTick)
   timingsAggregate = timingsInstrument.featAggregate
   timingsAggregate.ee.emit('rumresp', {})
 })
 
 afterEach(() => {
-  resetAgent(agentSetup.agentIdentifier)
+  resetAgent(mainAgent.agentIdentifier)
   jest.clearAllMocks()
 })
 

--- a/tests/components/page_view_timing/index.test.js
+++ b/tests/components/page_view_timing/index.test.js
@@ -1,8 +1,3 @@
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
-import { ee } from '../../../src/common/event-emitter/contextual-ee'
-import { setConfiguration } from '../../../src/common/config/init'
-import { setInfo } from '../../../src/common/config/info'
-import { setRuntime } from '../../../src/common/config/runtime'
 import { VITAL_NAMES } from '../../../src/common/vitals/constants'
 
 // Note: these callbacks fire right away unlike the real web-vitals API which are async-on-trigger
@@ -46,18 +41,21 @@ const expectedNetworkInfo = {
 }
 
 let pvtAgg
-const agentId = 'abcd'
+const agentIdentifier = 'abcd'
 describe('pvt aggregate tests', () => {
   beforeEach(async () => {
     triggerVisChange = undefined
     jest.doMock('../../../src/common/util/feature-flags', () => ({
       __esModule: true,
-      activatedFeatures: { [agentId]: { pvt: 1 } }
+      activatedFeatures: { [agentIdentifier]: { pvt: 1 } }
     }))
 
-    setInfo(agentId, { licenseKey: 'licenseKey', applicationID: 'applicationID' })
-    setConfiguration(agentId, {})
-    setRuntime(agentId, {})
+    const mainAgent = {
+      agentIdentifier,
+      info: { licenseKey: 'licenseKey', applicationID: 'applicationID' },
+      init: { page_view_timing: {} },
+      runtime: {}
+    }
     const { Aggregate } = await import('../../../src/features/page_view_timing/aggregate')
 
     global.navigator.connection = {
@@ -66,7 +64,7 @@ describe('pvt aggregate tests', () => {
       rtt: 270,
       downlink: 700
     }
-    pvtAgg = new Aggregate(agentId, new Aggregator({ agentIdentifier: agentId, ee }))
+    pvtAgg = new Aggregate(mainAgent)
     await pvtAgg.waitForFlags(([]))
     pvtAgg.prepareHarvest = jest.fn(() => ({}))
   })

--- a/tests/components/session_trace/aggregate.test.js
+++ b/tests/components/session_trace/aggregate.test.js
@@ -2,16 +2,16 @@ import { Instrument as SessionTrace } from '../../../src/features/session_trace/
 import { setupAgent } from '../setup-agent'
 import { MODE } from '../../../src/common/session/constants'
 
-let agentSetup
+let mainAgent
 
 beforeAll(() => {
-  agentSetup = setupAgent()
+  mainAgent = setupAgent()
 })
 
 let sessionTraceAggregate
 
 beforeEach(async () => {
-  const sessionTraceInstrument = new SessionTrace(agentSetup.agentIdentifier, agentSetup.aggregator)
+  const sessionTraceInstrument = new SessionTrace(mainAgent)
   await new Promise(process.nextTick)
   sessionTraceAggregate = sessionTraceInstrument.featAggregate
 

--- a/tests/components/setup-agent.js
+++ b/tests/components/setup-agent.js
@@ -38,7 +38,7 @@ export function setupAgent ({ agentOverrides = {}, info = {}, init = {}, loaderC
   const fakeAgent = {
     agentIdentifier,
     ee: eventEmitter,
-    sharedAggregator: new Aggregator({ agentIdentifier, ee: eventEmitter }),
+    sharedAggregator: new Aggregator(),
     ...agentOverrides
   }
   setNREUMInitializedAgent(agentIdentifier, fakeAgent)
@@ -58,7 +58,7 @@ export function setupAgent ({ agentOverrides = {}, info = {}, init = {}, loaderC
     }, 450, 600, Date.now())
   }
 
-  return { agentIdentifier, aggregator: fakeAgent.sharedAggregator }
+  return fakeAgent
 }
 
 export function resetAgent (agentIdentifier) {

--- a/tests/components/soft_navigations/aggregate.test.js
+++ b/tests/components/soft_navigations/aggregate.test.js
@@ -2,10 +2,10 @@ import { resetAgent, setupAgent } from '../setup-agent'
 import { Instrument as SoftNav } from '../../../src/features/soft_navigations/instrument'
 import * as ttfbModule from '../../../src/common/vitals/time-to-first-byte'
 
-let agentSetup
+let mainAgent
 
 beforeAll(() => {
-  agentSetup = setupAgent({
+  mainAgent = setupAgent({
     agentOverrides: {
       runSoftNavOverSpa: true
     },
@@ -21,7 +21,7 @@ let softNavAggregate
 beforeEach(async () => {
   jest.spyOn(ttfbModule.timeToFirstByte, 'subscribe')
 
-  const softNavInstrument = new SoftNav(agentSetup.agentIdentifier, agentSetup.aggregator)
+  const softNavInstrument = new SoftNav(mainAgent)
   await new Promise(process.nextTick)
   softNavAggregate = softNavInstrument.featAggregate
 
@@ -30,7 +30,7 @@ beforeEach(async () => {
 })
 
 afterEach(() => {
-  resetAgent(agentSetup.agentIdentifier)
+  resetAgent(mainAgent.agentIdentifier)
   jest.clearAllMocks()
 })
 

--- a/tests/components/soft_navigations/api.test.js
+++ b/tests/components/soft_navigations/api.test.js
@@ -9,10 +9,10 @@ import { resetAgent, setupAgent } from '../setup-agent'
 jest.retryTimes(3)
 
 const INTERACTION_API = 'api-ixn'
-let agentSetup
+let mainAgent
 
 beforeAll(() => {
-  agentSetup = setupAgent({
+  mainAgent = setupAgent({
     agentOverrides: {
       runSoftNavOverSpa: true
     },
@@ -26,7 +26,7 @@ beforeAll(() => {
 let softNavAggregate
 
 beforeEach(async () => {
-  const softNavInstrument = new SoftNav(agentSetup.agentIdentifier, agentSetup.aggregator)
+  const softNavInstrument = new SoftNav(mainAgent)
   await new Promise(process.nextTick)
   softNavAggregate = softNavInstrument.featAggregate
 
@@ -40,7 +40,7 @@ beforeEach(async () => {
 })
 
 afterEach(() => {
-  resetAgent(agentSetup.agentIdentifier)
+  resetAgent(mainAgent.agentIdentifier)
   jest.clearAllMocks()
 })
 

--- a/tests/components/soft_navigations/instrument.test.js
+++ b/tests/components/soft_navigations/instrument.test.js
@@ -4,10 +4,10 @@ import * as handleModule from '../../../src/common/event-emitter/handle'
 import { resetAgent, setupAgent } from '../setup-agent'
 import { faker } from '@faker-js/faker'
 
-let agentSetup
+let mainAgent
 
 beforeAll(() => {
-  agentSetup = setupAgent({
+  mainAgent = setupAgent({
     agentOverrides: {
       runSoftNavOverSpa: true
     },
@@ -20,11 +20,11 @@ beforeAll(() => {
 
 beforeEach(async () => {
   jest.spyOn(handleModule, 'handle')
-  new SoftNav(agentSetup.agentIdentifier, agentSetup.aggregator)
+  new SoftNav(mainAgent)
 })
 
 afterEach(() => {
-  resetAgent(agentSetup.agentIdentifier)
+  resetAgent(mainAgent.agentIdentifier)
   jest.clearAllMocks()
 })
 

--- a/tests/components/spa/api.test.js
+++ b/tests/components/spa/api.test.js
@@ -1,5 +1,4 @@
 import helpers from './helpers'
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
 import { ee } from '../../../src/common/event-emitter/contextual-ee'
 import { Spa } from '../../../src/features/spa'
 import { getInfo } from '../../../src/common/config/info'
@@ -30,8 +29,7 @@ beforeAll(async () => {
   mockCurrentInfo = { jsAttributes: {} }
   getInfo.mockReturnValue(mockCurrentInfo)
 
-  const aggregator = new Aggregator({ agentIdentifier, ee })
-  spaInstrument = new Spa(agentIdentifier, aggregator)
+  spaInstrument = new Spa({ agentIdentifier, info: mockCurrentInfo, init: { spa: { enabled: true } }, runtime: {} })
   await expect(spaInstrument.onAggregateImported).resolves.toEqual(true)
   spaAggregate = spaInstrument.featAggregate
   spaAggregate.blocked = true

--- a/tests/components/spa/capturing.test.js
+++ b/tests/components/spa/capturing.test.js
@@ -1,5 +1,4 @@
 import helpers from './helpers'
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
 import { ee } from '../../../src/common/event-emitter/contextual-ee'
 import { Spa } from '../../../src/features/spa'
 
@@ -22,8 +21,7 @@ let spaInstrument, spaAggregate, newrelic
 const agentIdentifier = 'abcdefg'
 
 beforeAll(async () => {
-  const aggregator = new Aggregator({ agentIdentifier, ee })
-  spaInstrument = new Spa(agentIdentifier, aggregator)
+  spaInstrument = new Spa({ agentIdentifier, info: {}, init: { spa: { enabled: true } }, runtime: {} })
   await expect(spaInstrument.onAggregateImported).resolves.toEqual(true)
   spaAggregate = spaInstrument.featAggregate
   spaAggregate.blocked = true

--- a/tests/components/spa/initial-page-load.test.js
+++ b/tests/components/spa/initial-page-load.test.js
@@ -1,5 +1,4 @@
 import helpers from './helpers'
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
 import { ee } from '../../../src/common/event-emitter/contextual-ee'
 import { Spa } from '../../../src/features/spa'
 
@@ -22,8 +21,7 @@ let spaInstrument, spaAggregate, newrelic
 const agentIdentifier = 'abcdefg'
 
 beforeAll(async () => {
-  const aggregator = new Aggregator({ agentIdentifier, ee })
-  spaInstrument = new Spa(agentIdentifier, aggregator)
+  spaInstrument = new Spa({ agentIdentifier, info: {}, init: { spa: { enabled: true } }, runtime: {} })
   await expect(spaInstrument.onAggregateImported).resolves.toEqual(true)
   spaAggregate = spaInstrument.featAggregate
   spaAggregate.blocked = true

--- a/tests/components/spa/instrument.test.js
+++ b/tests/components/spa/instrument.test.js
@@ -1,5 +1,3 @@
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
-import { ee } from '../../../src/common/event-emitter/contextual-ee'
 import { Spa } from '../../../src/features/spa'
 import { registerHandler } from '../../../src/common/event-emitter/register-handler'
 import { drain } from '../../../src/common/drain/drain'
@@ -23,8 +21,7 @@ let spaInstrument
 const agentIdentifier = 'abcdefg'
 
 beforeAll(async () => {
-  const aggregator = new Aggregator({ agentIdentifier, ee })
-  spaInstrument = new Spa(agentIdentifier, aggregator, false)
+  spaInstrument = new Spa({ agentIdentifier, info: {}, init: { spa: { enabled: true } }, runtime: {} }, false)
 })
 
 describe('SPA instrument', () => {

--- a/tests/components/spa/mutation-observer.test.js
+++ b/tests/components/spa/mutation-observer.test.js
@@ -1,5 +1,4 @@
 import helpers from './helpers'
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
 import { ee } from '../../../src/common/event-emitter/contextual-ee'
 import { Spa } from '../../../src/features/spa'
 
@@ -22,8 +21,7 @@ let spaInstrument, spaAggregate, newrelic
 const agentIdentifier = 'abcdefg'
 
 beforeAll(async () => {
-  const aggregator = new Aggregator({ agentIdentifier, ee })
-  spaInstrument = new Spa(agentIdentifier, aggregator)
+  spaInstrument = new Spa({ agentIdentifier, info: {}, init: { spa: { enabled: true } }, runtime: {} })
   await expect(spaInstrument.onAggregateImported).resolves.toEqual(true)
   spaAggregate = spaInstrument.featAggregate
   spaAggregate.blocked = true

--- a/tests/components/spa/promises.test.js
+++ b/tests/components/spa/promises.test.js
@@ -1,6 +1,5 @@
 /* eslint-disable prefer-promise-reject-errors */
 import helpers from './helpers'
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
 import { ee } from '../../../src/common/event-emitter/contextual-ee'
 import { Spa } from '../../../src/features/spa'
 
@@ -31,8 +30,7 @@ jest.mock('../../../src/common/util/feature-flags', () => ({
 
 let spaInstrument, spaAggregate, newrelic
 beforeAll(async () => {
-  const aggregator = new Aggregator({ agentIdentifier, ee })
-  spaInstrument = new Spa(agentIdentifier, aggregator)
+  spaInstrument = new Spa({ agentIdentifier, info: {}, init: { spa: { enabled: true } }, runtime: {} })
   await expect(spaInstrument.onAggregateImported).resolves.toEqual(true)
   spaAggregate = spaInstrument.featAggregate
   newrelic = helpers.getNewrelicGlobal(spaAggregate.ee)

--- a/tests/components/spa/route-change.test.js
+++ b/tests/components/spa/route-change.test.js
@@ -1,5 +1,4 @@
 import helpers from './helpers'
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
 import { ee } from '../../../src/common/event-emitter/contextual-ee'
 import { Spa } from '../../../src/features/spa'
 
@@ -22,8 +21,7 @@ let spaInstrument, spaAggregate, newrelic
 const agentIdentifier = 'abcdefg'
 
 beforeAll(async () => {
-  const aggregator = new Aggregator({ agentIdentifier, ee })
-  spaInstrument = new Spa(agentIdentifier, aggregator)
+  spaInstrument = new Spa({ agentIdentifier, info: {}, init: { spa: { enabled: true } }, runtime: {} })
   await expect(spaInstrument.onAggregateImported).resolves.toEqual(true)
   spaAggregate = spaInstrument.featAggregate
   spaAggregate.blocked = true

--- a/tests/components/spa/timers.test.js
+++ b/tests/components/spa/timers.test.js
@@ -1,5 +1,4 @@
 import helpers from './helpers'
-import { Aggregator } from '../../../src/common/aggregate/aggregator'
 import { ee } from '../../../src/common/event-emitter/contextual-ee'
 import { Spa } from '../../../src/features/spa'
 
@@ -22,8 +21,7 @@ let spaInstrument, spaAggregate, newrelic
 const agentIdentifier = 'abcdefg'
 
 beforeAll(async () => {
-  const aggregator = new Aggregator({ agentIdentifier, ee })
-  spaInstrument = new Spa(agentIdentifier, aggregator)
+  spaInstrument = new Spa({ agentIdentifier, info: {}, init: { spa: { enabled: true } }, runtime: {} })
   await expect(spaInstrument.onAggregateImported).resolves.toEqual(true)
   spaAggregate = spaInstrument.featAggregate
   spaAggregate.blocked = true

--- a/tests/unit/features/utils/feature-base.test.js
+++ b/tests/unit/features/utils/feature-base.test.js
@@ -18,12 +18,10 @@ jest.mock('../../../../src/common/event-emitter/contextual-ee', () => ({
 }))
 
 let agentIdentifier
-let aggregator
 let featureName
 
 beforeEach(() => {
   agentIdentifier = faker.string.uuid()
-  aggregator = {}
   featureName = faker.string.uuid()
 })
 
@@ -31,10 +29,9 @@ test('should set instance defaults', () => {
   const mockEE = { [faker.string.uuid()]: faker.lorem.sentence() }
   jest.mocked(ee.get).mockReturnValue(mockEE)
 
-  const feature = new FeatureBase(agentIdentifier, aggregator, featureName)
+  const feature = new FeatureBase(agentIdentifier, featureName)
 
   expect(feature.agentIdentifier).toEqual(agentIdentifier)
-  expect(feature.aggregator).toEqual(aggregator)
   expect(feature.featureName).toEqual(featureName)
   expect(feature.blocked).toEqual(false)
   expect(feature.ee).toEqual(mockEE)

--- a/tests/unit/features/utils/instrument-base.test.js
+++ b/tests/unit/features/utils/instrument-base.test.js
@@ -10,12 +10,12 @@ import { warn } from '../../../../src/common/util/console'
 import * as runtimeConstantsModule from '../../../../src/common/constants/runtime'
 import { canEnableSessionTracking } from '../../../../src/features/utils/feature-gates'
 import { getConfigurationValue } from '../../../../src/common/config/init'
+import { Aggregator } from '../../../../src/common/aggregate/aggregator'
 
 jest.enableAutomock()
 jest.unmock('../../../../src/features/utils/instrument-base')
 
 let agentIdentifier
-let aggregator
 let featureName
 let mockAggregate
 let agentBase
@@ -26,13 +26,13 @@ beforeEach(() => {
   jest.mocked(canEnableSessionTracking).mockReturnValue(true)
 
   agentIdentifier = faker.string.uuid()
-  aggregator = {}
   featureName = faker.string.uuid()
   agentBase = {
     agentIdentifier,
-    sharedAggregator: aggregator,
     init: {
       [featureName]: { autoStart: true },
+      [FEATURE_NAMES.pageViewEvent]: { autoStart: true },
+      [FEATURE_NAMES.pageViewTiming]: { autoStart: true },
       [FEATURE_NAMES.sessionReplay]: { autoStart: true }
     }
   }
@@ -175,4 +175,19 @@ test('should drain and not import agg when shouldImportAgg is false for session_
   expect(drain).toHaveBeenCalledWith(agentIdentifier, FEATURE_NAMES.sessionReplay)
   expect(lazyFeatureLoader).not.toHaveBeenCalled()
   expect(mockAggregate).not.toHaveBeenCalled()
+})
+
+test('does not initialized Aggregator more than once with multiple features', async () => {
+  delete InstrumentBase.getAggregator // "reset" the shared Aggregator for this test
+  const pve = new InstrumentBase(agentBase, FEATURE_NAMES.pageViewEvent)
+  const pvt = new InstrumentBase(agentBase, FEATURE_NAMES.pageViewTiming)
+  pve.importAggregator(agentBase)
+  pvt.importAggregator(agentBase)
+
+  expect(Aggregator).toHaveBeenCalledTimes(0)
+  await Promise.all([
+    jest.mocked(onWindowLoad).mock.calls[0][0](), // PVE should import & initialize Aggregator
+    jest.mocked(onWindowLoad).mock.calls[1][0]() // and PVT should wait for PVE to do that instead of initializing it again
+  ])
+  expect(Aggregator).toHaveBeenCalledTimes(1)
 })

--- a/tests/unit/features/utils/instrument-base.test.js
+++ b/tests/unit/features/utils/instrument-base.test.js
@@ -18,6 +18,7 @@ let agentIdentifier
 let aggregator
 let featureName
 let mockAggregate
+let agentBase
 
 beforeEach(() => {
   jest.replaceProperty(runtimeConstantsModule, 'isBrowserScope', true)
@@ -27,15 +28,23 @@ beforeEach(() => {
   agentIdentifier = faker.string.uuid()
   aggregator = {}
   featureName = faker.string.uuid()
+  agentBase = {
+    agentIdentifier,
+    sharedAggregator: aggregator,
+    init: {
+      [featureName]: { autoStart: true },
+      [FEATURE_NAMES.sessionReplay]: { autoStart: true }
+    }
+  }
 
   mockAggregate = jest.fn()
   jest.mocked(lazyFeatureLoader).mockResolvedValue({ Aggregate: mockAggregate })
 })
 
 test('should construct a new instrument', () => {
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, featureName)
+  const instrument = new InstrumentBase(agentBase, featureName)
 
-  expect(FeatureBase).toHaveBeenCalledWith(agentIdentifier, aggregator, featureName)
+  expect(FeatureBase).toHaveBeenCalledWith(agentIdentifier, featureName)
   expect(instrument.featAggregate).toBeUndefined()
   expect(instrument.auto).toEqual(true)
   expect(instrument.abortHandler).toBeUndefined()
@@ -43,7 +52,7 @@ test('should construct a new instrument', () => {
 })
 
 test('should wait for feature opt-in to import the aggregate', () => {
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, featureName, false)
+  const instrument = new InstrumentBase(agentBase, featureName, false)
   jest.spyOn(instrument, 'importAggregator').mockImplementation(jest.fn)
 
   expect(registerDrain).not.toHaveBeenCalled()
@@ -59,38 +68,38 @@ test('should wait for feature opt-in to import the aggregate', () => {
 
 test('should import aggregator on window load', async () => {
   jest.mocked(getConfigurationValue).mockReturnValue({ feature_flags: [] })
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, featureName)
+  const instrument = new InstrumentBase(agentBase, featureName)
   const aggregateArgs = { [faker.string.uuid()]: faker.lorem.sentence() }
-  instrument.importAggregator(aggregateArgs)
+  instrument.importAggregator(agentBase, aggregateArgs)
 
   const windowLoadCallback = jest.mocked(onWindowLoad).mock.calls[0][0]
   await windowLoadCallback()
 
   expect(onWindowLoad).toHaveBeenCalledWith(expect.any(Function), true)
   expect(lazyFeatureLoader).toHaveBeenCalledWith(featureName, 'aggregate')
-  expect(mockAggregate).toHaveBeenCalledWith(agentIdentifier, aggregator, aggregateArgs)
+  expect(mockAggregate).toHaveBeenCalledWith(agentBase, aggregateArgs)
 })
 
 test('should immediately import aggregator in worker scope', async () => {
   jest.replaceProperty(runtimeConstantsModule, 'isBrowserScope', false)
   jest.replaceProperty(runtimeConstantsModule, 'isWorkerScope', true)
 
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, featureName)
+  const instrument = new InstrumentBase(agentBase, featureName)
   const aggregateArgs = { [faker.string.uuid()]: faker.lorem.sentence() }
-  instrument.importAggregator(aggregateArgs)
+  instrument.importAggregator(agentBase, aggregateArgs)
 
   // In worker scope, we cannot wait on importLater method
   await new Promise(process.nextTick)
 
   expect(onWindowLoad).not.toHaveBeenCalled()
   expect(lazyFeatureLoader).toHaveBeenCalledWith(featureName, 'aggregate')
-  expect(mockAggregate).toHaveBeenCalledWith(agentIdentifier, aggregator, aggregateArgs)
+  expect(mockAggregate).toHaveBeenCalledWith(agentBase, aggregateArgs)
 })
 
 test('should not import aggregate more than once', async () => {
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, featureName)
+  const instrument = new InstrumentBase(agentBase, featureName)
   const aggregateArgs = { [faker.string.uuid()]: faker.lorem.sentence() }
-  instrument.importAggregator(aggregateArgs)
+  instrument.importAggregator(agentBase, aggregateArgs)
 
   const windowLoadCallback = jest.mocked(onWindowLoad).mock.calls[0][0]
   await windowLoadCallback()
@@ -101,17 +110,17 @@ test('should not import aggregate more than once', async () => {
 test('feature still imports by default even when setupAgentSession throws an error', async () => {
   jest.mocked(setupAgentSession).mockImplementation(() => { throw new Error(faker.lorem.sentence()) })
 
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, featureName)
+  const instrument = new InstrumentBase(agentBase, featureName)
   const aggregateArgs = { [faker.string.uuid()]: faker.lorem.sentence() }
   instrument.abortHandler = jest.fn()
-  instrument.importAggregator(aggregateArgs)
+  instrument.importAggregator(agentBase, aggregateArgs)
   expect(instrument.featAggregate).toBeUndefined()
 
   const windowLoadCallback = jest.mocked(onWindowLoad).mock.calls[0][0]
   await windowLoadCallback()
 
   expect(lazyFeatureLoader).toHaveBeenCalledWith(featureName, 'aggregate')
-  expect(mockAggregate).toHaveBeenCalledWith(agentIdentifier, aggregator, aggregateArgs)
+  expect(mockAggregate).toHaveBeenCalledWith(agentBase, aggregateArgs)
   expect(instrument.featAggregate).toBeDefined()
 })
 
@@ -120,9 +129,9 @@ test('no uncaught async exception is thrown when an import fails', async () => {
   const mockOnError = jest.fn()
   global.onerror = mockOnError
 
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, featureName)
+  const instrument = new InstrumentBase(agentBase, featureName)
   instrument.abortHandler = jest.fn()
-  instrument.importAggregator()
+  instrument.importAggregator(agentBase)
   expect(instrument.featAggregate).toBeUndefined()
 
   const windowLoadCallback = jest.mocked(onWindowLoad).mock.calls[0][0]
@@ -138,10 +147,10 @@ test('no uncaught async exception is thrown when an import fails', async () => {
 test('should not import agent-session when session tracking is disabled', async () => {
   jest.mocked(canEnableSessionTracking).mockReturnValue(false)
 
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, featureName)
+  const instrument = new InstrumentBase(agentBase, featureName)
   const aggregateArgs = { [faker.string.uuid()]: faker.lorem.sentence() }
   instrument.abortHandler = jest.fn()
-  instrument.importAggregator(aggregateArgs)
+  instrument.importAggregator(agentBase, aggregateArgs)
   expect(instrument.featAggregate).toBeUndefined()
 
   const windowLoadCallback = jest.mocked(onWindowLoad).mock.calls[0][0]
@@ -149,16 +158,16 @@ test('should not import agent-session when session tracking is disabled', async 
 
   expect(setupAgentSession).not.toHaveBeenCalled()
   expect(lazyFeatureLoader).toHaveBeenCalledWith(featureName, 'aggregate')
-  expect(mockAggregate).toHaveBeenCalledWith(agentIdentifier, aggregator, aggregateArgs)
+  expect(mockAggregate).toHaveBeenCalledWith(agentBase, aggregateArgs)
   expect(instrument.featAggregate).toBeDefined()
 })
 
 test('should drain and not import agg when shouldImportAgg is false for session_replay', async () => {
   jest.mocked(canEnableSessionTracking).mockReturnValue(false)
 
-  const instrument = new InstrumentBase(agentIdentifier, aggregator, FEATURE_NAMES.sessionReplay)
+  const instrument = new InstrumentBase(agentBase, FEATURE_NAMES.sessionReplay)
   const aggregateArgs = { [faker.string.uuid()]: faker.lorem.sentence() }
-  instrument.importAggregator(aggregateArgs)
+  instrument.importAggregator(agentBase, aggregateArgs)
 
   const windowLoadCallback = jest.mocked(onWindowLoad).mock.calls[0][0]
   await windowLoadCallback()

--- a/tools/webpack/configs/standard.mjs
+++ b/tools/webpack/configs/standard.mjs
@@ -25,9 +25,9 @@ export default (env) => {
       plugins: [
         new webpack.IgnorePlugin({
           checkResource: (resource, context) => {
-            if (context.match(/features\/utils/) && resource.indexOf('aggregate') > -1) {
+            if (context.match(/features\/utils/) && resource.endsWith('aggregate')) {
               // Only allow page_view_event, page_view_timing, and metrics features
-              return !resource.match(/(page_view_event|page_view_timing|metrics)\/aggregate/)
+              return !/(page_view_event|page_view_timing|metrics)\/aggregate/.test(resource)
             }
 
             return false
@@ -44,9 +44,9 @@ export default (env) => {
       plugins: [
         new webpack.IgnorePlugin({
           checkResource: (resource, context) => {
-            if (context.match(/features\/utils/) && resource.indexOf('aggregate') > -1) {
+            if (context.match(/features\/utils/) && resource.endsWith('aggregate')) {
               // Allow all features except spa
-              return resource.match(/(spa)\/aggregate/)
+              return /(spa)\/aggregate/.test(resource)
             }
 
             return false


### PR DESCRIPTION
Styling and architectural changes that will reduce agent loader size by moving the Aggregator module to async chunk and removing the need for some configuration getters in the features. No behavioral change or significant performance impact from the agent is expected. 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

`aggregator` no longer given to feature aggregate classes at initialization as it's widely unused. The couple features that uses the central aggregator can now reference the agent instance's `sharedAggregator` field. Further, configs can be grabbed off said instance directly rather than calling getX methods, so they have also been replaced as part of this.

Impact:

- aggregator code moved to async chunk from loader.
- since this modifies core code and every feature, this PR release should be treated as having mid to high risk.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-324625
https://new-relic.atlassian.net/browse/NR-322022

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
