### PR TITLE
feat: Upgrade SessionReplay libraries to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "fflate": "0.7.4",
-        "rrweb": "2.0.0-alpha.12",
+        "rrweb": "^2.0.0-alpha.17",
         "web-vitals": "4.2.3"
       },
       "devDependencies": {
@@ -6129,6 +6129,12 @@
       "dependencies": {
         "rrweb-snapshot": "^2.0.0-alpha.17"
       }
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.17.tgz",
+      "integrity": "sha512-HCsasPERBwOS9/LQeOytO2ETKTCqRj1wORBuxiy3t41hKhmi225DdrUPiWnyDdTQm1GdVbOymMRknJVPnZaSXw==",
+      "license": "MIT"
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -21896,19 +21902,19 @@
       }
     },
     "node_modules/rrweb": {
-      "version": "2.0.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.12.tgz",
-      "integrity": "sha512-lUGwBV7gmbwz1dIgzo9EEayIVyxoTIF6NBF6+Jctqs4Uy45QkyARtikpQlCUfxVCGTCQ0FOee9jeVYsG39oq1g==",
+      "version": "2.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.17.tgz",
+      "integrity": "sha512-GQxBkCC4r9XL2bwSdv7iIS49M3cEA8OtObVq0rrQ4GUT4+h7omucGQ4x7m5YN5Vq1oalStBaBlYqF7yRnfG3JA==",
       "license": "MIT",
       "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.12",
+        "@rrweb/types": "^2.0.0-alpha.17",
+        "@rrweb/utils": "^2.0.0-alpha.17",
         "@types/css-font-loading-module": "0.0.7",
         "@xstate/fsm": "^1.4.0",
         "base64-arraybuffer": "^1.0.1",
-        "fflate": "^0.4.4",
         "mitt": "^3.0.0",
-        "rrdom": "^2.0.0-alpha.12",
-        "rrweb-snapshot": "^2.0.0-alpha.12"
+        "rrdom": "^2.0.0-alpha.17",
+        "rrweb-snapshot": "^2.0.0-alpha.17"
       }
     },
     "node_modules/rrweb-snapshot": {
@@ -21919,12 +21925,6 @@
       "dependencies": {
         "postcss": "^8.4.38"
       }
-    },
-    "node_modules/rrweb/node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
-      "license": "MIT"
     },
     "node_modules/run-async": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
   },
   "dependencies": {
     "fflate": "0.7.4",
-    "rrweb": "2.0.0-alpha.12",
+    "rrweb": "^2.0.0-alpha.17",
     "web-vitals": "4.2.3"
   },
   "devDependencies": {

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -99,13 +99,6 @@ export class Recorder {
       inlineImages: inline_images,
       collectFonts: collect_fonts,
       checkoutEveryNms: CHECKOUT_MS[this.parent.mode],
-      /** Emits errors thrown by rrweb directly before bubbling them up to the window */
-      errorHandler: (err) => {
-        /** capture rrweb errors as "internal" errors only */
-        this.parent.ee.emit('internal-error', [err])
-        /** returning true informs rrweb to swallow the error instead of throwing it to the window */
-        return true
-      },
       recordAfter: 'DOMContentLoaded'
     })
 


### PR DESCRIPTION
Upgrade underlying session replay libraries to latest version which addresses some known bugs. This change also removes the error swallower inside the session replay module and instead handles all session replay errors at the window level to allow for external libraries to observe known errors to induce fallback behaviors, such as those implemented in CSS-as-JS libraries.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
