### PR TITLE
fix: Clean BrowserPerformance entryName for resources

### DIFF
--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -143,7 +143,7 @@ export class Aggregate extends AggregateBase {
                       ...detailObj,
                       eventType: 'BrowserPerformance',
                       timestamp: this.toEpoch(entry.startTime),
-                      entryName: cleanURL(entry.name),
+                      entryName: entry.name,
                       entryDuration: entry.duration,
                       entryType: type
                     })
@@ -208,7 +208,7 @@ export class Aggregate extends AggregateBase {
               ...entryObject,
               eventType: 'BrowserPerformance',
               timestamp: Math.floor(agentRef.runtime.timeKeeper.correctRelativeTimestamp(entryObject.startTime)),
-              entryName: name,
+              entryName: cleanURL(name),
               entryDuration: duration,
               firstParty
             }


### PR DESCRIPTION
The `entryName` attribute of resource type `BrowserPerformance` events will now have a cleaner URL, removing the hash fragment from reported URLs.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-418312

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
