### PR TITLE
fix: Removing websocket wrapping & SM

### DIFF
--- a/src/features/metrics/aggregate/index.js
+++ b/src/features/metrics/aggregate/index.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { registerHandler } from '../../../common/event-emitter/register-handler'
-import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL, WATCHABLE_WEB_SOCKET_EVENTS } from '../constants'
+import { FEATURE_NAME, SUPPORTABILITY_METRIC, CUSTOM_METRIC, SUPPORTABILITY_METRIC_CHANNEL, CUSTOM_METRIC_CHANNEL } from '../constants'
 import { getFrameworks } from './framework-detection'
 import { isFileProtocol } from '../../../common/url/protocol'
 import { onDOMContentLoaded } from '../../../common/window/load'
@@ -11,8 +11,8 @@ import { windowAddEventListener } from '../../../common/event-listener/event-lis
 import { isBrowserScope, isWorkerScope } from '../../../common/constants/runtime'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { isIFrameWindow } from '../../../common/dom/iframe'
-import { WEBSOCKET_TAG } from '../../../common/wrap/wrap-websocket'
-import { handleWebsocketEvents } from './websocket-detection'
+// import { WEBSOCKET_TAG } from '../../../common/wrap/wrap-websocket'
+// import { handleWebsocketEvents } from './websocket-detection'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -116,11 +116,11 @@ export class Aggregate extends AggregateBase {
       mo.observe(window.document.body, { childList: true, subtree: true })
     }
 
-    WATCHABLE_WEB_SOCKET_EVENTS.forEach(tag => {
-      registerHandler('buffered-' + WEBSOCKET_TAG + tag, (...args) => {
-        handleWebsocketEvents(this.storeSupportabilityMetrics.bind(this), tag, ...args)
-      }, this.featureName, this.ee)
-    })
+    // WATCHABLE_WEB_SOCKET_EVENTS.forEach(tag => {
+    //   registerHandler('buffered-' + WEBSOCKET_TAG + tag, (...args) => {
+    //     handleWebsocketEvents(this.storeSupportabilityMetrics.bind(this), tag, ...args)
+    //   }, this.featureName, this.ee)
+    // })
   }
 
   eachSessionChecks () {

--- a/src/features/metrics/instrument/index.js
+++ b/src/features/metrics/instrument/index.js
@@ -3,22 +3,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { handle } from '../../../common/event-emitter/handle'
-import { WEBSOCKET_TAG, wrapWebSocket } from '../../../common/wrap/wrap-websocket'
+// import { handle } from '../../../common/event-emitter/handle'
+// import { WEBSOCKET_TAG, wrapWebSocket } from '../../../common/wrap/wrap-websocket'
 import { InstrumentBase } from '../../utils/instrument-base'
-import { FEATURE_NAME, WATCHABLE_WEB_SOCKET_EVENTS } from '../constants'
+import { FEATURE_NAME } from '../constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   constructor (agentRef, auto = true) {
     super(agentRef, FEATURE_NAME, auto)
-    wrapWebSocket(this.ee)
+    // wrapWebSocket(this.ee) - feb'25 : removing wrapping again to avoid integration issues
 
-    WATCHABLE_WEB_SOCKET_EVENTS.forEach((suffix) => {
-      this.ee.on(WEBSOCKET_TAG + suffix, (...args) => {
-        handle('buffered-' + WEBSOCKET_TAG + suffix, [...args], undefined, this.featureName, this.ee)
-      })
-    })
+    // WATCHABLE_WEB_SOCKET_EVENTS.forEach((suffix) => {
+    //   this.ee.on(WEBSOCKET_TAG + suffix, (...args) => {
+    //     handle('buffered-' + WEBSOCKET_TAG + suffix, [...args], undefined, this.featureName, this.ee)
+    //   })
+    // })
 
     this.importAggregator(agentRef)
   }

--- a/tests/specs/websockets/metrics.e2e.js
+++ b/tests/specs/websockets/metrics.e2e.js
@@ -1,72 +1,72 @@
-const { notIOS, notSafari } = require('../../../tools/browser-matcher/common-matchers.mjs')
-const { testSupportMetricsRequest, testErrorsRequest } = require('../../../tools/testing-server/utils/expect-tests')
+// const { notIOS, notSafari } = require('../../../tools/browser-matcher/common-matchers.mjs')
+// const { testSupportMetricsRequest, testErrorsRequest } = require('../../../tools/testing-server/utils/expect-tests')
 
 /** NOTE: Safari and iOS safari are blocked from connecting to the websocket protocol (on LT!), which throws socket errors instead of connecting and capturing the expected payloads.
    *  validated that this works locally for these envs.  Any websocket changes must be validated manually for these envs */
-describe.withBrowsersMatching([notSafari, notIOS])('WebSocket supportability metrics', () => {
-  it('should capture expected SMs', async () => {
-    const supportabilityMetricsRequest = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
-    const url = await browser.testHandle.assetURL('websockets.html')
+// describe.withBrowsersMatching([notSafari, notIOS])('WebSocket supportability metrics', () => {
+//   it('should capture expected SMs', async () => {
+//     const supportabilityMetricsRequest = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
+//     const url = await browser.testHandle.assetURL('websockets.html')
 
-    await browser.url(url)
-      .then(() => browser.waitForAgentLoad())
-      .then(() => browser.refresh())
+//     await browser.url(url)
+//       .then(() => browser.waitForAgentLoad())
+//       .then(() => browser.refresh())
 
-    const [sms] = await supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
-    const smPayload = sms.request.body.sm
-    const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
+//     const [sms] = await supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
+//     const smPayload = sms.request.body.sm
+//     const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
 
-    smTags.forEach(expectedSm => {
-      const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
-      const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
-      const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
+//     smTags.forEach(expectedSm => {
+//       const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
+//       const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
+//       const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
 
-      expect(ms).toBeTruthy()
-      expect(ms.stats.t).toBeGreaterThan(0)
-      expect(ms.stats.c).toEqual(2)
+//       expect(ms).toBeTruthy()
+//       expect(ms.stats.t).toBeGreaterThan(0)
+//       expect(ms.stats.c).toEqual(2)
 
-      expect(msSinceClassInit).toBeTruthy()
-      if (expectedSm === 'New') expect(msSinceClassInit.stats.t).toBeLessThanOrEqual(1)
-      else expect(msSinceClassInit.stats.t).toBeGreaterThan(0)
-      expect(msSinceClassInit.stats.c).toEqual(2)
+//       expect(msSinceClassInit).toBeTruthy()
+//       if (expectedSm === 'New') expect(msSinceClassInit.stats.t).toBeLessThanOrEqual(1)
+//       else expect(msSinceClassInit.stats.t).toBeGreaterThan(0)
+//       expect(msSinceClassInit.stats.c).toEqual(2)
 
-      if (['Send', 'Message'].includes(expectedSm)) {
-        expect(bytes).toBeTruthy()
-        if (expectedSm === 'Send') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(8) // we are sending about 8 bytes from client to server
-        if (expectedSm === 'Message') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(40) // we are sending about 40 bytes from server to client
-      } else expect(bytes).toBeFalsy()
-    })
-  })
+//       if (['Send', 'Message'].includes(expectedSm)) {
+//         expect(bytes).toBeTruthy()
+//         if (expectedSm === 'Send') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(8) // we are sending about 8 bytes from client to server
+//         if (expectedSm === 'Message') expect(bytes.stats.t / bytes.stats.c).toBeGreaterThanOrEqual(40) // we are sending about 40 bytes from server to client
+//       } else expect(bytes).toBeFalsy()
+//     })
+//   })
 
-  ;['robust-websocket', 'reconnecting-websocket'].forEach((thirdPartyWSWrapper) => {
-    it('should work with known third-party WS wrapper - ' + thirdPartyWSWrapper, async () => {
-      const [supportabilityMetricsRequest, errorsRequest] =
-        await browser.testHandle.createNetworkCaptures('bamServer', [
-          { test: testSupportMetricsRequest },
-          { test: testErrorsRequest }
-        ])
-      const url = await browser.testHandle.assetURL(`test-builds/library-wrapper/${thirdPartyWSWrapper}.html`)
+//   ;['robust-websocket', 'reconnecting-websocket'].forEach((thirdPartyWSWrapper) => {
+//     it('should work with known third-party WS wrapper - ' + thirdPartyWSWrapper, async () => {
+//       const [supportabilityMetricsRequest, errorsRequest] =
+//         await browser.testHandle.createNetworkCaptures('bamServer', [
+//           { test: testSupportMetricsRequest },
+//           { test: testErrorsRequest }
+//         ])
+//       const url = await browser.testHandle.assetURL(`test-builds/library-wrapper/${thirdPartyWSWrapper}.html`)
 
-      await browser.url(url)
+//       await browser.url(url)
 
-      const [errors, [sms]] = await Promise.all([
-        errorsRequest.waitForResult({ timeout: 10000 }),
-        supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
-      ])
-      // should not have thrown errors
-      expect(errors.length).toEqual(0)
+//       const [errors, [sms]] = await Promise.all([
+//         errorsRequest.waitForResult({ timeout: 10000 }),
+//         supportabilityMetricsRequest.waitForResult({ totalCount: 1 })
+//       ])
+//       // should not have thrown errors
+//       expect(errors.length).toEqual(0)
 
-      const smPayload = sms.request.body.sm
-      const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
+//       const smPayload = sms.request.body.sm
+//       const smTags = ['New', 'Open', 'Send', 'Message', 'Close-Clean']
 
-      smTags.forEach(expectedSm => {
-        const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
-        const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
-        const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
-        expect(ms).toBeTruthy()
-        expect(msSinceClassInit).toBeTruthy()
-        if (['Send', 'Message'].includes(expectedSm))expect(bytes).toBeTruthy()
-      })
-    })
-  })
-})
+//       smTags.forEach(expectedSm => {
+//         const ms = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Ms`)
+//         const msSinceClassInit = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/MsSinceClassInit`)
+//         const bytes = smPayload.find(sm => sm.params.name === `WebSocket/${expectedSm}/Bytes`)
+//         expect(ms).toBeTruthy()
+//         expect(msSinceClassInit).toBeTruthy()
+//         if (['Send', 'Message'].includes(expectedSm))expect(bytes).toBeTruthy()
+//       })
+//     })
+//   })
+// })


### PR DESCRIPTION
Removing websocket wrapping and metrics. WS instrumentation may be re-implemented behind a feature flag at a later time.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Post-discussion with team, we're removing ws wrapping again for now rather than introduce a FF system until a later time.

### Related Issue(s)

#1387 

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
