### PR TITLE
fix: Ensure all lazy loaded modules issue warning instead of errors

### DIFF
--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -90,18 +90,29 @@ export class InstrumentBase extends FeatureBase {
         if (this.featureName === FEATURE_NAMES.sessionReplay) this.abortHandler?.() // SR should stop recording if session DNE
       }
 
-      // Create a single Aggregator for this agent if DNE yet; to be used by jserror endpoint features.
-      if (!agentRef.sharedAggregator) {
-        agentRef.sharedAggregator = import(/* webpackChunkName: "shared-aggregator" */ '../../common/aggregate/aggregator')
-        const { Aggregator } = await agentRef.sharedAggregator
-        agentRef.sharedAggregator = new Aggregator()
-      } else await agentRef.sharedAggregator // if another feature is already importing the aggregator, wait for it to finish
+      try {
+        if (canEnableSessionTracking(this.agentIdentifier)) { // would require some setup before certain features start
+          const { setupAgentSession } = await import(/* webpackChunkName: "session-manager" */ './agent-session')
+          session = setupAgentSession(this.agentIdentifier)
+        }
+      } catch (e) {
+        warn(20, e)
+        this.ee.emit('internal-error', [e])
+        if (this.featureName === FEATURE_NAMES.sessionReplay) this.abortHandler?.() // SR should stop recording if session DNE
+      }
 
       /**
        * Note this try-catch differs from the one in Agent.run() in that it's placed later in a page's lifecycle and
        * it's only responsible for aborting its one specific feature, rather than all.
        */
       try {
+        // Create a single Aggregator for this agent if DNE yet; to be used by jserror endpoint features.
+        if (!agentRef.sharedAggregator) {
+          agentRef.sharedAggregator = import(/* webpackChunkName: "shared-aggregator" */ '../../common/aggregate/aggregator')
+          const { Aggregator } = await agentRef.sharedAggregator
+          agentRef.sharedAggregator = new Aggregator()
+        } else await agentRef.sharedAggregator // if another feature is already importing the aggregator, wait for it to finish
+
         if (!this.#shouldImportAgg(this.featureName, session)) {
           drain(this.agentIdentifier, this.featureName)
           loadedSuccessfully(false) // aggregate module isn't loaded at all

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -90,17 +90,6 @@ export class InstrumentBase extends FeatureBase {
         if (this.featureName === FEATURE_NAMES.sessionReplay) this.abortHandler?.() // SR should stop recording if session DNE
       }
 
-      try {
-        if (canEnableSessionTracking(this.agentIdentifier)) { // would require some setup before certain features start
-          const { setupAgentSession } = await import(/* webpackChunkName: "session-manager" */ './agent-session')
-          session = setupAgentSession(this.agentIdentifier)
-        }
-      } catch (e) {
-        warn(20, e)
-        this.ee.emit('internal-error', [e])
-        if (this.featureName === FEATURE_NAMES.sessionReplay) this.abortHandler?.() // SR should stop recording if session DNE
-      }
-
       /**
        * Note this try-catch differs from the one in Agent.run() in that it's placed later in a page's lifecycle and
        * it's only responsible for aborting its one specific feature, rather than all.


### PR DESCRIPTION
Lazy loaded modules that are blocked from loading by third party tools such as adblocking mechanisms will issue a warning to console instead of throwing an error.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-335501
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
