### PR TITLE
feat: Decorate harvest requests with ht (hasTrace) param where applicable

### DIFF
--- a/src/common/harvest/harvester.js
+++ b/src/common/harvest/harvester.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../features/metrics/constants'
-import { FEATURE_TO_ENDPOINT, JSERRORS, RUM, EVENTS, FEATURE_NAMES } from '../../loaders/features/features'
+import { FEATURE_TO_ENDPOINT, JSERRORS, RUM, EVENTS, FEATURE_NAMES, BLOBS, LOGS } from '../../loaders/features/features'
 import { VERSION } from '../constants/env'
 import { globalScope, isWorkerScope } from '../constants/runtime'
 import { handle } from '../event-emitter/handle'
@@ -218,6 +218,7 @@ function cleanPayload (payload = {}) {
 function baseQueryString (agentRef, qs, endpoint, applicationID) {
   const ref = agentRef.runtime.obfuscator.obfuscateString(cleanURL('' + globalScope.location))
   const hr = agentRef.runtime.session?.state.sessionReplayMode === 1 && endpoint !== JSERRORS
+  const ht = agentRef.runtime.session?.state.sessionTraceMode === 1 && ![LOGS, BLOBS].includes(endpoint)
 
   const qps = [
     'a=' + applicationID,
@@ -232,6 +233,8 @@ function baseQueryString (agentRef, qs, endpoint, applicationID) {
     param('ptid', (agentRef.runtime.ptid ? '' + agentRef.runtime.ptid : ''))
   ]
   if (hr) qps.push(param('hr', '1', qs))
+  if (ht) qps.push(param('ht', '1', qs))
+
   return qps.join('')
 
   // Constructs the transaction name param for the beacon URL.

--- a/src/loaders/features/features.js
+++ b/src/loaders/features/features.js
@@ -6,8 +6,9 @@
 // To reduce build size a bit:
 export const EVENTS = 'events'
 export const JSERRORS = 'jserrors'
-const BLOBS = 'browser/blobs'
+export const BLOBS = 'browser/blobs'
 export const RUM = 'rum'
+export const LOGS = 'browser/logs'
 
 export const FEATURE_NAMES = {
   ajax: 'ajax',
@@ -55,6 +56,6 @@ export const FEATURE_TO_ENDPOINT = {
   [FEATURE_NAMES.jserrors]: JSERRORS,
   [FEATURE_NAMES.sessionTrace]: BLOBS,
   [FEATURE_NAMES.sessionReplay]: BLOBS,
-  [FEATURE_NAMES.logging]: 'browser/logs',
+  [FEATURE_NAMES.logging]: LOGS,
   [FEATURE_NAMES.genericEvents]: 'ins'
 }

--- a/tests/specs/session-trace/query-params.e2e.js
+++ b/tests/specs/session-trace/query-params.e2e.js
@@ -1,0 +1,169 @@
+import { rumFlags } from '../../../tools/testing-server/constants'
+import { testAjaxEventsRequest, testBlobReplayRequest, testBlobTraceRequest, testErrorsRequest, testInsRequest, testInteractionEventsRequest, testLogsRequest, testMetricsRequest, testRumRequest, testTimingEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { srConfig, stConfig } from '../util/helpers'
+
+/*
+This is a series of tests for ensuring the 'ht' (hasTrace) query param is set for expected harvests.
+The ht query param will be set on all harvests except for logs and blobs (ones that are considered 'raw').
+ */
+describe('ht query param', () => {
+  let sessionTraceCapture
+  let logsCapture
+  let sessionReplaysCapture
+  let timingEventsCapture
+  let metricsCapture
+  let ajaxEventsCapture
+  let errorsCapture
+  let insightsCapture
+  let interactionEventsCapture
+  beforeEach(async () => {
+    [sessionTraceCapture, logsCapture, sessionReplaysCapture, timingEventsCapture,
+      metricsCapture, ajaxEventsCapture, errorsCapture, insightsCapture, interactionEventsCapture] =
+      await browser.testHandle.createNetworkCaptures('bamServer', [
+        { test: testBlobTraceRequest },
+        { test: testLogsRequest },
+        { test: testBlobReplayRequest },
+        { test: testTimingEventsRequest },
+        { test: testMetricsRequest },
+        { test: testAjaxEventsRequest },
+        { test: testErrorsRequest },
+        { test: testInsRequest },
+        { test: testInteractionEventsRequest }
+      ])
+    await browser.destroyAgentSession()
+  })
+
+  // afterEach(async () => {
+  //   await browser.destroyAgentSession()
+  // })
+
+  it('should be undefined if session trace is running - logs endpoint', async () => {
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify(rumFlags({ st: 1, sts: 1, sr: 0, srs: 0, logs: 3 }))
+    })
+    const url = await browser.testHandle.assetURL('logs-console-logger-pre-load.html', stConfig())
+
+    const [[{ request }]] = await Promise.all([
+      logsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      browser.url(url)
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    expect(request.query.ht).toBeUndefined()
+  })
+
+  it('should be undefined if session trace is running - blobs endpoint, ST', async () => {
+    const url = await browser.testHandle.assetURL('instrumented.html', stConfig())
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify(rumFlags({ st: 1, sts: 1, sr: 1, srs: 0 }))
+    })
+
+    let [[{ request }]] = await Promise.all([
+      sessionTraceCapture.waitForResult({ timeout: 10000 }),
+      browser.url(url)
+        .then(() => browser.waitForAgentLoad())
+    ])
+    expect(request.query.ht).toBeUndefined()
+  })
+
+  it('should be undefined if session trace is running - blobs endpoint, SR', async () => {
+    await browser.enableSessionReplay()
+    const url = await browser.testHandle.assetURL('rrweb-instrumented.html', srConfig())
+
+    let [[{ request }]] = await Promise.all([
+      sessionReplaysCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      browser.url(url)
+        .then(() => browser.waitForSessionReplayRecording())
+    ])
+    expect(request.query.ht).toBeUndefined()
+  })
+
+  // should have the header for every endpoint except logging and blobs
+  it('should be \'1\' if session trace is running - all other endpoints', async () => {
+    const url = await browser.testHandle.assetURL('all-events.html', { loader: 'spa', ...stConfig() })
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify(rumFlags({ st: 1, sts: 1 }))
+    })
+
+    const [timingEventsHarvests, metricsHarvests, ajaxEventsHarvests,
+      errorsHarvests, insightsHarvests, interactionEventsHarvests
+    ] = await Promise.all([
+      timingEventsCapture.waitForResult({ timeout: 10000 }),
+      metricsCapture.waitForResult({ timeout: 10000 }),
+      ajaxEventsCapture.waitForResult({ timeout: 10000 }),
+      errorsCapture.waitForResult({ timeout: 10000 }),
+      insightsCapture.waitForResult({ timeout: 10000 }),
+      interactionEventsCapture.waitForResult({ timeout: 10000 }),
+      browser.url(url)
+        .then(() => browser.waitForAgentLoad())
+        .then(() => browser.pause(5000))
+        .then(() => browser.refresh())
+    ])
+
+    timingEventsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toEqual('1')
+    })
+    metricsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toEqual('1')
+    })
+    ajaxEventsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toEqual('1')
+    })
+
+    errorsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toEqual('1')
+    })
+    insightsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toEqual('1')
+    })
+    interactionEventsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toEqual('1')
+    })
+  })
+
+  it('should be undefined if session trace is NOT running - all other endpoints', async () => {
+    const url = await browser.testHandle.assetURL('all-events.html', { loader: 'spa', ...stConfig() })
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify(rumFlags({ st: 0 }))
+    })
+
+    const [timingEventsHarvests, metricsHarvests, ajaxEventsHarvests,
+      errorsHarvests, insightsHarvests, interactionEventsHarvests
+    ] = await Promise.all([
+      timingEventsCapture.waitForResult({ timeout: 10000 }),
+      metricsCapture.waitForResult({ timeout: 10000 }),
+      ajaxEventsCapture.waitForResult({ timeout: 10000 }),
+      errorsCapture.waitForResult({ timeout: 10000 }),
+      insightsCapture.waitForResult({ timeout: 10000 }),
+      interactionEventsCapture.waitForResult({ timeout: 10000 }),
+      browser.url(url)
+        .then(() => browser.waitForAgentLoad())
+        .then(() => browser.pause(5000))
+        .then(() => browser.refresh())
+    ])
+
+    timingEventsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toBeUndefined()
+    })
+    metricsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toBeUndefined()
+    })
+    ajaxEventsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toBeUndefined()
+    })
+
+    errorsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toBeUndefined()
+    })
+    insightsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toBeUndefined()
+    })
+    interactionEventsHarvests.forEach(harvest => {
+      expect(harvest.request.query.ht).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
Decorate with `ht` (hasTrace) query param for all harvest requests except for blobs and logs endpoints.  This helps support searching for browser data with associated tracing data.
---

### Overview

In this PR, a `ht` query param will be added to most outgoing requests when tracing is running to indicate the presence of tracing data.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-367653

### Testing

Added integration test to look for the presence/absence of the `ht` param
Also manually checked on a test page
