### PR TITLE
fix: Change obfuscator to read dynamically from configuration

### DIFF
--- a/src/common/util/obfuscate.js
+++ b/src/common/util/obfuscate.js
@@ -22,6 +22,9 @@ import { warn } from './console'
 export class Obfuscator {
   constructor (agentRef) {
     this.agentRef = agentRef
+    this.warnedRegexMissing = false
+    this.warnedInvalidRegex = false
+    this.warnedInvalidReplacement = false
   }
 
   get obfuscateConfigRules () {
@@ -63,9 +66,17 @@ export class Obfuscator {
     const invalidRegexDetected = Boolean(rule.regex !== undefined && typeof rule.regex !== 'string' && !(rule.regex instanceof RegExp))
     const invalidReplacementDetected = Boolean(rule.replacement && typeof rule.replacement !== 'string')
 
-    if (regexMissingDetected) warn(12, rule)
-    else if (invalidRegexDetected) warn(13, rule)
-    if (invalidReplacementDetected) warn(14, rule)
+    if (regexMissingDetected && !this.warnedRegexMissing) {
+      warn(12, rule)
+      this.warnedRegexMissing = true
+    } else if (invalidRegexDetected && !this.warnedInvalidRegex) {
+      warn(13, rule)
+      this.warnedInvalidRegex = true
+    }
+    if (invalidReplacementDetected && !this.warnedInvalidReplacement) {
+      warn(14, rule)
+      this.warnedInvalidReplacement = true
+    }
 
     return {
       rule,

--- a/src/common/util/obfuscate.js
+++ b/src/common/util/obfuscate.js
@@ -1,5 +1,4 @@
 import { isFileProtocol } from '../url/protocol'
-import { gosNREUM } from '../window/nreum'
 import { warn } from './console'
 
 /**
@@ -26,8 +25,7 @@ export class Obfuscator {
   }
 
   get obfuscateConfigRules () {
-    // try to read directly from global init first! Some customers add to this array over time in async way
-    return gosNREUM().init?.obfuscate || this.agentRef.init.obfuscate || []
+    return this.agentRef.init.obfuscate || []
   }
 
   /**

--- a/src/common/util/obfuscate.js
+++ b/src/common/util/obfuscate.js
@@ -40,7 +40,7 @@ export class Obfuscator {
     // if input is not of type string or is an empty string, short-circuit
     if (typeof input !== 'string' || input.trim().length === 0) return input
 
-    const rules = (this.obfuscateConfigRules).map(rule => Obfuscator.validateObfuscationRule(rule))
+    const rules = (this.obfuscateConfigRules).map(rule => this.validateObfuscationRule(rule))
     if (isFileProtocol()) {
       rules.push({
         regex: /^file:\/\/(.*)/,
@@ -61,7 +61,7 @@ export class Obfuscator {
    * @param {ObfuscationRule} rule The rule to validate
    * @returns {ObfuscationRuleValidation} The validation state of the rule
    */
-  static validateObfuscationRule (rule) {
+  validateObfuscationRule (rule) {
     const regexMissingDetected = Boolean(rule.regex === undefined)
     const invalidRegexDetected = Boolean(rule.regex !== undefined && typeof rule.regex !== 'string' && !(rule.regex instanceof RegExp))
     const invalidReplacementDetected = Boolean(rule.replacement && typeof rule.replacement !== 'string')

--- a/src/common/util/obfuscate.js
+++ b/src/common/util/obfuscate.js
@@ -1,5 +1,5 @@
-import { getConfigurationValue } from '../config/init'
 import { isFileProtocol } from '../url/protocol'
+import { gosNREUM } from '../window/nreum'
 import { warn } from './console'
 
 /**
@@ -21,18 +21,13 @@ import { warn } from './console'
  */
 
 export class Obfuscator {
-  /**
-   * @type {ObfuscationRuleValidation[]}
-   */
-  #ruleValidationCache
-
-  constructor (agentIdentifier) {
-    this.#ruleValidationCache = Obfuscator.getRuleValidationCache(agentIdentifier)
-    Obfuscator.logObfuscationRuleErrors(this.#ruleValidationCache)
+  constructor (agentRef) {
+    this.agentRef = agentRef
   }
 
-  get ruleValidationCache () {
-    return this.#ruleValidationCache
+  get obfuscateConfigRules () {
+    // try to read directly from global init first! Some customers add to this array over time in async way
+    return gosNREUM().init?.obfuscate || this.agentRef.init.obfuscate || []
   }
 
   /**
@@ -44,24 +39,7 @@ export class Obfuscator {
     // if input is not of type string or is an empty string, short-circuit
     if (typeof input !== 'string' || input.trim().length === 0) return input
 
-    return this.#ruleValidationCache
-      .filter(ruleValidation => ruleValidation.isValid)
-      .reduce((input, ruleValidation) => {
-        const { rule } = ruleValidation
-        return input.replace(rule.regex, rule.replacement || '*')
-      }, input)
-  }
-
-  /**
-   * Returns an array of obfuscation rules to be applied to harvested payloads
-   * @param {string} agentIdentifier The agent identifier to get rules for
-   * @returns {ObfuscationRuleValidation[]} The array of rules or validation states
-   */
-  static getRuleValidationCache (agentIdentifier) {
-    /**
-     * @type {ObfuscationRule[]}
-     */
-    let rules = getConfigurationValue(agentIdentifier, 'obfuscate') || []
+    const rules = (this.obfuscateConfigRules).map(rule => Obfuscator.validateObfuscationRule(rule))
     if (isFileProtocol()) {
       rules.push({
         regex: /^file:\/\/(.*)/,
@@ -69,7 +47,12 @@ export class Obfuscator {
       })
     }
 
-    return rules.map(rule => Obfuscator.validateObfuscationRule(rule))
+    return rules
+      .filter(ruleValidation => ruleValidation.isValid)
+      .reduce((input, ruleValidation) => {
+        const { rule } = ruleValidation
+        return input.replace(rule.regex, rule.replacement || '*')
+      }, input)
   }
 
   /**
@@ -82,6 +65,10 @@ export class Obfuscator {
     const invalidRegexDetected = Boolean(rule.regex !== undefined && typeof rule.regex !== 'string' && !(rule.regex instanceof RegExp))
     const invalidReplacementDetected = Boolean(rule.replacement && typeof rule.replacement !== 'string')
 
+    if (regexMissingDetected) warn(12, rule)
+    else if (invalidRegexDetected) warn(13, rule)
+    if (invalidReplacementDetected) warn(14, rule)
+
     return {
       rule,
       isValid: !regexMissingDetected && !invalidRegexDetected && !invalidReplacementDetected,
@@ -90,22 +77,6 @@ export class Obfuscator {
         invalidRegexDetected,
         invalidReplacementDetected
       }
-    }
-  }
-
-  /**
-   * Logs any obfuscation rule errors to the console. This is called when an obfuscator
-   * instance is created.
-   * @param {ObfuscationRuleValidation[]} ruleValidationCache The cache of rule validation states
-   */
-  static logObfuscationRuleErrors (ruleValidationCache) {
-    for (const ruleValidation of ruleValidationCache) {
-      const { rule, isValid, errors } = ruleValidation
-      if (isValid) continue
-
-      if (errors.regexMissingDetected) warn(12, rule)
-      else if (errors.invalidRegexDetected) warn(13, rule)
-      if (errors.invalidReplacementDetected) warn(14, rule)
     }
   }
 }

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -87,10 +87,8 @@ export class Aggregate extends AggregateBase {
     }
 
     // Capture SMs to assess customer engagement with the obfuscation config
-    const ruleValidations = this.obfuscator.ruleValidationCache
-    if (ruleValidations.length > 0) {
+    if (this.obfuscator.obfuscateConfigRules.length > 0) {
       this.storeSupportabilityMetrics('Generic/Obfuscate/Detected')
-      if (ruleValidations.filter(ruleValidation => !ruleValidation.isValid).length > 0) this.storeSupportabilityMetrics('Generic/Obfuscate/Invalid')
     }
 
     // Check if proxy for either chunks or beacon is being used

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -142,7 +142,7 @@ export class AggregateBase extends FeatureBase {
    * This method should run after checkConfiguration, which may reset the agent's info/runtime object that is used here.
    */
   doOnceForAllAggregate (agentRef) {
-    if (!agentRef.runtime.obfuscator) agentRef.runtime.obfuscator = new Obfuscator(this.agentIdentifier)
+    if (!agentRef.runtime.obfuscator) agentRef.runtime.obfuscator = new Obfuscator(agentRef)
     this.obfuscator = agentRef.runtime.obfuscator
 
     if (!agentRef.mainAppKey) agentRef.mainAppKey = { licenseKey: agentRef.info.licenseKey, appId: agentRef.info.applicationID }

--- a/tests/components/spa/serializer.test.js
+++ b/tests/components/spa/serializer.test.js
@@ -43,7 +43,7 @@ const fieldPropMap = {
 beforeEach(() => {
   jest.mocked(runtimeModule.getRuntime).mockReturnValue({
     origin: 'localhost',
-    obfuscator: new Obfuscator(agentIdentifier)
+    obfuscator: new Obfuscator({ init: { obfuscate: [] } })
   })
 })
 

--- a/tests/specs/metrics.e2e.js
+++ b/tests/specs/metrics.e2e.js
@@ -95,7 +95,7 @@ describe('metrics', () => {
     }]))
   })
 
-  it('should create SMs for valid obfuscation rules', async () => {
+  it('should create SMs when obfuscation rules are detected', async () => {
     await browser.url(await browser.testHandle.assetURL('obfuscate-pii-valid.html'))
       .then(() => browser.waitForAgentLoad())
 
@@ -107,70 +107,6 @@ describe('metrics', () => {
     const supportabilityMetrics = supportabilityMetricsHarvests[0].request.body.sm
     expect(supportabilityMetrics).toEqual(expect.arrayContaining([{
       params: { name: 'Generic/Obfuscate/Detected' },
-      stats: { c: 1 }
-    }]))
-    expect(supportabilityMetrics).not.toEqual(expect.arrayContaining([{
-      params: { name: 'Generic/Obfuscate/Invalid' },
-      stats: { c: 1 }
-    }]))
-  })
-
-  it('should create SMs for obfuscation rule containing invalid regex type', async () => {
-    await browser.url(await browser.testHandle.assetURL('obfuscate-pii-invalid-regex-type.html'))
-      .then(() => browser.waitForAgentLoad())
-
-    const [supportabilityMetricsHarvests] = await Promise.all([
-      supportabilityMetricsCapture.waitForResult({ totalCount: 1 }),
-      await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
-    ])
-
-    const supportabilityMetrics = supportabilityMetricsHarvests[0].request.body.sm
-    expect(supportabilityMetrics).toEqual(expect.arrayContaining([{
-      params: { name: 'Generic/Obfuscate/Detected' },
-      stats: { c: 1 }
-    }]))
-    expect(supportabilityMetrics).toEqual(expect.arrayContaining([{
-      params: { name: 'Generic/Obfuscate/Invalid' },
-      stats: { c: 1 }
-    }]))
-  })
-
-  it('should create SMs for obfuscation rule containing undefined regex type', async () => {
-    await browser.url(await browser.testHandle.assetURL('obfuscate-pii-invalid-regex-undefined.html'))
-      .then(() => browser.waitForAgentLoad())
-
-    const [supportabilityMetricsHarvests] = await Promise.all([
-      supportabilityMetricsCapture.waitForResult({ totalCount: 1 }),
-      await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
-    ])
-
-    const supportabilityMetrics = supportabilityMetricsHarvests[0].request.body.sm
-    expect(supportabilityMetrics).toEqual(expect.arrayContaining([{
-      params: { name: 'Generic/Obfuscate/Detected' },
-      stats: { c: 1 }
-    }]))
-    expect(supportabilityMetrics).toEqual(expect.arrayContaining([{
-      params: { name: 'Generic/Obfuscate/Invalid' },
-      stats: { c: 1 }
-    }]))
-  })
-
-  it('should create SMs for obfuscation rule containing invalid replacement type', async () => {
-    await browser.url(await browser.testHandle.assetURL('obfuscate-pii-invalid-replacement-type.html'))
-      .then(() => browser.waitForAgentLoad())
-
-    const [supportabilityMetricsHarvests] = await Promise.all([
-      supportabilityMetricsCapture.waitForResult({ totalCount: 1 }),
-      await browser.url(await browser.testHandle.assetURL('/')) // Setup expects before navigating
-    ])
-
-    const supportabilityMetrics = supportabilityMetricsHarvests[0].request.body.sm
-    expect(supportabilityMetrics).toEqual(expect.arrayContaining([{
-      params: { name: 'Generic/Obfuscate/Detected' },
-      stats: { c: 1 }
-    }]))
-    expect(supportabilityMetrics).toEqual(expect.arrayContaining([{
-      params: { name: 'Generic/Obfuscate/Invalid' },
       stats: { c: 1 }
     }]))
   })

--- a/tests/specs/obfuscate.e2e.js
+++ b/tests/specs/obfuscate.e2e.js
@@ -95,9 +95,40 @@ describe('obfuscate rules', () => {
       checkPayload(harvest.request.query)
     })
   })
+
+  it('should apply to obfuscation rules added after init', async () => {
+    const [insightsHarvests] = await Promise.all([
+      insightsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('obfuscate-pii.html', config))
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    expect(insightsHarvests.length).toBeGreaterThan(0)
+    insightsHarvests.forEach(harvest => {
+      checkPayload(harvest.request.body)
+      checkPayload(harvest.request.query)
+    })
+
+    const [insightsHarvests2] = await Promise.all([
+      insightsCapture.waitForResult({ totalCount: 2 }),
+      browser.execute(function () {
+        window.NREUM.init.obfuscate.push({
+          regex: /newrule/g,
+          replacement: 'OBFUSCATED'
+        })
+        window.newrelic.addPageAction('my newrule pageaction', { foo: 'bar' })
+      })
+    ])
+
+    expect(insightsHarvests2.length).toBeGreaterThan(0)
+    insightsHarvests2.forEach(harvest => {
+      checkPayload(harvest.request.body, 'newrule')
+      checkPayload(harvest.request.query, 'newrule')
+    })
+  })
 })
 
-function checkPayload (payload) {
+function checkPayload (payload, customStringCheck) {
   expect(payload).toBeDefined() // payload exists
 
   var strPayload = JSON.stringify(payload)
@@ -105,4 +136,5 @@ function checkPayload (payload) {
   expect(strPayload.includes('pii')).toBeFalsy() // pii was obfuscated
   expect(strPayload.includes('bam-test')).toBeFalsy() // bam-test was obfuscated
   expect(strPayload.includes('fakeid')).toBeFalsy() // fakeid was obfuscated
+  if (customStringCheck) expect(strPayload.includes(customStringCheck)).toBeFalsy()
 }

--- a/tests/specs/obfuscate.e2e.js
+++ b/tests/specs/obfuscate.e2e.js
@@ -113,7 +113,7 @@ describe('obfuscate rules', () => {
       insightsCapture.waitForResult({ totalCount: 2 }),
       browser.execute(function () {
         Object.values(newrelic.initializedAgents)[0].init.obfuscate.push({
-          regex: /newrule/g,
+          regex: 'newrule',
           replacement: 'OBFUSCATED'
         })
         window.newrelic.addPageAction('my newrule pageaction', { foo: 'bar' })

--- a/tests/specs/obfuscate.e2e.js
+++ b/tests/specs/obfuscate.e2e.js
@@ -112,7 +112,7 @@ describe('obfuscate rules', () => {
     const [insightsHarvests2] = await Promise.all([
       insightsCapture.waitForResult({ totalCount: 2 }),
       browser.execute(function () {
-        window.NREUM.init.obfuscate.push({
+        Object.values(newrelic.initializedAgents)[0].init.obfuscate.push({
           regex: /newrule/g,
           replacement: 'OBFUSCATED'
         })

--- a/tests/unit/common/util/obfuscate.test.js
+++ b/tests/unit/common/util/obfuscate.test.js
@@ -1,8 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { Obfuscator } from '../../../../src/common/util/obfuscate'
 import * as initModule from '../../../../src/common/config/init'
-import * as urlProtocolModule from '../../../../src/common/url/protocol'
-import * as consoleModule from '../../../../src/common/util/console'
 
 jest.mock('../../../../src/common/config/init')
 jest.mock('../../../../src/common/context/shared-context')
@@ -25,11 +23,8 @@ afterEach(() => {
 
 describe('obfuscateString', () => {
   test('obfuscateString returns the input when there are no rules', () => {
-    jest.spyOn(initModule, 'getConfigurationValue').mockReturnValue([])
-
     const input = faker.lorem.sentence()
-    const obfuscator = new Obfuscator()
-    obfuscator.sharedContext = { agentIdentifier }
+    const obfuscator = new Obfuscator({ init: { obfuscate: [] } })
 
     expect(obfuscator.obfuscateString(input)).toEqual(input)
   })
@@ -38,8 +33,7 @@ describe('obfuscateString', () => {
     jest.spyOn(initModule, 'getConfigurationValue').mockReturnValue(rules)
 
     const input = 'pii'
-    const obfuscator = new Obfuscator()
-    obfuscator.sharedContext = { agentIdentifier }
+    const obfuscator = new Obfuscator({ init: { obfuscate: rules } })
 
     expect(obfuscator.obfuscateString(input)).toEqual(rules[0].replacement)
   })
@@ -49,11 +43,8 @@ describe('obfuscateString', () => {
       regex: rules[0].regex
     }]
 
-    jest.spyOn(initModule, 'getConfigurationValue').mockReturnValue(newRules)
-
     const input = 'pii'
-    const obfuscator = new Obfuscator()
-    obfuscator.sharedContext = { agentIdentifier }
+    const obfuscator = new Obfuscator({ init: { obfuscate: newRules } })
 
     expect(obfuscator.obfuscateString(input)).toEqual('*')
   })
@@ -70,51 +61,6 @@ describe('obfuscateString', () => {
     obfuscator.sharedContext = { agentIdentifier }
 
     expect(obfuscator.obfuscateString(input)).toEqual(input)
-  })
-})
-
-describe('getRuleValidationCache', () => {
-  test('should return configured rules with validation information', () => {
-    jest.spyOn(initModule, 'getConfigurationValue').mockReturnValue(rules)
-
-    expect(Obfuscator.getRuleValidationCache(agentIdentifier)).toEqual([
-      {
-        rule: rules[0],
-        isValid: true,
-        errors: {
-          regexMissingDetected: false,
-          invalidRegexDetected: false,
-          invalidReplacementDetected: false
-        }
-      }
-    ])
-  })
-
-  test('should include the file protocol obfuscation', () => {
-    jest.spyOn(initModule, 'getConfigurationValue').mockReturnValue(rules)
-    jest.spyOn(urlProtocolModule, 'isFileProtocol').mockReturnValue(rules)
-
-    expect(Obfuscator.getRuleValidationCache(agentIdentifier)).toEqual(expect.arrayContaining([{
-      rule: {
-        regex: /^file:\/\/(.*)/,
-        replacement: 'file://OBFUSCATED'
-      },
-      isValid: true,
-      errors: {
-        regexMissingDetected: false,
-        invalidRegexDetected: false,
-        invalidReplacementDetected: false
-      }
-    }]))
-  })
-
-  test.each([
-    null,
-    undefined
-  ])('should return an empty array when obfuscation rules are %s', (input) => {
-    jest.spyOn(initModule, 'getConfigurationValue').mockReturnValue(input)
-
-    expect(Obfuscator.getRuleValidationCache(agentIdentifier)).toEqual([])
   })
 })
 
@@ -190,52 +136,5 @@ describe('validateObfuscationRule', () => {
         invalidReplacementDetected: false
       }
     })
-  })
-})
-
-describe('logObfuscationRuleErrors', () => {
-  test('should warn for rule missing regex', () => {
-    const rule = {
-      replacement: faker.lorem.text()
-    }
-    Obfuscator.logObfuscationRuleErrors([Obfuscator.validateObfuscationRule(rule)])
-
-    expect(consoleModule.warn).toHaveBeenCalledWith(12, rule)
-  })
-
-  test.each([
-    null,
-    123,
-    {},
-    []
-  ])('should warn for rule containing regex type %s', (input) => {
-    const rule = {
-      regex: input,
-      replacement: faker.lorem.text()
-    }
-    Obfuscator.logObfuscationRuleErrors([Obfuscator.validateObfuscationRule(rule)])
-
-    expect(consoleModule.warn).toHaveBeenCalledWith(13, rule)
-  })
-
-  test.each([
-    123,
-    {},
-    []
-  ])('should warn for rule containing replacement type %s', (input) => {
-    const rule = {
-      regex: rules[0].regex,
-      replacement: input
-    }
-    Obfuscator.logObfuscationRuleErrors([Obfuscator.validateObfuscationRule(rule)])
-
-    expect(consoleModule.warn).toHaveBeenCalledWith(14, rule)
-  })
-
-  test('should not warn for a valid rule', () => {
-    const rule = rules[0]
-    Obfuscator.logObfuscationRuleErrors([Obfuscator.validateObfuscationRule(rule)])
-
-    expect(consoleModule.warn).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/common/util/obfuscate.test.js
+++ b/tests/unit/common/util/obfuscate.test.js
@@ -57,7 +57,7 @@ describe('obfuscateString', () => {
   ])('obfuscateString returns the input it is %s', (input) => {
     jest.spyOn(initModule, 'getConfigurationValue').mockReturnValue(rules)
 
-    const obfuscator = new Obfuscator()
+    const obfuscator = new Obfuscator({ init: { obfuscate: [] } })
     obfuscator.sharedContext = { agentIdentifier }
 
     expect(obfuscator.obfuscateString(input)).toEqual(input)
@@ -70,7 +70,8 @@ describe('validateObfuscationRule', () => {
       replacement: faker.lorem.text()
     }
 
-    expect(Obfuscator.validateObfuscationRule(rule)).toEqual({
+    const obfuscator = new Obfuscator({ init: { obfuscate: [] } })
+    expect(obfuscator.validateObfuscationRule(rule)).toEqual({
       rule,
       isValid: false,
       errors: {
@@ -92,7 +93,9 @@ describe('validateObfuscationRule', () => {
       replacement: faker.lorem.text()
     }
 
-    expect(Obfuscator.validateObfuscationRule(rule)).toEqual({
+    const obfuscator = new Obfuscator({ init: { obfuscate: [] } })
+
+    expect(obfuscator.validateObfuscationRule(rule)).toEqual({
       rule,
       isValid: false,
       errors: {
@@ -113,7 +116,8 @@ describe('validateObfuscationRule', () => {
       replacement: input
     }
 
-    expect(Obfuscator.validateObfuscationRule(rule)).toEqual({
+    const obfuscator = new Obfuscator({ init: { obfuscate: [] } })
+    expect(obfuscator.validateObfuscationRule(rule)).toEqual({
       rule,
       isValid: false,
       errors: {
@@ -127,7 +131,8 @@ describe('validateObfuscationRule', () => {
   test('should return valid for a valid rule', () => {
     const rule = rules[0]
 
-    expect(Obfuscator.validateObfuscationRule(rule)).toEqual({
+    const obfuscator = new Obfuscator({ init: { obfuscate: [] } })
+    expect(obfuscator.validateObfuscationRule(rule)).toEqual({
       rule,
       isValid: true,
       errors: {

--- a/tests/unit/features/soft_navigations/aggregate/initial-page-load-interaction.test.js
+++ b/tests/unit/features/soft_navigations/aggregate/initial-page-load-interaction.test.js
@@ -36,7 +36,7 @@ jest.mock('../../../../../src/common/timing/nav-timing', () => ({
 
 beforeEach(() => {
   jest.mocked(runtimeModule.getRuntime).mockReturnValue({
-    obfuscator: new Obfuscator('abcd')
+    obfuscator: new Obfuscator({ init: { obfuscate: [] } })
   })
 })
 

--- a/tests/unit/features/soft_navigations/aggregate/interaction.test.js
+++ b/tests/unit/features/soft_navigations/aggregate/interaction.test.js
@@ -24,7 +24,7 @@ jest.mock('../../../../../src/common/config/runtime', () => ({
 
 beforeEach(() => {
   jest.mocked(runtimeModule.getRuntime).mockReturnValue({
-    obfuscator: new Obfuscator('abcd')
+    obfuscator: new Obfuscator({ init: { obfuscate: [] } })
   })
 })
 
@@ -210,7 +210,7 @@ test('Interaction serialize output is correct', () => {
   jest.doMock('../../../../../src/common/config/runtime', () => ({
     __esModule: true,
     getRuntime: jest.fn().mockReturnValue({
-      obfuscator: new Obfuscator('abcd')
+      obfuscator: new Obfuscator({ init: { obfuscate: [] } })
     })
   }))
   const { Interaction } = require('../../../../../src/features/soft_navigations/aggregate/interaction')


### PR DESCRIPTION
Fix an issue where obfuscation rules are not honored if added after the agent has initialized.  Some user cases require obfuscation rules to be dynamically added, this change will allow that behavior -- as long as the obfuscation rules are added to `newrelic.initializedAgents[index].init.obfuscate`
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
This is related to an ongoing incident
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new test has been added that validates that obfuscation rules can be added later and still affect outgoing payloads.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
