### PR TITLE
fix: Solve race condition in logging abort

### DIFF
--- a/src/features/logging/aggregate/index.js
+++ b/src/features/logging/aggregate/index.js
@@ -162,8 +162,10 @@ export class Aggregate extends AggregateBase {
   abort (reason = {}) {
     this.reportSupportabilityMetric(`Logging/Abort/${reason.sm}`)
     this.blocked = true
-    this.events.clear()
-    this.events.clearSave()
+    if (this.events) {
+      this.events.clear()
+      this.events.clearSave()
+    }
     this.updateLoggingMode(LOGGING_MODE.OFF)
     this.deregisterDrain()
   }

--- a/tests/components/logging/aggregate.test.js
+++ b/tests/components/logging/aggregate.test.js
@@ -256,3 +256,8 @@ test('can harvest early', async () => {
   expect(handleModule.handle).toHaveBeenCalledWith(...harvestEarlySm)
   expect(mainAgent.runtime.harvester.triggerHarvestFor).toHaveBeenCalled()
 })
+
+test('should not error if aborting before events have been set', async () => {
+  delete loggingAggregate.events
+  expect(() => loggingAggregate.abort()).not.toThrow()
+})


### PR DESCRIPTION
If the logging feature aborted before the agent had set up the event buffer, it could throw errors.  This was addressed by checking for the presence of the event buffer before running methods against it.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
See customer thread here https://newrelic.slack.com/archives/G019T80B1EJ/p1744722309280769

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
A new unit test has been added that validates that calling `abort` while an event buffer does not exist will not throw errors
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
