### PR TITLE
feat: Re-implement wrap-websocket into agent

### DIFF
--- a/src/common/wrap/wrap-function.js
+++ b/src/common/wrap/wrap-function.js
@@ -183,7 +183,7 @@ function report (args, emitter) {
  *     Defaults to the global event emitter.
  * @returns {object} - The destination founction or object with copied properties.
  */
-function copy (from, to, emitter) {
+export function copy (from, to, emitter) {
   if (Object.defineProperty && Object.keys) {
     // Create accessors that proxy to actual function
     try {

--- a/src/common/wrap/wrap-websocket.js
+++ b/src/common/wrap/wrap-websocket.js
@@ -27,51 +27,35 @@ export function wrapWebSocket (sharedEE) {
     }
   }
 
-  Object.defineProperty(WrappedWebSocket, 'name', {
-    value: 'WebSocket'
-  })
+  class WrappedWebSocket extends WebSocket {
+    static name = 'WebSocket'
 
-  function WrappedWebSocket () {
-    const ws = new originals.WS(...arguments)
-    const socketId = generateRandomHexString(6)
-    const report = reporter(socketId)
-    report('new')
+    constructor (...args) {
+      super(...args)
+      const socketId = generateRandomHexString(6)
+      this.report = reporter(socketId)
+      this.report('new')
 
-    const events = ['message', 'error', 'open', 'close']
-    /** add event listeners */
-    events.forEach(evt => {
-      ws.addEventListener(evt, function (e) {
-        report(ADD_EVENT_LISTENER_TAG, { eventType: evt, event: e })
-      })
-    })
-
-    /** could also observe the on-events for runtime processing, but not implemented yet */
-
-    /** observe the static method send, but noteably not close, as that is currently observed with the event listener */
-    ;['send'].forEach(wrapStaticProperty)
-
-    function wrapStaticProperty (prop) {
-      const originalProp = ws[prop]
-      if (originalProp) {
-        Object.defineProperty(proxiedProp, 'name', {
-          value: prop
+      const events = ['message', 'error', 'open', 'close']
+      /** add event listeners */
+      events.forEach(evt => {
+        this.addEventListener(evt, function (e) {
+          this.report(ADD_EVENT_LISTENER_TAG, { eventType: evt, event: e })
         })
-        function proxiedProp () {
-          report(prop, ...arguments)
-          try {
-            return originalProp.apply(this, arguments)
-          } catch (err) {
-            report(prop + '-err', ...arguments)
-            // rethrow error so we don't effect execution by observing.
-            throw err
-          }
-        }
-        ws[prop] = proxiedProp
-      }
+      })
     }
 
-    return ws
+    send (...args) {
+      this.report('send', ...args)
+      try {
+        return super.send(...args)
+      } catch (err) {
+        this.report('send-err', ...args)
+        throw err
+      }
+    }
   }
+
   globalScope.WebSocket = WrappedWebSocket
   return sharedEE
 }

--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { registerHandler } from '../../../common/event-emitter/register-handler'
-import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL/*, WATCHABLE_WEB_SOCKET_EVENTS */ } from '../constants'
+import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL, WATCHABLE_WEB_SOCKET_EVENTS } from '../constants'
 import { getFrameworks } from './framework-detection'
 import { isFileProtocol } from '../../../common/url/protocol'
 import { onDOMContentLoaded } from '../../../common/window/load'
@@ -11,8 +11,8 @@ import { windowAddEventListener } from '../../../common/event-listener/event-lis
 import { isBrowserScope, isWorkerScope } from '../../../common/constants/runtime'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { isIFrameWindow } from '../../../common/dom/iframe'
-// import { WEBSOCKET_TAG } from '../../../common/wrap/wrap-websocket'
-// import { handleWebsocketEvents } from './websocket-detection'
+import { WEBSOCKET_TAG } from '../../../common/wrap/wrap-websocket'
+import { handleWebsocketEvents } from './websocket-detection'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -116,11 +116,11 @@ export class Aggregate extends AggregateBase {
       mo.observe(window.document.body, { childList: true, subtree: true })
     }
 
-    // WATCHABLE_WEB_SOCKET_EVENTS.forEach(tag => {
-    //   registerHandler('buffered-' + WEBSOCKET_TAG + tag, (...args) => {
-    //     handleWebsocketEvents(this.storeSupportabilityMetrics.bind(this), tag, ...args)
-    //   }, this.featureName, this.ee)
-    // })
+    WATCHABLE_WEB_SOCKET_EVENTS.forEach(tag => {
+      registerHandler('buffered-' + WEBSOCKET_TAG + tag, (...args) => {
+        handleWebsocketEvents(this.storeSupportabilityMetrics.bind(this), tag, ...args)
+      }, this.featureName, this.ee)
+    })
   }
 
   eachSessionChecks () {

--- a/src/features/metrics/constants.js
+++ b/src/features/metrics/constants.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// import { ADD_EVENT_LISTENER_TAG } from '../../common/wrap/wrap-websocket'
+import { ADD_EVENT_LISTENER_TAG } from '../../common/wrap/wrap-websocket'
 import { FEATURE_NAMES } from '../../loaders/features/features'
 
 export const FEATURE_NAME = FEATURE_NAMES.metrics
@@ -12,4 +12,4 @@ export const CUSTOM_METRIC = 'cm'
 export const SUPPORTABILITY_METRIC_CHANNEL = 'storeSupportabilityMetrics'
 export const CUSTOM_METRIC_CHANNEL = 'storeEventMetrics'
 
-// export const WATCHABLE_WEB_SOCKET_EVENTS = ['new', 'send', 'close', ADD_EVENT_LISTENER_TAG]
+export const WATCHABLE_WEB_SOCKET_EVENTS = ['new', 'send', 'close', ADD_EVENT_LISTENER_TAG]

--- a/src/features/metrics/instrument/index.js
+++ b/src/features/metrics/instrument/index.js
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// import { handle } from '../../../common/event-emitter/handle'
-// import { WEBSOCKET_TAG, wrapWebSocket } from '../../../common/wrap/wrap-websocket'
+import { handle } from '../../../common/event-emitter/handle'
+import { WEBSOCKET_TAG, wrapWebSocket } from '../../../common/wrap/wrap-websocket'
 import { InstrumentBase } from '../../utils/instrument-base'
-import { FEATURE_NAME/*, WATCHABLE_WEB_SOCKET_EVENTS */ } from '../constants'
+import { FEATURE_NAME, WATCHABLE_WEB_SOCKET_EVENTS } from '../constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   constructor (agentRef, auto = true) {
     super(agentRef, FEATURE_NAME, auto)
-    // wrapWebSocket(this.ee)
+    wrapWebSocket(this.ee)
 
-    // WATCHABLE_WEB_SOCKET_EVENTS.forEach((suffix) => {
-    //   this.ee.on(WEBSOCKET_TAG + suffix, (...args) => {
-    //     handle('buffered-' + WEBSOCKET_TAG + suffix, [...args], undefined, this.featureName, this.ee)
-    //   })
-    // })
+    WATCHABLE_WEB_SOCKET_EVENTS.forEach((suffix) => {
+      this.ee.on(WEBSOCKET_TAG + suffix, (...args) => {
+        handle('buffered-' + WEBSOCKET_TAG + suffix, [...args], undefined, this.featureName, this.ee)
+      })
+    })
 
     this.importAggregator(agentRef)
   }

--- a/tests/components/wrappings/wrap-websocket.test.js
+++ b/tests/components/wrappings/wrap-websocket.test.js
@@ -29,6 +29,12 @@ describe('wrap-websocket', () => {
     expect(ws.protocol).toEqual('')
     expect(ws.readyState).toEqual(0)
     expect(ws.url).toEqual('ws://foo.com/websocket')
+
+    expect(WebSocket.length).not.toBeUndefined()
+    expect(WebSocket.CONNECTING).toEqual(0)
+    expect(WebSocket.OPEN).toEqual(1)
+    expect(WebSocket.CLOSING).toEqual(2)
+    expect(WebSocket.CLOSED).toEqual(3)
   })
 
   it('should not run if no WS global', async () => {

--- a/tests/specs/websockets/metrics.e2e.js
+++ b/tests/specs/websockets/metrics.e2e.js
@@ -1,40 +1,72 @@
-// const { notIOS, notSafari } = require('../../../tools/browser-matcher/common-matchers.mjs')
-// const { testSupportMetricsRequest } = require('../../../tools/testing-server/utils/expect-tests')
+const { notIOS, notSafari } = require('../../../tools/browser-matcher/common-matchers.mjs')
+const { testSupportMetricsRequest, testErrorsRequest } = require('../../../tools/testing-server/utils/expect-tests')
 
 describe('WebSocket supportability metrics', () => {
   /** Safari and iOS safari are blocked from connecting to the websocket protocol on LT, which throws socket errors instead of connecting and capturing the expected payloads.
    *  validated that this works locally for these envs */
-  // it.withBrowsersMatching([notSafari, notIOS])('should capture expected SMs', async () => {
-  //   const supportabilityMetricsRequest = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
-  //   const url = await browser.testHandle.assetURL('websockets.html')
+  it.withBrowsersMatching([notSafari, notIOS])('should capture expected SMs', async () => {
+    const supportabilityMetricsRequest = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
+    const url = await browser.testHandle.assetURL('websockets.html')
 
-  //   await browser.url(url)
-  //     .then(() => browser.waitForAgentLoad())
-  //     .then(() => browser.refresh())
+    await browser.url(url)
+      .then(() => browser.waitForAgentLoad())
+      .then(() => browser.refresh())
 
-  //   const [sms] = await supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
-  //   const smPayload = sms.request.body.sm
-  //   const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
+    const [sms] = await supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
+    const smPayload = sms.request.body.sm
+    const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
 
-  //   smTags.forEach(expectedSm => {
-  //     const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
-  //     const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
-  //     const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
+    smTags.forEach(expectedSm => {
+      const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
+      const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
+      const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
 
-  //     expect(ms).toBeTruthy()
-  //     expect(ms.stats.t).toBeGreaterThan(0)
-  //     expect(ms.stats.c).toEqual(2)
+      expect(ms).toBeTruthy()
+      expect(ms.stats.t).toBeGreaterThan(0)
+      expect(ms.stats.c).toEqual(2)
 
-  //     expect(msSinceClassInit).toBeTruthy()
-  //     if (expectedSm === 'New') expect(msSinceClassInit.stats.t).toBeLessThanOrEqual(1)
-  //     else expect(msSinceClassInit.stats.t).toBeGreaterThan(0)
-  //     expect(msSinceClassInit.stats.c).toEqual(2)
+      expect(msSinceClassInit).toBeTruthy()
+      if (expectedSm === 'New') expect(msSinceClassInit.stats.t).toBeLessThanOrEqual(1)
+      else expect(msSinceClassInit.stats.t).toBeGreaterThan(0)
+      expect(msSinceClassInit.stats.c).toEqual(2)
 
-  //     if (['Send', 'Message'].includes(expectedSm)) {
-  //       expect(bytes).toBeTruthy()
-  //       if (expectedSm === 'Send') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(8) // we are sending about 8 bytes from client to server
-  //       if (expectedSm === 'Message') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(40) // we are sending about 40 bytes from server to client
-  //     } else expect(bytes).toBeFalsy()
-  //   })
-  // })
+      if (['Send', 'Message'].includes(expectedSm)) {
+        expect(bytes).toBeTruthy()
+        if (expectedSm === 'Send') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(8) // we are sending about 8 bytes from client to server
+        if (expectedSm === 'Message') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(40) // we are sending about 40 bytes from server to client
+      } else expect(bytes).toBeFalsy()
+    })
+  })
+
+  ;['robust-websocket', 'reconnecting-websocket'].forEach((thirdPartyWSWrapper) => {
+    it('should work with known third-party WS wrapper - ' + thirdPartyWSWrapper, async () => {
+      const [supportabilityMetricsRequest, errorsRequest] =
+        await browser.testHandle.createNetworkCaptures('bamServer', [
+          { test: testSupportMetricsRequest },
+          { test: testErrorsRequest }
+        ])
+      const url = await browser.testHandle.assetURL(`test-builds/library-wrapper/${thirdPartyWSWrapper}.html`)
+
+      await browser.url(url)
+
+      const [errors, [sms]] = await Promise.all([
+        errorsRequest.waitForResult({ timeout: 10000 }),
+        supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
+      ])
+      // should not have thrown errors
+      expect(errors.length).toEqual(0)
+
+      const smPayload = sms.request.body.sm
+      const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
+
+      smTags.forEach(expectedSm => {
+        const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
+        const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
+        const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
+        expect(ms).toBeTruthy()
+        expect(msSinceClassInit).toBeTruthy()
+        if (['Send', 'Message'].includes(expectedSm))expect(bytes).toBeTruthy()
+      })
+    })
+  })
 })

--- a/tools/test-builds/library-wrapper/package.json
+++ b/tools/test-builds/library-wrapper/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@apollo/client": "^3.8.8",
     "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.281.0.tgz",
-    "graphql": "^16.8.1"
+    "graphql": "^16.8.1",
+    "reconnecting-websocket": "^4.4.0",
+    "robust-websocket": "^1.0.0"
   }
 }

--- a/tools/test-builds/library-wrapper/src/reconnecting-websocket.js
+++ b/tools/test-builds/library-wrapper/src/reconnecting-websocket.js
@@ -1,0 +1,25 @@
+import { BrowserAgent } from '@newrelic/browser-agent/loaders/browser-agent'
+
+import ReconnectingWebSocket from 'reconnecting-websocket'
+
+const opts = {
+  info: NREUM.info,
+  init: NREUM.init
+}
+
+new BrowserAgent(opts)
+
+window.bamServer = NREUM.info.beacon
+
+const rws = new ReconnectingWebSocket(`ws://${window.bamServer}/websocket`)
+
+rws.addEventListener('open', () => {
+  rws.send('hello!')
+  rws.addEventListener('message', (message) => {
+    rws.close()
+  })
+
+  rws.addEventListener('close', function () {
+    window.location.reload()
+  })
+})

--- a/tools/test-builds/library-wrapper/src/robust-websocket.js
+++ b/tools/test-builds/library-wrapper/src/robust-websocket.js
@@ -1,0 +1,26 @@
+import { BrowserAgent } from '@newrelic/browser-agent/loaders/browser-agent'
+
+import * as RobustWebSocket from 'robust-websocket'
+
+const opts = {
+  info: NREUM.info,
+  init: NREUM.init
+}
+
+new BrowserAgent(opts)
+
+window.bamServer = NREUM.info.beacon
+
+var ws = new RobustWebSocket(`ws://${window.bamServer}/websocket`)
+
+ws.addEventListener('open', function (event) {
+  ws.send('Hello!')
+})
+
+ws.addEventListener('message', function (event) {
+  ws.close()
+})
+
+ws.addEventListener('close', function () {
+  window.location.reload()
+})

--- a/tools/test-builds/library-wrapper/webpack.config.js
+++ b/tools/test-builds/library-wrapper/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 const isProduction = process.env.NODE_ENV === 'production'
-const htmlTemplate = (script) => `<html>
+const htmlTemplate = (script) => `<!DOCTYPE html>
   <head>
     <title>RUM Unit Test</title>
     {init}
@@ -19,7 +19,9 @@ const config = [
   {
     cache: false,
     entry: {
-      'apollo-client': './src/apollo-client.js'
+      'apollo-client': './src/apollo-client.js',
+      'reconnecting-websocket': './src/reconnecting-websocket.js',
+      'robust-websocket': './src/robust-websocket.js'
     },
     output: {
       path: path.resolve(__dirname, '../../../tests/assets/test-builds/library-wrapper')
@@ -66,6 +68,18 @@ const config = [
         minify: false,
         inject: false,
         templateContent: htmlTemplate('apollo-client')
+      }),
+      new HtmlWebpackPlugin({
+        filename: 'reconnecting-websocket.html',
+        minify: false,
+        inject: false,
+        templateContent: htmlTemplate('reconnecting-websocket')
+      }),
+      new HtmlWebpackPlugin({
+        filename: 'robust-websocket.html',
+        minify: false,
+        inject: false,
+        templateContent: htmlTemplate('robust-websocket')
       })
     ]
   }


### PR DESCRIPTION
Re-implement wrap-websocket code using ES6 extends syntax into the agent. This will allow supportability metrics to be reportable from websocket API usage.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

We're re-implementing the wrap-websocket code into the agent that was taken out in 1.265.1 patch to address deploy issues. The new implementation uses ES6 extends syntax to include static class constants and all the properties of the original WebSocket object. Tests are included that cover usage with the third-party libraries `robust-websocket` and `reconnecting-websocket`.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-311646

### Testing

Make sure tests pass.
