### PR TITLE
fix: Patch `newrelic` event detail

### DIFF
--- a/src/common/dispatch/global-event.js
+++ b/src/common/dispatch/global-event.js
@@ -6,6 +6,16 @@ import { globalScope } from '../constants/runtime'
 
 const GLOBAL_EVENT_NAMESPACE = 'newrelic'
 
+/**
+ * Dispatches a global event with the given detail object
+ * - Deprecation Notice: The `loaded` property for detail object is deprecated and will be removed in a future release.
+ * @param detail - event detail
+ *  - agentIdentifier: string - agent instance identifier
+ *  - loaded: boolean - indicates whether the agent has finished loading, deprecated since 1.286.0. Replaced by 'drained'
+ *  - drained: boolean - indicates whether the agent has finished draining
+ *  - type: string - event type (e.g. lifecycle, data)
+ *  - name: string - event name (e.g. load, harvest, buffer, api, initialize)
+ */
 export function dispatchGlobalEvent (detail = {}) {
   try {
     globalScope.dispatchEvent(new CustomEvent(GLOBAL_EVENT_NAMESPACE, { detail }))

--- a/src/common/dispatch/global-event.js
+++ b/src/common/dispatch/global-event.js
@@ -6,16 +6,6 @@ import { globalScope } from '../constants/runtime'
 
 const GLOBAL_EVENT_NAMESPACE = 'newrelic'
 
-/**
- * Dispatches a global event with the given detail object
- * - Deprecation Notice: The `loaded` property for detail object is deprecated and will be removed in a future release.
- * @param detail - event detail
- *  - agentIdentifier: string - agent instance identifier
- *  - loaded: boolean - indicates whether the agent has finished loading, deprecated since 1.286.0. Replaced by 'drained'
- *  - drained: boolean - indicates whether the agent has finished draining
- *  - type: string - event type (e.g. lifecycle, data)
- *  - name: string - event name (e.g. load, harvest, buffer, api, initialize)
- */
 export function dispatchGlobalEvent (detail = {}) {
   try {
     globalScope.dispatchEvent(new CustomEvent(GLOBAL_EVENT_NAMESPACE, { detail }))

--- a/src/common/harvest/harvester.js
+++ b/src/common/harvest/harvester.js
@@ -178,7 +178,7 @@ function send (agentRef, { endpoint, targetApp, payload, localOpts = {}, submitM
 
   dispatchGlobalEvent({
     agentIdentifier: agentRef.agentIdentifier,
-    loaded: !!activatedFeatures?.[agentRef.agentIdentifier],
+    drained: !!activatedFeatures?.[agentRef.agentIdentifier],
     type: 'data',
     name: 'harvest',
     feature: featureName,

--- a/src/common/util/feature-flags.js
+++ b/src/common/util/feature-flags.js
@@ -31,7 +31,7 @@ export function activateFeatures (flags, agentIdentifier) {
   // let any window level subscribers know that the agent is running, per install docs
   dispatchGlobalEvent({
     agentIdentifier,
-    loaded: true, // TODO: deprecate
+    loaded: true,
     drained: true,
     type: 'lifecycle',
     name: 'load',

--- a/src/common/util/feature-flags.js
+++ b/src/common/util/feature-flags.js
@@ -28,10 +28,11 @@ export function activateFeatures (flags, agentIdentifier) {
 
   sentIds.add(agentIdentifier)
 
-  // let any window level subscribers know that the agent is running
+  // let any window level subscribers know that the agent is running, per install docs
   dispatchGlobalEvent({
     agentIdentifier,
-    loaded: true,
+    loaded: true, // TODO: deprecate
+    drained: true,
     type: 'lifecycle',
     name: 'load',
     feature: undefined,

--- a/src/common/util/feature-flags.js
+++ b/src/common/util/feature-flags.js
@@ -31,7 +31,7 @@ export function activateFeatures (flags, agentIdentifier) {
   // let any window level subscribers know that the agent is running, per install docs
   dispatchGlobalEvent({
     agentIdentifier,
-    loaded: true, // TODO: deprecate
+    loaded: true, // @deprecated, replaced by 'drained'
     drained: true,
     type: 'lifecycle',
     name: 'load',

--- a/src/common/util/feature-flags.js
+++ b/src/common/util/feature-flags.js
@@ -31,7 +31,7 @@ export function activateFeatures (flags, agentIdentifier) {
   // let any window level subscribers know that the agent is running, per install docs
   dispatchGlobalEvent({
     agentIdentifier,
-    loaded: true, // @deprecated, replaced by 'drained'
+    loaded: true, // TODO: deprecate
     drained: true,
     type: 'lifecycle',
     name: 'load',

--- a/src/features/utils/event-store-manager.js
+++ b/src/features/utils/event-store-manager.js
@@ -53,7 +53,7 @@ export class EventStoreManager {
   add (event, target) {
     dispatchGlobalEvent({
       agentIdentifier: this.agentIdentifier,
-      loaded: !!activatedFeatures?.[this.agentIdentifier],
+      drained: !!activatedFeatures?.[this.agentIdentifier],
       type: 'data',
       name: 'buffer',
       feature: this.featureName,

--- a/src/loaders/api/api.js
+++ b/src/loaders/api/api.js
@@ -194,7 +194,7 @@ export function setAPI (agent, forceDrain) {
       handle(SUPPORTABILITY_METRIC_CHANNEL, ['API/' + name + '/called'], undefined, FEATURE_NAMES.metrics, agent.ee)
       dispatchGlobalEvent({
         agentIdentifier: agent.agentIdentifier,
-        loaded: !!activatedFeatures?.[agent.agentIdentifier],
+        drained: !!activatedFeatures?.[agent.agentIdentifier],
         type: 'data',
         name: 'api',
         feature: prefix + name,

--- a/src/loaders/configure/configure.js
+++ b/src/loaders/configure/configure.js
@@ -73,7 +73,7 @@ export function configure (agent, opts = {}, loaderType, forceDrain) {
 
     dispatchGlobalEvent({
       agentIdentifier: agent.agentIdentifier,
-      loaded: !!activatedFeatures?.[agent.agentIdentifier],
+      drained: !!activatedFeatures?.[agent.agentIdentifier],
       type: 'lifecycle',
       name: 'initialize',
       feature: undefined,

--- a/tests/assets/event-listener-newrelic.html
+++ b/tests/assets/event-listener-newrelic.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html lang="en">
+  <head>
+    <title>RUM Unit Test</title>
+    {init}
+    {config}
+    {loader}
+    <script>
+      addEventListener("newrelic", (evt) => {
+        if (evt.detail.loaded) {
+          // ensure API works as expected when listening to `newrelic` event
+          newrelic.setPageViewName('some-page');
+          newrelic.setApplicationVersion('1.0.0');
+          newrelic.setCustomAttribute('foo', 'bar');
+          newrelic.setErrorHandler((error) => {
+              if (error.foobar) {
+                return true;
+              }
+
+              // To group errors: return { group: 'GroupName' };
+              return false;
+            }
+          );
+          newrelic.log('test message');
+        }
+      })
+    </script>
+  </head>
+  <body>
+    <div id="initial">initial content</div>
+  </body>
+</html>

--- a/tests/assets/event-listener-newrelic.html
+++ b/tests/assets/event-listener-newrelic.html
@@ -11,6 +11,7 @@
     {loader}
     <script>
       addEventListener("newrelic", (evt) => {
+        window.newrelicEventTime = Date.now()
         if (evt.detail.loaded) {
           // ensure API works as expected when listening to `newrelic` event
           newrelic.setPageViewName('some-page');
@@ -26,6 +27,8 @@
             }
           );
           newrelic.log('test message');
+
+          throw new Error('error 1')
         }
       })
     </script>

--- a/tests/assets/inspection-events.html
+++ b/tests/assets/inspection-events.html
@@ -17,11 +17,11 @@
     }
     window.addEventListener('newrelic', ({ detail }) => {
       if (!detail || !detail.agentIdentifier) return
-      const { name, loaded, type, feature, data } = detail
+      const { name, drained, type, feature, data } = detail
 
       if (
         name == 'initialize' &&
-        loaded == false &&
+        drained == false &&
         type == 'lifecycle' &&
         feature == undefined &&
         data
@@ -31,7 +31,7 @@
 
       if (
         name === 'load' &&
-        loaded === true &&
+        drained === true &&
         type === 'lifecycle' &&
         feature === undefined &&
         data
@@ -41,7 +41,7 @@
 
       if (
         name === 'buffer' &&
-        loaded === true &&
+        drained === true &&
         type === 'data' &&
         feature &&
         data
@@ -51,7 +51,7 @@
 
       if (
         name === 'harvest' &&
-        loaded === true &&
+        drained === true &&
         type === 'data' &&
         feature &&
         data
@@ -62,7 +62,7 @@
       // The API call in this test is called before the agent is loaded, so loaded should be false
       if (
         name === 'api' &&
-        loaded === false &&
+        drained === false &&
         type === 'data' &&
         feature &&
         data

--- a/tests/specs/api.e2e.js
+++ b/tests/specs/api.e2e.js
@@ -51,20 +51,69 @@ describe('newrelic api', () => {
     expect(result).toEqual(true)
   })
 
-  it('should work as expected within `newrelic` event listeners', async () => {
-    const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testLogsRequest })
+  it('should fire `newrelic` event after RUM call', async () => {
+    const rumCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testRumRequest })
+
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
       body: JSON.stringify(rumFlags({ log: LOGGING_MODE.INFO }))
     })
 
-    const [logsHarvests] = await Promise.all([
-      logsCapture.waitForResult({ timeout: 10000 }),
+    const [rumHarvests] =
+      await Promise.all([
+        rumCapture.waitForResult({ timeout: 10000 }),
+        browser.url(await browser.testHandle.assetURL('event-listener-newrelic.html'))
+          .then(() => browser.waitForAgentLoad())
+          .then(() => browser.waitUntil(
+            () => browser.execute(function () {
+              return window?.newrelicEventTime
+            }),
+            {
+              timeout: 10000,
+              timeoutMsg: 'Timeout while waiting on `newrelic` event'
+            }
+          ))
+      ])
+
+    expect(rumHarvests.length).toEqual(1)
+    const rumResult = JSON.parse(rumHarvests[0].reply.body)
+
+    const newrelicEventTime = await browser.execute(function () {
+      return window.newrelicEventTime
+    })
+
+    expect(newrelicEventTime > rumResult.app.nrServerTime).toBe(true)
+  })
+
+  it('should work as expected within `newrelic` event listeners', async () => {
+    const [logsCapture, errorsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testLogsRequest },
+      { test: testErrorsRequest }
+    ])
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify(rumFlags({ log: LOGGING_MODE.INFO }))
+    })
+
+    const [logsHarvests, errorsHarvests] =
+    await Promise.all([
+      logsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      errorsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
       browser.url(await browser.testHandle.assetURL('event-listener-newrelic.html'))
         .then(() => browser.waitForAgentLoad())
     ])
 
+    expect(errorsHarvests.length).toEqual(1)
+    expect(errorsHarvests[0].request.query.ct).toEqual('http://custom.transaction/some-page')
+    const actualErrors = errorsHarvests[0].request.body.err
+    expect(actualErrors.length).toEqual(1)
+    expect(actualErrors[0].params.message).toEqual('error 1')
+
     expect(logsHarvests.length).toEqual(1)
+    const logsPayload = JSON.parse(logsHarvests[0].request.body)
+    expect(logsPayload[0].common.attributes['application.version']).toEqual('1.0.0')
+    expect(logsPayload[0].common.attributes.foo).toEqual('bar')
+    expect(logsPayload[0].logs[0].message).toEqual('test message')
   })
 
   describe('setPageViewName()', () => {

--- a/tests/specs/rum/index.e2e.js
+++ b/tests/specs/rum/index.e2e.js
@@ -50,7 +50,7 @@ describe('basic pve capturing', () => {
     checkRumQuery(rumHarvest.request)
     checkRumBody(rumHarvest.request)
     expect(parseInt(rumHarvest.request.query.be, 10)).toBeGreaterThanOrEqual(500)
-    expect(parseInt(rumHarvest.request.query.fe, 10)).toBeGreaterThanOrEqual(100)
+    expect(parseInt(rumHarvest.request.query.fe, 10)).toBeGreaterThanOrEqual(80)
     expect(parseInt(rumHarvest.request.query.dc, 10)).toBeGreaterThanOrEqual(100)
   })
 


### PR DESCRIPTION
There is an edge case where if there is a listener on the `newrelic` event (as described in the install [docs](https://docs.newrelic.com/docs/browser/browser-monitoring/installation/install-browser-monitoring-agent/#browser_delay)) and any API call is invoked inside this listener, it will trigger an infinite loop. 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

In this PR, we are deprecating the `loaded` detail attribute and replacing it with `drained`.

CURRENT/EXISTING USAGE
```
window.addEventListener("newrelic", (evt) => {
  if (evt.detail.loaded) {
    // you can start using newrelic.interaction(), etc. now
  }
});
```

TO-BE USAGE
```
window.addEventListener("newrelic", (evt) => {
  if (evt.detail.drained && evt.name === 'load') {
    // you can start using newrelic.interaction(), etc. now
  }
});
```

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-387674

### Testing

Added new test around `event-listener-newrelic.html`
