### PR TITLE
feat: Aggregate log events based on rum flag

### DIFF
--- a/src/features/logging/constants.js
+++ b/src/features/logging/constants.js
@@ -8,6 +8,15 @@ export const LOG_LEVELS = {
   TRACE: 'TRACE'
 }
 
+export const LOGGING_MODE = {
+  OFF: 0,
+  ERROR: 1,
+  WARN: 2,
+  INFO: 3,
+  DEBUG: 4,
+  TRACE: 5
+}
+
 export const LOGGING_EVENT_EMITTER_CHANNEL = 'log'
 
 export const FEATURE_NAME = FEATURE_NAMES.logging

--- a/tests/components/logging/aggregate.test.js
+++ b/tests/components/logging/aggregate.test.js
@@ -232,48 +232,8 @@ describe('payloads - log events are emitted (or not) according to flag from rum 
     expect(loggingAggregate.events.isEmpty()).toBe(true)
   })
 
-  test('should emit event if logging mode matches message log level - ERROR', async () => {
-    const logLevel = 'ERROR'
-    await mockLoggingRumResponse(LOGGING_MODE[logLevel])
-    loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [SOME_TIMESTAMP, logLevel, { myAttributes: 1 }, logLevel])
-
-    expect(loggingAggregate.events.isEmpty()).toBe(false)
-    expect(loggingAggregate.events.get()[0]?.message).toEqual(logLevel)
-    loggingAggregate.events.clear()
-  })
-
-  test('should emit event if logging mode matches message log level - WARN', async () => {
-    const logLevel = 'WARN'
-    await mockLoggingRumResponse(LOGGING_MODE[logLevel])
-    loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [SOME_TIMESTAMP, logLevel, { myAttributes: 1 }, logLevel])
-
-    expect(loggingAggregate.events.isEmpty()).toBe(false)
-    expect(loggingAggregate.events.get()[0]?.message).toEqual(logLevel)
-    loggingAggregate.events.clear()
-  })
-
-  test('should emit event if logging mode matches message log level - INFO', async () => {
-    const logLevel = 'INFO'
-    await mockLoggingRumResponse(LOGGING_MODE[logLevel])
-    loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [SOME_TIMESTAMP, logLevel, { myAttributes: 1 }, logLevel])
-
-    expect(loggingAggregate.events.isEmpty()).toBe(false)
-    expect(loggingAggregate.events.get()[0]?.message).toEqual(logLevel)
-    loggingAggregate.events.clear()
-  })
-
-  test('should emit event if logging mode matches message log level - DEBUG', async () => {
-    const logLevel = 'DEBUG'
-    await mockLoggingRumResponse(LOGGING_MODE[logLevel])
-    loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [SOME_TIMESTAMP, logLevel, { myAttributes: 1 }, logLevel])
-
-    expect(loggingAggregate.events.isEmpty()).toBe(false)
-    expect(loggingAggregate.events.get()[0]?.message).toEqual(logLevel)
-    loggingAggregate.events.clear()
-  })
-
-  test('should emit event if logging mode matches message log level - TRACE', async () => {
-    const logLevel = 'TRACE'
+  const logLevels = Object.keys(LOGGING_MODE).filter(mode => mode !== 'OFF')
+  test.each(logLevels)('should emit event if logging mode matches message log level - %s', async (logLevel) => {
     await mockLoggingRumResponse(LOGGING_MODE[logLevel])
     loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [SOME_TIMESTAMP, logLevel, { myAttributes: 1 }, logLevel])
 

--- a/tests/components/logging/aggregate.test.js
+++ b/tests/components/logging/aggregate.test.js
@@ -53,9 +53,9 @@ describe('class setup', () => {
     ]))
   })
 
-  test('should wait for flags - undefined', async () => {
+  test('should wait for flags - log flag is missing', async () => {
     expect(loggingAggregate.drained).toBeUndefined()
-    loggingAggregate.ee.emit('rumresp', [{}]) // log flag is missing
+    loggingAggregate.ee.emit('rumresp', [{}])
     await new Promise(process.nextTick)
     expect(loggingAggregate.blocked).toEqual(true)
   })

--- a/tests/specs/cleanup-on-halt.e2e.js
+++ b/tests/specs/cleanup-on-halt.e2e.js
@@ -5,7 +5,7 @@ describe('Memory leaks', () => {
   it('does not occur on ee backlog when RUM flags are 0', async () => {
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
-      body: JSON.stringify(rumFlags({ st: 0, sr: 0, err: 0, ins: 0, spa: 0, loaded: 1 }))
+      body: JSON.stringify(rumFlags({ st: 0, sr: 0, err: 0, ins: 0, spa: 0, log: 0, loaded: 1 }))
     })
     // This test relies on features to call deregisterDrain when not enabled by flags which in turn should clear their backlogs.
 
@@ -22,6 +22,7 @@ describe('Memory leaks', () => {
     expect(backlog).toEqual(expect.objectContaining({
       ajax: 0, // ajax does not rely on any flags anyways so it's always drained
       jserrors: 0,
+      logging: 0,
       metrics: 0,
       generic_events: 0,
       page_view_event: 0, // no handler

--- a/tests/specs/harvesting/disable-harvesting.e2e.js
+++ b/tests/specs/harvesting/disable-harvesting.e2e.js
@@ -1,4 +1,4 @@
-import { testBlobTraceRequest, testErrorsRequest, testEventsRequest, testInsRequest, testMetricsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { testBlobTraceRequest, testErrorsRequest, testEventsRequest, testInsRequest, testLogsRequest, testMetricsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
 import { rumFlags } from '../../../tools/testing-server/constants'
 
 describe('disable harvesting', () => {
@@ -58,6 +58,22 @@ describe('disable harvesting', () => {
     ])
 
     expect(insightsHarvests).toEqual([])
+  })
+
+  it('should disable harvesting console logs when log entitlement is 0', async () => {
+    const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testLogsRequest })
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify(rumFlags({ log: 0 }))
+    })
+
+    const [logsHarvests] = await Promise.all([
+      logsCapture.waitForResult({ timeout: 10000 }),
+      browser.url(await browser.testHandle.assetURL('obfuscate-pii.html'))
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    expect(logsHarvests).toEqual([])
   })
 
   it('should disable harvesting session traces when stn entitlement is 0', async () => {

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -1,11 +1,27 @@
-import { testLogsRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { testLogsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { rumFlags } from '../../../tools/testing-server/constants'
+import { LOGGING_MODE } from '../../../src/features/logging/constants'
 
 describe('logging harvesting', () => {
   let logsCapture
 
   beforeEach(async () => {
-    logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testLogsRequest })
+    logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', {
+      test: testLogsRequest
+    })
   })
+
+  const mockRumResponse = async (logLevel) => {
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify(rumFlags({ log: logLevel }))
+    })
+  }
+  const checkPayload = (actualPayload, expectedPayload) => {
+    expect(actualPayload).toContainAllKeys(['common', 'logs'])
+    expect(actualPayload.common).toEqual(expectedPayload.common)
+    expect(actualPayload.logs).toIncludeSameMembers(expectedPayload.logs)
+  }
 
   describe('logging harvests', () => {
     const pageUrl = expect.any(String)
@@ -27,57 +43,54 @@ describe('logging harvesting', () => {
         }
       }
     }
-    const expectedLogs = (type) => {
-      if (type === 'api' || type === 'api-wrap-logger') {
-        return ['INFO', 'DEBUG', 'TRACE', 'ERROR', 'WARN'].map(level => ({
-          level,
-          message: level.toLowerCase(),
-          timestamp: expect.any(Number),
-          attributes: {
-            pageUrl,
-            ...customAttributes
-          }
-        }))
-      } else if (type === 'console-logger') {
-        return ['LOG', 'INFO', 'DEBUG', 'TRACE', 'ERROR', 'WARN'].map(level => ({
-          level: level === 'LOG' ? 'INFO' : level,
-          message: level.toLowerCase(),
-          timestamp: expect.any(Number),
-          attributes: {
-            pageUrl
-          }
-        }))
-      }
+    const expectedLogs = (type, logLevels = []) => {
+      return logLevels.map(level => ({
+        level: type === 'console-logger' && level === 'LOG' ? 'INFO' : level,
+        message: level.toLowerCase(),
+        timestamp: expect.any(Number),
+        attributes: {
+          pageUrl,
+          ...(type === 'api' || type === 'api-wrap-logger' ? customAttributes : {})
+        }
+      }))
     }
 
     ;['api', 'api-wrap-logger', 'console-logger'].forEach(type => {
-      it(`should harvest expected logs - ${type} pre load`, async () => {
-        const [[{ request: { body } }]] = await Promise.all([
-          logsCapture.waitForResult({ totalCount: 1 }),
-          browser.url(await browser.testHandle.assetURL(`logs-${type}-pre-load.html`))
-        ])
+      Object.keys(LOGGING_MODE).filter(mode => mode !== 'OFF').forEach(mode => {
+        const logLevel = LOGGING_MODE[mode]
+        const loggingModes = Object.entries(LOGGING_MODE).filter(entry => entry[1] > LOGGING_MODE.OFF && entry[1] <= logLevel).map(entry => entry[0])
+        if (type === 'console-logger' && logLevel >= LOGGING_MODE.INFO) {
+          loggingModes.push('LOG')
+        }
         const expectedPayload = [{
           ...commonAttributes,
-          logs: expectedLogs(type)
+          logs: expectedLogs(type, loggingModes)
         }]
 
-        expect(JSON.parse(body)).toEqual(expectedPayload)
-      })
+        it(`should harvest expected logs - ${type} pre load - logging mode: ${mode}`, async () => {
+          await mockRumResponse(logLevel)
+          const [[{ request: { body } }]] = await Promise.all([
+            logsCapture.waitForResult({ totalCount: 1 }),
+            browser.url(await browser.testHandle.assetURL(`logs-${type}-pre-load.html`))
+          ])
 
-      it(`should harvest expected logs - ${type} post load`, async () => {
-        const [[{ request: { body } }]] = await Promise.all([
-          logsCapture.waitForResult({ totalCount: 1 }),
-          browser.url(await browser.testHandle.assetURL(`logs-${type}-post-load.html`))
-        ])
-        const expectedPayload = [{
-          ...commonAttributes,
-          logs: expectedLogs(type)
-        }]
+          const actualPayload = JSON.parse(body)
+          checkPayload(actualPayload[0], expectedPayload[0])
+        })
 
-        expect(JSON.parse(body)).toEqual(expectedPayload)
+        it(`should harvest expected logs - ${type} post load - logging mode: ${mode}`, async () => {
+          await mockRumResponse(logLevel)
+          const [[{ request: { body } }]] = await Promise.all([
+            logsCapture.waitForResult({ totalCount: 1 }),
+            browser.url(await browser.testHandle.assetURL(`logs-${type}-post-load.html`))
+          ])
+          const actualPayload = JSON.parse(body)
+          checkPayload(actualPayload[0], expectedPayload[0])
+        })
       })
 
       it(`should harvest early if reaching limit - ${type}`, async () => {
+        await mockRumResponse(LOGGING_MODE.INFO)
         let now = Date.now(); let then
         await Promise.all([
           logsCapture.waitForResult({ totalCount: 1 }).then(() => { then = Date.now() }),
@@ -88,12 +101,16 @@ describe('logging harvesting', () => {
       })
 
       it(`should ignore log if too large - ${type}`, async () => {
+        await mockRumResponse(LOGGING_MODE.TRACE)
         const [[{ request: { body } }]] = await Promise.all([
           logsCapture.waitForResult({ totalCount: 1 }),
           browser.url(await browser.testHandle.assetURL(`logs-${type}-too-large.html`))
         ])
-
-        const logs = [...expectedLogs(type), {
+        const loggingModes = Object.entries(LOGGING_MODE).filter(entry => entry[1] > LOGGING_MODE.OFF).map(entry => entry[0])
+        if (type === 'console-logger') {
+          loggingModes.push('LOG')
+        }
+        const logs = [...expectedLogs(type, loggingModes), {
           level: 'DEBUG',
           message: 'New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#31',
           timestamp: expect.any(Number),
@@ -105,7 +122,7 @@ describe('logging harvesting', () => {
           ...commonAttributes,
           logs
         }]
-        expect(JSON.parse(body)).toEqual(expectedPayload) // should not contain the '...xxxxx...' payload in it
+        checkPayload(JSON.parse(body)[0], expectedPayload[0]) // should not contain the '...xxxxx...' payload in it
       })
     })
 
@@ -119,6 +136,7 @@ describe('logging harvesting', () => {
     })
 
     it('should not double harvest on navigation logs', async () => {
+      await mockRumResponse(LOGGING_MODE.INFO)
       const [logsRequests] = await Promise.all([
         logsCapture.waitForResult({ timeout: 15000 }),
         browser.url(await browser.testHandle.assetURL('logs-redirect.html'))
@@ -133,6 +151,7 @@ describe('logging harvesting', () => {
     })
 
     it('should allow for re-wrapping and 3rd party wrapping', async () => {
+      await mockRumResponse(LOGGING_MODE.INFO)
       const [[{ request: { body } }]] = await Promise.all([
         logsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('logs-api-wrap-logger-rewrapped.html'))
@@ -157,6 +176,7 @@ describe('logging harvesting', () => {
   describe('logging retry harvests', () => {
     [429].forEach(statusCode =>
       it(`should send the logs on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
+        await mockRumResponse(LOGGING_MODE.TRACE)
         await browser.testHandle.scheduleReply('bamServer', {
           test: testLogsRequest,
           permanent: true,

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -42,7 +42,7 @@ module.exports.rumFlags = (flags = {}, app = {}) => ({
   sr: defaultFlagValue(flags.sr), // session replay entitlements 0|1
   sts: defaultFlagValue(flags.sts), // session trace sampling 0|1|2 - off full error
   srs: defaultFlagValue(flags.srs), // session replay sampling 0|1|2 - off full error
-  log: defaultFlagValue(flags.log), // logging sampling 0|1|2|3|4|5 - off error warn info debug trace
+  log: flags.log ?? 3, // logging sampling 0|1|2|3|4|5 - off error warn info debug trace
   app: {
     agents: app.agents || [
       { entityGuid: defaultEntityGuid }

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -42,6 +42,7 @@ module.exports.rumFlags = (flags = {}, app = {}) => ({
   sr: defaultFlagValue(flags.sr), // session replay entitlements 0|1
   sts: defaultFlagValue(flags.sts), // session trace sampling 0|1|2 - off full error
   srs: defaultFlagValue(flags.srs), // session replay sampling 0|1|2 - off full error
+  log: defaultFlagValue(flags.log), // logging sampling 0|1|2|3|4|5 - off error warn info debug trace
   app: {
     agents: app.agents || [
       { entityGuid: defaultEntityGuid }


### PR DESCRIPTION
Aggregate logging events according to the `log` flag received from rum call to BCS.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Part 2 of the auto-logging feature work. This work will enable the logging feature to be controlled via BCS, which is ultimately based on user settings from UI (on/off, sampling, log level).

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-323597

### Testing

Extended existing logging aggregate unit and e2e tests around handling the flag.  Includes tests for each logging mode to ensure log messages of equal or higher levels are collected.  For example, if the `log` flag = 3 (INFO), then collect `console.error`, `console.warn`, `console.info`, and `console.log` events.

Extended existing tests to ensure no harvests when rum flag = 0 and events are drained.
