### PR TITLE
chore: Exclude ios & safari from websocket metrics tests

### DIFF
--- a/tests/specs/websockets/metrics.e2e.js
+++ b/tests/specs/websockets/metrics.e2e.js
@@ -1,10 +1,10 @@
 const { notIOS, notSafari } = require('../../../tools/browser-matcher/common-matchers.mjs')
 const { testSupportMetricsRequest, testErrorsRequest } = require('../../../tools/testing-server/utils/expect-tests')
 
-describe('WebSocket supportability metrics', () => {
-  /** Safari and iOS safari are blocked from connecting to the websocket protocol on LT, which throws socket errors instead of connecting and capturing the expected payloads.
-   *  validated that this works locally for these envs */
-  it.withBrowsersMatching([notSafari, notIOS])('should capture expected SMs', async () => {
+/** NOTE: Safari and iOS safari are blocked from connecting to the websocket protocol (on LT!), which throws socket errors instead of connecting and capturing the expected payloads.
+   *  validated that this works locally for these envs.  Any websocket changes must be validated manually for these envs */
+describe.withBrowsersMatching([notSafari, notIOS])('WebSocket supportability metrics', () => {
+  it('should capture expected SMs', async () => {
     const supportabilityMetricsRequest = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
     const url = await browser.testHandle.assetURL('websockets.html')
 


### PR DESCRIPTION
See [this slack thread](https://newrelic.slack.com/archives/G019T80B1EJ/p1739374405314629) for more context
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
