### PR TITLE
feat: Add Firefox to LCP test matcher

### DIFF
--- a/tools/browser-matcher/common-matchers.mjs
+++ b/tools/browser-matcher/common-matchers.mjs
@@ -145,6 +145,7 @@ export const supportsFirstInputDelay = new SpecMatcher()
 export const supportsLargestContentfulPaint = new SpecMatcher()
   .include('chrome>=77')
   .include('edge>=79')
+  .include('firefox>=122')
   .include('android>=9.0')
 
 export const supportsInteractionToNextPaint = new SpecMatcher()
@@ -152,4 +153,7 @@ export const supportsInteractionToNextPaint = new SpecMatcher()
   .include('edge>=96')
   .include('android>=9.0')
 
-export const supportsCumulativeLayoutShift = supportsLargestContentfulPaint
+export const supportsCumulativeLayoutShift = new SpecMatcher()
+  .include('chrome>=77')
+  .include('edge>=79')
+  .include('android>=9.0')


### PR DESCRIPTION
Add Firefox versions 122 and above to LCP test matcher since versions 122 and above now support collection of LCP web vital timings.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Add Firefox versions 122 and above to LCP test matcher since versions 122 and above now support collection of LCP web vital timings. CLS matcher now uses a separate SpecMatcher object.

These changes are needed to keep test consistency with browser additions and features. Web standards change constantly on what browsers support what standard and we need to keep up to date on them.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-328547

### Testing

Make sure tests pass. Check that Firefox 122+ is additionally tested for:
- LCP is not collected on hidden pages for rum agent
- LCP is not collected on hidden pages for spa agent
