### PR TITLE
feat: Wrap various console logging methods

### DIFF
--- a/src/features/logging/instrument/index.js
+++ b/src/features/logging/instrument/index.js
@@ -1,6 +1,8 @@
 import { InstrumentBase } from '../../utils/instrument-base'
 import { FEATURE_NAME } from '../constants'
 import { bufferLog } from '../shared/utils'
+import { wrapLogger } from '../../../common/wrap/wrap-logger'
+import { globalScope } from '../../../common/constants/runtime'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
@@ -8,6 +10,12 @@ export class Instrument extends InstrumentBase {
     super(agentRef, FEATURE_NAME, auto)
 
     const instanceEE = this.ee
+    wrapLogger(instanceEE, globalScope.console, 'log', { customAttributes: { wrappedFn: 'console.log' }, level: 'info' })
+    wrapLogger(instanceEE, globalScope.console, 'error', { customAttributes: { wrappedFn: 'console.error' }, level: 'error' })
+    wrapLogger(instanceEE, globalScope.console, 'warn', { customAttributes: { wrappedFn: 'console.warn' }, level: 'warn' })
+    wrapLogger(instanceEE, globalScope.console, 'info', { customAttributes: { wrappedFn: 'console.info' }, level: 'info' })
+    wrapLogger(instanceEE, globalScope.console, 'debug', { customAttributes: { wrappedFn: 'console.debug' }, level: 'debug' })
+    wrapLogger(instanceEE, globalScope.console, 'trace', { customAttributes: { wrappedFn: 'console.trace' }, level: 'trace' })
     /** emitted by wrap-logger function */
     this.ee.on('wrap-logger-end', function handleLog ([message]) {
       const { level, customAttributes } = this

--- a/tests/assets/logs-api-wrap-logger-rewrapped.html
+++ b/tests/assets/logs-api-wrap-logger-rewrapped.html
@@ -11,7 +11,7 @@
       var loggers = {
         log: function(message, attr){}
       }
-      
+
       newrelic.wrapLogger(loggers, 'log', { level: "warn" })
       loggers.log('test1')
       // should capture event with `warn` level
@@ -22,7 +22,8 @@
       // should NOT duplicate the log events (ie, capture 2 logs for this one call)
 
       var orig = loggers.log
-      loggers.log = (...args) => {console.log('wrapped again by 3rd party'); orig(...args)} 
+      // simulate wrapping by 3rd party
+      loggers.log = (...args) => { orig(...args)}
       loggers.log('test3')
       // should capture another event, and still have the `warn` level even though the parent context was changed
     </script>

--- a/tests/assets/logs-console-logger-harvest-early.html
+++ b/tests/assets/logs-console-logger-harvest-early.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2024 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>Logs - Console Logs - Harvest Early</title>
+    {init} {config} {loader}
+  </head>
+  <body>Logs - Console Logs - Harvest Early
+    <script>
+      const longMessage = 'x'.repeat(800*800)
+      /** the combination of the two large messages pushes it past the MAX_PAYLOAD_SIZE,
+       * causing the first valid one to get harvested before buffering the second one **/
+      console.info(longMessage)
+      console.info(longMessage)
+      // harvest should not have the '...xxxxx...' payload in it
+    </script>
+  </body>
+</html>

--- a/tests/assets/logs-console-logger-post-load.html
+++ b/tests/assets/logs-console-logger-post-load.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2024 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>Logs - Console Logs - Post Load</title>
+    {init} {config} {loader}
+  </head>
+  <body>Logs - Console Logs - Post Load
+    <script>
+      console.log('log')
+      console.info('info')
+      console.debug('debug')
+      console.trace('trace')
+      console.error('error')
+      console.warn('warn')
+    </script>
+</html>

--- a/tests/assets/logs-console-logger-pre-load.html
+++ b/tests/assets/logs-console-logger-pre-load.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2024 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>Logs - Console Logs - Pre Load</title>
+    {init} {config} {loader}
+    <script>
+      console.log('log')
+      console.info('info')
+      console.debug('debug')
+      console.trace('trace')
+      console.error('error')
+      console.warn('warn')
+    </script>
+  </head>
+  <body>Logs - Console Logs - Pre Load
+</html>

--- a/tests/assets/logs-console-logger-too-large.html
+++ b/tests/assets/logs-console-logger-too-large.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2024 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>Logs - Console Logs - Payload Too Large</title>
+    {init} {config} {loader}
+  </head>
+  <body>Logs - Console Logs - Payload Too Large
+    <script>
+      console.log('x'.repeat(1024*1024)) // too big
+      console.log('log')
+      console.info('info')
+      console.debug('debug')
+      console.trace('trace')
+      console.error('error')
+      console.warn('warn')
+
+      // harvest should not have the '...xxxxx...' payload in it
+    </script>
+  </body>
+</html>

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -14,7 +14,7 @@ describe('logging harvesting', () => {
     const expectedLogs = ['INFO', 'DEBUG', 'TRACE', 'ERROR', 'WARN'].map(level => ({
       level, message: level.toLowerCase(), timestamp: expect.any(Number), attributes
     }))
-    const expectedPayload = [{
+    const commonAttributes = {
       common: {
         attributes: {
           appId: 42,
@@ -29,7 +29,10 @@ describe('logging harvesting', () => {
           session: expect.any(String),
           ptid: expect.any(String)
         }
-      },
+      }
+    }
+    const expectedPayload = [{
+      ...commonAttributes,
       logs: expectedLogs
     }]
 
@@ -67,6 +70,20 @@ describe('logging harvesting', () => {
           logsCapture.waitForResult({ totalCount: 1 }),
           browser.url(await browser.testHandle.assetURL(`logs-${type}-too-large.html`))
         ])
+
+        const logs = [...expectedLogs, {
+          level: 'DEBUG',
+          message: 'New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#31',
+          timestamp: expect.any(Number),
+          attributes: {
+            pageUrl: expect.any(String),
+            wrappedFn: 'console.debug'
+          }
+        }]
+        const expectedPayload = [{
+          ...commonAttributes,
+          logs
+        }]
         expect(JSON.parse(body)).toEqual(expectedPayload) // should not contain the '...xxxxx...' payload in it
       })
     })

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -10,10 +10,6 @@ describe('logging harvesting', () => {
   describe('logging harvests', () => {
     const pageUrl = expect.any(String)
     const customAttributes = { test: 1 }
-    const attributes = { ...customAttributes, pageUrl }
-    const expectedLogs = ['INFO', 'DEBUG', 'TRACE', 'ERROR', 'WARN'].map(level => ({
-      level, message: level.toLowerCase(), timestamp: expect.any(Number), attributes
-    }))
     const commonAttributes = {
       common: {
         attributes: {
@@ -31,17 +27,40 @@ describe('logging harvesting', () => {
         }
       }
     }
-    const expectedPayload = [{
-      ...commonAttributes,
-      logs: expectedLogs
-    }]
+    const expectedLogs = (type) => {
+      if (type === 'api' || type === 'api-wrap-logger') {
+        return ['INFO', 'DEBUG', 'TRACE', 'ERROR', 'WARN'].map(level => ({
+          level,
+          message: level.toLowerCase(),
+          timestamp: expect.any(Number),
+          attributes: {
+            pageUrl,
+            ...customAttributes
+          }
+        }))
+      } else if (type === 'console-logger') {
+        return ['LOG', 'INFO', 'DEBUG', 'TRACE', 'ERROR', 'WARN'].map(level => ({
+          level: level === 'LOG' ? 'INFO' : level,
+          message: level.toLowerCase(),
+          timestamp: expect.any(Number),
+          attributes: {
+            pageUrl,
+            wrappedFn: `console.${level.toLowerCase()}`
+          }
+        }))
+      }
+    }
 
-    ;['api', 'api-wrap-logger'].forEach(type => {
+    ;['api', 'api-wrap-logger', 'console-logger'].forEach(type => {
       it(`should harvest expected logs - ${type} pre load`, async () => {
         const [[{ request: { body } }]] = await Promise.all([
           logsCapture.waitForResult({ totalCount: 1 }),
           browser.url(await browser.testHandle.assetURL(`logs-${type}-pre-load.html`))
         ])
+        const expectedPayload = [{
+          ...commonAttributes,
+          logs: expectedLogs(type)
+        }]
 
         expect(JSON.parse(body)).toEqual(expectedPayload)
       })
@@ -51,6 +70,10 @@ describe('logging harvesting', () => {
           logsCapture.waitForResult({ totalCount: 1 }),
           browser.url(await browser.testHandle.assetURL(`logs-${type}-post-load.html`))
         ])
+        const expectedPayload = [{
+          ...commonAttributes,
+          logs: expectedLogs(type)
+        }]
 
         expect(JSON.parse(body)).toEqual(expectedPayload)
       })
@@ -71,7 +94,7 @@ describe('logging harvesting', () => {
           browser.url(await browser.testHandle.assetURL(`logs-${type}-too-large.html`))
         ])
 
-        const logs = [...expectedLogs, {
+        const logs = [...expectedLogs(type), {
           level: 'DEBUG',
           message: 'New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#31',
           timestamp: expect.any(Number),


### PR DESCRIPTION
This is work in progress for adding auto-logging.  This first part wraps the various logging methods of the console, regardless of any logging settings, sampling, or feature enablement.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

This PR includes work that:
- wraps the various logging methods of the console
- extends the current e2e tests for logging harvests

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-323591

### Testing

Extended the existing e2e tests for logging harvests:
- pre-load
- post-load
- too large
- harvest early
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
