### PR TITLE
chore: add browser pressure poc to postamble script

### DIFF
--- a/.github/actions/build-ab/templates/postamble.js
+++ b/.github/actions/build-ab/templates/postamble.js
@@ -7,16 +7,16 @@ window.NREUM.info.licenseKey = '{{{args.licenseKey}}}'
 window.NREUM.init.proxy = {}
 window.NREUM.init.session_replay.enabled = true
 window.NREUM.init.session_trace.enabled = true
-window.NREUM.init.user_actions = {elementAttributes: ['id', 'className', 'tagName', 'type', 'innerText', 'textContent', 'ariaLabel', 'alt', 'title']}
+window.NREUM.init.user_actions = { elementAttributes: ['id', 'className', 'tagName', 'type', 'innerText', 'textContent', 'ariaLabel', 'alt', 'title'] }
 
 // Session replay entitlements check
 try {
   var xhr = new XMLHttpRequest()
   xhr.open('POST', '/graphql')
-  xhr.setRequestHeader('cache-control','no-cache')
+  xhr.setRequestHeader('cache-control', 'no-cache')
   xhr.setRequestHeader('content-type', 'application/json; charset=utf-8')
-  xhr.setRequestHeader('newrelic-requesting-services','browser-agent')
-  xhr.setRequestHeader('pragma','no-cache')
+  xhr.setRequestHeader('newrelic-requesting-services', 'browser-agent')
+  xhr.setRequestHeader('pragma', 'no-cache')
 
   xhr.send(
     JSON.stringify({
@@ -30,35 +30,68 @@ try {
     })
   )
 
-  xhr.addEventListener('load', function(evt){
-    try{
+  xhr.addEventListener('load', function (evt) {
+    try {
       var entitlementsData = JSON.parse(evt.currentTarget.responseText)
       // call the newrelic api(s) after evaluating entitlements...
       var canRunSr = true
       if (entitlementsData.data && entitlementsData.data.currentUser && entitlementsData.data.currentUser.authorizedAccounts && entitlementsData.data.currentUser.authorizedAccounts.length) {
-        for (var i = 0; i < entitlementsData.data.currentUser.authorizedAccounts.length; i++){
+        for (var i = 0; i < entitlementsData.data.currentUser.authorizedAccounts.length; i++) {
           var ent = entitlementsData.data.currentUser.authorizedAccounts[i]
           if (!ent.entitlements || !ent.entitlements.length) continue
-          for (var j = 0; j < ent.entitlements.length; j++){
+          for (var j = 0; j < ent.entitlements.length; j++) {
             if (ent.entitlements[j].name === 'fedramp' || ent.entitlements[j].name === 'hipaa') canRunSr = false
           }
         }
       }
       if (canRunSr && newrelic && !!newrelic.start) newrelic.start('session_replay')
-    } catch(e){
+    } catch (e) {
       // something went wrong...
       if (!!newrelic && !!newrelic.noticeError) newrelic.noticeError(e)
     }
   })
-} catch(err){
+} catch (err) {
   // we failed our mission....
   if (!!newrelic && !!newrelic.noticeError) newrelic.noticeError(err)
 }
 
 if (!!newrelic && !!newrelic.log) {
-  newrelic.log('NRBA log API - error', {level: 'error'})
-  newrelic.log('NRBA log API - trace', {level: 'trace'})
-  newrelic.log('NRBA log API - warn', {level: 'warn'})
-  newrelic.log('NRBA log API - info', {level: 'info'})
-  newrelic.log('NRBA log API - debug', {level: 'debug'})
+  newrelic.log('NRBA log API - error', { level: 'error' })
+  newrelic.log('NRBA log API - trace', { level: 'trace' })
+  newrelic.log('NRBA log API - warn', { level: 'warn' })
+  newrelic.log('NRBA log API - info', { level: 'info' })
+  newrelic.log('NRBA log API - debug', { level: 'debug' })
+}
+
+try {
+  // Browser Pressure POC
+  if (typeof window.PressureObserver === "function") {
+    let lastPressure = ''
+    const pressureObserverCallback = (records) => {
+      const latestRecord = records[records.length - 1];
+      const impact = {
+        "nominal": 0,
+        "fair": 1,
+        "serious": 2,
+        "critical": 3
+      }
+      if (lastPressure === latestRecord.state) return // report once per status change
+
+      lastPressure = latestRecord.state
+      newrelic.setCustomAttribute("pressure", latestRecord.state);
+      newrelic.setCustomAttribute("pressureImpact", impact[latestRecord.state]);
+
+      newrelic.recordCustomEvent('BrowserPressure', {
+        pressure: latestRecord.state,
+        pressureImpact: impact[latestRecord.state],
+        pageHasLoaded: document.readyState === 'complete',
+        originSource: 'cpu',
+        deviceCpu: navigator.deviceMemory
+      })
+    };
+    const pressureObserver = new window.PressureObserver(pressureObserverCallback);
+    pressureObserver.observe("cpu", { sampleInterval: 1000 });
+  }
+} catch (e) {
+  newrelic.noticeError("swallowed preamble error: " + e);
 }


### PR DESCRIPTION
Please see this [thread](https://newrelic.slack.com/archives/G019T80B1EJ/p1738948320495519) for more context if needed
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This POC will generate attributes `pressure` and `pressureImpact` on all data, and generate a new event `BrowserPressure` on each status change.  This is for validation purposes only and will be removed from postamble at a future time.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
