### PR TITLE
fix: Make Metrics harvest only on EoL for new Harvester

### DIFF
--- a/src/common/harvest/harvester.js
+++ b/src/common/harvest/harvester.js
@@ -57,7 +57,7 @@ export class Harvester {
     const shouldRetryOnFail = !localOpts.isFinalHarvest && submitMethod === xhrMethod // always retry all features harvests except for final
     let dataToSendArr; let ranSend = false
     if (!localOpts.directSend) { // primarily used by rum call to bypass makeHarvestPayload by providing payload directly
-      dataToSendArr = aggregateInst.makeHarvestPayload(shouldRetryOnFail) // be sure the 'this' of makeHarvestPayload is the aggregate w/ access to its harvestOpts
+      dataToSendArr = aggregateInst.makeHarvestPayload(shouldRetryOnFail, localOpts) // be sure the 'this' of makeHarvestPayload is the aggregate w/ access to its harvestOpts
       if (!dataToSendArr) return false // can be undefined if storage is empty or preharvest checks failed
     } else dataToSendArr = [localOpts.directSend]
 

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -34,7 +34,7 @@ export class Aggregate extends AggregateBase {
     this.eachSessionChecks() // the start of every time user engages with page
   }
 
-  preHarvestChecks () { return this.drained } // only allow any metrics to be sent if we know for sure it has gotten the go-ahead RUM flag
+  preHarvestChecks (opts) { return this.drained && opts.isFinalHarvest } // only allow any metrics to be sent after we get the right RUM flag and only on EoL
 
   storeSupportabilityMetrics (name, value) {
     if (this.blocked) return

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -71,18 +71,18 @@ export class AggregateBase extends FeatureBase {
   /**
    * Return harvest payload. A "serializer" function can be defined on a derived class to format the payload.
    * @param {Boolean} shouldRetryOnFail - harvester flag to backup payload for retry later if harvest request fails; this should be moved to harvester logic
-   * @param {object|undefined} target - the target app passed onto the event store manager to determine which app's data to return; if none provided, all apps data will be returned
+   * @param {object|undefined} opts.target - the target app passed onto the event store manager to determine which app's data to return; if none provided, all apps data will be returned
    * @returns {Array} Final payload tagged with their targeting browser app. The value of `payload` can be undefined if there are no pending events for an app. This should be a minimum length of 1.
    */
-  makeHarvestPayload (shouldRetryOnFail = false, target) {
-    if (this.events.isEmpty(this.harvestOpts, target)) return
+  makeHarvestPayload (shouldRetryOnFail = false, opts = {}) {
+    if (this.events.isEmpty(this.harvestOpts, opts.target)) return
     // Other conditions and things to do when preparing harvest that is required.
-    if (this.preHarvestChecks && !this.preHarvestChecks()) return
+    if (this.preHarvestChecks && !this.preHarvestChecks(opts)) return
 
-    if (shouldRetryOnFail) this.events.save(this.harvestOpts, target)
-    const returnedDataArr = this.events.get(this.harvestOpts, target)
+    if (shouldRetryOnFail) this.events.save(this.harvestOpts, opts.target)
+    const returnedDataArr = this.events.get(this.harvestOpts, opts.target)
     if (!returnedDataArr.length) throw new Error('Unexpected problem encountered. There should be at least one app for harvest!')
-    this.events.clear(this.harvestOpts, target)
+    this.events.clear(this.harvestOpts, opts.target)
 
     return returnedDataArr.map(({ targetApp, data }) => {
       // A serializer or formatter assists in creating the payload `body` from stored events on harvest when defined by derived feature class.

--- a/tests/components/setup-agent.js
+++ b/tests/components/setup-agent.js
@@ -5,8 +5,8 @@ import { ee } from '../../src/common/event-emitter/contextual-ee'
 import { TimeKeeper } from '../../src/common/timing/time-keeper'
 import { getRuntime } from '../../src/common/config/runtime'
 import { setupAgentSession } from '../../src/features/utils/agent-session'
-import { EventAggregator } from '../../src/common/aggregate/event-aggregator'
 import { Harvester } from '../../src/common/harvest/harvester'
+import { EventStoreManager } from '../../src/features/utils/event-store-manager'
 
 /**
  * Sets up a new agent for component testing. This should be called only
@@ -39,7 +39,7 @@ export function setupAgent ({ agentOverrides = {}, info = {}, init = {}, loaderC
   const fakeAgent = {
     agentIdentifier,
     ee: eventEmitter,
-    sharedAggregator: new EventAggregator(),
+    sharedAggregator: new EventStoreManager({ licenseKey: info.licenseKey, appId: info.applicationID }, 2),
     ...agentOverrides
   }
   setNREUMInitializedAgent(agentIdentifier, fakeAgent)


### PR DESCRIPTION
Prevent Metrics feature from harvesting on interval after changes in v1.278.0. This reverts its behavior back to sending only final harvests.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-356543

### Testing

New component test added for this case
