### PR TITLE
Fix: Silent setting getter only harvestCount message

### DIFF
--- a/src/loaders/api/sharedHandlers.js
+++ b/src/loaders/api/sharedHandlers.js
@@ -57,7 +57,7 @@ export function appendJsAttribute (agent, key, value, apiName, addToBrowserStora
   if (value === null) {
     delete currentInfo.jsAttributes[key]
   } else {
-    agent.info = { ...agent.info, jsAttributes: { ...currentInfo.jsAttributes, [key]: value } }
+    currentInfo.jsAttributes[key] = value
   }
   if (addToBrowserStorage || value === null) handle(prefix + apiName, [now(), key, value], undefined, 'session', agent.ee)
 }


### PR DESCRIPTION
The warning that results from the agent attempting to overwrite the runtime `harvestCount` will be correctly silenced.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

This is actually a proxy PR to get https://github.com/newrelic/newrelic-browser-agent/pull/1471 into production via patch version release.

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
