### PR TITLE
fix: Correct naming for logging pageUrl attribute

### DIFF
--- a/src/common/config/runtime.js
+++ b/src/common/config/runtime.js
@@ -1,6 +1,6 @@
 import { getModeledObject } from './configurable'
 import { getNREUMInitializedAgent } from '../window/nreum'
-import { globalScope, originTime } from '../constants/runtime'
+import { originTime } from '../constants/runtime'
 import { BUILD_ENV, DIST_METHOD, VERSION } from '../constants/env'
 
 /**
@@ -23,7 +23,6 @@ const model = {
   loaderType: undefined,
   maxBytes: 30000,
   onerror: undefined,
-  origin: '' + globalScope.location,
   ptid: undefined,
   releaseIds: {},
   /** Agent-specific metadata found in the RUM call response. ex. entityGuid */

--- a/src/features/logging/shared/log.js
+++ b/src/features/logging/shared/log.js
@@ -1,4 +1,4 @@
-import { globalScope } from '../../../common/constants/runtime'
+import { initialLocation } from '../../../common/constants/runtime'
 import { cleanURL } from '../../../common/url/clean-url'
 import { LOG_LEVELS } from '../constants'
 
@@ -22,7 +22,7 @@ export class Log {
     /** @type {long} */
     this.timestamp = timestamp
     this.message = message
-    this.attributes = { ...attributes, pageUrl: cleanURL('' + globalScope.location) }
+    this.attributes = { ...attributes, pageUrl: cleanURL('' + initialLocation) }
     this.level = level.toUpperCase()
   }
 }

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -19,7 +19,7 @@ import { AggregateBase } from '../../utils/aggregate-base'
 import { firstContentfulPaint } from '../../../common/vitals/first-contentful-paint'
 import { firstPaint } from '../../../common/vitals/first-paint'
 import { bundleId } from '../../../common/ids/bundle-id'
-import { loadedAsDeferredBrowserScript } from '../../../common/constants/runtime'
+import { initialLocation, loadedAsDeferredBrowserScript } from '../../../common/constants/runtime'
 import { handle } from '../../../common/event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { warn } from '../../../common/util/console'
@@ -35,8 +35,8 @@ export class Aggregate extends AggregateBase {
     super(agentRef, FEATURE_NAME)
 
     this.state = {
-      initialPageURL: agentRef.runtime.origin,
-      lastSeenUrl: agentRef.runtime.origin,
+      initialPageURL: initialLocation,
+      lastSeenUrl: initialLocation,
       lastSeenRouteName: null,
       timerMap: {},
       timerBudget: MAX_TIMER_BUDGET,

--- a/src/features/spa/aggregate/interaction.js
+++ b/src/features/spa/aggregate/interaction.js
@@ -4,7 +4,7 @@
  */
 
 import { getInfo } from '../../../common/config/info'
-import { getRuntime } from '../../../common/config/runtime'
+import { initialLocation } from '../../../common/constants/runtime'
 import { gosNREUMOriginals } from '../../../common/window/nreum'
 import { ee } from '../../../common/event-emitter/contextual-ee'
 import { InteractionNode } from './interaction-node'
@@ -34,7 +34,7 @@ export function Interaction (eventName, timestamp, url, routeName, onFinished, a
   var attrs = root.attrs
 
   attrs.trigger = eventName
-  attrs.initialPageURL = getRuntime(agentIdentifier).origin
+  attrs.initialPageURL = initialLocation
   attrs.oldRoute = routeName
   attrs.newURL = attrs.oldURL = url
   attrs.custom = {}

--- a/tests/components/logging/aggregate.test.js
+++ b/tests/components/logging/aggregate.test.js
@@ -1,4 +1,5 @@
 import { getRuntime } from '../../../src/common/config/runtime'
+import { initialLocation } from '../../../src/common/constants/runtime'
 import { LOGGING_EVENT_EMITTER_CHANNEL } from '../../../src/features/logging/constants'
 import { Instrument as Logging } from '../../../src/features/logging/instrument'
 import { Log } from '../../../src/features/logging/shared/log'
@@ -181,6 +182,20 @@ describe('payloads', () => {
 
     loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [1234, Symbol('test'), {}, 'error'])
     expect(logs.pop().message).toEqual('Symbol(test)')
+  })
+
+  test('initialLocation should be in pageUrl of log object attributes', async () => {
+    const log = new Log(
+      Math.floor(runtime.timeKeeper.correctAbsoluteTimestamp(
+        runtime.timeKeeper.convertRelativeTimestamp(1234)
+      )),
+      'test message',
+      { },
+      'error'
+    )
+    const expected = initialLocation.toString()
+
+    expect(log.attributes.pageUrl).toEqual(expected)
   })
 })
 

--- a/tests/components/logging/aggregate.test.js
+++ b/tests/components/logging/aggregate.test.js
@@ -8,6 +8,8 @@ import * as handleModule from '../../../src/common/event-emitter/handle'
 import { resetAgent, setupAgent } from '../setup-agent'
 import { getInfo } from '../../../src/common/config/info'
 
+import { faker } from '@faker-js/faker'
+
 let mainAgent, info, runtime
 
 beforeAll(async () => {
@@ -185,6 +187,9 @@ describe('payloads', () => {
   })
 
   test('initialLocation should be in pageUrl of log object attributes', async () => {
+    const currentUrl = faker.internet.url()
+    jest.spyOn(window, 'location', 'get').mockReturnValue(currentUrl)
+
     const log = new Log(
       Math.floor(runtime.timeKeeper.correctAbsoluteTimestamp(
         runtime.timeKeeper.convertRelativeTimestamp(1234)


### PR DESCRIPTION
Corrects naming for the Logging pageUrl attribute by using the original url of the page instead of the url of when the event happens. Removes origin attribute from the runtime model object.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Corrects the naming for the Logging `pageUrl` attribute by using the original url of the page instead of the url of when the event happens. The original url of the page is also referred to as `initialLocation`. A test has been added to check that the `pageUrl` attribute in the Log object is `initialLocation`.

Removes origin attribute from the runtime model object by cleaning up usage of `runtime.origin` in spa feature. The `initialLocation` constant is a direct replacement for it.

These changes are for cleaning up the agent code.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-320541

### Testing

Make sure tests pass. Agent should work identically to before except that the `pageUrl` for logging events is now corrected to the original URL.
