### PR TITLE
fix: Ignore reserved attribute names on UserActions tied to the window

### DIFF
--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -72,11 +72,20 @@ export class Aggregate extends AggregateBase {
                 rageClick: aggregatedUserAction.rageClick,
                 target: aggregatedUserAction.selectorPath,
                 ...(isIFrameWindow(window) && { iframe: true }),
-                ...(target?.id && { targetId: target.id }),
-                ...(target?.tagName && { targetTag: target.tagName }),
-                ...(target?.type && { targetType: target.type }),
-                ...(target?.className && { targetClass: target.className })
+                ...(canTrustTargetAttribute('id') && { targetId: target.id }),
+                ...(canTrustTargetAttribute('tagName') && { targetTag: target.tagName }),
+                ...(canTrustTargetAttribute('type') && { targetType: target.type }),
+                ...(canTrustTargetAttribute('className') && { targetClass: target.className })
               })
+
+              /**
+               * Only trust attributes that exist on HTML element targets, which excludes the window and the document targets
+               * @param {string} attribute The attribute to check for on the target element
+               * @returns {boolean} Whether the target element has the attribute and can be trusted
+               */
+              function canTrustTargetAttribute (attribute) {
+                return !!(aggregatedUserAction.selectorPath !== 'window' && aggregatedUserAction.selectorPath !== 'document' && target instanceof HTMLElement && target?.[attribute])
+              }
             }
           } catch (e) {
             // do nothing for now

--- a/tests/assets/user-actions-modified-window.html
+++ b/tests/assets/user-actions-modified-window.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>User Action Test</title>
+    {init} {config} {loader}
+  </head>
+  <body style="height: 200vh; overflow: scroll;">
+		<button id="pay-btn" class="btn-cart-add flex-grow container" type="submit">Create click user action</button>
+		<input type="text" id="textbox"/>
+    <script>
+      // having a type attribute on the window should be ignored by the collected UserActions
+      window.type = 'test'
+    </script>
+  </body>
+</html>

--- a/tests/specs/ins/harvesting.e2e.js
+++ b/tests/specs/ins/harvesting.e2e.js
@@ -1,4 +1,3 @@
-const { onlyFirefox } = require('../../../tools/browser-matcher/common-matchers.mjs')
 const { testInsRequest, testErrorsRequest } = require('../../../tools/testing-server/utils/expect-tests')
 const { onlyFirefox, onlyChrome } = require('../../../tools/browser-matcher/common-matchers.mjs')
 const { deepmergeInto } = require('deepmerge-ts')
@@ -90,7 +89,7 @@ describe('ins harvesting', () => {
 
   // firefox generates a focus event when the page loads, which makes testing this easier
   it.withBrowsersMatching(onlyFirefox)('should ignore window attributes on UserAction blur and focus', async () => {
-    const testUrl = await browser.testHandle.assetURL('user-actions.html', { init: { user_actions: { enabled: true } } })
+    const testUrl = await browser.testHandle.assetURL('user-actions-modified-window.html', { init: { user_actions: { enabled: true } } })
     await browser.url(testUrl).then(() => browser.waitForAgentLoad())
 
     const [insHarvests] = await Promise.all([
@@ -350,7 +349,6 @@ describe('ins harvesting', () => {
     }
 
     checkAllTested () {
-      console.log(this.typesToTest)
       return Object.entries(this.typesToTest).forEach(([type, { tested }]) => {
         expect(tested).toEqual(this.expectedTypes.includes(type))
       })


### PR DESCRIPTION
Force the agent to not capture target-level attributes for window-level UserActions. Customers can set window-level variables that mimic HTML element attributes like type or tagName. This change prevents the potential capture of those attributes as part of blur or focus user actions tied to the window.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
