### PR TITLE
feat: Capture details in marks and measures

### DIFF
--- a/src/common/config/init.js
+++ b/src/common/config/init.js
@@ -63,6 +63,7 @@ const model = () => {
       set capture_marks (val) { hiddenState.experimental.marks = val },
       get capture_measures () { return hiddenState.feature_flags.includes(FEATURE_FLAGS.MEASURES) || hiddenState.experimental.measures },
       set capture_measures (val) { hiddenState.experimental.measures = val },
+      capture_detail: true,
       resources: {
         // whether to run this subfeature or not in the generic_events feature. false by default through experimental phase, but flipped to true once GA'd
         get enabled () { return hiddenState.feature_flags.includes(FEATURE_FLAGS.RESOURCES) || hiddenState.experimental.resources },

--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -133,7 +133,6 @@ export class Aggregate extends AggregateBase {
 
                     function createDetailAttrs (obj, rootKey = '', output = {}) {
                       if (obj === null || obj === undefined) return output
-                      // if (typeof obj === 'string') output.entryDetail = obj
                       else if (typeof obj !== 'object') output.entryDetail = obj
                       else {
                         Object.entries(obj).forEach(([key, value]) => {

--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -142,10 +142,10 @@ export class Aggregate extends AggregateBase {
                         if (nestedJSON === null || nestedJSON === undefined) return items
                         Object.keys(nestedJSON).forEach(key => {
                           let newKey = parentKey + '.' + key
-                          if (typeof nestedJSON[key] === 'object' && nestedJSON[key] !== null && !Array.isArray(nestedJSON[key])) {
+                          if (isPureObject(nestedJSON[key])) {
                             Object.assign(items, flattenJSON(nestedJSON[key], newKey))
                           } else {
-                            items[newKey] = nestedJSON[key]
+                            if (nestedJSON[key] !== null && nestedJSON[key] !== undefined) items[newKey] = nestedJSON[key]
                           }
                         })
                         return items

--- a/tests/assets/marks-and-measures-detail.html
+++ b/tests/assets/marks-and-measures-detail.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    <script>performance.mark('before-agent')</script>
+    {init} {config} {loader}
+    <script>performance.mark('after-agent')</script>
+  </head>
+  <body>Instrumented
+    <script>
+      performance.measure('simple-object', {detail: {foo:'bar'}, start: 'before-agent', end: 'after-agent'} )
+      performance.measure('nested-object', {detail: {nested1:{nested2:{nested3:{nested4: {foo: 'bar'}}}}, notNested: 'hi'}, start: 'before-agent', end: 'after-agent'} )
+      performance.measure('string', {detail: 'hi', start: 'before-agent', end: 'after-agent'} )
+      performance.measure('falsy-string', {detail: '', start: 'before-agent', end: 'after-agent'} )
+      performance.measure('number', {detail: 1, start: 'before-agent', end: 'after-agent'} )
+      performance.measure('falsy-number', {detail: 0, start: 'before-agent', end: 'after-agent'} )
+      performance.measure('boolean', {detail: true, start: 'before-agent', end: 'after-agent'} )
+      performance.measure('falsy-boolean', {detail: false, start: 'before-agent', end: 'after-agent'} )
+    </script>
+  </body>
+</html>

--- a/tests/assets/marks-and-measures-detail.html
+++ b/tests/assets/marks-and-measures-detail.html
@@ -20,6 +20,8 @@
       performance.measure('falsy-number', {detail: 0, start: 'before-agent', end: 'after-agent'} )
       performance.measure('boolean', {detail: true, start: 'before-agent', end: 'after-agent'} )
       performance.measure('falsy-boolean', {detail: false, start: 'before-agent', end: 'after-agent'} )
+      performance.measure('array', {detail: [1,2,3], start: 'before-agent', end: 'after-agent'} )
+      performance.measure('falsy-array', {detail: [], start: 'before-agent', end: 'after-agent'} )
     </script>
   </body>
 </html>

--- a/tests/components/generic_events/aggregate/index.test.js
+++ b/tests/components/generic_events/aggregate/index.test.js
@@ -166,7 +166,6 @@ describe('sub-features', () => {
     genericEventsAggregate.ee.emit('ua', [{ timeStamp: 234567, type: 'blur', target: window }])
 
     const harvest = genericEventsAggregate.makeHarvestPayload() // force it to put the aggregation into the event buffer
-    console.log(harvest)
     expect(harvest[0].payload.body.ins[0]).toMatchObject({
       eventType: 'UserAction',
       timestamp: expect.any(Number),
@@ -286,7 +285,7 @@ describe('sub-features', () => {
   })
 
   test('should record measures when enabled', async () => {
-    mainAgent.init.performance = { capture_measures: true, resources: { enabled: false, asset_types: [], first_party_domains: [], ignore_newrelic: true } }
+    mainAgent.init.performance = { capture_measures: true, capture_detail: true, resources: { enabled: false, asset_types: [], first_party_domains: [], ignore_newrelic: true } }
     getInfo(mainAgent.agentIdentifier).jsAttributes = { globalFoo: 'globalBar' }
     const mockPerformanceObserver = jest.fn(cb => ({
       observe: () => {
@@ -295,7 +294,7 @@ describe('sub-features', () => {
           cb({getEntries: () => [{
             name: 'test',
             duration: 10,
-            detail: JSON.stringify({ foo: 'bar' }),
+            detail: { foo: 'bar' },
             startTime: performance.now()
           }]
           })
@@ -321,7 +320,7 @@ describe('sub-features', () => {
       entryName: 'test',
       entryDuration: 10,
       entryType: 'measure',
-      entryDetail: JSON.stringify({ foo: 'bar' })
+      'entryDetail.foo': 'bar'
     })
   })
 })

--- a/tests/specs/ins/harvesting.e2e.js
+++ b/tests/specs/ins/harvesting.e2e.js
@@ -245,21 +245,21 @@ describe('ins harvesting', () => {
 
     expect(insHarvest.length).toEqual(8) // this page sets seven measures
     // detail: {foo:'bar'}
-    expect(insHarvest[0]['entryDetail.foo']).toEqual('bar')
+    expect(insHarvest.find(x => x.entryName === 'simple-object')['entryDetail.foo']).toEqual('bar')
     // detail: {nested1:{nested2:{nested3:{nested4: {foo: 'bar'}}}}
-    expect(insHarvest[1]['entryDetail.nested1.nested2.nested3.nested4.foo']).toEqual('bar')
+    expect(insHarvest.find(x => x.entryName === 'nested-object')['entryDetail.nested1.nested2.nested3.nested4.foo']).toEqual('bar')
     // detail: 'hi'
-    expect(insHarvest[2].entryDetail).toEqual('hi')
+    expect(insHarvest.find(x => x.entryName === 'string').entryDetail).toEqual('hi')
     // detail: ''
-    expect(insHarvest[3].entryDetail).toEqual('')
+    expect(insHarvest.find(x => x.entryName === 'falsy-string').entryDetail).toEqual('')
     // detail: 1
-    expect(insHarvest[4].entryDetail).toEqual(1)
+    expect(insHarvest.find(x => x.entryName === 'number').entryDetail).toEqual(1)
     // detail: 0
-    expect(insHarvest[5].entryDetail).toEqual(0)
+    expect(insHarvest.find(x => x.entryName === 'falsy-number').entryDetail).toEqual(0)
     // detail: true
-    expect(insHarvest[6].entryDetail).toEqual(true)
+    expect(insHarvest.find(x => x.entryName === 'boolean').entryDetail).toEqual(true)
     // detail: false
-    expect(insHarvest[7].entryDetail).toEqual(false)
+    expect(insHarvest.find(x => x.entryName === 'falsy-boolean').entryDetail).toEqual(false)
   })
 
   ;[

--- a/tests/specs/ins/harvesting.e2e.js
+++ b/tests/specs/ins/harvesting.e2e.js
@@ -224,7 +224,7 @@ describe('ins harvesting', () => {
 
       expect(insHarvest.length).toEqual(1) // this page sets one measure
       expect(insHarvest[0]).toMatchObject({
-        entryDetail: '{"foo":"bar"}',
+        'entryDetail.foo': 'bar',
         entryDuration: expect.any(Number),
         eventType: 'BrowserPerformance',
         entryName: 'agent-load',
@@ -233,6 +233,33 @@ describe('ins harvesting', () => {
         entryType: 'measure'
       })
     })
+  })
+
+  it('should spread detail', async () => {
+    const testUrl = await browser.testHandle.assetURL('marks-and-measures-detail.html', getInsInit({ performance: { capture_measures: true } }))
+    await browser.url(testUrl).then(() => browser.waitForAgentLoad())
+
+    const [[{ request: { body: { ins: insHarvest } } }]] = await Promise.all([
+      insightsCapture.waitForResult({ totalCount: 1 })
+    ])
+
+    expect(insHarvest.length).toEqual(8) // this page sets seven measures
+    // detail: {foo:'bar'}
+    expect(insHarvest[0]['entryDetail.foo']).toEqual('bar')
+    // detail: {nested1:{nested2:{nested3:{nested4: {foo: 'bar'}}}}
+    expect(insHarvest[1]['entryDetail.nested1.nested2.nested3.nested4.foo']).toEqual('bar')
+    // detail: 'hi'
+    expect(insHarvest[2].entryDetail).toEqual('hi')
+    // detail: ''
+    expect(insHarvest[3].entryDetail).toEqual('')
+    // detail: 1
+    expect(insHarvest[4].entryDetail).toEqual(1)
+    // detail: 0
+    expect(insHarvest[5].entryDetail).toEqual(0)
+    // detail: true
+    expect(insHarvest[6].entryDetail).toEqual(true)
+    // detail: false
+    expect(insHarvest[7].entryDetail).toEqual(false)
   })
 
   ;[

--- a/tests/specs/ins/harvesting.e2e.js
+++ b/tests/specs/ins/harvesting.e2e.js
@@ -243,7 +243,7 @@ describe('ins harvesting', () => {
       insightsCapture.waitForResult({ totalCount: 1 })
     ])
 
-    expect(insHarvest.length).toEqual(8) // this page sets seven measures
+    expect(insHarvest.length).toEqual(10) // this page sets 10 measures
     // detail: {foo:'bar'}
     expect(insHarvest.find(x => x.entryName === 'simple-object')['entryDetail.foo']).toEqual('bar')
     // detail: {nested1:{nested2:{nested3:{nested4: {foo: 'bar'}}}}
@@ -260,6 +260,10 @@ describe('ins harvesting', () => {
     expect(insHarvest.find(x => x.entryName === 'boolean').entryDetail).toEqual(true)
     // detail: false
     expect(insHarvest.find(x => x.entryName === 'falsy-boolean').entryDetail).toEqual(false)
+    // detail: [1,2,3]
+    expect(insHarvest.find(x => x.entryName === 'array').entryDetail).toEqual('[1,2,3]')
+    // detail: []
+    expect(insHarvest.find(x => x.entryName === 'falsy-array').entryDetail).toEqual('[]')
   })
 
   ;[

--- a/tests/unit/common/config/init.test.js
+++ b/tests/unit/common/config/init.test.js
@@ -86,6 +86,7 @@ test('init props exist and return expected defaults', () => {
   expect(config.performance).toEqual({
     capture_marks: false,
     capture_measures: false,
+    capture_detail: true,
     resources: {
       enabled: false,
       asset_types: [],


### PR DESCRIPTION
The `detail` property of `PerformanceMark` and `PerformanceMeasure` events will now be captured in New Relic `BrowserPerformance` under the `entryDetail` attribute.  If `detail` is an object, it and any nested objects within it will be flatten into string path keys prefixed with `entryDetail`. See [the PR](https://github.com/newrelic/newrelic-browser-agent/pull/1332) for elucidation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR is to support changes requested by the platform team to be utilized in conjunction with MFE POC.

Flattening examples:

- `detail: { foo: { bar: 'baz' }, other: 'hello' }` will create an attribute on the BrowserPerformance event called `entryDetail.foo.bar: 'baz'` and another attribute called `entryDetail.other: 'hello'`. 
- Other non-object data types provided to the `detail` option will be processed as-is.  `detail: 'hello'` will create an attribute called `entryDetail: 'hello'`. 

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
 tests have been added/updated
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
