### PR TITLE
feat: Erase .api property on agent instance

### DIFF
--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -136,14 +136,14 @@ export class AggregateBase extends FeatureBase {
       } catch (err) {
         // do nothing
       }
-      configure({ agentIdentifier: this.agentIdentifier }, {
+      configure(existingAgent, {
         ...cdn,
         info: {
           ...cdn.info,
           jsAttributes
         },
         runtime: existingAgent.runtime
-      })
+      }, existingAgent.runtime.loaderType)
     }
   }
 

--- a/src/features/utils/nr1-debugger.js
+++ b/src/features/utils/nr1-debugger.js
@@ -7,7 +7,7 @@ import { gosCDN } from '../../common/window/nreum'
 const debugId = 1
 const newrelic = gosCDN()
 export function debugNR1 (agentIdentifier, location, event, otherprops = {}, debugName = 'SR') {
-  const api = agentIdentifier ? newrelic.initializedAgents[agentIdentifier].api.addPageAction : newrelic.addPageAction
+  const api = agentIdentifier ? newrelic.initializedAgents[agentIdentifier].addPageAction : newrelic.addPageAction
   let url
   try {
     const locURL = new URL(window.location)

--- a/src/loaders/agent-base.js
+++ b/src/loaders/agent-base.js
@@ -20,8 +20,8 @@ export class AgentBase extends MicroAgentBase {
    * @param  {...any} args
    */
   #callMethod (methodName, ...args) {
-    if (typeof this.api?.[methodName] !== 'function') warn(35, methodName)
-    else return this.api[methodName](...args)
+    if (this[methodName] === AgentBase.prototype[methodName] || this[methodName] === MicroAgentBase.prototype[methodName]) warn(35, methodName)
+    else return this[methodName](...args)
   }
 
   /**

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -72,6 +72,10 @@ export class Agent extends AgentBase {
     }
   }
 
+  get api () {
+    return this
+  }
+
   run () {
     // Attempt to initialize all the requested features (sequentially in prio order & synchronously), with any failure aborting the whole process.
     try {
@@ -102,7 +106,6 @@ export class Agent extends AgentBase {
       }
 
       const newrelic = gosNREUM()
-      delete newrelic.initializedAgents[this.agentIdentifier]?.api // prevent further calls to agent-specific APIs (see "configure.js")
       delete newrelic.initializedAgents[this.agentIdentifier]?.features // GC mem used internally by features
       delete this.sharedAggregator
       // Keep the initialized agent object with its configs for troubleshooting purposes.

--- a/src/loaders/api/apiAsync.js
+++ b/src/loaders/api/apiAsync.js
@@ -3,18 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { FEATURE_NAMES } from '../features/features'
-import { getRuntime } from '../../common/config/runtime'
-import { ee } from '../../common/event-emitter/contextual-ee'
 import { handle } from '../../common/event-emitter/handle'
 import { registerHandler } from '../../common/event-emitter/register-handler'
 import { single } from '../../common/util/invoke'
 import { CUSTOM_METRIC_CHANNEL } from '../../features/metrics/constants'
 import { originTime } from '../../common/constants/runtime'
 
-export function setAPI (agentIdentifier) {
-  var instanceEE = ee.get(agentIdentifier)
-
-  var api = {
+export function setAsyncAPI (agent) {
+  const api = {
     finished: single(finished),
     setErrorHandler,
     addToTrace,
@@ -22,22 +18,22 @@ export function setAPI (agentIdentifier) {
   }
 
   // Hook all of the api functions up to the queues/stubs created in loader/api.js
-  Object.entries(api).forEach(([fnName, fnCall]) => registerHandler('api-' + fnName, fnCall, 'api', instanceEE))
+  Object.entries(api).forEach(([fnName, fnCall]) => registerHandler('api-' + fnName, fnCall, 'api', agent.ee))
 
   // All API functions get passed the time they were called as their
   // first parameter. These functions can be called asynchronously.
 
   function finished (t, providedTime) {
-    var time = providedTime ? providedTime - originTime : t
-    handle(CUSTOM_METRIC_CHANNEL, ['finished', { time }], undefined, FEATURE_NAMES.metrics, instanceEE)
+    const time = providedTime ? providedTime - originTime : t
+    handle(CUSTOM_METRIC_CHANNEL, ['finished', { time }], undefined, FEATURE_NAMES.metrics, agent.ee)
     addToTrace(t, { name: 'finished', start: time + originTime, origin: 'nr' })
-    handle('api-addPageAction', [time, 'finished'], undefined, FEATURE_NAMES.genericEvents, instanceEE)
+    handle('api-addPageAction', [time, 'finished'], undefined, FEATURE_NAMES.genericEvents, agent.ee)
   }
 
-  function addToTrace (t, evt) {
+  function addToTrace (_, evt) {
     if (!(evt && typeof evt === 'object' && evt.name && evt.start)) return
 
-    var report = {
+    const report = {
       n: evt.name,
       s: evt.start - originTime,
       e: (evt.end || evt.start) - originTime,
@@ -45,16 +41,16 @@ export function setAPI (agentIdentifier) {
       t: 'api'
     }
 
-    handle('bstApi', [report], undefined, FEATURE_NAMES.sessionTrace, instanceEE)
+    handle('bstApi', [report], undefined, FEATURE_NAMES.sessionTrace, agent.ee)
   }
 
-  function setErrorHandler (t, handler) {
-    getRuntime(agentIdentifier).onerror = handler
+  function setErrorHandler (_, handler) {
+    agent.runtime.onerror = handler
   }
 
-  var releaseCount = 0
-  function addRelease (t, name, id) {
+  let releaseCount = 0
+  function addRelease (_, name, id) {
     if (++releaseCount > 10) return
-    getRuntime(agentIdentifier).releaseIds[name.slice(-200)] = ('' + id).slice(-200)
+    agent.runtime.releaseIds[name.slice(-200)] = ('' + id).slice(-200)
   }
 }

--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -14,7 +14,7 @@ import { redefinePublicPath } from './public-path'
 import { ee } from '../../common/event-emitter/contextual-ee'
 import { dispatchGlobalEvent } from '../../common/dispatch/global-event'
 
-let alreadySetOnce = false // the configure() function can run multiple times in agent lifecycle
+const alreadySetOnce = new Set() // the configure() function can run multiple times in agent lifecycle for different agents
 
 /**
  * Sets or re-sets the agent's configuration values from global settings. This also attach those as properties to the agent instance.
@@ -45,7 +45,7 @@ export function configure (agent, opts = {}, loaderType, forceDrain) {
   const updatedInit = agent.init
   const internalTrafficList = [info.beacon, info.errorBeacon]
 
-  if (!alreadySetOnce) {
+  if (!alreadySetOnce.has(agent.agentIdentifier)) {
     if (updatedInit.proxy.assets) {
       redefinePublicPath(updatedInit.proxy.assets)
       internalTrafficList.push(updatedInit.proxy.assets)
@@ -66,7 +66,7 @@ export function configure (agent, opts = {}, loaderType, forceDrain) {
   runtime.ptid = agent.agentIdentifier
   setRuntime(agent.agentIdentifier, runtime)
 
-  if (!alreadySetOnce) {
+  if (!alreadySetOnce.has(agent.agentIdentifier)) {
     agent.ee = ee.get(agent.agentIdentifier)
     agent.exposed = exposed
     setAPI(agent, forceDrain) // assign our API functions to the agent instance
@@ -81,5 +81,5 @@ export function configure (agent, opts = {}, loaderType, forceDrain) {
     })
   }
 
-  alreadySetOnce = true
+  alreadySetOnce.add(agent.agentIdentifier)
 }

--- a/src/loaders/micro-agent-base.js
+++ b/src/loaders/micro-agent-base.js
@@ -18,8 +18,8 @@ export class MicroAgentBase {
    * @param  {...any} args
    */
   #callMethod (methodName, ...args) {
-    if (typeof this.api?.[methodName] !== 'function') warn(35, methodName)
-    else return this.api[methodName](...args)
+    if (this[methodName] === MicroAgentBase.prototype[methodName]) warn(35, methodName)
+    else return this[methodName](...args)
   }
 
   // MicroAgent class custom defines its own start

--- a/src/loaders/micro-agent.js
+++ b/src/loaders/micro-agent.js
@@ -36,7 +36,6 @@ export class MicroAgent extends MicroAgentBase {
     setNREUMInitializedAgent(this.agentIdentifier, this)
 
     configure(this, { ...options, runtime: { isolatedBacklog: true } }, options.loaderType || 'micro-agent')
-    Object.assign(this, this.api) // the APIs should be available at the class level for micro-agent
 
     /**
      * Starts a set of agent features if not running in "autoStart" mode
@@ -90,5 +89,9 @@ export class MicroAgent extends MicroAgentBase {
       loader_config: this.loader_config,
       runtime: this.runtime
     }
+  }
+
+  get api () {
+    return this
   }
 }

--- a/tests/components/page_view_timing/index.test.js
+++ b/tests/components/page_view_timing/index.test.js
@@ -1,4 +1,5 @@
 import { VITAL_NAMES } from '../../../src/common/vitals/constants'
+import { setNREUMInitializedAgent } from '../../../src/common/window/nreum'
 
 // Note: these callbacks fire right away unlike the real web-vitals API which are async-on-trigger
 jest.mock('web-vitals/attribution', () => ({
@@ -73,6 +74,7 @@ describe('pvt aggregate tests', () => {
       ee: { on: jest.fn() },
       runtime: { harvester: { initializedAggregates: [] } }
     }
+    setNREUMInitializedAgent(mainAgent.agentIdentifier, mainAgent) // needed since configure calls setInit instead of modifying agentInst.init directly
     const { Aggregate } = await import('../../../src/features/page_view_timing/aggregate')
 
     global.navigator.connection = {

--- a/tests/unit/features/page_view_timing/aggregate/index.test.js
+++ b/tests/unit/features/page_view_timing/aggregate/index.test.js
@@ -1,5 +1,6 @@
 import * as qp from '@newrelic/nr-querypack'
 import { Aggregate } from '../../../../../src/features/page_view_timing/aggregate'
+import { setNREUMInitializedAgent } from '../../../../../src/common/window/nreum'
 
 const mockRuntime = {} // getAddStringContext in the serializer still relies on getRuntime() fn
 jest.mock('../../../../../src/common/config/runtime', () => ({
@@ -9,12 +10,14 @@ jest.mock('../../../../../src/common/config/runtime', () => ({
 }))
 jest.mock('../../../../../src/common/harvest/harvester')
 
-const pvtAgg = new Aggregate({
+const agentInst = {
   agentIdentifier: 'abcd',
   info: { },
   init: { page_view_timing: {} },
   runtime: mockRuntime
-})
+}
+setNREUMInitializedAgent(agentInst.agentIdentifier, agentInst) // needed since configure calls setInit instead of modifying agentInst.init directly
+const pvtAgg = new Aggregate(agentInst)
 
 describe('PVT aggregate', () => {
   test('serializer default attributes', () => {

--- a/tests/unit/features/utils/aggregate-base.test.js
+++ b/tests/unit/features/utils/aggregate-base.test.js
@@ -86,7 +86,7 @@ test('should merge info, jsattributes, and runtime objects', () => {
 
   expect(isValid).toHaveBeenCalledWith(agentIdentifier)
   expect(gosCDN).toHaveBeenCalledTimes(1)
-  expect(configure).toHaveBeenCalledWith({ agentIdentifier }, {
+  expect(configure).toHaveBeenCalledWith(mainAgent, {
     info: {
       ...mockInfo1,
       jsAttributes: {
@@ -95,7 +95,7 @@ test('should merge info, jsattributes, and runtime objects', () => {
       }
     },
     runtime: mainAgent.runtime
-  })
+  }, mainAgent.runtime.loaderType)
 })
 
 test('should only configure the agent once', () => {

--- a/tests/unit/loaders/api/api.test.js
+++ b/tests/unit/loaders/api/api.test.js
@@ -39,27 +39,21 @@ describe('setTopLevelCallers', () => {
     nreum.initializedAgents = {
       [faker.string.uuid()]: {
         exposed: true,
-        api: {
-          setErrorHandler: jest.fn()
-        },
+        setErrorHandler: jest.fn(),
         runtime: {
           loaderType: 'micro-agent'
         }
       },
       [faker.string.uuid()]: {
         exposed: true,
-        api: {
-          setErrorHandler: jest.fn()
-        },
+        setErrorHandler: jest.fn(),
         runtime: {
           loaderType: 'browser-agent'
         }
       },
       [faker.string.uuid()]: {
         exposed: false,
-        api: {
-          setErrorHandler: jest.fn()
-        },
+        setErrorHandler: jest.fn(),
         runtime: {
           loaderType: 'browser-agent'
         }
@@ -71,10 +65,10 @@ describe('setTopLevelCallers', () => {
 
     Object.values(nreum.initializedAgents).forEach(agent => {
       if (agent.exposed && agent.runtime.loaderType === 'browser-agent') {
-        expect(agent.api.setErrorHandler).toHaveBeenCalledTimes(1)
-        expect(agent.api.setErrorHandler).toHaveBeenCalledWith(errorHandler)
+        expect(agent.setErrorHandler).toHaveBeenCalledTimes(1)
+        expect(agent.setErrorHandler).toHaveBeenCalledWith(errorHandler)
       } else {
-        expect(agent.api.setErrorHandler).not.toHaveBeenCalled()
+        expect(agent.setErrorHandler).not.toHaveBeenCalled()
       }
     })
   })
@@ -87,27 +81,21 @@ describe('setTopLevelCallers', () => {
     nreum.initializedAgents = {
       [faker.string.uuid()]: {
         exposed: true,
-        api: {
-          interaction: jest.fn().mockReturnValue(expected)
-        },
+        interaction: jest.fn().mockReturnValue(expected),
         runtime: {
           loaderType: 'browser-agent'
         }
       },
       [faker.string.uuid()]: {
         exposed: true,
-        api: {
-          interaction: jest.fn().mockReturnValue(expected)
-        },
+        interaction: jest.fn().mockReturnValue(expected),
         runtime: {
           loaderType: 'browser-agent'
         }
       },
       [faker.string.uuid()]: {
         exposed: false,
-        api: {
-          interaction: jest.fn().mockReturnValue(expected)
-        },
+        interaction: jest.fn().mockReturnValue(expected),
         runtime: {
           loaderType: 'browser-agent'
         }


### PR DESCRIPTION
The `.api` property of full and micro agents have been removed. The browser API methods are instead moved to the agent instance itself for ease of targeted access. This includes a minor fix of runtime `loaderType` for agents that are re-configured after load.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Instead of:
```js
agent: {
 features: ...,
 info: ...,
 api: {
  setErrorHandler: () => {},
  setAPI: () => {},
  ...
 },
 ...
}
```
The API will now be:
```js
agent: {
 features: ...,
 info: ...,
 setErrorHandler: () => {},
 setAPI: () => {},
 ...
}
```

`mainOrMicroAgent.api.___` will still work as it will redirect up a level and call `mainOrMicroAgent.___`.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-172955

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
