### PR TITLE
fix: Remove undefined agentRuntime in Session Trace

### DIFF
--- a/src/features/session_trace/aggregate/trace/storage.js
+++ b/src/features/session_trace/aggregate/trace/storage.js
@@ -40,7 +40,7 @@ export class TraceStorage {
   storeSTN (stn) {
     if (this.parent.blocked) return
     if (this.nodeCount >= MAX_NODES_PER_HARVEST) { // limit the amount of pending data awaiting next harvest
-      if (this.parent.agentRuntime.session.state.sessionTraceMode !== MODE.ERROR) return
+      if (this.parent.mode !== MODE.ERROR) return
       const openedSpace = this.trimSTNs(ERROR_MODE_SECONDS_WINDOW) // but maybe we could make some space by discarding irrelevant nodes if we're in sessioned Error mode
       if (openedSpace === 0) return
     }

--- a/tests/components/session_trace/aggregate.test.js
+++ b/tests/components/session_trace/aggregate.test.js
@@ -1,6 +1,7 @@
 import { Instrument as SessionTrace } from '../../../src/features/session_trace/instrument'
 import { setupAgent } from '../setup-agent'
 import { MODE } from '../../../src/common/session/constants'
+import { MAX_NODES_PER_HARVEST } from '../../../src/features/session_trace/constants'
 
 let mainAgent
 
@@ -102,4 +103,23 @@ test('tracks previously stored events and processes them once per occurrence', d
     expect(sessionTraceAggregate.traceStorage.prevStoredEvents.size).toEqual(2)
     done()
   }, 100)
+})
+
+test('when max nodes per harvest is reached, no node is further added in FULL mode', () => {
+  sessionTraceAggregate.traceStorage.nodeCount = MAX_NODES_PER_HARVEST
+  sessionTraceAggregate.mode = MODE.FULL
+
+  sessionTraceAggregate.traceStorage.storeSTN({ n: 'someNode', s: 123 })
+  expect(sessionTraceAggregate.traceStorage.nodeCount).toEqual(MAX_NODES_PER_HARVEST)
+  expect(Object.keys(sessionTraceAggregate.traceStorage.trace).length).toEqual(0)
+})
+
+test('when max nodes per harvest is reached, node is still added in ERROR mode', () => {
+  sessionTraceAggregate.traceStorage.nodeCount = MAX_NODES_PER_HARVEST
+  sessionTraceAggregate.mode = MODE.ERROR
+  jest.spyOn(sessionTraceAggregate.traceStorage, 'trimSTNs').mockReturnValue(MAX_NODES_PER_HARVEST)
+
+  sessionTraceAggregate.traceStorage.storeSTN({ n: 'someNode', s: 123 })
+  expect(sessionTraceAggregate.traceStorage.nodeCount).toEqual(MAX_NODES_PER_HARVEST + 1)
+  expect(Object.keys(sessionTraceAggregate.traceStorage.trace).length).toEqual(1)
 })


### PR DESCRIPTION
Remove an outdated reference to `agentRuntime` variable in the Trace feature released in 1.270.0. It caused undefined errors in sub-cases wherein max harvest nodes were reached.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

The if-check causing the undefined error has been changed to checking the mode on the feature instance instead of the runtime session reference, as this makes more sense. By effect, this also remove & fixes the problem in 1.270.0

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-331791

### Testing

Jest test added that would detect issue with storeSTN logic, and the problematic check by extension.
