### PR TITLE
chore: Allow logs api wrapper to add custom attributes

### DIFF
--- a/src/common/wrap/wrap-logger.js
+++ b/src/common/wrap/wrap-logger.js
@@ -34,7 +34,7 @@ export function wrapLogger(sharedEE, parent, loggerFn, context) {
   ctx.customAttributes = context.customAttributes
 
   /** observe calls to <loggerFn> and emit events prefixed with `wrap-logger-` */
-  wrapFn.inPlace(parent, [loggerFn], 'wrap-logger-', ctx)
+  wrapFn.inPlace(parent, [loggerFn], 'wrap-logger-', ctx, true, true)
 
   return ee
 }

--- a/tests/assets/logs-api-wrap-logger-rewrapped.html
+++ b/tests/assets/logs-api-wrap-logger-rewrapped.html
@@ -18,14 +18,14 @@
 
       newrelic.wrapLogger(loggers, 'log', { level: "debug" })
       loggers.log('test2')
-      // should capture another event, ignoring the `debug` level and harvesting with `warn`
+      // should capture another event, update to harvest with `debug` level
       // should NOT duplicate the log events (ie, capture 2 logs for this one call)
 
       var orig = loggers.log
       // simulate wrapping by 3rd party
       loggers.log = (...args) => { orig(...args)}
       loggers.log('test3')
-      // should capture another event, and still have the `warn` level even though the parent context was changed
+      // should capture another event, and still have the `debug` level even though the parent context was changed
     </script>
   </head>
   <body>Logs API Error Object</body>

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -151,7 +151,7 @@ describe('logging harvesting', () => {
     })
 
     it('should allow for re-wrapping and 3rd party wrapping', async () => {
-      await mockRumResponse(LOGGING_MODE.INFO)
+      await mockRumResponse(LOGGING_MODE.DEBUG)
       const [[{ request: { body } }]] = await Promise.all([
         logsCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('logs-api-wrap-logger-rewrapped.html'))
@@ -164,12 +164,12 @@ describe('logging harvesting', () => {
       // original wrapping context (warn)
       expect(logs[0].message).toEqual('test1')
       expect(logs[0].level).toEqual('WARN')
-      // should not re-wrap, meaning the level should not change, but the message should here
+      // should not re-wrap but will overwrite the attributes so it'll become a DEBUG; the 'test2' message should be there
       expect(logs[1].message).toEqual('test2')
-      expect(logs[1].level).toEqual('WARN')
-      // should allow a 3rd party to wrap the function and not affect the context (warn)
+      expect(logs[1].level).toEqual('DEBUG')
+      // should allow a 3rd party to wrap the function and not affect the context (debug)
       expect(logs[2].message).toEqual('test3')
-      expect(logs[2].level).toEqual('WARN')
+      expect(logs[2].level).toEqual('DEBUG')
     })
   })
 


### PR DESCRIPTION
This will support the rollout of the auto-logging feature without disrupting customers that may currently be using `wrapLogger` to wrap the `console` object.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Currently, once an object's method is wrapped, it is blocked from being re-wrapped.  With the auto-logging feature, the browser agent's internal wrapping for `console` will be triggered before any other wrappers that may be invoked via `wrapLogger`.  This creates a small potential change in behavior if customers are already using `wrapLogger` to wrap the `console` object. 

So the logging context is now modifiable, such that log api wrappers can overwrite the custom attributes sent along with the log events.  For a given wrapped method, attributes supplied by the last wrapper will "win".

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-323597

### Testing

Updated existing test regarding re-wrapping.  Attributes supplied by subsequent re-wrapping will be used instead of the initial ones. 
