### PR TITLE
fix: Session Replay text masking for whitespace

### DIFF
--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -11,7 +11,7 @@ import { stylesheetEvaluator } from './stylesheet-evaluator'
 import { handle } from '../../../common/event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
-import { buildNRMetaNode } from './utils'
+import { buildNRMetaNode, customMasker } from './utils'
 import { IDEAL_PAYLOAD_SIZE } from '../../../common/constants/agent-constants'
 import { AggregateBase } from '../../utils/aggregate-base'
 
@@ -78,14 +78,7 @@ export class Recorder {
   startRecording () {
     this.recording = true
     const { block_class, ignore_class, mask_text_class, block_selector, mask_input_options, mask_text_selector, mask_all_inputs, inline_images, collect_fonts } = this.parent.agentRef.init.session_replay
-    const customMasker = (text, element) => {
-      try {
-        if (typeof element?.type === 'string' && element.type.toLowerCase() !== 'password' && (element?.dataset?.nrUnmask !== undefined || element?.classList?.contains('nr-unmask'))) return text
-      } catch (err) {
-        // likely an element was passed to this handler that was invalid and was missing attributes or methods
-      }
-      return '*'.repeat(text?.length || 0)
-    }
+
     // set up rrweb configurations for maximum privacy --
     // https://newrelic.atlassian.net/wiki/spaces/O11Y/pages/2792293280/2023+02+28+Browser+-+Session+Replay#Configuration-options
     const stop = recorder({

--- a/src/features/session_replay/shared/utils.js
+++ b/src/features/session_replay/shared/utils.js
@@ -28,3 +28,15 @@ export function buildNRMetaNode (timestamp, timeKeeper) {
     originTimeDiff: Math.floor(originTime - timeKeeper.correctedOriginTime)
   }
 }
+
+export function customMasker (text, element) {
+  try {
+    if (typeof element?.type === 'string') {
+      if (element.type.toLowerCase() === 'password') return '*'.repeat(text?.length || 0)
+      if (element?.dataset?.nrUnmask !== undefined || element?.classList?.contains('nr-unmask')) return text
+    }
+  } catch (err) {
+    // likely an element was passed to this handler that was invalid and was missing attributes or methods
+  }
+  return typeof text === 'string' ? text.replace(/[\S]/g, '*') : '*'.repeat(text?.length || 0)
+}

--- a/tests/unit/features/session_replay/shared/utils.test.js
+++ b/tests/unit/features/session_replay/shared/utils.test.js
@@ -98,3 +98,52 @@ describe('buildNRMetaNode', () => {
     expect(metadata.correctedTimestamp).toEqual(expected)
   })
 })
+
+describe('customMasker', () => {
+  test('should return input text as masked when the element is a non-password field and not decorated with unmask option', async () => {
+    const text = 'foobar'
+    const element = { type: 'string' }
+
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('******')
+  })
+
+  // NR-739491 - fixes issue where whitespace was masked, pushing layout/styling out-of-place
+  test('should return input text as-is when the input text is whitespace and the element is a non-password field and not decorated with unmask option', async () => {
+    const text = '   \n   '
+    const element = { type: 'string' }
+
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('   \n   ')
+  })
+
+  test('should return input text as masked when the element is a password field', async () => {
+    const text = 'foobar'
+    const element = { type: 'password' }
+
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('******')
+  })
+
+  test('should return input text as masked when the input text is whitespace and the element is a password field', async () => {
+    const text = '   \n   '
+    const element = { type: 'password' }
+
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('*******')
+  })
+
+  test('should return input text as-is when the element is a non-password field decorated with unmask option', async () => {
+    const text = 'foobar'
+    const element = { type: 'string', dataset: { nrUnmask: true } }
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('foobar')
+
+    const element2 = { type: 'string', classList: { contains: () => true } }
+    expect(sessionReplaySharedUtils.customMasker(text, element2)).toEqual('foobar')
+  })
+
+  test('should return input text as-is when input text is whitespace and the element is a non-password field decorated with unmask option', async () => {
+    const text = '   \n   '
+    const element = { type: 'string', dataset: { nrUnmask: true } }
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('   \n   ')
+
+    const element2 = { type: 'string', classList: { contains: () => true } }
+    expect(sessionReplaySharedUtils.customMasker(text, element2)).toEqual('   \n   ')
+  })
+})


### PR DESCRIPTION
There is an edge case where whitespace was being masked, which interferes with the layout/styling in session replays.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

In this PR, we address the edge case by allowing the whitespace to return as-is when it's not a password field.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-379491

### Testing

Added unit test for `customMasker` function
Manually tested session replay on customer's site using rrweb REPL
