### PR TITLE
feat: Persist logging flag in session

### DIFF
--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -12,6 +12,7 @@ import { handle } from '../event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../features/metrics/constants'
 import { FEATURE_NAMES } from '../../loaders/features/features'
 import { windowAddEventListener } from '../event-listener/event-listener-opts'
+import { LOGGING_MODE } from '../../features/logging/constants'
 
 // this is what can be stored in local storage (not enforced but probably should be)
 // these values should sync between local storage and the parent class props
@@ -24,6 +25,7 @@ const model = {
   sessionReplaySentFirstChunk: false,
   sessionTraceMode: MODE.OFF,
   traceHarvestStarted: false,
+  loggingMode: LOGGING_MODE.OFF,
   serverTimeDiff: null, // set by TimeKeeper; "undefined" value will not be stringified and stored but "null" will
   custom: {}
 }

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -147,16 +147,14 @@ export class Aggregate extends AggregateBase {
       this.scheduler.startTimer(this.harvestTimeSeconds)
       this.syncWithSessionManager({ sessionReplayMode: this.mode })
     } else {
-      this.initializeRecording(false, true, true)
+      this.initializeRecording(false, true)
     }
   }
 
   /**
-   * Evaluate entitlements and sampling before starting feature mechanics, importing and configuring recording library, and setting storage state
-   * @param {boolean} entitlements - the true/false state of the "sr" flag from RUM response
-   * @param {boolean} errorSample - the true/false state of the error sampling decision
-   * @param {boolean} fullSample - the true/false state of the full sampling decision
-   * @param {boolean} ignoreSession - whether to force the method to ignore the session state and use just the sample flags
+   * Evaluate entitlements (which already accounts for sampling) before starting feature mechanics, importing and configuring recording library, and setting storage state
+   * @param {boolean} srMode - the true/false state of the "sr" flag from RUM response
+   * @param {boolean} ignoreSession - whether to force the method to ignore the session state and use just the "sr" flag
    * @returns {void}
    */
   async initializeRecording (srMode, ignoreSession) {

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -73,7 +73,7 @@ export class Aggregate extends AggregateBase {
     this.ee.on(SESSION_EVENTS.UPDATE, (type, data) => {
       if (!this.recorder || !this.initialized || this.blocked || type !== SESSION_EVENT_TYPES.CROSS_TAB) return
       if (this.mode !== MODE.OFF && data.sessionReplayMode === MODE.OFF) this.abort(ABORT_REASONS.CROSS_TAB)
-      this.mode = data.sessionReplay
+      this.mode = data.sessionReplayMode
     })
 
     // Bespoke logic for blobs endpoint.
@@ -393,9 +393,5 @@ export class Aggregate extends AggregateBase {
     this.recorder?.clearTimestamps?.()
     this.ee.emit('REPLAY_ABORTED')
     while (this.recorder?.getEvents().events.length) this.recorder?.clearBuffer?.()
-  }
-
-  syncWithSessionManager (state = {}) {
-    this.agentRef.runtime.session.write(state)
   }
 }

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -7,6 +7,7 @@ import { activatedFeatures } from '../../common/util/feature-flags'
 import { Obfuscator } from '../../common/util/obfuscate'
 import { EventBuffer } from './event-buffer'
 import { FEATURE_NAMES } from '../../loaders/features/features'
+import { canEnableSessionTracking } from './feature-gates'
 
 export class AggregateBase extends FeatureBase {
   constructor (agentRef, featureName) {
@@ -18,6 +19,7 @@ export class AggregateBase extends FeatureBase {
     else if (![FEATURE_NAMES.pageViewEvent, FEATURE_NAMES.sessionTrace].includes(this.featureName)) this.events = new EventBuffer()
     this.checkConfiguration(agentRef)
     this.obfuscator = agentRef.runtime.obfuscator
+    this.isSessionTrackingEnabled = canEnableSessionTracking(this.agentIdentifier)
   }
 
   /**
@@ -119,6 +121,8 @@ export class AggregateBase extends FeatureBase {
   }
 
   syncWithSessionManager (state = {}) {
-    this.agentRef.runtime.session.write(state)
+    if (this.isSessionTrackingEnabled) {
+      this.agentRef.runtime.session.write(state)
+    }
   }
 }

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -19,7 +19,7 @@ export class AggregateBase extends FeatureBase {
     else if (![FEATURE_NAMES.pageViewEvent, FEATURE_NAMES.sessionTrace].includes(this.featureName)) this.events = new EventBuffer()
     this.checkConfiguration(agentRef)
     this.obfuscator = agentRef.runtime.obfuscator
-    this.isSessionTrackingEnabled = canEnableSessionTracking(this.agentIdentifier)
+    this.isSessionTrackingEnabled = canEnableSessionTracking(this.agentIdentifier) && this.agentRef.runtime.session
   }
 
   /**

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -117,4 +117,8 @@ export class AggregateBase extends FeatureBase {
       existingAgent.runtime.obfuscator = new Obfuscator(this.agentIdentifier)
     }
   }
+
+  syncWithSessionManager (state = {}) {
+    this.agentRef.runtime.session.write(state)
+  }
 }

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -139,8 +139,6 @@ export class InstrumentBase extends FeatureBase {
         return hasReplayPrerequisite(this.agentIdentifier) && !!session
       case FEATURE_NAMES.sessionTrace:
         return !!session
-      case FEATURE_NAMES.logging:
-        return !!session
       default:
         return true
     }

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -139,6 +139,8 @@ export class InstrumentBase extends FeatureBase {
         return hasReplayPrerequisite(this.agentIdentifier) && !!session
       case FEATURE_NAMES.sessionTrace:
         return !!session
+      case FEATURE_NAMES.logging:
+        return !!session
       default:
         return true
     }

--- a/tests/components/session-entity.test.js
+++ b/tests/components/session-entity.test.js
@@ -2,6 +2,7 @@ import { PREFIX } from '../../src/common/session/constants'
 import { SessionEntity } from '../../src/common/session/session-entity'
 import { LocalMemory, model } from './session-helpers'
 import * as runtimeModule from '../../src/common/constants/runtime'
+import { buildExpectedSessionState } from '../specs/util/helpers'
 
 jest.useFakeTimers()
 
@@ -33,30 +34,13 @@ describe('constructor', () => {
       inactiveTimer: expect.any(Object),
       isNew: expect.any(Boolean),
       storage: expect.any(Object),
-      state: expect.objectContaining({
-        value: expect.any(String),
-        expiresAt: expect.any(Number),
-        inactiveAt: expect.any(Number),
-        sessionReplayMode: expect.any(Number),
-        sessionReplaySentFirstChunk: expect.any(Boolean),
-        sessionTraceMode: expect.any(Number),
-        loggingMode: expect.any(Number)
-      })
+      state: expect.objectContaining(buildExpectedSessionState())
     })
   })
 
   test('can use sane defaults', () => {
     const session = new SessionEntity({ agentIdentifier, key, storage })
-    expect(session.state).toEqual(expect.objectContaining({
-      value: expect.any(String),
-      expiresAt: expect.any(Number),
-      inactiveAt: expect.any(Number),
-      updatedAt: expect.any(Number),
-      sessionReplayMode: expect.any(Number),
-      sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number),
-      loggingMode: expect.any(Number)
-    }))
+    expect(session.state).toEqual(expect.objectContaining(buildExpectedSessionState()))
   })
 
   test('expiresAt is the correct future timestamp - new session', () => {
@@ -112,16 +96,7 @@ describe('constructor', () => {
     // missing required fields
     const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { invalid_fields: true } })
     const session = new SessionEntity({ agentIdentifier, key, storage })
-    expect(session.state).toEqual(expect.objectContaining({
-      value: expect.any(String),
-      expiresAt: expect.any(Number),
-      inactiveAt: expect.any(Number),
-      updatedAt: expect.any(Number),
-      sessionReplayMode: expect.any(Number),
-      sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number),
-      loggingMode: expect.any(Number)
-    }))
+    expect(session.state).toEqual(expect.objectContaining(buildExpectedSessionState()))
   })
 
   test('expired expiresAt value in storage sets new defaults', () => {
@@ -129,16 +104,7 @@ describe('constructor', () => {
     jest.setSystemTime(now)
     const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { value, expiresAt: now - 100, inactiveAt: Infinity } })
     const session = new SessionEntity({ agentIdentifier, key, storage })
-    expect(session.state).toEqual(expect.objectContaining({
-      value: expect.any(String),
-      expiresAt: expect.any(Number),
-      inactiveAt: expect.any(Number),
-      updatedAt: expect.any(Number),
-      sessionReplayMode: expect.any(Number),
-      sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number),
-      loggingMode: expect.any(Number)
-    }))
+    expect(session.state).toEqual(expect.objectContaining(buildExpectedSessionState()))
   })
 
   test('expired inactiveAt value in storage sets new defaults', () => {
@@ -146,16 +112,7 @@ describe('constructor', () => {
     jest.setSystemTime(now)
     const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { value, inactiveAt: now - 100, expiresAt: Infinity } })
     const session = new SessionEntity({ agentIdentifier, key, storage })
-    expect(session.state).toEqual(expect.objectContaining({
-      value: expect.any(String),
-      expiresAt: expect.any(Number),
-      inactiveAt: expect.any(Number),
-      updatedAt: expect.any(Number),
-      sessionReplayMode: expect.any(Number),
-      sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number),
-      loggingMode: expect.any(Number)
-    }))
+    expect(session.state).toEqual(expect.objectContaining(buildExpectedSessionState()))
   })
 })
 
@@ -217,15 +174,7 @@ describe('read()', () => {
     const newSession = new SessionEntity({ agentIdentifier, key, storage, expiresMs: 10 })
     expect(newSession.isNew).toBeTruthy()
 
-    expect(newSession.read()).toEqual(expect.objectContaining({
-      value: expect.any(String),
-      expiresAt: expect.any(Number),
-      inactiveAt: expect.any(Number),
-      sessionReplayMode: expect.any(Number),
-      sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number),
-      loggingMode: expect.any(Number)
-    }))
+    expect(newSession.read()).toEqual(expect.objectContaining(buildExpectedSessionState()))
   })
 
   test('"pre-existing" sessions get data from read()', () => {

--- a/tests/components/session-entity.test.js
+++ b/tests/components/session-entity.test.js
@@ -39,7 +39,8 @@ describe('constructor', () => {
         inactiveAt: expect.any(Number),
         sessionReplayMode: expect.any(Number),
         sessionReplaySentFirstChunk: expect.any(Boolean),
-        sessionTraceMode: expect.any(Number)
+        sessionTraceMode: expect.any(Number),
+        loggingMode: expect.any(Number)
       })
     })
   })
@@ -53,7 +54,8 @@ describe('constructor', () => {
       updatedAt: expect.any(Number),
       sessionReplayMode: expect.any(Number),
       sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number)
+      sessionTraceMode: expect.any(Number),
+      loggingMode: expect.any(Number)
     }))
   })
 
@@ -117,7 +119,8 @@ describe('constructor', () => {
       updatedAt: expect.any(Number),
       sessionReplayMode: expect.any(Number),
       sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number)
+      sessionTraceMode: expect.any(Number),
+      loggingMode: expect.any(Number)
     }))
   })
 
@@ -133,7 +136,8 @@ describe('constructor', () => {
       updatedAt: expect.any(Number),
       sessionReplayMode: expect.any(Number),
       sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number)
+      sessionTraceMode: expect.any(Number),
+      loggingMode: expect.any(Number)
     }))
   })
 
@@ -149,7 +153,8 @@ describe('constructor', () => {
       updatedAt: expect.any(Number),
       sessionReplayMode: expect.any(Number),
       sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number)
+      sessionTraceMode: expect.any(Number),
+      loggingMode: expect.any(Number)
     }))
   })
 })
@@ -218,7 +223,8 @@ describe('read()', () => {
       inactiveAt: expect.any(Number),
       sessionReplayMode: expect.any(Number),
       sessionReplaySentFirstChunk: expect.any(Boolean),
-      sessionTraceMode: expect.any(Number)
+      sessionTraceMode: expect.any(Number),
+      loggingMode: expect.any(Number)
     }))
   })
 

--- a/tests/components/session-helpers.js
+++ b/tests/components/session-helpers.js
@@ -38,6 +38,7 @@ export const model = {
   sessionReplaySentFirstChunk: false,
   sessionTraceMode: 0,
   traceHarvestStarted: false,
+  loggingMode: 0,
   serverTimeDiff: null,
   custom: {}
 }

--- a/tests/specs/harvesting/disable-harvesting.e2e.js
+++ b/tests/specs/harvesting/disable-harvesting.e2e.js
@@ -63,8 +63,10 @@ describe('disable harvesting', () => {
 
   it('should disable harvesting console logs when log entitlement is 0', async () => {
     // logging mode will only take effect on a fresh session
-    const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer2', { test: testLogsRequest })
-    await browser.testHandle.scheduleReply('bamServer2', {
+    await browser.destroyAgentSession()
+
+    const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testLogsRequest })
+    await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
       body: JSON.stringify(rumFlags({ log: LOGGING_MODE.OFF }))
     })
@@ -114,23 +116,3 @@ describe('disable harvesting', () => {
     })
   })
 })
-
-// logging mode will only take effect on a fresh session
-// describe('disable harvesting - logging', () => {
-//   it('should disable harvesting console logs when log entitlement is 0', async () => {
-//     const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer2', { test: testLogsRequest })
-//     await browser.testHandle.scheduleReply('bamServer2', {
-//       test: testRumRequest,
-//       body: JSON.stringify(rumFlags({ log: 0 }))
-//     })
-//
-//     const [logsHarvests] = await Promise.all([
-//       logsCapture.waitForResult({ timeout: 10000 }),
-//       browser.url(await browser.testHandle.assetURL('obfuscate-pii.html'))
-//         .then(() => browser.waitForAgentLoad())
-//     ])
-//
-//     console.log('logHarvests: ', logsHarvests)
-//     expect(logsHarvests).toEqual([])
-//   })
-// })

--- a/tests/specs/harvesting/disable-harvesting.e2e.js
+++ b/tests/specs/harvesting/disable-harvesting.e2e.js
@@ -1,5 +1,6 @@
 import { testBlobTraceRequest, testErrorsRequest, testEventsRequest, testInsRequest, testLogsRequest, testMetricsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
 import { rumFlags } from '../../../tools/testing-server/constants'
+import { LOGGING_MODE } from '../../../src/features/logging/constants'
 
 describe('disable harvesting', () => {
   it('should disable harvesting metrics and errors when err entitlement is 0', async () => {
@@ -61,10 +62,11 @@ describe('disable harvesting', () => {
   })
 
   it('should disable harvesting console logs when log entitlement is 0', async () => {
-    const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testLogsRequest })
-    await browser.testHandle.scheduleReply('bamServer', {
+    // logging mode will only take effect on a fresh session
+    const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer2', { test: testLogsRequest })
+    await browser.testHandle.scheduleReply('bamServer2', {
       test: testRumRequest,
-      body: JSON.stringify(rumFlags({ log: 0 }))
+      body: JSON.stringify(rumFlags({ log: LOGGING_MODE.OFF }))
     })
 
     const [logsHarvests] = await Promise.all([
@@ -112,3 +114,23 @@ describe('disable harvesting', () => {
     })
   })
 })
+
+// logging mode will only take effect on a fresh session
+// describe('disable harvesting - logging', () => {
+//   it('should disable harvesting console logs when log entitlement is 0', async () => {
+//     const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer2', { test: testLogsRequest })
+//     await browser.testHandle.scheduleReply('bamServer2', {
+//       test: testRumRequest,
+//       body: JSON.stringify(rumFlags({ log: 0 }))
+//     })
+//
+//     const [logsHarvests] = await Promise.all([
+//       logsCapture.waitForResult({ timeout: 10000 }),
+//       browser.url(await browser.testHandle.assetURL('obfuscate-pii.html'))
+//         .then(() => browser.waitForAgentLoad())
+//     ])
+//
+//     console.log('logHarvests: ', logsHarvests)
+//     expect(logsHarvests).toEqual([])
+//   })
+// })

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -11,12 +11,18 @@ describe('logging harvesting', () => {
     })
   })
 
+  afterEach(async () => {
+    // logging mode is sticky to the session, so we need to reset before the next test
+    await await browser.destroyAgentSession()
+  })
+
   const mockRumResponse = async (logLevel) => {
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
       body: JSON.stringify(rumFlags({ log: logLevel }))
     })
   }
+
   const checkPayload = (actualPayload, expectedPayload) => {
     expect(actualPayload).toContainAllKeys(['common', 'logs'])
     expect(actualPayload.common).toEqual(expectedPayload.common)
@@ -70,8 +76,8 @@ describe('logging harvesting', () => {
         it(`should harvest expected logs - ${type} pre load - logging mode: ${mode}`, async () => {
           await mockRumResponse(logLevel)
           const [[{ request: { body } }]] = await Promise.all([
-            logsCapture.waitForResult({ totalCount: 1 }),
-            browser.url(await browser.testHandle.assetURL(`logs-${type}-pre-load.html`))
+            logsCapture.waitForResult({ totalCount: 1, timeout: 15000 }),
+            await browser.url(await browser.testHandle.assetURL(`logs-${type}-pre-load.html`))
           ])
 
           const actualPayload = JSON.parse(body)
@@ -81,7 +87,7 @@ describe('logging harvesting', () => {
         it(`should harvest expected logs - ${type} post load - logging mode: ${mode}`, async () => {
           await mockRumResponse(logLevel)
           const [[{ request: { body } }]] = await Promise.all([
-            logsCapture.waitForResult({ totalCount: 1 }),
+            logsCapture.waitForResult({ totalCount: 1, timeout: 15000 }),
             browser.url(await browser.testHandle.assetURL(`logs-${type}-post-load.html`))
           ])
           const actualPayload = JSON.parse(body)

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -13,7 +13,7 @@ describe('logging harvesting', () => {
 
   afterEach(async () => {
     // logging mode is sticky to the session, so we need to reset before the next test
-    await await browser.destroyAgentSession()
+    await browser.destroyAgentSession()
   })
 
   const mockRumResponse = async (logLevel) => {

--- a/tests/specs/logging/session-pages.e2e.js
+++ b/tests/specs/logging/session-pages.e2e.js
@@ -1,0 +1,166 @@
+import { testLogsRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { LOGGING_MODE } from '../../../src/features/logging/constants'
+import { supportsMultiTabSessions } from '../../../tools/browser-matcher/common-matchers.mjs'
+import { getLogs } from '../util/helpers'
+
+describe('Logging Across Pages', () => {
+  let logsCapture
+  const TIMEOUT = 10000
+
+  beforeEach(async () => {
+    logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', {
+      test: testLogsRequest
+    })
+    await browser.enableLogging()
+  })
+
+  afterEach(async () => {
+    await browser.destroyAgentSession()
+  })
+
+  it('should record across same-tab page refresh', async () => {
+    let [logsHarvests] = await Promise.all([
+      logsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('logs-console-logger-pre-load.html'))
+    ])
+
+    const { localStorage } = await browser.getAgentSessionInfo()
+    const sessionId = localStorage.value
+    const page1Payload = JSON.parse(logsHarvests[0].request.body)
+    expect(page1Payload[0].common.attributes.session).toEqual(sessionId)
+    // expect log entries for: error, warn, info, log
+    expect(page1Payload[0].logs.length).toBe(4)
+
+    // simulate a second call to rum in same session, which should return log = 0
+    await browser.enableLogging({ logMode: LOGGING_MODE.OFF })
+    let [refreshHarvests] = await Promise.all([
+      logsCapture.waitForResult({ timeout: TIMEOUT }),
+      browser.refresh()
+    ])
+
+    // confirm we are still sending logs because logging is already enabled in this session
+    // note: the network capture has not been cleared, so the previous harvest is still there
+    expect(refreshHarvests.length).toBe(2)
+    const page2Payload = JSON.parse(refreshHarvests[1].request.body)
+    expect(page2Payload[0].common.attributes.session).toEqual(sessionId)
+    expect(page2Payload[0].logs.length).toBe(4)
+  })
+
+  it('should record across same-tab page navigation', async () => {
+    let [logsHarvests] = await Promise.all([
+      logsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('logs-console-logger-pre-load.html'))
+    ])
+
+    const { localStorage } = await browser.getAgentSessionInfo()
+    const sessionId = localStorage.value
+    const page1Payload = JSON.parse(logsHarvests[0].request.body)
+    expect(page1Payload[0].common.attributes.session).toEqual(sessionId)
+    // expect log entries for: error, warn, info, log
+    expect(page1Payload[0].logs.length).toBe(4)
+
+    // simulate a second call to rum in same session, which should return log = 0
+    await browser.enableLogging({ logMode: LOGGING_MODE.OFF })
+    let [navigationHarvests] = await Promise.all([
+      logsCapture.waitForResult({ timeout: TIMEOUT }),
+      browser.url(await browser.testHandle.assetURL('logs-console-logger-post-load.html'))
+    ])
+
+    // confirm we are still sending logs because logging is already enabled in this session
+    // note: the network capture has not been cleared, so the previous harvest is still there
+    expect(navigationHarvests.length).toBe(2)
+    const page2Payload = JSON.parse(navigationHarvests[1].request.body)
+    expect(page2Payload[0].common.attributes.session).toEqual(sessionId)
+    expect(page2Payload[0].logs.length).toBe(4)
+  })
+
+  it.withBrowsersMatching(supportsMultiTabSessions)('should record across new-tab page navigation', async () => {
+    let [logsHarvests] = await Promise.all([
+      logsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('logs-console-logger-pre-load.html'))
+    ])
+
+    const { localStorage } = await browser.getAgentSessionInfo()
+    const sessionId = localStorage.value
+    const page1Payload = JSON.parse(logsHarvests[0].request.body)
+    expect(page1Payload[0].common.attributes.session).toEqual(sessionId)
+    // expect log entries for: error, warn, info, log
+    expect(page1Payload[0].logs.length).toBe(4)
+
+    // simulate a second call to rum in same session, which should return log = 0
+    await browser.enableLogging({ logMode: LOGGING_MODE.OFF })
+    let [newTabHarvests] = await Promise.all([
+      logsCapture.waitForResult({ timeout: TIMEOUT }),
+      browser.newWindow(await browser.testHandle.assetURL('logs-console-logger-post-load.html'), { type: 'tab' }),
+      browser.waitForAgentLoad()
+    ])
+
+    // confirm we are still sending logs because logging is already enabled in this session
+    // note: the network capture has not been cleared, so the previous harvest is still there
+    expect(newTabHarvests.length).toBe(2)
+    const page2Payload = JSON.parse(newTabHarvests[1].request.body)
+    expect(page2Payload[0].common.attributes.session).toEqual(sessionId)
+    expect(page2Payload[0].logs.length).toBe(4)
+
+    // IMPORTANT! - Reset the browser for the next test or it will fail
+    await browser.closeWindow()
+    await browser.switchToWindow((await browser.getWindowHandles())[0])
+  })
+
+  it.withBrowsersMatching(supportsMultiTabSessions)('should kill active tab if killed in backgrounded tab', async () => {
+    let [logsHarvests] = await Promise.all([
+      logsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('logs-console-logger-pre-load.html'))
+    ])
+
+    const { localStorage } = await browser.getAgentSessionInfo()
+    const sessionId = localStorage.value
+    const page1Payload = JSON.parse(logsHarvests[0].request.body)
+    expect(page1Payload[0].common.attributes.session).toEqual(sessionId)
+    // expect log entries for: error, warn, info, log
+    expect(page1Payload[0].logs.length).toBe(4)
+
+    await Promise.all([
+      logsCapture.waitForResult({ timeout: TIMEOUT }),
+      browser.newWindow(await browser.testHandle.assetURL('logs-console-logger-post-load.html'), { type: 'tab' }),
+      browser.waitForAgentLoad()
+    ])
+
+    const page2BlockedBeforeAbort = await browser.execute(function () {
+      try {
+        return Object.values(newrelic.initializedAgents)[0].features.logging.featAggregate.blocked
+      } catch (err) {
+        return false
+      }
+    })
+    expect(page2BlockedBeforeAbort).toEqual(false)
+
+    const page2Blocked = await browser.execute(function () {
+      try {
+        var agg = Object.values(newrelic.initializedAgents)[0].features.logging.featAggregate
+        agg.abort()
+        return agg.blocked
+      } catch (err) {
+        return false
+      }
+    })
+    expect(page2Blocked).toEqual(true)
+
+    await browser.pause(1000) // Give the agent time to update the session state
+    await expect(getLogs()).resolves.toEqual(expect.objectContaining({
+      events: [],
+      blocked: true,
+      loggingMode: 0
+    }))
+
+    await browser.closeWindow()
+    await browser.switchToWindow((await browser.getWindowHandles())[0])
+
+    await browser.pause(1000) // Give the agent time to update the session state
+    await expect(getLogs()).resolves.toEqual(expect.objectContaining({
+      events: [],
+      blocked: true,
+      loggingMode: 0
+    }))
+  })
+})

--- a/tests/specs/logging/session-pages.e2e.js
+++ b/tests/specs/logging/session-pages.e2e.js
@@ -150,7 +150,7 @@ describe('Logging Across Pages', () => {
     await expect(getLogs()).resolves.toEqual(expect.objectContaining({
       events: [],
       blocked: true,
-      loggingMode: 0
+      loggingMode: LOGGING_MODE.OFF
     }))
 
     await browser.closeWindow()
@@ -160,7 +160,7 @@ describe('Logging Across Pages', () => {
     await expect(getLogs()).resolves.toEqual(expect.objectContaining({
       events: [],
       blocked: true,
-      loggingMode: 0
+      loggingMode: LOGGING_MODE.OFF
     }))
   })
 })

--- a/tests/specs/npm/micro-agent.e2e.js
+++ b/tests/specs/npm/micro-agent.e2e.js
@@ -3,6 +3,10 @@
 import { testErrorsRequest, testInsRequest, testLogsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('micro-agent', () => {
+  beforeEach(async () => {
+    await browser.enableLogging()
+  })
+
   it('Smoke Test - Can send distinct payloads of all relevant data types to 2 distinct app IDs', async () => {
     const [rumCapture, errorsCapture, insightsCapture, logsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
       { test: testRumRequest },
@@ -40,7 +44,7 @@ describe('micro-agent', () => {
       rumCapture.waitForResult({ totalCount: 2 }),
       errorsCapture.waitForResult({ totalCount: 2 }),
       insightsCapture.waitForResult({ totalCount: 2 }),
-      logsCapture.waitForResult({ totalCount: 2 })
+      logsCapture.waitForResult({ totalCount: 2, timeout: 15000 })
     ])
 
     // these props will get set to true once a test has matched it

--- a/tests/specs/session-manager.e2e.js
+++ b/tests/specs/session-manager.e2e.js
@@ -1,5 +1,6 @@
 import { supportsMultiTabSessions } from '../../tools/browser-matcher/common-matchers.mjs'
 import { testErrorsRequest } from '../../tools/testing-server/utils/expect-tests'
+import { buildExpectedSessionState } from './util/helpers'
 
 const config = {
   init: {
@@ -8,14 +9,7 @@ const config = {
 }
 
 describe('newrelic session ID', () => {
-  const anySession = () => ({
-    value: expect.any(String),
-    expiresAt: expect.any(Number),
-    inactiveAt: expect.any(Number),
-    updatedAt: expect.any(Number),
-    sessionReplayMode: expect.any(Number),
-    sessionReplaySentFirstChunk: expect.any(Boolean),
-    sessionTraceMode: expect.any(Number),
+  const anySession = () => buildExpectedSessionState({
     traceHarvestStarted: expect.any(Boolean),
     custom: expect.any(Object),
     serverTimeDiff: expect.any(Number)

--- a/tests/specs/util/helpers.js
+++ b/tests/specs/util/helpers.js
@@ -14,6 +14,19 @@ export const RRWEB_EVENT_TYPES = {
   Custom: 5
 }
 
+export function buildExpectedSessionState (additionalExpectations) {
+  return Object.assign({
+    value: expect.any(String),
+    expiresAt: expect.any(Number),
+    inactiveAt: expect.any(Number),
+    updatedAt: expect.any(Number),
+    sessionReplayMode: expect.any(Number),
+    sessionReplaySentFirstChunk: expect.any(Boolean),
+    sessionTraceMode: expect.any(Number),
+    loggingMode: expect.any(Number)
+  }, additionalExpectations)
+}
+
 export function testExpectedReplay ({ data, session, hasMeta, hasSnapshot, hasError, isFirstChunk, contentEncoding, decompressedBytes, appId, entityGuid, harvestId, currentUrl }) {
   expect(data.query).toMatchObject({
     browser_monitoring_key: expect.any(String),

--- a/tests/specs/util/helpers.js
+++ b/tests/specs/util/helpers.js
@@ -166,3 +166,23 @@ export async function getSR () {
     }
   })
 }
+
+export async function getLogs () {
+  return browser.execute(function () {
+    try {
+      var logs = Object.values(newrelic.initializedAgents)[0].features.logging.featAggregate
+      return {
+        events: logs.events.get(),
+        blocked: logs.blocked,
+        loggingMode: logs.loggingMode
+      }
+    } catch (err) {
+      return {
+        events: [],
+        blocked: undefined,
+        loggingMode: undefined,
+        err: JSON.stringify(err)
+      }
+    }
+  })
+}

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -116,6 +116,20 @@ export default class CustomCommands {
     })
 
     /**
+     * Sets a permanent scheduled reply for the rum call to include the log flag with sampling rate.
+     * Defaults to 100% sampling rate and log mode = 3/INFO.
+     */
+    browser.addCommand('enableLogging', async function ({ sampling_rate = 100, logMode = 3 } = {}) {
+      const loggingMode = Math.random() * 100 < sampling_rate ? logMode : 0
+      await browser.testHandle.clearScheduledReply('bamServer', { test: testRumRequest })
+      await browser.testHandle.scheduleReply('bamServer', {
+        test: testRumRequest,
+        permanent: true,
+        body: JSON.stringify(rumFlags({ log: loggingMode }))
+      })
+    })
+
+    /**
      * Sets a permanent scheduled reply for the rum call to define the Date header
      * to a specific value. Default is to set the header to one hour in the past.
      */


### PR DESCRIPTION
This is another part of the work for the auto-logging feature.  The auto-logging mode should stay consistent within a given session and will auto-disable upon session expiration after 4 hours or session inactivity after 30 minutes.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
The auto-logging mode should stay consistent within a given [session](https://docs.newrelic.com/docs/browser/browser-monitoring/page-load-timing-resources/cookie-collection-session-tracking/) and will auto-disable upon session expiration after 4 hours or session inactivity after 30 minutes.

If cookies are not enabled, then the logging mode for each page will be set independently based on the rum response.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-341932

### Testing

Added/updated relevant tests for logging with regards to session
