### PR TITLE
feat: Introduce isFirstOfSession attribute on InitialPageLoad events

### DIFF
--- a/src/features/soft_navigations/aggregate/index.js
+++ b/src/features/soft_navigations/aggregate/index.js
@@ -23,6 +23,7 @@ export class Aggregate extends AggregateBase {
 
     this.initialPageLoadInteraction = new InitialPageLoadInteraction(agentRef.agentIdentifier)
     this.initialPageLoadInteraction.onDone.push(() => { // this ensures the .end() method also works with iPL
+      if (agentRef.runtime.session?.isNew) this.initialPageLoadInteraction.customAttributes.isFirstOfSession = true // mark the hard page load as first of its session
       this.initialPageLoadInteraction.forceSave = true // unless forcibly ignored, iPL always finish by default
       this.interactionsToHarvest.add(this.initialPageLoadInteraction)
       this.initialPageLoadInteraction = null

--- a/src/features/spa/aggregate/index.js
+++ b/src/features/spa/aggregate/index.js
@@ -110,6 +110,7 @@ export class Aggregate extends AggregateBase {
 
     state.initialPageLoad = new Interaction('initialPageLoad', 0, state.lastSeenUrl, state.lastSeenRouteName, onInteractionFinished, agentRef.agentIdentifier)
     state.initialPageLoad.save = true
+    if (agentRef.runtime.session?.isNew) state.initialPageLoad.root.attrs.custom.isFirstOfSession = true // mark the hard page load as first of its session
     state.prevInteraction = state.initialPageLoad
     state.currentNode = state.initialPageLoad.root // hint
     // ensure that checkFinish calls are safe during initialPageLoad

--- a/tests/specs/soft_navigations/session-behavior.e2e.js
+++ b/tests/specs/soft_navigations/session-behavior.e2e.js
@@ -1,0 +1,33 @@
+import { testInteractionEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
+
+describe('SPA session behavior - ', () => {
+  let interactionsCapture
+  beforeEach(async () => {
+    interactionsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInteractionEventsRequest })
+  })
+  afterEach(async () => {
+    await browser.destroyAgentSession()
+  })
+
+  it('IPL has isFirstOfSession custom attr for new sessions (only)', async () => {
+    const url = await browser.testHandle.assetURL('instrumented.html', { init: { feature_flags: ['soft_nav'] } })
+    let [spaHarvests] = await Promise.all([
+      interactionsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(url).then(() => browser.waitForAgentLoad())
+    ])
+
+    const iplNode = spaHarvests[0].request.body[0]
+    expect(iplNode.trigger).toEqual('initialPageLoad')
+    const desiredAttr = iplNode.children.find(node => node.key === 'isFirstOfSession')
+    expect(desiredAttr).toBeDefined()
+
+    ;[spaHarvests] = await Promise.all([
+      interactionsCapture.waitForResult({ totalCount: 2 }),
+      browser.refresh().then(() => browser.waitForAgentLoad())
+    ])
+    const iplNode2 = spaHarvests[1].request.body[0]
+    expect(iplNode2.trigger).toEqual('initialPageLoad')
+    const desiredAttr2 = iplNode2.children.find(node => node.key === 'isFirstOfSession')
+    expect(desiredAttr2).toBeUndefined() // subsequent page loads in the same session should not have this attribute
+  })
+})

--- a/tests/specs/spa/session-behavior.e2e.js
+++ b/tests/specs/spa/session-behavior.e2e.js
@@ -1,0 +1,33 @@
+import { testInteractionEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
+
+describe('SPA session behavior - ', () => {
+  let interactionsCapture
+  beforeEach(async () => {
+    interactionsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInteractionEventsRequest })
+  })
+  afterEach(async () => {
+    await browser.destroyAgentSession()
+  })
+
+  it('IPL has isFirstOfSession custom attr for new sessions (only)', async () => {
+    const url = await browser.testHandle.assetURL('instrumented.html')
+    let [spaHarvests] = await Promise.all([
+      interactionsCapture.waitForResult({ totalCount: 1 }),
+      browser.url(url).then(() => browser.waitForAgentLoad())
+    ])
+
+    const iplNode = spaHarvests[0].request.body[0]
+    expect(iplNode.trigger).toEqual('initialPageLoad')
+    const desiredAttr = iplNode.children.find(node => node.key === 'isFirstOfSession')
+    expect(desiredAttr).toBeDefined()
+
+    ;[spaHarvests] = await Promise.all([
+      interactionsCapture.waitForResult({ totalCount: 2 }),
+      browser.refresh().then(() => browser.waitForAgentLoad())
+    ])
+    const iplNode2 = spaHarvests[1].request.body[0]
+    expect(iplNode2.trigger).toEqual('initialPageLoad')
+    const desiredAttr2 = iplNode2.children.find(node => node.key === 'isFirstOfSession')
+    expect(desiredAttr2).toBeUndefined() // subsequent page loads in the same session should not have this attribute
+  })
+})


### PR DESCRIPTION
To help support User Journeys, the `isFirstOfSession` custom attribute will be added to `BrowserInteraction` events of initial page load kind if the page is the first of a new session.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

The attribute indicates that the end user initiated their session on the SPA page whose URL is reported with the IPL BrowserInteraction event. This could give insight into popular starting flows under a session-tracked context.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-398666

### Testing

New e2e tests added
