### PR TITLE
chore: Add warning if fix_stylesheet is off

### DIFF
--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -93,3 +93,5 @@
 `An internal agent process failed to execute.`
 ### 46
 `A reserved eventType was provided to recordCustomEvent(...) -- The event was not recorded.`
+### 47
+`With fix_stylesheet off, ensure that all of your CSS are decorated with the "crossorigin='anonymous'" attribute or are publicly accessible. Replays may display bad layout otherwise.`

--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -94,4 +94,4 @@
 ### 46
 `A reserved eventType was provided to recordCustomEvent(...) -- The event was not recorded.`
 ### 47
-`With fix_stylesheet off, ensure that all of your CSS are decorated with the "crossorigin='anonymous'" attribute or are publicly accessible. Replays may display bad layout otherwise.`
+`We tried to access a stylesheet's contents but failed due to browser security. For best results, ensure that cross-domain CSS assets are decorated with "crossorigin='anonymous'" attribution or are otherwise publicly accessible.`

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -14,6 +14,7 @@ import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { buildNRMetaNode, customMasker } from './utils'
 import { IDEAL_PAYLOAD_SIZE } from '../../../common/constants/agent-constants'
 import { AggregateBase } from '../../utils/aggregate-base'
+import { warn } from '../../../common/util/console'
 
 export class Recorder {
   /** Each page mutation or event will be stored (raw) in this array. This array will be cleared on each harvest */
@@ -43,6 +44,8 @@ export class Recorder {
     this.shouldFix = this.parent.agentRef.init.session_replay.fix_stylesheets
     /** The method to stop recording. This defaults to a noop, but is overwritten once the recording library is imported and initialized */
     this.stopRecording = () => { /* no-op until set by rrweb initializer */ }
+
+    if (this.shouldFix === false) warn(47) // notifies user of potential replayer issue if fix_stylesheets is off
   }
 
   getEvents () {


### PR DESCRIPTION
Warn users if fix_stylesheet is off so that they can follow steps to ensure their replays don't get mangled.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-317321

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
