### PR TITLE
chore: prepare dist for npm publishing via postbuild custom script

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Build npm package
         run: npm run build:npm
       - name: Publish npm package
-        run: npm publish
+        run: cd dist && npm publish
 
   # Raise the release notes pr on the docs website repo
   raise-release-notes-pr:

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "test:types": "tsd -f ./tests/dts/**/*.ts",
     "wdio": "node --max-old-space-size=8192 tools/wdio/bin/cli.js",
     "build:all": "npm run cdn:build:local && npm run build:npm && npm run tools:test-builds",
-    "build:npm": "npm run npm:build:esm && npm run npm:build:cjs && npm run npm:build:types && npm run npm:pack",
+    "build:npm": "npm run npm:build:esm && npm run npm:build:cjs && npm run npm:build:types && npm run npm:postbuild && npm run npm:pack",
     "cdn:build": "npm run cdn:build:prod",
     "cdn:build:local": "npm run cdn:webpack",
     "cdn:build:prod": "npm run cdn:webpack -- --env mode=prod",
@@ -183,7 +183,8 @@
     "npm:build:esm": "npx babel --env-name npm-esm --out-dir dist/esm --out-file-extension .js ./src",
     "npm:build:cjs": "npx babel --env-name npm-cjs --out-dir dist/cjs --out-file-extension .js ./src",
     "npm:build:types": "npx tsc -b",
-    "npm:pack": "mkdir -p temp && export PKG_NAME=$(npm pack --pack-destination temp) && echo ./temp/$PKG_NAME",
+    "npm:postbuild": "node scripts/npm-postbuild.js",
+    "npm:pack": "mkdir -p temp && (cd dist && export PKG_NAME=$(npm pack --pack-destination ../temp) && echo ../temp/$PKG_NAME)",
     "publish:nrdb:stage": "npm --prefix .github/actions install && node .github/actions/nr-upload/index.js --environment=stage --loader-version=$npm_package_version --stage-api-key=$STAGE_API_KEY && node .github/actions/nr-verify/index.js --loader-version=$npm_package_version"
   },
   "config": {

--- a/scripts/npm-postbuild.js
+++ b/scripts/npm-postbuild.js
@@ -1,0 +1,20 @@
+const fs = require('fs-extra')
+const pkgJSON = require('../package.json')
+
+;(async function () {
+  // Copy essential files into the dist directory for package distribution
+  ['LICENSE', 'README.md', 'CHANGELOG.md'].forEach((file) => {
+    fs.copySync(file, `dist/${file}`)
+  })
+
+  // Prepare a minimized package.json for distribution
+  const distPackageJson = { ...pkgJSON }
+
+  delete distPackageJson.private // Remove private field, as this is intended for public distribution
+  delete distPackageJson.devDependencies // Exclude development dependencies to avoid unnecessary installs
+  delete distPackageJson.scripts // Remove scripts as they’re not required for distribution
+  delete distPackageJson.files // As its already in dist no need to add files as whole dist is distribution
+  delete distPackageJson.config // Exclude build / development specific config
+
+  fs.writeFileSync('dist/package.json', JSON.stringify(distPackageJson, null, 2))
+})()


### PR DESCRIPTION
Prepare `dist` for npm Publishing by Including Only Essential Files and a Minimized `package.json`
---

### Overview

This PR introduces a post-build process to prepare the `dist` directory for npm publishing. Key changes include:

- **Post-Build Script**: A new script, `scripts/npm-postbuild.js`, is added to handle the final packaging tasks. This script:
  - Copies essential files (`LICENSE`, `README.md`, `CHANGELOG.md`) to `dist`.
  - Cleans up `package.json` for publishing by removing unnecessary fields: `private`, `devDependencies`, `scripts`, `files`, and `config`.

### Reasons for Removing Fields from `package.json`

- **`private`**: This field prevents accidental publishing of packages. Since the `dist` directory is specifically prepared for publishing, this field is unnecessary and could prevent successful publication.

- **`devDependencies`**: These dependencies are only needed for development, not for running the package. Removing them to clean package json.

- **`scripts`**: The `scripts` section often contains commands for building, testing, or other development tasks, which are not required for end-users.

- **`files`**: This field specifies which files to include in the package, but since the entire `dist` folder is curated for distribution, specifying individual files is redundant.

- **`config`**: This field often contains build or environment-specific settings that are irrelevant to end-users. Removing it avoids exposing internal configuration details and keeps the package focused on production use.

This cleanup ensures a smaller, safer, and more production-focused npm package.

**Note:** This PR removes the src folder and relocates necessary files to the root for a cleaner package structure. After submitting the PR, I noticed some examples and documentation referencing imports from `@newrelic/browser-agent/src/` if any active usage depends on these src imports then we can skip this PR.

### Testing

- **Build**: Run the `build:npm` script to build the package, which also triggers the post-build step.
- **Verify `dist`**: Ensure that `dist` contains only the essential files and a minimized `package.json`.
- **Further Testing**: Additional CI/CD testing required to verify npm publishing.
