### PR TITLE
feat: reduce harvest interval to 10 seconds

### DIFF
--- a/src/common/config/init.js
+++ b/src/common/config/init.js
@@ -63,7 +63,7 @@ const InitModelFn = () => {
     get feature_flags () { return hiddenState.feature_flags },
     set feature_flags (val) { hiddenState.feature_flags = val },
     generic_events: { enabled: true, autoStart: true },
-    harvest: { interval: 30 },
+    harvest: { interval: 10 },
     jserrors: { enabled: true, autoStart: true },
     logging: { enabled: true, autoStart: true },
     metrics: { enabled: true, autoStart: true },

--- a/tests/unit/common/config/init.test.js
+++ b/tests/unit/common/config/init.test.js
@@ -28,7 +28,7 @@ test('init props exist and return expected defaults', () => {
   })
   expect(config.feature_flags).toEqual([])
   expect(config.harvest).toEqual({
-    interval: 30
+    interval: 10
   })
   expect(config.jserrors).toEqual({
     autoStart: true,


### PR DESCRIPTION
Reduce the standard harvest interval to 10 seconds to aid with late-page harvesting and unloading behaviors
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
