### PR TITLE
feat: Remove wrap-events usage from soft nav

### DIFF
--- a/tests/assets/soft-nav-interaction-on-click.html
+++ b/tests/assets/soft-nav-interaction-on-click.html
@@ -4,6 +4,9 @@
     <title>RUM Unit Test</title>
     {init}
     {config}
+    <script>
+      NREUM.init.feature_flags = ['soft_nav']
+    </script>
     {loader}
   </head>
   <body>


### PR DESCRIPTION
Remove wrap-events module from usage for soft navigation feature. This is part of an effort to cleanup code in the agent.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Remove wrap-events module from usage for soft navigation feature. This is part of an effort to cleanup code in the agent.

I also added the "soft_nav" feature flag to the `soft-nav-interaction-on-click.html` asset file. I want to be sure it's testing the soft_nav feature there.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-250813

### Testing

Make sure tests pass.
