### PR TITLE
feat: Remove agentIdentifier argument from agent constructors

### DIFF
--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -26,10 +26,9 @@ import { globalScope } from '../common/constants/runtime'
 export class Agent extends AgentBase {
   /**
    * @param {Object} options Options to initialize agent with
-   * @param {string} [agentIdentifier] Optional identifier of agent
    */
-  constructor (options, agentIdentifier) {
-    super(agentIdentifier)
+  constructor (options) {
+    super()
 
     if (!globalScope) {
       // We could not determine the runtime environment. Short-circuite the agent here

--- a/src/loaders/micro-agent-base.js
+++ b/src/loaders/micro-agent-base.js
@@ -8,8 +8,8 @@ import { generateRandomHexString } from '../common/ids/unique-id'
 export class MicroAgentBase {
   agentIdentifier
 
-  constructor (agentIdentifier = generateRandomHexString(16)) {
-    this.agentIdentifier = agentIdentifier
+  constructor () {
+    this.agentIdentifier = generateRandomHexString(16)
   }
 
   /**

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -28,10 +28,9 @@ const nonAutoFeatures = [
 export class MicroAgent extends MicroAgentBase {
   /**
    * @param {Object} options - Specifies features and runtime configuration,
-   * @param {string=} agentIdentifier - The optional unique ID of the agent.
    */
-  constructor (options, agentIdentifier) {
-    super(agentIdentifier)
+  constructor (options) {
+    super()
 
     this.features = {}
     setNREUMInitializedAgent(this.agentIdentifier, this)


### PR DESCRIPTION
Removes the agentIdentifier argument from the Agent and MicroAgent class constructors. The agentIdentifier should always be a random hex string to guarantee uniqueness across agent instances.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

The agentIdentifier argument was removed from the Agent and MicroAgent constructors. This excludes the feature classes which need the agentIdentifier passed in from the agent reference. There is no public documentation on setting the agentIdentifier manually as far as I'm aware.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-352908

### Testing

Make sure tests pass.
