### PR TITLE
fix: Add safeguards for addToTrace

### DIFF
--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -121,3 +121,5 @@
 `Session replay harvested before a session trace payload could be sent. This could be problematic for replays that rely on a trace`
 ### 60
 `Session trace aborted`
+### 61
+`Timestamps must be valid UNIX timestamps.`

--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -122,4 +122,4 @@
 ### 60
 `Session trace aborted`
 ### 61
-`Timestamps must be valid UNIX timestamps.`
+`Timestamps must be non-negative and end time cannot be before start time.`

--- a/src/loaders/api/addToTrace.js
+++ b/src/loaders/api/addToTrace.js
@@ -21,7 +21,7 @@ export function setupAddToTraceAPI (agent) {
       t: 'api'
     }
 
-    if (report.s < 0 || report.e < 0) {
+    if (report.s < 0 || report.e < 0 || report.e < report.s) {
       warn(61, { start: report.s, end: report.e })
       return
     }

--- a/src/loaders/api/addToTrace.js
+++ b/src/loaders/api/addToTrace.js
@@ -4,6 +4,7 @@
  */
 import { originTime } from '../../common/constants/runtime'
 import { handle } from '../../common/event-emitter/handle'
+import { warn } from '../../common/util/console'
 import { FEATURE_NAMES } from '../features/features'
 import { ADD_TO_TRACE } from './constants'
 import { setupAPI } from './sharedHandlers'
@@ -18,6 +19,11 @@ export function setupAddToTraceAPI (agent) {
       e: (evt.end || evt.start) - originTime,
       o: evt.origin || '',
       t: 'api'
+    }
+
+    if (report.s < 0 || report.e < 0) {
+      warn(61, { start: report.s, end: report.e })
+      return
     }
 
     handle('bstApi', [report], undefined, FEATURE_NAMES.sessionTrace, agent.ee)

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -154,6 +154,28 @@ describe('API tests', () => {
         const payload = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'bstApi')[1][0]
         expect(payload.e - payload.s).toEqual(1000) // end - start was 1000ms apart in API call
       })
+
+      test('should return error code for non-valid UNIX timestamps', () => {
+        agent.addToTrace({
+          name: 'Event Name',
+          start: Date.now(),
+          end: -1000,
+          origin: 'Origin of event'
+        })
+
+        expect(console.debug).toHaveBeenCalledTimes(1)
+        expect(console.debug).toHaveBeenLastCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#61'), expect.any(Object))
+
+        agent.addToTrace({
+          name: 'Event Name',
+          start: -1234,
+          end: Date.now() + 1000,
+          origin: 'Origin of event'
+        })
+
+        expect(console.debug).toHaveBeenCalledTimes(2)
+        expect(console.debug).toHaveBeenLastCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#61'), expect.any(Object))
+      })
     })
 
     describe('addRelease', () => {

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -155,7 +155,7 @@ describe('API tests', () => {
         expect(payload.e - payload.s).toEqual(1000) // end - start was 1000ms apart in API call
       })
 
-      test('should return error code for non-valid UNIX timestamps', () => {
+      test('should return error code for negative timestamps', () => {
         agent.addToTrace({
           name: 'Event Name',
           start: Date.now(),
@@ -174,6 +174,18 @@ describe('API tests', () => {
         })
 
         expect(console.debug).toHaveBeenCalledTimes(2)
+        expect(console.debug).toHaveBeenLastCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#61'), expect.any(Object))
+      })
+
+      test('should return error code for end time before start time', () => {
+        agent.addToTrace({
+          name: 'Event Name',
+          start: Date.now() + 2000,
+          end: Date.now() + 1000,
+          origin: 'Origin of event'
+        })
+
+        expect(console.debug).toHaveBeenCalled()
         expect(console.debug).toHaveBeenLastCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#61'), expect.any(Object))
       })
     })


### PR DESCRIPTION
Events created with addToTrace API, which have an invalid UNIX timestamp, emit a warning and return without creating the event.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Added safeguards for `addToTrace()` API call. It was possible to have negative timestamps before with misuse. This PR does not create the event if the timestamps are negative. A warning is emitted of error code 61 if the timestamps are invalid.

At first I thought that the requirements were to only check that the arguments of the method are valid timestamps, but it makes more sense to me to check that the timestamps in the event creation are valid.

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-366078

### Testing

Make sure tests pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
