### PR TITLE
chore: Post release repo updates

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -117,7 +117,7 @@ SOFTWARE.
 
 ### rrweb
 
-This product includes source derived from [rrweb](https://github.com/rrweb-io/rrweb) ([v2.0.0-alpha.12](https://github.com/rrweb-io/rrweb/tree/v2.0.0-alpha.12)), distributed under the [MIT License](https://github.com/rrweb-io/rrweb/blob/v2.0.0-alpha.12/README.md):
+This product includes source derived from [rrweb](https://github.com/rrweb-io/rrweb) ([v2.0.0-alpha.17](https://github.com/rrweb-io/rrweb/tree/v2.0.0-alpha.17)), distributed under the [MIT License](https://github.com/rrweb-io/rrweb/blob/v2.0.0-alpha.17/README.md):
 
 ```
 MIT License

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Nov 11 2024 18:20:57 GMT+0000 (Coordinated Universal Time)",
+  "lastUpdated": "Wed Nov 20 2024 01:00:51 GMT+0000 (Coordinated Universal Time)",
   "projectName": "New Relic Browser Agent",
   "projectUrl": "https://github.com/newrelic/newrelic-browser-agent",
   "includeOptDeps": true,
@@ -19,15 +19,15 @@
       "publisher": "Arjun Barrett",
       "email": "arjunbarrett@gmail.com"
     },
-    "rrweb@2.0.0-alpha.12": {
+    "rrweb@2.0.0-alpha.17": {
       "name": "rrweb",
-      "version": "2.0.0-alpha.12",
-      "range": "2.0.0-alpha.12",
+      "version": "2.0.0-alpha.17",
+      "range": "^2.0.0-alpha.17",
       "licenses": "MIT",
       "repoUrl": "https://github.com/rrweb-io/rrweb",
-      "versionedRepoUrl": "https://github.com/rrweb-io/rrweb/tree/v2.0.0-alpha.12",
+      "versionedRepoUrl": "https://github.com/rrweb-io/rrweb/tree/v2.0.0-alpha.17",
       "licenseFile": "node_modules/rrweb/README.md",
-      "licenseUrl": "https://github.com/rrweb-io/rrweb/blob/v2.0.0-alpha.12/README.md",
+      "licenseUrl": "https://github.com/rrweb-io/rrweb/blob/v2.0.0-alpha.17/README.md",
       "licenseTextSource": "spdx",
       "publisher": "yanzhen@smartx.com"
     },

--- a/tools/test-builds/browser-agent-wrapper/package.json
+++ b/tools/test-builds/browser-agent-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.273.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.274.0.tgz"
   }
 }

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "@apollo/client": "^3.8.8",
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.273.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.274.0.tgz",
     "graphql": "^16.8.1"
   }
 }

--- a/tools/test-builds/raw-src-wrapper/package.json
+++ b/tools/test-builds/raw-src-wrapper/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.273.0.tgz"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.274.0.tgz"
   }
 }

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.273.0.tgz",
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.274.0.tgz",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },


### PR DESCRIPTION
When this PR is merged, caniuse-lite database is updated, latest browserslist for SauceLabs is retrieved, and third-party dependencies docs are updates.
---

This PR was generated with post-release-updates GitHub action.