### PR TITLE
chore: decrease harvest interval to 5 to see if staging issues narrow

### DIFF
--- a/.github/actions/build-ab/templates/released.js
+++ b/.github/actions/build-ab/templates/released.js
@@ -12,6 +12,7 @@ window.NREUM={
         'bam-cell.nr-data.net'
       ]
     },
+    harvest: {interval: 5},
     session_replay: {
       enabled: true,
       autoStart: false,


### PR DESCRIPTION
This PR sets the harvest interval to 5 seconds `internally` in NR1 envs to see if product analytics issues decrease with a smaller event buffer.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-403791?atlOrigin=eyJpIjoiN2U1NjRiZWM0YTYzNGQxNTgyMTM5ZjYzOGRhNDEyOWQiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
