### PR TITLE
fix: CLS timing node not being reported post new Harvester

### DIFF
--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -50,7 +50,7 @@ export class Aggregate extends AggregateBase {
         const { name, value, attrs } = cumulativeLayoutShift.current
         if (value === undefined) return
         this.addTiming(name, value * 1000, attrs)
-      }, true) // CLS node should only reports on vis change rather than on every change
+      }, true, true) // CLS node should only reports on vis change rather than on every change
 
       this.drain()
     })

--- a/tests/specs/pvt/timings.e2e.js
+++ b/tests/specs/pvt/timings.e2e.js
@@ -12,7 +12,7 @@ describe('pvt timings tests', () => {
 
   describe('page viz related timings', () => {
     loadersToTest.forEach(loader => {
-      it(`Load, Unload, FP, FCP & pageHide for ${loader} agent`, async () => {
+      it(`Load, Unload, FP, FCP, CLS & pageHide for ${loader} agent`, async () => {
         const start = Date.now()
         await browser.url(
           await browser.testHandle.assetURL('instrumented.html', { loader })
@@ -50,6 +50,9 @@ describe('pvt timings tests', () => {
         if (browserMatch(supportsCumulativeLayoutShift)) {
           const emptyCls = pageHide.attributes.find(a => a.key === 'cls')
           expect(emptyCls.value).toEqual(0)
+
+          // There should also be a standalone CLS node sent on EoL
+          expect(timingsHarvests.find(harvest => harvest.request.body.find(t => t.name === 'cls'))).toBeTruthy()
         }
       })
 
@@ -124,7 +127,7 @@ describe('pvt timings tests', () => {
   describe('layout shift related timings', () => {
     loadersToTest.forEach(loader => {
       [['unload', 'cls-basic.html'], ['pageHide', 'cls-pagehide.html']].forEach(([prop, testAsset]) => {
-        it.withBrowsersMatching([supportsCumulativeLayoutShift])(`${prop} for ${loader} agent collects cls attribute`, async () => {
+        it.withBrowsersMatching([supportsCumulativeLayoutShift])(`${prop} for ${loader} agent collects cls attribute & node`, async () => {
           await browser.url(
             await browser.testHandle.assetURL(testAsset, { loader })
           ).then(() => browser.waitForAgentLoad())
@@ -148,6 +151,7 @@ describe('pvt timings tests', () => {
           const cls = evt.attributes.find(a => a.key === 'cls')
           expect(cls?.value).toBeGreaterThan(0)
           expect(cls?.type).toEqual('doubleAttribute')
+          expect(timingsHarvests.find(harvest => harvest.request.body.find(t => t.name === 'cls'))).toBeTruthy()
         })
       })
     })


### PR DESCRIPTION
Re-introduce the `cumulativeLayoutShift` timing of `PageViewTiming` events into EoL harvests. After v1.278.0, this timing stopped being sent when the user leaves the page, resulting in a drop in CLS counts. The node contain attributes that aid in identifying the cause of bad scores.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-358897

### Testing

Modify to include check for CLS node.