### PR TITLE
fix: Console error on some cross-origin requests without NR CAT header

### DIFF
--- a/src/features/ajax/instrument/index.js
+++ b/src/features/ajax/instrument/index.js
@@ -25,6 +25,7 @@ var handlersLen = handlers.length
 
 var origRequest = gosNREUMOriginals().o.REQ
 var origXHR = gosNREUMOriginals().o.XHR
+const NR_CAT_HEADER = 'X-NewRelic-App-Data'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
@@ -392,8 +393,8 @@ function subscribeToEvents (agentRef, ee, handler, dt) {
     var size = responseSizeFromXhr(xhr, ctx.lastSize)
     if (size) ctx.metrics.rxSize = size
 
-    if (ctx.sameOrigin) {
-      var header = xhr.getResponseHeader('X-NewRelic-App-Data')
+    if (ctx.sameOrigin && xhr.getAllResponseHeaders().indexOf(NR_CAT_HEADER) >= 0) {
+      var header = xhr.getResponseHeader(NR_CAT_HEADER)
       if (header) {
         handle(SUPPORTABILITY_METRIC, ['Ajax/CrossApplicationTracing/Header/Seen'], undefined, FEATURE_NAMES.metrics, ee)
         ctx.params.cat = header.split(', ').pop()

--- a/tests/components/setup-agent.js
+++ b/tests/components/setup-agent.js
@@ -54,9 +54,7 @@ export function setupAgent ({ agentOverrides = {}, info = {}, init = {}, loaderC
   runtime = getRuntime(agentIdentifier)
   if (!runtime.timeKeeper) {
     runtime.timeKeeper = new TimeKeeper(agentIdentifier)
-    runtime.timeKeeper.processRumRequest({
-      getResponseHeader: jest.fn(() => (new Date()).toUTCString())
-    }, 450, 600, Date.now())
+    runtime.timeKeeper.processRumRequest({}, 450, 600, Date.now())
   }
   fakeAgent.features = {}
   if (!runtime.harvester) runtime.harvester = new Harvester(fakeAgent)


### PR DESCRIPTION
XHR headers will be checked for the deprecated New Relic CAT header before calling `getResponseHeader`, which throws a console error if it does not exist for cross-origin requests.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

`getResponseHeader` behavior when dealing with a nonexistent header:
* It doesn’t show the error in console ("Refuse to get unsafe header") if the XHR is deemed same-origin (by browser). This only throws if it’s cross-origin request. If header DNE, it returns null.
* There is a test for “xhr_no_cat” that doesn’t return CAT header in response. But it doesn’t throw because it requests from the same origin [:3333]/xhr_no_cat as the test-server.
* Even if it requests from cross-origin (say, another port), it still won’t throw if it’s listed in `Access-Control-Expose-Headers` … which is the case for all response from the test-server.
* While the code does check that it's the "same origin" (from agent's perspective), before running this method, there may have been some slip through wherein the XHR is actually cross origin but misinterpreted as same origin by agent.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-371864

### Testing

Non-error (cannot be tracked via JSErrors feat) + difficult to test for.
