### PR TITLE
feat: Control log API through separate RUM flag

### DIFF
--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -30,6 +30,7 @@ const model = {
   sessionTraceMode: MODE.OFF,
   traceHarvestStarted: false,
   loggingMode: LOGGING_MODE.OFF,
+  logApiMode: LOGGING_MODE.OFF,
   serverTimeDiff: null, // set by TimeKeeper; "undefined" value will not be stringified and stored but "null" will
   custom: {},
   numOfResets: 0

--- a/src/features/logging/shared/utils.js
+++ b/src/features/logging/shared/utils.js
@@ -13,11 +13,12 @@ import { LOGGING_EVENT_EMITTER_CHANNEL, LOG_LEVELS } from '../constants'
    * @param {string} message - the log message string
    * @param {{[key: string]: *}} customAttributes - The log's custom attributes if any
    * @param {enum} level - the log level enum
+   * @param {boolean} [autoCaptured=true] - True if log was captured from auto wrapping. False if it was captured from the API manual usage.
    * @param {object=} targetEntityGuid - the optional target entity guid provided by an api call
    */
-export function bufferLog (ee, message, customAttributes = {}, level = LOG_LEVELS.INFO, targetEntityGuid, timestamp = now()) {
+export function bufferLog (ee, message, customAttributes = {}, level = LOG_LEVELS.INFO, autoCaptured = true, targetEntityGuid, timestamp = now()) {
   handle(SUPPORTABILITY_METRIC_CHANNEL, [`API/logging/${level.toLowerCase()}/called`], undefined, FEATURE_NAMES.metrics, ee)
-  handle(LOGGING_EVENT_EMITTER_CHANNEL, [timestamp, message, customAttributes, level, targetEntityGuid], undefined, FEATURE_NAMES.logging, ee)
+  handle(LOGGING_EVENT_EMITTER_CHANNEL, [timestamp, message, customAttributes, level, autoCaptured, targetEntityGuid], undefined, FEATURE_NAMES.logging, ee)
 }
 
 /**

--- a/src/loaders/api/log.js
+++ b/src/loaders/api/log.js
@@ -14,5 +14,5 @@ export function setupLogAPI (agent) {
 }
 
 export function log (message, { customAttributes = {}, level = LOG_LEVELS.INFO } = {}, agentRef, targetEntityGuid, timestamp = now()) {
-  bufferLog(agentRef.ee, message, customAttributes, level, targetEntityGuid, timestamp)
+  bufferLog(agentRef.ee, message, customAttributes, level, false, targetEntityGuid, timestamp)
 }

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -728,7 +728,7 @@ describe('API tests', () => {
           expectEmitted('wrap-logger-end', [['test1'], expect.any(Object), undefined])
 
           expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/logging/info/called'])
-          expectHandled('log', [expect.any(Number), 'test1', {}, 'INFO', undefined])
+          expectHandled('log', [expect.any(Number), 'test1', {}, 'INFO', true, undefined])
 
           const callCount = agent.ee.emit.mock.calls.length
           /** does NOT emit data for observed fn */
@@ -756,7 +756,7 @@ describe('API tests', () => {
           expectEmitted('wrap-logger-end', [['test1'], expect.any(Object), undefined])
 
           expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/logging/warn/called'])
-          expectHandled('log', [expect.any(Number), 'test1', {}, 'warn', undefined])
+          expectHandled('log', [expect.any(Number), 'test1', {}, 'warn', true, undefined])
         })
 
         test('should emit events with concat string for multiple args', () => {
@@ -815,7 +815,7 @@ describe('API tests', () => {
 
             expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/log/called'])
             expectHandled(SUPPORTABILITY_METRIC_CHANNEL, [`API/logging/${logMethod.toLowerCase().replace('log', '')}/called`])
-            expectHandled('log', [expect.any(Number), args[0], args[1].customAttributes, logMethod.replace('log', '')])
+            expectHandled('log', [expect.any(Number), args[0], args[1].customAttributes, logMethod.replace('log', ''), false])
           })
         })
       })

--- a/tests/components/logging/aggregate.test.js
+++ b/tests/components/logging/aggregate.test.js
@@ -35,9 +35,10 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-const mockLoggingRumResponse = async (mode) => {
+const mockLoggingRumResponse = async (mode, apiMode) => {
   loggingAggregate.ee.emit('rumresp', [{
-    log: mode
+    log: mode,
+    logapi: apiMode
   }])
   return await new Promise(process.nextTick)
 }
@@ -64,22 +65,37 @@ describe('class setup', () => {
 
   test('should wait for flags - 0 = OFF', async () => {
     expect(loggingAggregate.drained).toBeUndefined()
-    await mockLoggingRumResponse(LOGGING_MODE.OFF)
+    await mockLoggingRumResponse(LOGGING_MODE.OFF, LOGGING_MODE.OFF)
 
     expect(loggingAggregate.blocked).toEqual(true)
   })
 
   test('should wait for flags - 1 = ERROR', async () => {
     expect(loggingAggregate.drained).toBeUndefined()
-    await mockLoggingRumResponse(LOGGING_MODE.ERROR)
+    await mockLoggingRumResponse(LOGGING_MODE.ERROR, LOGGING_MODE.OFF)
 
     expect(loggingAggregate.drained).toEqual(true)
+  })
+
+  test('is not blocked if just logapi is on while log is flagged off', async () => {
+    expect(loggingAggregate.drained).toBeUndefined()
+    await mockLoggingRumResponse(LOGGING_MODE.OFF, LOGGING_MODE.INFO)
+
+    expect(loggingAggregate.drained).toEqual(true)
+  })
+
+  test('does not overwrite logging modes if set prior to rum response', async () => {
+    loggingAggregate.loggingMode = { auto: LOGGING_MODE.WARN, api: LOGGING_MODE.TRACE }
+    await mockLoggingRumResponse(LOGGING_MODE.OFF, LOGGING_MODE.OFF)
+
+    expect(loggingAggregate.loggingMode).toEqual({ auto: LOGGING_MODE.WARN, api: LOGGING_MODE.TRACE })
+    expect(loggingAggregate.blocked).toEqual(false)
   })
 })
 
 describe('payloads', () => {
   beforeEach(() => {
-    mockLoggingRumResponse(LOGGING_MODE.INFO)
+    mockLoggingRumResponse(LOGGING_MODE.INFO, LOGGING_MODE.INFO)
   })
 
   test('fills buffered logs with event emitter messages and prepares matching payload', async () => {
@@ -228,7 +244,7 @@ describe('payloads', () => {
 
 test.each(Object.keys(LOGGING_MODE))('payloads - log events are emitted (or not) according to flag from rum response - %s', async (logLevel) => {
   const SOME_TIMESTAMP = 1234
-  await mockLoggingRumResponse(LOGGING_MODE[logLevel])
+  await mockLoggingRumResponse(LOGGING_MODE[logLevel], LOGGING_MODE[logLevel])
   loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [SOME_TIMESTAMP, LOG_LEVELS.ERROR, { myAttributes: 1 }, LOG_LEVELS.ERROR])
   loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [SOME_TIMESTAMP, LOG_LEVELS.WARN, { myAttributes: 1 }, LOG_LEVELS.WARN])
   loggingAggregate.ee.emit(LOGGING_EVENT_EMITTER_CHANNEL, [SOME_TIMESTAMP, LOG_LEVELS.INFO, { myAttributes: 1 }, LOG_LEVELS.INFO])
@@ -240,7 +256,7 @@ test.each(Object.keys(LOGGING_MODE))('payloads - log events are emitted (or not)
 })
 
 test('can harvest early', async () => {
-  await mockLoggingRumResponse(LOGGING_MODE.INFO)
+  await mockLoggingRumResponse(LOGGING_MODE.INFO, LOGGING_MODE.INFO)
 
   jest.spyOn(mainAgent.runtime.harvester, 'triggerHarvestFor')
 

--- a/tests/components/logging/utils.test.js
+++ b/tests/components/logging/utils.test.js
@@ -22,7 +22,7 @@ describe('bufferLog', () => {
     expect(handleModule.handle.mock.calls[0][0]).toEqual('storeSupportabilityMetrics')
     expect(handleModule.handle.mock.calls[0][1]).toEqual(['API/logging/info/called'])
     expect(handleModule.handle.mock.calls[1][0]).toEqual('log')
-    expect(handleModule.handle.mock.calls[1][1]).toEqual([expect.any(Number), message, {}, 'INFO'])
+    expect(handleModule.handle.mock.calls[1][1]).toEqual([expect.any(Number), message, {}, 'INFO', true])
 
     // method should not cast to '' or '{}'
     expect(handleModule.handle.mock.calls[1][1][1]).not.toEqual('')
@@ -37,7 +37,7 @@ describe('bufferLog', () => {
     expect(handleModule.handle.mock.calls[0][0]).toEqual('storeSupportabilityMetrics')
     expect(handleModule.handle.mock.calls[0][1]).toEqual(['API/logging/info/called'])
     expect(handleModule.handle.mock.calls[1][0]).toEqual('log')
-    expect(handleModule.handle.mock.calls[1][1]).toEqual([expect.any(Number), message, {}, 'INFO'])
+    expect(handleModule.handle.mock.calls[1][1]).toEqual([expect.any(Number), message, {}, 'INFO', true])
   })
 
   test('should buffer logs with message and custom attributes', () => {
@@ -48,7 +48,7 @@ describe('bufferLog', () => {
     expect(handleModule.handle.mock.calls[0][0]).toEqual('storeSupportabilityMetrics')
     expect(handleModule.handle.mock.calls[0][1]).toEqual(['API/logging/info/called'])
     expect(handleModule.handle.mock.calls[1][0]).toEqual('log')
-    expect(handleModule.handle.mock.calls[1][1]).toEqual([expect.any(Number), message, customAttributes, 'INFO'])
+    expect(handleModule.handle.mock.calls[1][1]).toEqual([expect.any(Number), message, customAttributes, 'INFO', true])
   })
 
   test('should buffer logs with message, custom attributes, and custom level', () => {
@@ -59,7 +59,7 @@ describe('bufferLog', () => {
     expect(handleModule.handle.mock.calls[0][0]).toEqual('storeSupportabilityMetrics')
     expect(handleModule.handle.mock.calls[0][1]).toEqual(['API/logging/error/called'])
     expect(handleModule.handle.mock.calls[1][0]).toEqual('log')
-    expect(handleModule.handle.mock.calls[1][1]).toEqual([expect.any(Number), message, customAttributes, 'ERROR'])
+    expect(handleModule.handle.mock.calls[1][1]).toEqual([expect.any(Number), message, customAttributes, 'ERROR', true])
   })
 })
 

--- a/tests/components/session-helpers.js
+++ b/tests/components/session-helpers.js
@@ -39,6 +39,7 @@ export const model = {
   sessionTraceMode: 0,
   traceHarvestStarted: false,
   loggingMode: 0,
+  logApiMode: 0,
   serverTimeDiff: null,
   custom: {},
   numOfResets: 0

--- a/tests/specs/harvesting/disable-harvesting.e2e.js
+++ b/tests/specs/harvesting/disable-harvesting.e2e.js
@@ -68,7 +68,7 @@ describe('disable harvesting', () => {
     const logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testLogsRequest })
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
-      body: JSON.stringify(rumFlags({ log: LOGGING_MODE.OFF }))
+      body: JSON.stringify(rumFlags({ log: LOGGING_MODE.OFF, logapi: LOGGING_MODE.OFF }))
     })
 
     const [logsHarvests] = await Promise.all([

--- a/tests/specs/logging/harvesting.e2e.js
+++ b/tests/specs/logging/harvesting.e2e.js
@@ -19,7 +19,7 @@ describe('logging harvesting', () => {
   const mockRumResponse = async (logLevel) => {
     await browser.testHandle.scheduleReply('bamServer', {
       test: testRumRequest,
-      body: JSON.stringify(rumFlags({ log: logLevel }))
+      body: JSON.stringify(rumFlags({ log: logLevel, logapi: logLevel }))
     })
   }
 

--- a/tests/specs/logging/modes.e2e.js
+++ b/tests/specs/logging/modes.e2e.js
@@ -1,0 +1,59 @@
+import { testLogsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { rumFlags } from '../../../tools/testing-server/constants'
+import { LOGGING_MODE } from '../../../src/features/logging/constants'
+
+describe('logging mode from RUM flags', () => {
+  let logsCapture
+  const mockRumResponse = async (log, logapi) => {
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testRumRequest,
+      body: JSON.stringify(rumFlags({ log, logapi }))
+    })
+  }
+  const sessionOffSetting = { init: { privacy: { cookies_enabled: false } } }
+  beforeEach(async () => {
+    logsCapture = await browser.testHandle.createNetworkCaptures('bamServer', {
+      test: testLogsRequest
+    })
+  })
+
+  it('only captures wrapped logs when logapi is 0', async () => {
+    await mockRumResponse(LOGGING_MODE.INFO, LOGGING_MODE.OFF)
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', sessionOffSetting)).then(() => browser.waitForAgentLoad())
+
+    const [logsHarvests] = await Promise.all([
+      logsCapture.waitForResult({ totalCount: 1 }),
+      browser.execute(() => {
+        console.log("It's a-me, Mario")
+        console.debug('Mamma mia')
+        newrelic.log('Here we go')
+      })
+    ])
+
+    const logPayload = JSON.parse(logsHarvests[0].request.body)[0]
+    expect(logPayload.logs.length).toEqual(1)
+    expect(logPayload.logs[0].message).toEqual("It's a-me, Mario")
+    // The console.debug should not be captured because it's above verbosity level.
+    // The newrelic.log should not be captured because logapi flag is set to OFF.
+  })
+
+  it('only captures api logs when log flag is 0', async () => {
+    await mockRumResponse(LOGGING_MODE.OFF, LOGGING_MODE.INFO)
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', sessionOffSetting)).then(() => browser.waitForAgentLoad())
+
+    const [logsHarvests] = await Promise.all([
+      logsCapture.waitForResult({ totalCount: 1 }),
+      browser.execute(() => {
+        console.log("It's a-me, Mario")
+        newrelic.log('Mamma mia')
+        newrelic.log('Here we go', { level: 'trace' })
+      })
+    ])
+
+    const logPayload = JSON.parse(logsHarvests[0].request.body)[0]
+    expect(logPayload.logs.length).toEqual(1)
+    // The console.log should not be captured because log flag is set to OFF.
+    expect(logPayload.logs[0].message).toEqual('Mamma mia')
+    // The second newrelic.log should not be captured because the level is above INFO flag.
+  })
+})

--- a/tests/specs/util/helpers.js
+++ b/tests/specs/util/helpers.js
@@ -199,7 +199,7 @@ export async function getLogs () {
       return {
         events: logs.events.get(),
         blocked: logs.blocked,
-        loggingMode: logs.loggingMode
+        loggingMode: logs.loggingMode.auto
       }
     } catch (err) {
       return {

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -43,7 +43,8 @@ module.exports.rumFlags = (flags = {}, app = {}) => ({
   sr: defaultFlagValue(flags.sr), // session replay entitlements 0|1
   sts: defaultFlagValue(flags.sts), // session trace sampling 0|1|2 - off full error
   srs: defaultFlagValue(flags.srs), // session replay sampling 0|1|2 - off full error
-  log: flags.log ?? 3, // logging sampling 0|1|2|3|4|5 - off error warn info debug trace
+  log: flags.log ?? 3, // logging auto wrapping sampling 0|1|2|3|4|5 - off error warn info debug trace
+  logapi: flags.logapi ?? 3, // logging manual api sampling 0|1|2|3|4|5
   app: {
     agents: app.agents || [
       { entityGuid: mockEntityGuid() }


### PR DESCRIPTION
Logs captured by the `newrelic.log` method will now be configurable through settings and controlled separately from wrapped logs. This allows one to be disabled without affecting the other, as in the case that only `newrelic.log` is desired and not auto instrumented `console`.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-399179

### Testing

Added