### PR TITLE
feat: Reduce noise from `mousemove` events

### DIFF
--- a/src/common/wrap/wrap-events.js
+++ b/src/common/wrap/wrap-events.js
@@ -45,7 +45,8 @@ export function wrapEvents (sharedEE) {
   ee.on(ADD_EVENT_LISTENER + '-start', function (args, target) {
     var originalListener = args[1]
     if (originalListener === null ||
-      (typeof originalListener !== 'function' && typeof originalListener !== 'object')
+      (typeof originalListener !== 'function' && typeof originalListener !== 'object') ||
+      args[0] === 'mousemove'
     ) {
       return
     }

--- a/src/common/wrap/wrap-events.js
+++ b/src/common/wrap/wrap-events.js
@@ -45,8 +45,7 @@ export function wrapEvents (sharedEE) {
   ee.on(ADD_EVENT_LISTENER + '-start', function (args, target) {
     var originalListener = args[1]
     if (originalListener === null ||
-      (typeof originalListener !== 'function' && typeof originalListener !== 'object') ||
-      args[0] === 'mousemove'
+      (typeof originalListener !== 'function' && typeof originalListener !== 'object')
     ) {
       return
     }

--- a/src/features/session_trace/aggregate/trace/storage.js
+++ b/src/features/session_trace/aggregate/trace/storage.js
@@ -182,8 +182,8 @@ export class TraceStorage {
   }
 
   shouldIgnoreEvent (event, target) {
-    const origin = eventOrigin(event.target, target, this.parent.ee)
     if (event.type in ignoredEvents.global) return true
+    const origin = eventOrigin(event.target, target, this.parent.ee)
     if (!!ignoredEvents[origin] && ignoredEvents[origin].ignoreAll) return true
     return !!(!!ignoredEvents[origin] && event.type in ignoredEvents[origin])
   }

--- a/src/features/session_trace/aggregate/trace/storage.js
+++ b/src/features/session_trace/aggregate/trace/storage.js
@@ -15,7 +15,7 @@ const SUPPORTS_PERFORMANCE_OBSERVER = typeof globalScope.PerformanceObserver ===
 
 const ignoredEvents = {
   // we find that certain events make the data too noisy to be useful
-  global: { mouseup: true, mousedown: true },
+  global: { mouseup: true, mousedown: true, mousemove: true },
   // certain events are present both in the window and in PVT metrics.  PVT metrics are prefered so the window events should be ignored
   window: { load: true, pagehide: true },
   // when ajax instrumentation is disabled, all XMLHttpRequest events will return with origin = xhrOriginMissing and should be ignored

--- a/tests/assets/event-listener-mousemove.html
+++ b/tests/assets/event-listener-mousemove.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html lang="en">
+  <head>
+    <title>RUM Unit Test</title>
+    {init}
+    {config}
+    {loader}
+    <script>
+      addEventListener("mousemove", function() {
+        console.log("Mouse moved")
+      })
+    </script>
+  </head>
+  <body>
+    <div id="initial">initial content</div>
+
+    <div id="foobar">
+      FOOBAR!
+    </div>
+    <script>
+        // Create a new mouse event
+        const mouseMoveEvent = new MouseEvent('mousemove', {
+          clientX: 100, // X coordinate relative to the viewport
+          clientY: 200, // Y coordinate relative to the viewport
+          bubbles: true, // Allow the event to bubble up the DOM tree
+          cancelable: true // Allow the event to be canceled
+        })
+
+        // Get the element to dispatch the event to
+        const element = document.getElementById('foobar')
+
+        // Dispatch the event
+        element.dispatchEvent(mouseMoveEvent)
+    </script>
+  </body>
+</html>

--- a/tests/specs/session-trace/trace-nodes.e2e.js
+++ b/tests/specs/session-trace/trace-nodes.e2e.js
@@ -132,12 +132,7 @@ describe('Trace nodes', () => {
     await browser.url(url).then(() => browser.waitForAgentLoad())
 
     const [sessionTraceHarvests] = await Promise.all([
-      sessionTraceCapture.waitForResult({ timeout: 10000 }),
-      browser.execute(function () {
-        const storedEvents = Object.values(newrelic.initializedAgents)[0].features.session_trace.featAggregate.events.prevStoredEvents
-        for (let i = 0; i < 10; i++) storedEvents.add(i) // artificially add "events" since the counter is otherwise unreliable
-        return storedEvents
-      })
+      sessionTraceCapture.waitForResult({ timeout: 10000 })
     ])
 
     sessionTraceHarvests.forEach(harvest => {


### PR DESCRIPTION
There may be an edge case where a site performance can be impacted if the browser agent picked up `mousemove` events via `addEventListener`.
---

### Overview

In this PR, we are excluding `mousemove` events from SessionTrace instrumentation to reduce potential processing burden from high occurrences of said event.  

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-381325

### Testing

- Manually tested via adding a event listener for the `mousemove` event and confirming the event has been ignored successfully.
- Added an e2e test to ensure no `mousing` event is detected for `mousemove` event
