### PR TITLE
chore: Do not warn unless config actually fails to exist

### DIFF
--- a/src/common/config/configurable.js
+++ b/src/common/config/configurable.js
@@ -23,7 +23,7 @@ export function getModeledObject (obj, model) {
         else if (typeof obj[key] === 'object' && typeof model[key] === 'object') output[key] = getModeledObject(obj[key], model[key])
         else output[key] = obj[key]
       } catch (e) {
-        warn(1, e)
+        if (!output[key]) warn(1, e)
       }
     }
     return output

--- a/src/common/config/runtime.js
+++ b/src/common/config/runtime.js
@@ -10,7 +10,7 @@ import { BUILD_ENV, DIST_METHOD, VERSION } from '../constants/env'
  * Module level count of harvests. This property will auto-increment each time it is accessed.
  * @type {number}
  */
-let harvestCount = 0
+let _harvestCount = 0
 
 const ReadOnly = {
   buildEnv: BUILD_ENV,
@@ -36,7 +36,7 @@ const RuntimeModel = {
   releaseIds: {},
   session: undefined,
   timeKeeper: undefined,
-  get harvestCount () { return ++harvestCount }
+  get harvestCount () { return ++_harvestCount }
 }
 
 export const mergeRuntime = (runtime) => {

--- a/tests/unit/common/config/runtime.test.js
+++ b/tests/unit/common/config/runtime.test.js
@@ -29,3 +29,12 @@ test('accessing harvestCount should increment it', () => {
 
   expect(returnedRuntime.harvestCount).not.toEqual(returnedRuntime.harvestCount)
 })
+
+test('merging runtime with another runtime (like configure) should not throw getter errors from runtime harvestCount', () => {
+  const consoleSpy = jest.spyOn(global.console, 'debug')
+
+  const returnedRuntime = mergeRuntime({})
+  mergeRuntime({ ...returnedRuntime, harvestCount: 0 })
+
+  expect(consoleSpy).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
This PR updates the configure call to only warn if the attribute fails to exist.  In the off chance that `checkConfiguration` is called in the aggregate base and forces a re-configure, the `getter` used for `harvestCount` can be attempted to be overset and throw a console warning. This warning is misleading, as that getter does not cause issues and does in fact still exist. You can see this in action [here](https://docs.newrelic.com/). A new test has been added to ensure this case does not log a warning anymore.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
