### PR TITLE
feat: Remove 'pageHide' from page end-of-lifecycle listener

### DIFF
--- a/src/common/harvest/harvest-scheduler.js
+++ b/src/common/harvest/harvest-scheduler.js
@@ -34,8 +34,9 @@ export class HarvestScheduler extends SharedContext {
     this.harvesting = false
     this.harvest = new Harvest(this.sharedContext)
 
-    // unload if EOL mechanism fires
-    subscribeToEOL(this.unload.bind(this))
+    // If a feature specifies stuff to be done on page unload, those are frontrunned (via capture phase) before ANY feature final harvests.
+    if (typeof this.opts.onUnload === 'function') subscribeToEOL(this.opts.onUnload, true)
+    subscribeToEOL(this.unload.bind(this)) // this should consist only of sending final harvest
 
     /* Flush all buffered data if session resets and give up retries. This should be synchronous to ensure that the correct `session` value is sent.
       Since session-reset generates a new session ID and the ID is grabbed at send-time, any delays or retries would cause the payload to be sent under
@@ -49,11 +50,7 @@ export class HarvestScheduler extends SharedContext {
    */
   unload () {
     if (this.aborted) return
-    // If opts.onUnload is defined, these are special actions to execute before attempting to send the final payload.
-    if (this.opts.onUnload) this.opts.onUnload()
-    // Events may still be added at unload time by other features, which we want to include in the final harvest of the feature. Hence, all final harvests are delayed to the
-    // end of the event loop to allow time via macrotask. All features will get to run their onUnload fn first before any final harvests are sent.
-    setTimeout(() => this.runHarvest({ unload: true }), 0)
+    this.runHarvest({ unload: true })
   }
 
   startTimer (interval, initialDelay) {

--- a/src/common/harvest/harvest-scheduler.js
+++ b/src/common/harvest/harvest-scheduler.js
@@ -51,7 +51,9 @@ export class HarvestScheduler extends SharedContext {
     if (this.aborted) return
     // If opts.onUnload is defined, these are special actions to execute before attempting to send the final payload.
     if (this.opts.onUnload) this.opts.onUnload()
-    this.runHarvest({ unload: true })
+    // Events may still be added at unload time by other features, which we want to include in the final harvest of the feature. Hence, all final harvests are delayed to the
+    // end of the event loop to allow time via macrotask. All features will get to run their onUnload fn first before any final harvests are sent.
+    setTimeout(() => this.runHarvest({ unload: true }), 0)
   }
 
   startTimer (interval, initialDelay) {

--- a/src/common/unload/eol.js
+++ b/src/common/unload/eol.js
@@ -2,7 +2,6 @@
  * Copyright 2020 New Relic Corporation. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { windowAddEventListener } from '../event-listener/event-listener-opts'
 import { globalScope, isWorkerScope, isBrowserScope } from '../constants/runtime'
 import { subscribeToVisibilityChange } from '../window/page-visibility'
 
@@ -26,8 +25,6 @@ if (isWorkerScope) {
 export function subscribeToEOL (cb) {
   if (isBrowserScope) {
     subscribeToVisibilityChange(cb, true) // when user switches tab or hides window, esp. mobile scenario
-    windowAddEventListener('pagehide', cb) // when user navigates away, and because safari iOS v14.4- doesn't fully support vis change
-    // --this ought to be removed once support for version below 14.5 phases out
   } else if (isWorkerScope) {
     globalScope.cleanupTasks.push(cb) // close() should run these tasks before quitting thread
   }

--- a/src/common/unload/eol.js
+++ b/src/common/unload/eol.js
@@ -22,9 +22,9 @@ if (isWorkerScope) {
  * This is used, for example, to submit a final harvest and send all remaining data on best-effort.
  * @param {function} cb - func to run before or during the last reliable event or time of an env's life span
  */
-export function subscribeToEOL (cb) {
+export function subscribeToEOL (cb, capturePhase) {
   if (isBrowserScope) {
-    subscribeToVisibilityChange(cb, true) // when user switches tab or hides window, esp. mobile scenario
+    subscribeToVisibilityChange(cb, true, capturePhase) // when user switches tab or hides window, esp. mobile scenario
   } else if (isWorkerScope) {
     globalScope.cleanupTasks.push(cb) // close() should run these tasks before quitting thread
   }

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -37,7 +37,8 @@ export class Aggregate extends AggregateBase {
     this.curSessEndRecorded = false
 
     registerHandler('docHidden', msTimestamp => this.endCurrentSession(msTimestamp), this.featureName, this.ee)
-    registerHandler('winPagehide', msTimestamp => this.recordPageUnload(msTimestamp), this.featureName, this.ee)
+    // Add the time of _window pagehide event_ firing to the next PVT harvest == NRDB windowUnload attr:
+    registerHandler('winPagehide', msTimestamp => this.addTiming('unload', msTimestamp, null), this.featureName, this.ee)
 
     const harvestTimeSeconds = getConfigurationValue(this.agentIdentifier, 'page_view_timing.harvestTimeSeconds') || 30
 
@@ -80,21 +81,6 @@ export class Aggregate extends AggregateBase {
       this.addTiming('pageHide', timestamp, null)
       this.curSessEndRecorded = true
     }
-  }
-
-  /**
-   * Add the time of _window pagehide event_ firing to the next PVT harvest == NRDB windowUnload attr.
-   */
-  recordPageUnload (timestamp) {
-    this.addTiming('unload', timestamp, null)
-    /*
-    Issue: Because window's pageHide commonly fires BEFORE vis change and "final" harvest would happen at the former in this case, we also have to add our vis-change event now or it may not be sent.
-    Affected: Safari < v14.1/.5 ; versions that don't support 'visiilitychange' event
-    Impact: For affected w/o this, NR 'pageHide' attribute may not be sent. For other browsers w/o this, NR 'pageHide' gets fragmented into its own harvest call on page unloading because of dual EoL logic.
-    Mitigation: NR 'unload' and 'pageHide' are both recorded when window pageHide fires, rather than only recording 'unload'.
-    Future: When EoL can become the singular subscribeToVisibilityChange, it's likely endCurrentSession isn't needed here as 'unload'-'pageHide' can be untangled.
-    */
-    this.endCurrentSession(timestamp)
   }
 
   addTiming (name, value, attrs) {

--- a/tests/unit/common/harvest/harvest-scheduler.test.js
+++ b/tests/unit/common/harvest/harvest-scheduler.test.js
@@ -36,21 +36,19 @@ describe('unload', () => {
     expect(subscribeToEOL).toHaveBeenCalledWith(expect.any(Function))
   })
 
-  test('should run onUnload callback when started', () => {
-    harvestSchedulerInstance.opts.onUnload = jest.fn()
+  test('should run onUnload callback on EoL when provided', () => {
+    harvestSchedulerInstance = new HarvestScheduler(undefined, { onUnload: jest.fn() })
 
-    eolSubscribeFn()
+    for (const arr of jest.mocked(subscribeToEOL).mock.calls) arr[0]()
 
     expect(harvestSchedulerInstance.opts.onUnload).toHaveBeenCalledTimes(1)
   })
 
-  test('should run harvest (on next tick) when started and not aborted', () => {
+  test('should run harvest on EoL if not aborted', () => {
     harvestSchedulerInstance.aborted = false
 
     eolSubscribeFn()
 
-    expect(harvestSchedulerInstance.runHarvest).not.toHaveBeenCalled()
-    jest.advanceTimersByTime(1)
     expect(harvestSchedulerInstance.runHarvest).toHaveBeenCalledWith({ unload: true })
   })
 

--- a/tests/unit/common/harvest/harvest-scheduler.test.js
+++ b/tests/unit/common/harvest/harvest-scheduler.test.js
@@ -44,11 +44,13 @@ describe('unload', () => {
     expect(harvestSchedulerInstance.opts.onUnload).toHaveBeenCalledTimes(1)
   })
 
-  test('should run harvest when started and not aborted', () => {
+  test('should run harvest (on next tick) when started and not aborted', () => {
     harvestSchedulerInstance.aborted = false
 
     eolSubscribeFn()
 
+    expect(harvestSchedulerInstance.runHarvest).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(1)
     expect(harvestSchedulerInstance.runHarvest).toHaveBeenCalledWith({ unload: true })
   })
 


### PR DESCRIPTION
Remove `pageHide` from page end-of-lifecycle listener since browser agent support for Safari 14.4 is deprecated
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Previously in support of Safari 14.4, we had retained the subscription to `pageHide` event for detecting when a page is entering a hidden state.  Safari 14.4 has now aged out of our current supported versions, so we are removing the `pageHide` logic.  Page unloads should now be detected via `visibilitychange` events across all supported browsers.

### Related Issue(s)

[NR-292875](https://new-relic.atlassian.net/browse/NR-292875)

### Testing

Ran `final-harvesting.e2e.js` to ensure tests are passing
Run pull-request-checks on PR branch to ensure everything still passes <-- ISSUES FOUND (TODO)


[NR-292875]: https://new-relic.atlassian.net/browse/NR-292875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ