### PR TITLE
fix: Fix syntax error in fallback when tracking xhr readyState

### DIFF
--- a/src/features/ajax/instrument/index.js
+++ b/src/features/ajax/instrument/index.js
@@ -374,7 +374,7 @@ function subscribeToEvents (agentRef, ee, handler, dt) {
     if (hasUndefinedHostname(params)) return // don't bother with XHR of url with no hostname
 
     metrics.duration = now() - this.startTime
-    if (!this.loadCazptureCalled && xhr.readyState === 4) {
+    if (!this.loadCaptureCalled && xhr.readyState === 4) {
       captureXhrData(this, xhr)
     } else if (params.status == null) {
       params.status = 0


### PR DESCRIPTION
A syntax error was introduced that would cause xhr readystate fallback checks to always capture.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Contributor @steve-cunnew found an issue in the code base where a typo was introduced.  This likely was not noticed because it was nearly always truthy, leading to expected behavior. This affects an edge case.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://newrelic.slack.com/archives/C0193KAHHAS/p1733483033474939
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests should continue to pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
