### PR TITLE
fix: Guard against non-CSSStyleSheet when fixing sheets for replay

### DIFF
--- a/src/features/session_replay/shared/stylesheet-evaluator.js
+++ b/src/features/session_replay/shared/stylesheet-evaluator.js
@@ -24,7 +24,7 @@ class StylesheetEvaluator {
     this.#brokenSheets = []
     if (isBrowserScope) {
       for (let i = 0; i < Object.keys(document.styleSheets).length; i++) {
-        if (!this.#evaluated.has(document.styleSheets[i]) && document.styleSheets[i]) {
+        if (!this.#evaluated.has(document.styleSheets[i]) && typeof document.styleSheets[i] === "object" && document.styleSheets[i] != null) {
           this.#evaluated.add(document.styleSheets[i])
           try {
             // eslint-disable-next-line

--- a/src/features/session_replay/shared/stylesheet-evaluator.js
+++ b/src/features/session_replay/shared/stylesheet-evaluator.js
@@ -24,7 +24,7 @@ class StylesheetEvaluator {
     this.#brokenSheets = []
     if (isBrowserScope) {
       for (let i = 0; i < Object.keys(document.styleSheets).length; i++) {
-        if (!this.#evaluated.has(document.styleSheets[i])) {
+        if (!this.#evaluated.has(document.styleSheets[i]) && document.styleSheets[i]) {
           this.#evaluated.add(document.styleSheets[i])
           try {
             // eslint-disable-next-line

--- a/src/features/session_replay/shared/stylesheet-evaluator.js
+++ b/src/features/session_replay/shared/stylesheet-evaluator.js
@@ -24,7 +24,7 @@ class StylesheetEvaluator {
     this.#brokenSheets = []
     if (isBrowserScope) {
       for (let i = 0; i < Object.keys(document.styleSheets).length; i++) {
-        if (!this.#evaluated.has(document.styleSheets[i]) && typeof document.styleSheets[i] === "object" && document.styleSheets[i] != null) {
+        if (!this.#evaluated.has(document.styleSheets[i]) && document.styleSheets[i] instanceof CSSStyleSheet) {
           this.#evaluated.add(document.styleSheets[i])
           try {
             // eslint-disable-next-line

--- a/tests/unit/features/session_replay/shared/stylesheet-evaluator.test.js
+++ b/tests/unit/features/session_replay/shared/stylesheet-evaluator.test.js
@@ -19,18 +19,6 @@ describe('stylesheet-evaluator', (done) => {
         }
       }))
     }))
-    class CSSStyleSheetMock {
-      cssRules = {}
-      rules = {}
-      replace (txt) {
-        return new Promise((resolve) => {
-          this.cssRules = { txt }
-          this.rules = { txt }
-          resolve()
-        })
-      }
-    }
-    global.CSSStyleSheet = CSSStyleSheetMock
   })
 
   test('should evaluate stylesheets with cssRules as false', async () => {
@@ -81,6 +69,18 @@ describe('stylesheet-evaluator', (done) => {
       }
     })
     expect(stylesheetEvaluator.evaluate()).toEqual(0)
+  })
+
+  test('should not throw error if null prop in global', async () => {
+    jest.resetModules()
+    const { stylesheetEvaluator } = await import('../../../../../src/features/session_replay/shared/stylesheet-evaluator')
+    Object.defineProperty(document, 'styleSheets', {
+      value: {
+        0: null
+      },
+      configurable: true
+    })
+    expect(() => stylesheetEvaluator.evaluate()).not.toThrow()
   })
 })
 


### PR DESCRIPTION
Nullish values in the global `styleSheets` API can break implementations with the weakMap object tracking their status, throwing an error similar to `TypeError: Invalid value used in weak set at WeakSet.add...`.  This fix checks that the value is acceptable before adding.
---

There appears to be a TypeError in the browser agent https://staging.onenr.io/0gR7nN1OZwo. We should ensure the object is a CSSStyleSheet before adding it.
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
