### PR TITLE
chore: Improve test result console report

### DIFF
--- a/tools/wdio/config/base.conf.mjs
+++ b/tools/wdio/config/base.conf.mjs
@@ -39,7 +39,7 @@ export default function config () {
       [path.resolve(__dirname, '../plugins/testing-server/index.mjs'), args],
       [path.resolve(__dirname, '../plugins/istanbul.mjs'), args]
     ],
-    reporters: ['spec'],
+    reporters: [['spec', { onlyFailures: true }]],
     specFileRetries: args.retry ? 1 : 0,
     specFileRetriesDeferred: true,
     framework: 'mocha',


### PR DESCRIPTION
Improves console reports for test results by only printing spec files containing test failures instead of all spec files.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

This PR changes a config setting in the spec reporter called `onlyFailures`. When set to `true`, it only prints out spec reports for test files that have a failing test. It used to print every single spec file result at the end regardless of passing or failure which made it difficult to find the tests that failed. This change results in a lot less noise at the bottom of the console log which makes it easy now to find test failures.

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-250731

### Testing

Look at the console report at the end of testing. Should now only have test failures reported (if there are any). It will still show a count of how many tests failed/passed.

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
