### PR TITLE
chore: fix circular error in handler

### DIFF
--- a/src/features/jserrors/aggregate/internal-errors.js
+++ b/src/features/jserrors/aggregate/internal-errors.js
@@ -9,7 +9,7 @@ export function evaluateInternalError (stackInfo, internal) {
   const output = { shouldSwallow: internal || false, reason: 'Other' }
   const leadingFrame = stackInfo.frames?.[0]
   /** If we cant otherwise determine from the frames and message, the default of internal + reason will be the fallback */
-  if (!leadingFrame || !stackInfo.message) return output
+  if (!leadingFrame || typeof stackInfo?.message !== 'string') return output
 
   // check if the error happened in expected modules or if messages match known patterns
   const isNrRecorder = leadingFrame?.url?.match(/nr-(.*)-recorder.min.js/)

--- a/tests/unit/features/jserrors/aggregate/internal-errors.test.js
+++ b/tests/unit/features/jserrors/aggregate/internal-errors.test.js
@@ -10,6 +10,15 @@ describe('isInternalError', () => {
     expect(result).toEqual({ shouldSwallow: false, reason: 'Other' })
   })
 
+  it('should not swallow and reason "Other" when no error has message that is not a string', () => {
+    const stackInfo = {
+      frames: [{ url: 'some-other-script.js' }],
+      message: { foo: 'bar' }
+    }
+    const result = evaluateInternalError(stackInfo, false)
+    expect(result).toEqual({ shouldSwallow: false, reason: 'Other' })
+  })
+
   it('should swallow and reason "Rrweb-Security-Policy" for nr-recorder security policy error', () => {
     const stackInfo = {
       frames: [{ url: 'nr-123-recorder.min.js' }],


### PR DESCRIPTION
Fix a test that was missed and caught by the nightly test runner.  The test stopped working with the addition of the internal errors evaluator, specifically if a circular error passed through the evaluator where a string check was made when there is no string type message.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
