### PR TITLE
feat: Ignore unhandled promise rejections that lack a valid reason

### DIFF
--- a/src/features/jserrors/shared/cast-error.js
+++ b/src/features/jserrors/shared/cast-error.js
@@ -31,16 +31,16 @@ export function castError (error) {
    * @returns {Error} An Error object with the message as the casted reason
    */
 export function castPromiseRejectionEvent (promiseRejectionEvent) {
-  let prefix = 'Unhandled Promise Rejection'
+  const prefix = 'Unhandled Promise Rejection'
 
   /**
    * If the casted return value is falsy like this, it will get dropped and not produce an error event for harvest.
    * We drop promise rejections that could not form a valid error stack or message deriving from the .reason attribute
    * -- such as a manually invoked rejection without an argument -- since they lack reproduction value and create confusion.
    * */
-  if (!promiseRejectionEvent.reason) return
+  if (!promiseRejectionEvent?.reason) return
 
-  if (canTrustError(promiseRejectionEvent?.reason)) {
+  if (canTrustError(promiseRejectionEvent.reason)) {
     try {
       promiseRejectionEvent.reason.message = prefix + ': ' + promiseRejectionEvent.reason.message
       return castError(promiseRejectionEvent.reason)

--- a/src/features/jserrors/shared/cast-error.js
+++ b/src/features/jserrors/shared/cast-error.js
@@ -33,6 +33,13 @@ export function castError (error) {
 export function castPromiseRejectionEvent (promiseRejectionEvent) {
   let prefix = 'Unhandled Promise Rejection'
 
+  /**
+   * If the casted return value is falsy like this, it will get dropped and not produce an error event for harvest.
+   * We drop promise rejections that could not form a valid error stack or message deriving from the .reason attribute
+   * -- such as a manually invoked rejection without an argument -- since they lack reproduction value and create confusion.
+   * */
+  if (!promiseRejectionEvent.reason) return
+
   if (canTrustError(promiseRejectionEvent?.reason)) {
     try {
       promiseRejectionEvent.reason.message = prefix + ': ' + promiseRejectionEvent.reason.message
@@ -41,8 +48,6 @@ export function castPromiseRejectionEvent (promiseRejectionEvent) {
       return castError(promiseRejectionEvent.reason)
     }
   }
-
-  if (typeof promiseRejectionEvent.reason === 'undefined') return castError(prefix)
 
   const error = castError(promiseRejectionEvent.reason)
   error.message = prefix + ': ' + error?.message

--- a/tests/assets/unhandled-promise-rejection-falsy-reason.html
+++ b/tests/assets/unhandled-promise-rejection-falsy-reason.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init} {config} {loader}
+  </head>
+
+  <body>
+    <script>
+      "use strict";
+       // falsy reasons, these should get dropped
+      new Promise(function(res, rej) { rej() });
+      new Promise(function(res, rej) { rej('') });
+      new Promise(function(res, rej) { rej(null) });
+    </script>
+    this is a generic page that is instrumented by the JS agent
+  </body>
+</html>

--- a/tests/assets/unhandled-promise-rejection-readable.html
+++ b/tests/assets/unhandled-promise-rejection-readable.html
@@ -52,6 +52,14 @@
         }
         rej(new Foo());
       });
+      new Promise(function(res, rej) {
+        throw new Error("test");
+      });
+      new Promise(function(res, rej) {
+        (function () {
+          throw new Error("test");
+        })()
+      });
     </script>
     this is a generic page that is instrumented by the JS agent
   </body>

--- a/tests/specs/err/scripts-and-callbacks.e2e.js
+++ b/tests/specs/err/scripts-and-callbacks.e2e.js
@@ -159,8 +159,6 @@ describe('JSE Error detection in various callbacks', () => {
     { message: 'Unhandled Promise Rejection: [1,2,3]', meta: 'array' },
     { message: 'Unhandled Promise Rejection: test', meta: 'error with message' },
     { message: 'test', meta: 'error with no setter with message' },
-    { message: 'Unhandled Promise Rejection', meta: 'undefined' },
-    { message: 'Unhandled Promise Rejection: null', meta: 'null' },
     { message: 'Unhandled Promise Rejection: ', meta: 'error with no message' },
     { message: 'Unhandled Promise Rejection: {}', meta: 'map object' },
     { message: 'Unhandled Promise Rejection: {"abc":"Hello"}', meta: 'factory function' },
@@ -187,6 +185,17 @@ describe('JSE Error detection in various callbacks', () => {
       expect(!!actualError.params.stack_trace).toBeTruthy()
       expect(!!actualError.params.stackHash).toBeTruthy()
     })
+  })
+
+  it('should not report unhandled rejections with falsy reasons', async () => {
+    const pageUrl = await browser.testHandle.assetURL('unhandled-promise-rejection-falsy-reason.html')
+    const [errorsExpect] = await Promise.all([
+      errorsCapture.waitForResult({ timeout: 10000 }),
+      browser.url(pageUrl)
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    expect(errorsExpect).toEqual([])
   })
 
   it('should report errors from XHR callbacks', async () => {

--- a/tests/specs/err/scripts-and-callbacks.e2e.js
+++ b/tests/specs/err/scripts-and-callbacks.e2e.js
@@ -163,7 +163,9 @@ describe('JSE Error detection in various callbacks', () => {
     { message: 'Unhandled Promise Rejection: {}', meta: 'map object' },
     { message: 'Unhandled Promise Rejection: {"abc":"Hello"}', meta: 'factory function' },
     { message: 'Unhandled Promise Rejection: ', meta: 'uncalled function' },
-    { message: 'Unhandled Promise Rejection: {"abc":"circular"}', meta: 'circular object' }
+    { message: 'Unhandled Promise Rejection: {"abc":"circular"}', meta: 'circular object' },
+    { message: 'Unhandled Promise Rejection: test', meta: 'thrown error' },
+    { message: 'Unhandled Promise Rejection: test', meta: 'thrown error in nested fn' }
   ]
   expectedErrorMessages.forEach(expected => {
     it('should report unhandledPromiseRejections that are readable - ' + expected.meta, async () => {

--- a/tests/unit/features/jserrors/shared/cast-error.test.js
+++ b/tests/unit/features/jserrors/shared/cast-error.test.js
@@ -133,15 +133,13 @@ describe('cast-error', () => {
       })
     })
 
-    test('handles events with an undefined reason', () => {
-      const castedError = castPromiseRejectionEvent({ reason: undefined })
-      expect(castedError).toMatchObject({
-        name: 'UncaughtError',
-        message: 'Unhandled Promise Rejection',
-        sourceURL: undefined,
-        line: undefined,
-        column: undefined
-      })
+    test('terminates for events with falsy reasons', () => {
+      let castedError = castPromiseRejectionEvent({ reason: undefined })
+      expect(castedError).toBeUndefined()
+      castedError = castPromiseRejectionEvent({ reason: null })
+      expect(castedError).toBeUndefined()
+      castedError = castPromiseRejectionEvent({ reason: '' })
+      expect(castedError).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
The agent will not report unhandled promise rejections that lack a reason property as they cannot generate sufficient stack trace or messaging information for debugging.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-329400
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added to validate the behavior
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
