### PR TITLE
chore: improve testing server debug shim

### DIFF
--- a/tests/specs/util/helpers.js
+++ b/tests/specs/util/helpers.js
@@ -106,6 +106,18 @@ export function decodeAttributes (attributes) {
   return decodedObj
 }
 
+export async function getDebugLogs () {
+  return browser.execute(function () {
+    return window.NRDEBUG_LOGS
+  })
+}
+
+export async function clearDebugLogs () {
+  return browser.execute(function () {
+    window.NRDEBUG_LOGS = []
+  })
+}
+
 export function srConfig (initOverrides = {}) {
   return deepmerge(
     {

--- a/tools/testing-server/plugins/agent-injector/debug-shim.js
+++ b/tools/testing-server/plugins/agent-injector/debug-shim.js
@@ -7,46 +7,47 @@ module.exports = `
   ;window.NRDEBUG_LOGS=[]
   ;window.NRDEBUG = (function() {
     var count = 0;
+    var id = Math.random().toString(36).substring(7);
     return nrdebug;
-    function nrdebug(msg, sync) {
+    function nrdebug(msg, method) {
       count++;
       if (typeof msg === 'object') {
         msg = JSON.stringify(msg)
       }
-      window.NRDEBUG_LOGS.push({timestamp: performance?.now(), msg, url: window?.location?.href});
+      window.NRDEBUG_LOGS.push({id, timestamp: performance?.now(), msg, url: window?.location?.href, method});
     };
   })()
   var origOnError = window.onerror
-  window.onerror = function() {
-    NRDEBUG('error thrown: ' + JSON.stringify(arguments))
+  window.onerror = function(...args) {
+    NRDEBUG(args, 'window.onerror')
     if (typeof origOnError === 'function') {
       origOnError(arguments)
     }
   }
   var origLog = window.console.log.bind(window.console)
-  window.console.log = function() {
-    NRDEBUG('console.log: ' + JSON.stringify(arguments))
+  window.console.log = function(...args) {
+    NRDEBUG(args, 'console.log')
     if (typeof origLog === 'function') {
       origLog(arguments)
     }
   }
   var origWarn = window.console.warn.bind(window.console)
-  window.console.warn = function() {
-    NRDEBUG('console.warn: ' + JSON.stringify(arguments))
+  window.console.warn = function(...args) {
+    NRDEBUG(args, 'console.warn')
     if (typeof origWarn === 'function') {
       //origWarn(arguments)
     }
   }
   var origErr = window.console.error.bind(window.console)
-  window.console.error = function() {
-    NRDEBUG('console.error: ' + JSON.stringify(arguments))
+  window.console.error = function(...args) {
+    NRDEBUG(args, 'console.error')
     if (typeof origErr === 'function') {
       origErr(arguments)
     }
   }
   var origTrace = window.console.trace.bind(window.console)
-  window.console.trace = function() {
-    NRDEBUG('console.trace: ' + JSON.stringify(arguments))
+  window.console.trace = function(...args) {
+    NRDEBUG(args, 'console.trace')
     if (typeof origTrace === 'function') {
       origTrace(arguments)
     }

--- a/tools/testing-server/plugins/agent-injector/debug-shim.js
+++ b/tools/testing-server/plugins/agent-injector/debug-shim.js
@@ -4,6 +4,7 @@
  * EXCMAScript standards.
  */
 module.exports = `
+  ;window.NRDEBUG_LOGS=[]
   ;window.NRDEBUG = (function() {
     var count = 0;
     return nrdebug;
@@ -12,17 +13,7 @@ module.exports = `
       if (typeof msg === 'object') {
         msg = JSON.stringify(msg)
       }
-      var url = 'http://' + NREUM.info.beacon + '/debug?m=' + escape(msg) + '&testId=' + NREUM.info.licenseKey + '&r=' + Math.random() + '&ix=' + count
-      if (!sync) {
-        var img = new window.Image()
-        img.src = url
-        return img
-      } else {
-        var request = new XMLHttpRequest()
-        request.open('POST', url, false)
-        request.setRequestHeader('content-type', 'text/plain')
-        request.send()
-      }
+      window.NRDEBUG_LOGS.push({timestamp: performance?.now(), msg, url: window?.location?.href});
     };
   })()
   var origOnError = window.onerror


### PR DESCRIPTION
The current logging shim output of the test server alters Ajax and resource payloads when enabled because it generates network requests to capture the log messages. This change introduces a global array that intercepts and stores log messages in it that can be fetched on the fly with a browser execute statement. 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
An example of how to use this would be something like:
1. *anywhere* in your test add the included helper method
    - `console.log(await getDebugLogs())`
This will return the current state of the log message buffer.  Anytime something like `console.log` is called in the test execution step (client side), the log buffer will be populated with the contents.  You must start the test server with the `-d` flag as before for the shim to be injected into the page. 
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
