### PR TITLE
chore: Post release repo updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9362,9 +9362,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001674",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001674.tgz",
-      "integrity": "sha512-jOsKlZVRnzfhLojb+Ykb+gyUSp9Xb57So+fAiFlLzzTKpqg8xxSav0e40c8/4F/v9N8QSvrRRaLeVzQbLqomYw==",
+      "version": "1.0.30001676",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001676.tgz",
+      "integrity": "sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==",
       "dev": true,
       "funding": [
         {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Tue Oct 29 2024 22:56:17 GMT+0000 (Coordinated Universal Time)",
+  "lastUpdated": "Thu Oct 31 2024 19:08:32 GMT+0000 (Coordinated Universal Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.270.2.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.270.3.tgz"
   }
 }

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/client": "^3.8.8",
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.270.2.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.270.3.tgz",
     "graphql": "^16.8.1"
   }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.270.2.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.270.3.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.270.2.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.270.3.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
When this PR is merged, caniuse-lite database is updated, latest browserslist for SauceLabs is retrieved, and third-party dependencies docs are updates.
---

This PR was generated with post-release-updates GitHub action.