### PR TITLE
fix: Allow the page view feature to have access to an event buffer to prevent undefined checks at harvest time

### DIFF
--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -115,7 +115,6 @@ export class Aggregate extends AggregateBase {
 
   postHarvestCleanup ({ status, responseText, xhr }) {
     const rumEndTime = now()
-    this.blocked = true // this prevents harvester from polling this feature's event buffer (DNE) on interval; in other words, harvests will skip PVE
 
     if (status >= 400 || status === 0) {
       warn(18, status)

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -18,8 +18,7 @@ export class AggregateBase extends FeatureBase {
 
     // This switch needs to be after doOnceForAllAggregate which may new sharedAggregator and reset mainAppKey.
     switch (this.featureName) {
-      // PVE has no need for eventBuffer, and SessionTrace + Replay have their own storage mechanisms.
-      case FEATURE_NAMES.pageViewEvent:
+      // SessionTrace + Replay have their own storage mechanisms.
       case FEATURE_NAMES.sessionTrace:
       case FEATURE_NAMES.sessionReplay:
         break
@@ -28,6 +27,9 @@ export class AggregateBase extends FeatureBase {
       case FEATURE_NAMES.metrics:
         this.events = agentRef.sharedAggregator
         break
+      /** All other features get EventBuffer in the ESM by default. Note: PVE is included here, but event buffer will always be empty so future harvests will still not happen by interval or EOL.
+      This was necessary to prevent race cond. issues where the event buffer was checked before the feature could "block" itself.
+      Its easier to just keep an empty event buffer in place. */
       default:
         this.events = new EventStoreManager(agentRef.mainAppKey, 1)
         break

--- a/tests/unit/features/utils/aggregate-base.test.js
+++ b/tests/unit/features/utils/aggregate-base.test.js
@@ -150,16 +150,16 @@ test('does not initialized Aggregator more than once with multiple features', as
   expect(mainAgent.mainAppKey).toBeUndefined()
 
   new AggregateBase(mainAgent, FEATURE_NAMES.pageViewEvent)
-  expect(EventStoreManager).toHaveBeenCalledTimes(1)
+  expect(EventStoreManager).toHaveBeenCalledTimes(2)
   expect(EventStoreManager).toHaveBeenCalledWith(mainAgent.mainAppKey, 2) // 2 = initialize EventAggregator
   expect(mainAgent.mainAppKey).toBeTruthy()
   expect(mainAgent.sharedAggregator).toBeTruthy()
 
   new AggregateBase(mainAgent, FEATURE_NAMES.jserrors) // this feature should be using that same aggregator as its .events
-  expect(EventStoreManager).toHaveBeenCalledTimes(1)
+  expect(EventStoreManager).toHaveBeenCalledTimes(2)
 
   new AggregateBase(mainAgent, FEATURE_NAMES.pageViewTiming) // PVT should use its own EventStoreManager
-  expect(EventStoreManager).toHaveBeenCalledTimes(2)
+  expect(EventStoreManager).toHaveBeenCalledTimes(3)
   expect(EventStoreManager).toHaveBeenCalledWith(mainAgent.mainAppKey, 1) // 1 = initialize EventBuffer
 })
 
@@ -175,10 +175,9 @@ test('does initialize separate Aggregators with multiple agents', async () => {
 
   new AggregateBase(mainAgent, FEATURE_NAMES.pageViewEvent)
   new AggregateBase(mainAgent2, FEATURE_NAMES.pageViewEvent)
-  expect(EventStoreManager).toHaveBeenCalledTimes(2)
-  expect(EventStoreManager).not.toHaveBeenCalledWith(expect.any(Object), 1)
+  expect(EventStoreManager).toHaveBeenCalledTimes(4)
 
   new AggregateBase(mainAgent, FEATURE_NAMES.jserrors) // still does not initialize sharedAgg again on the same agent
   new AggregateBase(mainAgent2, FEATURE_NAMES.jserrors)
-  expect(EventStoreManager).toHaveBeenCalledTimes(2)
+  expect(EventStoreManager).toHaveBeenCalledTimes(4)
 })


### PR DESCRIPTION
Fix an issue where if the page unloaded before the page view event could "block" itself, an undefined error could be thrown. The page view feature now has access to the event buffer, to prevent that undefined check.  The event buffer will remain empty, since the page view feature does not carry state. This change rectifies an issue observed in 1.278.1.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
