### PR TITLE
fix: Deduplicate Prefixes on Unhandled Promise Rejection Messages

### DIFF
--- a/src/features/jserrors/shared/cast-error.js
+++ b/src/features/jserrors/shared/cast-error.js
@@ -54,7 +54,7 @@ export function castPromiseRejectionEvent (promiseRejectionEvent) {
   }
 
   const error = castError(promiseRejectionEvent.reason)
-  if (!((error?.message || '').startsWith(prefix))) error.message = prefix + error?.message
+  if (!((error.message || '').startsWith(prefix))) error.message = prefix + error.message
   return error
 }
 

--- a/src/features/jserrors/shared/cast-error.js
+++ b/src/features/jserrors/shared/cast-error.js
@@ -35,7 +35,7 @@ export function castError (error) {
    * @returns {Error} An Error object with the message as the casted reason
    */
 export function castPromiseRejectionEvent (promiseRejectionEvent) {
-  const prefix = 'Unhandled Promise Rejection'
+  const prefix = 'Unhandled Promise Rejection: '
 
   /**
    * If the casted return value is falsy like this, it will get dropped and not produce an error event for harvest.
@@ -46,15 +46,15 @@ export function castPromiseRejectionEvent (promiseRejectionEvent) {
 
   if (canTrustError(promiseRejectionEvent.reason)) {
     try {
-      promiseRejectionEvent.reason.message = prefix + ': ' + promiseRejectionEvent.reason.message
-      return castError(promiseRejectionEvent.reason)
+      if (!promiseRejectionEvent.reason.message.startsWith(prefix)) promiseRejectionEvent.reason.message = prefix + promiseRejectionEvent.reason.message
     } catch (e) {
-      return castError(promiseRejectionEvent.reason)
+      // failed to modify the message, do nothing else
     }
+    return castError(promiseRejectionEvent.reason)
   }
 
   const error = castError(promiseRejectionEvent.reason)
-  error.message = prefix + ': ' + error?.message
+  if (!((error?.message || '').startsWith(prefix))) error.message = prefix + error?.message
   return error
 }
 

--- a/tests/unit/features/jserrors/shared/cast-error.test.js
+++ b/tests/unit/features/jserrors/shared/cast-error.test.js
@@ -133,6 +133,15 @@ describe('cast-error', () => {
       })
     })
 
+    test('handles promise rejections that already have a prefix (no prefix duplication)', () => {
+      err.message = 'Unhandled Promise Rejection: test'
+      const castedTrustedError = castPromiseRejectionEvent({ reason: err })
+      expect(castedTrustedError.message).toEqual('Unhandled Promise Rejection: test')
+
+      const castedError = castPromiseRejectionEvent({ reason: 'Unhandled Promise Rejection: test' })
+      expect(castedError.message).toEqual('Unhandled Promise Rejection: test')
+    })
+
     test('terminates for events with falsy reasons', () => {
       let castedError = castPromiseRejectionEvent({ reason: undefined })
       expect(castedError).toBeUndefined()


### PR DESCRIPTION
Remove an issue that caused `Unhandled Promise Rejection:` prefixes on casted error messages to be duplicated if already supplied on rejection reason messages.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
<img width="1201" alt="Screenshot 2025-02-25 at 11 39 41 AM" src="https://github.com/user-attachments/assets/aa87ce3a-f373-4623-b3e1-f8f53610cd4d" />

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new unit test was added to validate that prefixes are not duplicated
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
