### PR TITLE
fix: Harvest generic events when max size is reached

### DIFF
--- a/.github/actions/build-ab/templates/released.js
+++ b/.github/actions/build-ab/templates/released.js
@@ -25,7 +25,7 @@ window.NREUM={
       enabled: true
     },
     performance: {
-      capture_marks: true, 
+      capture_marks: false, 
       capture_measures: true
     },
     proxy: {}

--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -13,7 +13,6 @@ import { now } from '../../../common/timing/now'
 import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { applyFnToProps } from '../../../common/util/traverse'
-import { IDEAL_PAYLOAD_SIZE } from '../../../common/constants/agent-constants'
 import { FEATURE_TO_ENDPOINT } from '../../../loaders/features/features'
 import { UserActionsAggregator } from './user-actions/user-actions-aggregator'
 import { isIFrameWindow } from '../../../common/dom/iframe'
@@ -177,9 +176,16 @@ export class Aggregate extends AggregateBase {
       ...obj
     }
 
-    this.events.add(eventAttributes)
-
-    this.checkEventLimits()
+    const addedEvent = this.events.add(eventAttributes)
+    if (!addedEvent && !this.events.isEmpty()) {
+      /** could not add the event because it pushed the buffer over the limit
+       * so we harvest early, and try to add it again now that the buffer is cleared
+       * if it fails again, we do nothing
+       */
+      this.ee.emit(SUPPORTABILITY_METRIC_CHANNEL, ['GenericEvents/Harvest/Max/Seen'])
+      this.harvestScheduler.runHarvest()
+      this.events.add(eventAttributes)
+    }
   }
 
   serializer (eventBuffer) {
@@ -188,13 +194,5 @@ export class Aggregate extends AggregateBase {
 
   queryStringsBuilder () {
     return { ua: this.agentRef.info.userAttributes, at: this.agentRef.info.atts }
-  }
-
-  checkEventLimits () {
-    // check if we've reached any harvest limits...
-    if (this.events.byteSize() > IDEAL_PAYLOAD_SIZE) {
-      this.ee.emit(SUPPORTABILITY_METRIC_CHANNEL, ['GenericEvents/Harvest/Max/Seen'])
-      this.harvestScheduler.runHarvest()
-    }
   }
 }

--- a/tests/components/generic_events/aggregate/index.test.js
+++ b/tests/components/generic_events/aggregate/index.test.js
@@ -61,17 +61,28 @@ test('should warn if invalid event is provide', async () => {
   expect(console.debug).toHaveBeenCalledWith('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#44', undefined)
 })
 
-test('should only buffer 64kb of events at a time', async () => {
+test('should harvest early if will exceed 1mb', async () => {
   genericEventsAggregate.ee.emit('rumresp', [{ ins: 1 }])
 
   await new Promise(process.nextTick)
 
   genericEventsAggregate.harvestScheduler.runHarvest = jest.fn()
-  genericEventsAggregate.addEvent({ name: 'test', eventType: 'x'.repeat(63000) })
+  genericEventsAggregate.addEvent({ name: 'test', eventType: 'x'.repeat(900000) })
 
   expect(genericEventsAggregate.harvestScheduler.runHarvest).not.toHaveBeenCalled()
-  genericEventsAggregate.addEvent({ name: 1000, eventType: 'x'.repeat(1000) })
+  genericEventsAggregate.addEvent({ name: 1000, eventType: 'x'.repeat(100000) })
   expect(genericEventsAggregate.harvestScheduler.runHarvest).toHaveBeenCalled()
+})
+
+test('should not harvest if single event will exceed 1mb', async () => {
+  genericEventsAggregate.ee.emit('rumresp', [{ ins: 1 }])
+
+  await new Promise(process.nextTick)
+
+  genericEventsAggregate.harvestScheduler.runHarvest = jest.fn()
+  genericEventsAggregate.addEvent({ name: 'test', eventType: 'x'.repeat(1000000) })
+
+  expect(genericEventsAggregate.harvestScheduler.runHarvest).not.toHaveBeenCalled()
 })
 
 describe('sub-features', () => {

--- a/tests/specs/ins/harvesting.e2e.js
+++ b/tests/specs/ins/harvesting.e2e.js
@@ -51,7 +51,6 @@ describe('ins harvesting', () => {
     ])
 
     const userActionsHarvest = insHarvests.flatMap(harvest => harvest.request.body.ins) // firefox sends a window focus event on load, so we may end up with 2 harvests
-    console.log(userActionsHarvest)
     const clickUAs = userActionsHarvest.filter(ua => ua.action === 'click')
     expect(clickUAs.length).toBeGreaterThanOrEqual(2)
     expect(clickUAs[0]).toMatchObject({

--- a/tests/specs/ins/harvesting.e2e.js
+++ b/tests/specs/ins/harvesting.e2e.js
@@ -51,6 +51,7 @@ describe('ins harvesting', () => {
     ])
 
     const userActionsHarvest = insHarvests.flatMap(harvest => harvest.request.body.ins) // firefox sends a window focus event on load, so we may end up with 2 harvests
+    console.log(userActionsHarvest)
     const clickUAs = userActionsHarvest.filter(ua => ua.action === 'click')
     expect(clickUAs.length).toBeGreaterThanOrEqual(2)
     expect(clickUAs[0]).toMatchObject({
@@ -81,7 +82,7 @@ describe('ins harvesting', () => {
       pageUrl: expect.any(String),
       timestamp: expect.any(Number)
     })
-    expect(clickUAs[1].actionDuration).toBeGreaterThan(0)
+    expect(clickUAs[1].actionDuration).toBeGreaterThanOrEqual(0)
     expect(clickUAs[1].actionMs).toEqual(expect.stringMatching(/^\[\d+(,\d+){4}\]$/))
   })
 
@@ -167,29 +168,8 @@ describe('ins harvesting', () => {
       insightsCapture.waitForResult({ timeout: 10000 }),
       browser.execute(function () {
         let i = 0
-        while (i++ < 1010) {
+        while (i++ < 10000) {
           newrelic.addPageAction('foobar')
-        }
-      })
-    ])
-    expect(insightsResult.length).toBeTruthy()
-  })
-
-  it('should harvest early when buffer gets too large (one big event)', async () => {
-    const testUrl = await browser.testHandle.assetURL('instrumented.html', { init: { generic_events: { harvestTimeSeconds: 30 } } })
-    await browser.url(testUrl)
-      .then(() => browser.waitForAgentLoad())
-
-    const [insightsResult] = await Promise.all([
-      insightsCapture.waitForResult({ timeout: 10000 }),
-      browser.execute(function () {
-        newrelic.addPageAction('foobar', createLargeObject())
-        function createLargeObject () {
-          let i = 0; let obj = {}
-          while (i++ < 64000) {
-            obj[i] = 'x'
-          }
-          return obj
         }
       })
     ])
@@ -207,7 +187,7 @@ describe('ins harvesting', () => {
         newrelic.addPageAction('foobar', createLargeObject())
         function createLargeObject () {
           let i = 0; let obj = {}
-          while (i++ < 100000) {
+          while (i++ < 1000000) {
             obj[i] = Math.random()
           }
           return obj


### PR DESCRIPTION
To avoid behavior that could lead to more network requests than necessary, generic events will now harvest early only if the max payload size is reached. This represents an increase from 64kb to 1MB.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
