### PR TITLE
chore: create test matcher that can skip test suites with coverage

### DIFF
--- a/tests/specs/spa/harvesting.e2e.js
+++ b/tests/specs/spa/harvesting.e2e.js
@@ -1,54 +1,11 @@
 import { checkSpa } from '../../util/basic-checks'
 import { testInteractionEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
-import { JSONPath } from 'jsonpath-plus'
 
 describe('spa harvesting', () => {
   let interactionsCapture
 
   beforeEach(async () => {
     interactionsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInteractionEventsRequest })
-  })
-
-  it('should set correct customEnd value on multiple custom interactions', async () => {
-    const [interactionHarvests] = await Promise.all([
-      interactionsCapture.waitForResult({ timeout: 10000 }),
-      browser.url(await browser.testHandle.assetURL('spa/multiple-custom-interactions.html'))
-    ])
-
-    const customInteractions = JSONPath({ path: '$.[*].request.body.[?(!!@ && @.customName)]', json: interactionHarvests })
-    expect(customInteractions.length).toEqual(4)
-    expect(customInteractions).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        customName: 'interaction1',
-        children: expect.arrayContaining([expect.objectContaining({
-          type: 'customEnd'
-        })])
-      }),
-      expect.objectContaining({
-        customName: 'interaction2',
-        children: expect.arrayContaining([expect.objectContaining({
-          type: 'customEnd'
-        })])
-      }),
-      expect.objectContaining({
-        customName: 'interaction3',
-        children: expect.not.arrayContaining([expect.objectContaining({
-          type: 'customEnd'
-        })])
-      }),
-      expect.objectContaining({
-        customName: 'interaction4',
-        children: expect.arrayContaining([expect.objectContaining({
-          type: 'customEnd'
-        })])
-      })
-    ]))
-    customInteractions
-      .filter(interaction => ['interaction1', 'interaction2', 'interaction4'].includes(interaction.customName))
-      .forEach(interaction => {
-        const customEndTime = interaction.children.find(child => child.type === 'customEnd')
-        expect(customEndTime.time).toBeGreaterThanOrEqual(interaction.end)
-      })
   })
 
   it('should not exceed 128 child nodes', async () => {

--- a/tools/wdio/plugins/browser-matcher.mjs
+++ b/tools/wdio/plugins/browser-matcher.mjs
@@ -7,10 +7,15 @@ import { getBrowserName, getBrowserVersion } from '../../browsers-lists/utils.mj
 export default class BrowserMatcher {
   #browserName
   #browserVersion
+  #collectCoverage
 
   async beforeSession (_, capabilities) {
     this.#browserName = getBrowserName(capabilities)
     this.#browserVersion = getBrowserVersion(capabilities)
+
+    this.#collectCoverage = capabilities.collectCoverage
+    delete capabilities.collectCoverage
+
     this.#setupMochaGlobals()
   }
 
@@ -50,6 +55,32 @@ export default class BrowserMatcher {
         return this.#wrapFnWithBrowserMatcher(matcher, originalGlobal)
       }
     })
+
+    Object.defineProperty(originalGlobal, 'withoutCoverage', {
+      value: () => {
+        return this.#wrapFnWithCoverageCheck(originalGlobal)
+      }
+    })
+  }
+
+  #wrapFnWithCoverageCheck (originalGlobal) {
+    const skip = !!this.#collectCoverage
+
+    return function (...args) {
+      /*
+        We only call global.it for tests that are not skipped.
+        The test will skip if coverage flag is passed is on and the test is marked as 'withoutCoverage'. This registers the test
+        with the mocha engine. When all tests in a file are skipped, WDIO will not launch
+        a browser in LambdaTest.
+
+        Do not use global.it.skip. This still registers the test with mocha and will cause
+        WDIO to launch a browser in LambdaTest. If all the tests are skipped in a file, this
+        is a waste of time.
+      */
+      if (!skip) {
+        originalGlobal.apply(this, args)
+      }
+    }
   }
 
   #wrapFnWithBrowserMatcher (matcher, originalGlobal) {

--- a/tools/wdio/plugins/testing-server/launcher.mjs
+++ b/tools/wdio/plugins/testing-server/launcher.mjs
@@ -9,12 +9,14 @@ const log = logger('testing-server')
  */
 export default class TestingServerLauncher {
   #testingServer
+  #collectCoverage
 
   constructor (opts) {
     this.#testingServer = new TestServer({
       ...opts,
       logger: log
     })
+    this.#collectCoverage = opts.coverage
   }
 
   async onPrepare (_, capabilities) {
@@ -25,9 +27,11 @@ export default class TestingServerLauncher {
     log.info(`Command server started on http://${this.#testingServer.commandServer.host}:${this.#testingServer.commandServer.port}`)
 
     capabilities.forEach((capability) => {
+      /** these props will be deleted later before sending to LT */
       capability.assetServer = serialize({ host: this.#testingServer.assetServer.host, port: this.#testingServer.assetServer.port })
       capability.bamServer = serialize({ host: this.#testingServer.bamServer.host, port: this.#testingServer.bamServer.port })
       capability.commandServer = serialize({ host: this.#testingServer.commandServer.host, port: this.#testingServer.commandServer.port })
+      capability.collectCoverage = this.#collectCoverage
     })
   }
 


### PR DESCRIPTION
Added a matcher method to skip tests or entire test suites when collecting coverage with istanbul.  Istanbul has shown to cause issues with specific SPA tests.  Now you can skip tests when collecting coverage by including the method `withoutCoverage()` on `describe` blocks and `it` calls.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-315950
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
