### PR TITLE
feat: Remove supportsSendBeacon runtime property

### DIFF
--- a/src/common/constants/__mocks__/runtime.js
+++ b/src/common/constants/__mocks__/runtime.js
@@ -5,6 +5,5 @@ export const initialLocation = '' + globalScope?.location
 export const isiOS = false
 export const iOSBelow16 = false
 export const ffVersion = 0
-export const supportsSendBeacon = true
 
 export const originTime = Date.now()

--- a/src/common/constants/runtime.js
+++ b/src/common/constants/runtime.js
@@ -72,8 +72,6 @@ export const ffVersion = (() => {
   return 0
 })()
 
-export const supportsSendBeacon = !!globalScope.navigator?.sendBeacon
-
 /**
  * Represents the absolute timestamp in milliseconds that the page was loaded
  * according to the browser's local clock.

--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -4,7 +4,7 @@
  * @license Apache-2.0
  */
 
-import { isBrowserScope, supportsSendBeacon } from '../constants/runtime'
+import { isBrowserScope } from '../constants/runtime'
 
 /**
  * @typedef {xhr|beacon} NetworkMethods
@@ -17,7 +17,7 @@ import { isBrowserScope, supportsSendBeacon } from '../constants/runtime'
  * a final harvest within the agent.
  */
 export function getSubmitMethod ({ isFinalHarvest = false } = {}) {
-  return isFinalHarvest && isBrowserScope && supportsSendBeacon
+  return isFinalHarvest && isBrowserScope
     // Use sendBeacon for final harvest
     ? beacon
     // If not final harvest, or not browserScope, always use xhr post

--- a/tests/unit/common/constants/runtime.test.js
+++ b/tests/unit/common/constants/runtime.test.js
@@ -155,22 +155,3 @@ test.each([
   expect(runtime.ffVersion).toEqual(expected)
   delete global.window
 })
-
-test('should set supportsSendBeacon to false', async () => {
-  // Ensure we don't have a sendBeacon function
-  delete global.navigator.sendBeacon
-
-  const runtime = await import('../../../../src/common/constants/runtime')
-
-  expect(runtime.supportsSendBeacon).toEqual(false)
-})
-
-test('should set supportsSendBeacon to true', async () => {
-  global.navigator.sendBeacon = jest.fn()
-  global.window = { navigator: global.navigator, document: true }
-
-  const runtime = await import('../../../../src/common/constants/runtime')
-
-  expect(runtime.supportsSendBeacon).toEqual(true)
-  delete global.window
-})

--- a/tests/unit/common/util/submit-data.test.js
+++ b/tests/unit/common/util/submit-data.test.js
@@ -19,21 +19,12 @@ afterEach(() => {
 describe('getSubmitMethod', () => {
   test('should use xhr for final harvest when isBrowserScope is false', () => {
     jest.replaceProperty(runtimeModule, 'isBrowserScope', false)
-    jest.replaceProperty(runtimeModule, 'supportsSendBeacon', true)
 
     expect(submitData.getSubmitMethod({ isFinalHarvest: true })).toEqual(submitData.xhr)
   })
 
-  test('should use xhr for final harvest when supportsSendBeacon is false', () => {
+  test('should use beacon for final harvest when isBrowserScope is true', () => {
     jest.replaceProperty(runtimeModule, 'isBrowserScope', true)
-    jest.replaceProperty(runtimeModule, 'supportsSendBeacon', false)
-
-    expect(submitData.getSubmitMethod({ isFinalHarvest: true })).toEqual(submitData.xhr)
-  })
-
-  test('should use beacon for final harvest when isBrowserScope and supportsSendBeacon is true', () => {
-    jest.replaceProperty(runtimeModule, 'isBrowserScope', true)
-    jest.replaceProperty(runtimeModule, 'supportsSendBeacon', true)
 
     expect(submitData.getSubmitMethod({ isFinalHarvest: true })).toEqual(submitData.beacon)
   })
@@ -42,14 +33,12 @@ describe('getSubmitMethod', () => {
     null, undefined, false
   ])('should use xhr when final harvest is %s', (isFinalHarvest) => {
     jest.replaceProperty(runtimeModule, 'isBrowserScope', true)
-    jest.replaceProperty(runtimeModule, 'supportsSendBeacon', true)
 
     expect(submitData.getSubmitMethod({ isFinalHarvest })).toEqual(submitData.xhr)
   })
 
   test('should use xhr when opts is undefined', () => {
     jest.replaceProperty(runtimeModule, 'isBrowserScope', true)
-    jest.replaceProperty(runtimeModule, 'supportsSendBeacon', true)
 
     expect(submitData.getSubmitMethod()).toEqual(submitData.xhr)
   })


### PR DESCRIPTION
Removes the supportsSendBeacon runtime property from our agent code. We no longer officially support browsers that cannot use the sendBeacon method, so there's no point in checking for it.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Removes the supportsSendBeacon runtime property from our agent code. This is done to tidy up the agent code and shorten the agent payload size a little bit.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-259634

### Testing

Make sure tests pass.
