### PR TITLE
feat: Add HTTP codes for harvest retry attempts

### DIFF
--- a/src/common/harvest/harvester.js
+++ b/src/common/harvest/harvester.js
@@ -1,6 +1,8 @@
-import { FEATURE_TO_ENDPOINT, JSERRORS, RUM, EVENTS } from '../../loaders/features/features'
+import { SUPPORTABILITY_METRIC_CHANNEL } from '../../features/metrics/constants'
+import { FEATURE_TO_ENDPOINT, JSERRORS, RUM, EVENTS, FEATURE_NAMES } from '../../loaders/features/features'
 import { VERSION } from '../constants/env'
 import { globalScope, isWorkerScope } from '../constants/runtime'
+import { handle } from '../event-emitter/handle'
 import { eventListenerOpts } from '../event-listener/event-listener-opts'
 import { SESSION_EVENTS } from '../session/constants'
 import { now } from '../timing/now'
@@ -10,6 +12,9 @@ import { obj, param } from '../url/encode'
 import { warn } from '../util/console'
 import { stringify } from '../util/stringify'
 import { getSubmitMethod, xhr as xhrMethod, xhrFetch as fetchMethod } from '../util/submit-data'
+
+const RETRY_FAILED = 'Harvester/Retry/Failed/'
+const RETRY_SUCCEEDED = 'Harvester/Retry/Succeeded/'
 
 export class Harvester {
   #started = false
@@ -82,7 +87,14 @@ export class Harvester {
      * @param {Object} result - information regarding the result of the harvest attempt
      */
     function cbFinished (result) {
-      if (localOpts.forceNoRetry) result.retry = false // discard unsent data rather than re-queuing for next harvest attempt
+      if (aggregateInst.harvestOpts.prevAttemptCode) { // this means we just retried a harvest that last failed
+        handle(SUPPORTABILITY_METRIC_CHANNEL, [(result.retry ? RETRY_FAILED : RETRY_SUCCEEDED) + aggregateInst.harvestOpts.prevAttemptCode], undefined, FEATURE_NAMES.metrics, aggregateInst.ee)
+        delete aggregateInst.harvestOpts.prevAttemptCode // always reset last observation so we don't falsely report again next harvest
+        // In case this re-attempt failed again, that'll be handled (re-marked again) next.
+      }
+      if (result.retry) aggregateInst.harvestOpts.prevAttemptCode = result.status // earmark this Agg harvest as failed-but-retrying for next harvest trigger so we can capture metrics about retries
+
+      if (localOpts.forceNoRetry) result.retry = false // discard unsent data rather than re-queuing for next harvest attempt; used by session reset to flush data belonging to prev session
       aggregateInst.postHarvestCleanup(result)
     }
   }
@@ -160,14 +172,12 @@ function send (agentRef, { endpoint, targetApp, payload, localOpts = {}, submitM
 
   function shouldRetry (status) {
     switch (status) {
-      case 429:
       case 408:
+      case 429:
       case 500:
-      case 503:
         return true
-      default:
-        return false
     }
+    return (status >= 502 && status <= 504) || (status >= 512 && status <= 530)
   }
 }
 

--- a/tests/specs/ajax/retry-harvesting.e2e.js
+++ b/tests/specs/ajax/retry-harvesting.e2e.js
@@ -2,7 +2,7 @@ import { testAjaxEventsRequest, testAjaxTimeSlicesRequest } from '../../../tools
 import { checkAjaxEvents, checkAjaxMetrics } from '../../util/basic-checks'
 
 describe('xhr retry harvesting', () => {
-  ;[408, 429, 500, 503].forEach(statusCode =>
+  ;[408, 429, 500, 502, 504, 520].forEach(statusCode =>
     it(`should send the ajax event and metric on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       const [ajaxEventsCapture, ajaxMetricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
         { test: testAjaxEventsRequest },
@@ -72,7 +72,7 @@ describe('xhr retry harvesting', () => {
     })
   )
 
-  ;[400, 404, 502, 504, 512].forEach(statusCode =>
+  ;[400, 404].forEach(statusCode =>
     it(`should not send the ajax event and metric on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       const [ajaxEventsCapture, ajaxMetricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
         { test: testAjaxEventsRequest },

--- a/tests/specs/err/retry-harvesting.e2e.js
+++ b/tests/specs/err/retry-harvesting.e2e.js
@@ -7,7 +7,7 @@ describe('err retry harvesting', () => {
     errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
   })
 
-  ;[408, 429, 500, 503].forEach(statusCode =>
+  ;[408, 429, 500, 502, 504, 512, 530].forEach(statusCode =>
     it(`should send the error on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testErrorsRequest,
@@ -40,7 +40,7 @@ describe('err retry harvesting', () => {
     })
   )
 
-  ;[400, 404, 502, 504, 512].forEach(statusCode =>
+  ;[400, 404].forEach(statusCode =>
     it(`should not send the error on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testErrorsRequest,

--- a/tests/specs/ins/retry-harvesting.e2e.js
+++ b/tests/specs/ins/retry-harvesting.e2e.js
@@ -7,7 +7,7 @@ describe('ins retry harvesting', () => {
     insightsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInsRequest })
   })
 
-  ;[408, 429, 500, 503].forEach(statusCode =>
+  ;[408, 429, 500, 502, 504, 520].forEach(statusCode =>
     it(`should send the page action on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testInsRequest,
@@ -40,7 +40,7 @@ describe('ins retry harvesting', () => {
     })
   );
 
-  [400, 404, 502, 504, 512].forEach(statusCode =>
+  [400, 404].forEach(statusCode =>
     it(`should not send the page action on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testInsRequest,

--- a/tests/specs/pvt/retry-harvesting.e2e.js
+++ b/tests/specs/pvt/retry-harvesting.e2e.js
@@ -1,29 +1,33 @@
-import { testTimingEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { testMetricsRequest, testTimingEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('pvt harvesting', () => {
-  let timingsCapture
+  const localConfig = {
+    init: {
+      page_view_timing: {
+        enabled: true
+      },
+      harvest: {
+        interval: 2
+      }
+    }
+  }
+  let timingsCapture, metricsCapture
 
   beforeEach(async () => {
-    timingsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testTimingEventsRequest })
+    ;[metricsCapture, timingsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testMetricsRequest },
+      { test: testTimingEventsRequest }
+    ])
   })
 
-  ;[408, 429, 500, 503].forEach(statusCode => {
+  ;[408, 429, 500, 502, 504, 512, 530].forEach(statusCode => {
     it('timings are retried when collector returns ' + statusCode, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testTimingEventsRequest,
         permanent: true,
         statusCode
       })
-      let url = await browser.testHandle.assetURL('instrumented.html', {
-        init: {
-          page_view_timing: {
-            enabled: true
-          },
-          harvest: {
-            interval: 2
-          }
-        }
-      })
+      let url = await browser.testHandle.assetURL('instrumented.html', localConfig)
       const [firstTimingsHarvest] = await Promise.all([
         timingsCapture.waitForResult({ totalCount: 1 }),
         browser.url(url).then(() => browser.waitForAgentLoad())
@@ -37,23 +41,67 @@ describe('pvt harvesting', () => {
     })
   })
 
-  ;[400, 404, 502, 504, 512].forEach(statusCode => {
+  it('generates a SM when retry succeeds', async () => {
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testTimingEventsRequest,
+      permanent: true,
+      statusCode: 500
+    })
+    let url = await browser.testHandle.assetURL('instrumented.html', localConfig)
+    await Promise.all([
+      timingsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(url).then(() => browser.waitForAgentLoad())
+    ])
+
+    await browser.testHandle.clearScheduledReplies('bamServer')
+    await timingsCapture.waitForResult({ totalCount: 2 })
+
+    const offPageUrl = await browser.testHandle.assetURL('/')
+    const [metricsHarvest] = await Promise.all([
+      metricsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(offPageUrl)
+    ])
+
+    const smArray = metricsHarvest[0].request.body.sm
+    expect(smArray).toEqual(expect.arrayContaining([{
+      params: { name: 'Harvester/Retry/Succeeded/500' },
+      stats: { c: 1 }
+    }]))
+  })
+  it('generates a SM when retry fails', async () => {
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testTimingEventsRequest,
+      permanent: true,
+      statusCode: 512
+    })
+    let url = await browser.testHandle.assetURL('instrumented.html', localConfig)
+    await Promise.all([
+      timingsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(url).then(() => browser.waitForAgentLoad())
+    ])
+    await timingsCapture.waitForResult({ totalCount: 2 })
+
+    const offPageUrl = await browser.testHandle.assetURL('/')
+    const [metricsHarvest] = await Promise.all([
+      metricsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(offPageUrl)
+    ])
+
+    const smArray = metricsHarvest[0].request.body.sm
+    expect(smArray).toEqual(expect.arrayContaining([{
+      params: { name: 'Harvester/Retry/Failed/512' },
+      stats: { c: 1 }
+    }]))
+  })
+
+  ;[400, 404].forEach(statusCode => {
     it('timings are NOT retried when collector returns ' + statusCode, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testTimingEventsRequest,
         permanent: true,
         statusCode
       })
-      let url = await browser.testHandle.assetURL('instrumented.html', {
-        init: {
-          page_view_timing: {
-            enabled: true
-          },
-          harvest: {
-            interval: 2
-          }
-        }
-      })
+      let url = await browser.testHandle.assetURL('instrumented.html', localConfig)
       const [firstTimingsHarvest] = await Promise.all([
         timingsCapture.waitForResult({ totalCount: 1 }),
         browser.url(url).then(() => browser.waitForAgentLoad())

--- a/tests/specs/session-trace/retry-harvesting.e2e.js
+++ b/tests/specs/session-trace/retry-harvesting.e2e.js
@@ -8,7 +8,7 @@ describe('stn retry harvesting', () => {
     sessionTraceCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testBlobTraceRequest })
   })
 
-  ;[408, 429, 500, 503].forEach(statusCode =>
+  ;[408, 429, 500, 502, 504, 520].forEach(statusCode =>
     it(`should send the session trace on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testBlobRequest,

--- a/tests/specs/soft_navigations/retry-harvesting.e2e.js
+++ b/tests/specs/soft_navigations/retry-harvesting.e2e.js
@@ -8,7 +8,7 @@ describe('retry harvesting', () => {
     interactionsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInteractionEventsRequest })
   })
 
-  ;[408, 429, 500, 503].forEach(statusCode =>
+  ;[408, 429, 500, 502, 504, 520].forEach(statusCode =>
     it(`should send the interaction on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testInteractionEventsRequest,
@@ -38,7 +38,7 @@ describe('retry harvesting', () => {
     })
   )
 
-  ;[400, 404, 502, 504, 512].forEach(statusCode =>
+  ;[400, 404].forEach(statusCode =>
     it(`should not send the page action on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testInteractionEventsRequest,

--- a/tests/specs/spa/retry-harvesting.e2e.js
+++ b/tests/specs/spa/retry-harvesting.e2e.js
@@ -7,7 +7,7 @@ describe('retry harvesting', () => {
     interactionsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInteractionEventsRequest })
   })
 
-  ;[408, 429, 500, 503].forEach(statusCode =>
+  ;[408, 429, 500, 502, 504, 520].forEach(statusCode =>
     it(`should send the interaction on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testInteractionEventsRequest,
@@ -37,7 +37,7 @@ describe('retry harvesting', () => {
     })
   )
 
-  ;[400, 404, 502, 504, 512].forEach(statusCode =>
+  ;[400, 404].forEach(statusCode =>
     it(`should not send the page action on the next harvest when the first harvest statusCode is ${statusCode}`, async () => {
       await browser.testHandle.scheduleReply('bamServer', {
         test: testInteractionEventsRequest,


### PR DESCRIPTION
Agent will begin to retry harvests to the endpoints that failed for the following additional status codes: 502, 504, and 512-530. This is suggested by New Relic ingest teams as a possibility to recapture lost data in these marginal cases.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Harvester now will attempt to retry the following codes in total: 408, 429, 500, 502-504, 512-530.
Metrics track if a former failed attempt subsequently succeeded or failed on next attempt, split by the former returned HTTP code.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-137499
Angler update: https://source.datanerd.us/agents/angler/pull/657

### Testing

Retry e2es were updated. New SMs are tested in the PVT retry spec file (only).
