### PR TITLE
chore: Add download link to release notes automation

### DIFF
--- a/.github/actions/docs-pr/index.js
+++ b/.github/actions/docs-pr/index.js
@@ -54,6 +54,7 @@ for (const change of versionData.changes) {
 const frontMatter = {
   releaseDate,
   version: args.tag.substr(1),
+  downloadLink: "https://www.npmjs.com/package/@newrelic/browser-agent",
   features: [],
   bugs: [],
   security: []

--- a/.github/actions/docs-pr/templates/release-notes.handlebars
+++ b/.github/actions/docs-pr/templates/release-notes.handlebars
@@ -2,6 +2,7 @@
 subject: Browser agent
 releaseDate: "{{frontMatter.releaseDate}}"
 version: {{frontMatter.version}}
+downloadLink: {{frontMatter.downloadLink}}
 features: {{frontMatter.features}}
 bugs: {{frontMatter.bugs}}
 security: {{frontMatter.security}}


### PR DESCRIPTION
Adds a download link to agent release notes on the New Relic docs website.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-363054

### Testing

It _should_ have a download link on the next agent release. The link always points to the browser agent NPM package.
