### PR TITLE
feat: Allow logs api wrapper to update custom attributes

### DIFF
--- a/src/common/wrap/wrap-logger.js
+++ b/src/common/wrap/wrap-logger.js
@@ -10,7 +10,9 @@
 import { ee as baseEE, contextId } from '../event-emitter/contextual-ee'
 import { EventContext } from '../event-emitter/event-context'
 import { warn } from '../util/console'
-import { createWrapperWithEmitter as wfn } from './wrap-function'
+import { flag, createWrapperWithEmitter as wfn } from './wrap-function'
+
+const contextMap = new Map()
 
 /**
  * Wraps a supplied function and adds emitter events under the `-wrap-logger-` prefix
@@ -33,8 +35,11 @@ export function wrapLogger(sharedEE, parent, loggerFn, context) {
   ctx.level = context.level
   ctx.customAttributes = context.customAttributes
 
+  const contextLookupKey = parent[loggerFn]?.[flag] || parent[loggerFn]
+  contextMap.set(contextLookupKey, ctx)
+
   /** observe calls to <loggerFn> and emit events prefixed with `wrap-logger-` */
-  wrapFn.inPlace(parent, [loggerFn], 'wrap-logger-', ctx)
+  wrapFn.inPlace(parent, [loggerFn], 'wrap-logger-', () => contextMap.get(contextLookupKey))
 
   return ee
 }

--- a/tests/assets/logs-api-wrap-logger-rewrapped.html
+++ b/tests/assets/logs-api-wrap-logger-rewrapped.html
@@ -18,13 +18,14 @@
 
       newrelic.wrapLogger(loggers, 'log', { level: "debug" })
       loggers.log('test2')
-      // should capture another event, ignoring the `debug` level and harvesting with `warn`
+      // should capture another event, update to harvest with `debug` level
       // should NOT duplicate the log events (ie, capture 2 logs for this one call)
 
       var orig = loggers.log
-      loggers.log = (...args) => {console.log('wrapped again by 3rd party'); orig(...args)} 
+      // simulate wrapping by 3rd party
+      loggers.log = (...args) => { orig(...args)}
       loggers.log('test3')
-      // should capture another event, and still have the `warn` level even though the parent context was changed
+      // should capture another event, and still have the `debug` level even though the parent context was changed
     </script>
   </head>
   <body>Logs API Error Object</body>

--- a/tests/components/logging/instrument.test.js
+++ b/tests/components/logging/instrument.test.js
@@ -47,9 +47,10 @@ test('wrapLogger should not re-wrap or overwrite context if called more than onc
   myLoggerSuite.myTestLogger(message)
   expect(loggingUtilsModule.bufferLog).toHaveBeenCalledWith(loggingInstrument.ee, message, customAttributes, 'error') // ignores args: 2
 
+  const newCustomAttributes = { args: faker.string.uuid() }
   /** re-wrap the logger with a NEW context, new events should NOT get that context because the wrapper should early-exit */
-  wrapLogger(loggingInstrument.ee, myLoggerSuite, 'myTestLogger', { customAttributes: { args: 'abc' }, level: 'info' })
+  wrapLogger(loggingInstrument.ee, myLoggerSuite, 'myTestLogger', { customAttributes: newCustomAttributes, level: 'info' })
   message = faker.string.uuid()
   myLoggerSuite.myTestLogger(message)
-  expect(loggingUtilsModule.bufferLog).toHaveBeenCalledWith(loggingInstrument.ee, message, customAttributes, 'error')
+  expect(loggingUtilsModule.bufferLog).toHaveBeenCalledWith(loggingInstrument.ee, message, newCustomAttributes, 'info')
 })

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -107,12 +107,12 @@ describe('logging harvesting', () => {
       // original wrapping context (warn)
       expect(logs[0].message).toEqual('test1')
       expect(logs[0].level).toEqual('WARN')
-      // should not re-wrap, meaning the level should not change, but the message should here
+      // should not re-wrap but will overwrite the attributes so it'll become a DEBUG; the 'test2' message should be there
       expect(logs[1].message).toEqual('test2')
-      expect(logs[1].level).toEqual('WARN')
-      // should allow a 3rd party to wrap the function and not affect the context (warn)
+      expect(logs[1].level).toEqual('DEBUG')
+      // should allow a 3rd party to wrap the function and not affect the context (debug)
       expect(logs[2].message).toEqual('test3')
-      expect(logs[2].level).toEqual('WARN')
+      expect(logs[2].level).toEqual('DEBUG')
     })
   })
 


### PR DESCRIPTION
This will support the rollout of the auto-logging feature without disrupting customers that may currently be using `wrapLogger` to wrap the `console` object.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Currently, once an object's method is wrapped, it is blocked from being re-wrapped.  With the auto-logging feature, the browser agent's internal wrapping for `console` will be triggered before any other wrappers that may be invoked via `wrapLogger`.  This creates a small potential change in behavior if customers are already using `wrapLogger` to wrap the `console` object. 

So the logging context is now modifiable, such that log api wrappers can overwrite the custom attributes sent along with the log events.  For a given wrapped method, attributes supplied by the last wrapper will "win".

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-323597

### Testing

Updated existing test regarding re-wrapping.  Attributes supplied by subsequent re-wrapping will be used instead of the initial ones. 
