### PR TITLE
fix: Limit MicroAgent API based on available features

### DIFF
--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -4,13 +4,9 @@ import { getEnabledFeatures } from './features/enabled-features'
 import { configure } from './configure/configure'
 // core files
 import { setNREUMInitializedAgent } from '../common/window/nreum'
-import { getInfo } from '../common/config/info'
-import { getConfiguration, getConfigurationValue } from '../common/config/init'
-import { getLoaderConfig } from '../common/config/loader-config'
-import { getRuntime } from '../common/config/runtime'
 import { FEATURE_NAMES } from './features/features'
 import { warn } from '../common/util/console'
-import { AgentBase } from './agent-base'
+import { MicroAgentBase } from './agent-base'
 
 const nonAutoFeatures = [
   FEATURE_NAMES.jserrors,
@@ -24,7 +20,7 @@ const nonAutoFeatures = [
  * automatically instrument. Instead, each MicroAgent instance will lazy load the required features and can support loading multiple instances on one page.
  * Out of the box, it can manually handle and report Page View, Page Action, and Error events.
  */
-export class MicroAgent extends AgentBase {
+export class MicroAgent extends MicroAgentBase {
   /**
    * @param {Object} options - Specifies features and runtime configuration,
    * @param {string=} agentIdentifier - The optional unique ID of the agent.
@@ -38,38 +34,29 @@ export class MicroAgent extends AgentBase {
     configure(this, { ...options, runtime: { isolatedBacklog: true } }, options.loaderType || 'micro-agent')
     Object.assign(this, this.api) // the APIs should be available at the class level for micro-agent
 
-    /**
-     * Starts a set of agent features if not running in "autoStart" mode
-     * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/start/}
-     * @param {string|string[]|undefined} name The feature name(s) to start.  If no name(s) are passed, all features will be started
-     */
-    this.start = features => this.run(features)
-    this.run(nonAutoFeatures.filter(featureName => getConfigurationValue(this.agentIdentifier, `${featureName}.autoStart`)))
+    this.start(nonAutoFeatures.filter(featureName => !!this.init[featureName].autoStart))
   }
 
   get config () {
     return {
-      info: getInfo(this.agentIdentifier),
-      init: getConfiguration(this.agentIdentifier),
-      loader_config: getLoaderConfig(this.agentIdentifier),
-      runtime: getRuntime(this.agentIdentifier)
+      info: this.info,
+      init: this.init,
+      loader_config: this.loader_config,
+      runtime: this.runtime
     }
   }
 
-  run (features) {
+  /**
+   * Starts a set of agent features if not running in "autoStart" mode
+   * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/start/}
+   * @param {string|string[]} [featureNames] The feature name(s) to start.  If no name(s) are passed, all features will be started
+   */
+  start (featureNames) {
     try {
-      const featNames = nonAutoFeatures
-      if (features === undefined) features = featNames
-      else {
-        features = Array.isArray(features) && features.length ? features : [features]
-        if (features.some(f => !featNames.includes(f))) return warn(37, featNames)
-        if (!features.includes(FEATURE_NAMES.pageViewEvent)) features.push(FEATURE_NAMES.pageViewEvent)
-      }
-    } catch (err) {
-      warn(23, err)
-    }
+      if (featureNames === undefined || (Array.isArray(featureNames) && featureNames.length === 0)) featureNames = nonAutoFeatures
+      else if (typeof featureNames === 'string') featureNames = [featureNames]
 
-    try {
+      if (featureNames.some(f => !nonAutoFeatures.includes(f))) warn(37, nonAutoFeatures)
       const enabledFeatures = getEnabledFeatures(this.agentIdentifier)
 
       try {
@@ -84,7 +71,7 @@ export class MicroAgent extends AgentBase {
         Since the missing instrument-base class handles drain-gating (racing behavior) and PVE handles some setup, these are chained until after PVE has finished initializing
         so as to avoid the race condition of things like session and sharedAggregator not being ready by features that uses them right away. */
         nonAutoFeatures.forEach(f => {
-          if (enabledFeatures[f] && features.includes(f)) {
+          if (enabledFeatures[f] && featureNames.includes(f)) {
             import(/* webpackChunkName: "lazy-feature-loader" */ '../features/utils/lazy-feature-loader').then(({ lazyFeatureLoader }) => {
               return lazyFeatureLoader(f, 'aggregate')
             }).then(({ Aggregate }) => {

--- a/tests/dts/api.test-d.ts
+++ b/tests/dts/api.test-d.ts
@@ -1,7 +1,7 @@
 import { BrowserAgent } from '../../dist/types/loaders/browser-agent'
 import { MicroAgent } from '../../dist/types/loaders/micro-agent'
 import { InteractionInstance, getContext, onEnd } from '../../dist/types/loaders/api/interaction-types'
-import { expectType } from 'tsd'
+import { expectType, expectError } from 'tsd'
 
 // Browser Agent APIs
 const browserAgent = new BrowserAgent({})
@@ -26,7 +26,7 @@ expectType<(value: string | null) => any>(browserAgent.setApplicationVersion)
 expectType<(callback: (error: Error | string) => boolean | { group: string; }) => any>(browserAgent.setErrorHandler)
 expectType<(timeStamp?: number) => any>(browserAgent.finished)
 expectType<(name: string, id: string) => any>(browserAgent.addRelease)
-expectType<(featureNames?: string | string[]) => any>(browserAgent.start)
+expectType<() => any>(browserAgent.start)
 expectType<() => any>(browserAgent.recordReplay)
 expectType<() => any>(browserAgent.pauseReplay)
 expectType<(message: string, options?: { customAttributes?: object, level?: 'ERROR' | 'TRACE' | 'DEBUG' | 'INFO' | 'WARN'}) => any>(browserAgent.log)
@@ -45,20 +45,8 @@ expectType<(name: string, trigger?: string) => InteractionInstance>(browserAgent
 
 // Micro Agent APIs
 const microAgent = new MicroAgent({})
-expectType<(customAttributes: {
-  name: string;
-  start: number;
-  end?: number;
-  origin?: string;
-  type?: string;
-  // @ts-ignore
-}) => any>(microAgent.addToTrace)
-// @ts-ignore
-expectType<(name: string) => any>(microAgent.setCurrentRouteName)
-// @ts-ignore
-expectType<() => InteractionInstance>(microAgent.interaction)
+expectType<(featureNames?: string | string[]) => boolean>(microAgent.start)
 
-// Base Agent APIs
 expectType<(name: string, attributes?: object) => any>(microAgent.addPageAction)
 expectType<(name: string, host?: string) => any>(microAgent.setPageViewName)
 expectType<(name: string, value: string | number | boolean | null, persist?: boolean) => any>(microAgent.setCustomAttribute)
@@ -66,6 +54,14 @@ expectType<(error: Error | string, customAttributes?: object) => any>(microAgent
 expectType<(value: string | null) => any>(microAgent.setUserId)
 expectType<(value: string | null) => any>(microAgent.setApplicationVersion)
 expectType<(callback: (error: Error | string) => boolean | { group: string; }) => any>(microAgent.setErrorHandler)
-expectType<(timeStamp?: number) => any>(microAgent.finished)
 expectType<(name: string, id: string) => any>(microAgent.addRelease)
 expectType<(message: string, options?: { customAttributes?: object, level?: 'ERROR' | 'TRACE' | 'DEBUG' | 'INFO' | 'WARN'}) => any>(microAgent.log)
+
+// The following browser agent APIs should not be available in the Micro Agent:
+expectError(() => expectType<any>(microAgent.addToTrace))
+expectError(() => expectType<any>(microAgent.setCurrentRouteName))
+expectError(() => expectType<any>(microAgent.interaction))
+expectError(() => expectType<any>(microAgent.finished))
+expectError(() => expectType<any>(microAgent.recordReplay))
+expectError(() => expectType<any>(microAgent.pauseReplay))
+expectError(() => expectType<any>(microAgent.wrapLogger))


### PR DESCRIPTION
MicroAgent class now only shows the relevant API for use with NPM. The set is limited to methods that relate to features available with the MicroAgent.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

MicroAgent is trimmed down to the 10 methods, including `start`, that are relevant. The full set of `api.js` is still imported and set, but the public interface or users' IDE will not list the other methods used by non-MicroAgent features.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-289146

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
