### PR TITLE
fix: Logging mode on session update

### DIFF
--- a/src/features/logging/aggregate/index.js
+++ b/src/features/logging/aggregate/index.js
@@ -28,8 +28,8 @@ export class Aggregate extends AggregateBase {
 
     this.ee.on(SESSION_EVENTS.UPDATE, (type, data) => {
       if (this.blocked || type !== SESSION_EVENT_TYPES.CROSS_TAB) return
-      if (this.mode !== LOGGING_MODE.OFF && data.loggingMode === LOGGING_MODE.OFF) this.abort(ABORT_REASONS.CROSS_TAB)
-      else this.mode = data.loggingMode
+      if (this.loggingMode !== LOGGING_MODE.OFF && data.loggingMode === LOGGING_MODE.OFF) this.abort(ABORT_REASONS.CROSS_TAB)
+      else this.loggingMode = data.loggingMode
     })
 
     this.harvestOpts.raw = true


### PR DESCRIPTION
Fixes a typo in the session update handler for logging feature. The `loggingMode` which controls feature output will be correctly set after its session mode value is updated from another tab or window.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
