### PR TITLE
feat: Add more inspection events

### DIFF
--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { dispatchGlobalEvent } from '../../common/dispatch/global-event'
 import { ee } from '../event-emitter/contextual-ee'
 import { registerHandler as defaultRegister } from '../event-emitter/register-handler'
 import { featurePriority } from '../../loaders/features/features'
@@ -91,6 +92,13 @@ function drainGroup (agentIdentifier, group, activateGroup = true) {
   const baseEE = agentIdentifier ? ee.get(agentIdentifier) : ee
   const handlers = defaultRegister.handlers // other storage in registerHandler
   if (baseEE.aborted || !baseEE.backlog || !handlers) return
+
+  dispatchGlobalEvent({
+    agentIdentifier,
+    type: 'lifecycle',
+    name: 'drain',
+    feature: group
+  })
 
   // Only activated features being drained should run queued listeners on buffered events. Deactivated features only need to release memory.
   if (activateGroup) {

--- a/src/common/window/load.js
+++ b/src/common/window/load.js
@@ -17,3 +17,8 @@ export function onDOMContentLoaded (cb) {
   if (checkState()) return cb()
   documentAddEventListener('DOMContentLoaded', cb)
 }
+
+export function onPopstateChange (cb) {
+  if (checkState()) return cb()
+  windowAddEventListener('popstate', cb)
+}

--- a/src/features/page_view_event/instrument/index.js
+++ b/src/features/page_view_event/instrument/index.js
@@ -6,11 +6,17 @@ import { handle } from '../../../common/event-emitter/handle'
 import { setupSetPageViewNameAPI } from '../../../loaders/api/setPageViewName'
 import { InstrumentBase } from '../../utils/instrument-base'
 import * as CONSTANTS from '../constants'
+import { SESSION_EVENTS } from '../../../common/session/constants'
+import { dispatchGlobalEvent } from '../../../common/dispatch/global-event'
+import { onDOMContentLoaded, onPopstateChange, onWindowLoad } from '../../../common/window/load'
 
 export class Instrument extends InstrumentBase {
   static featureName = CONSTANTS.FEATURE_NAME
   constructor (agentRef) {
     super(agentRef, CONSTANTS.FEATURE_NAME)
+
+    /** setup inspection events for window lifecycle */
+    this.setupInspectionEvents(agentRef.agentIdentifier)
 
     /** feature specific APIs */
     setupSetPageViewNameAPI(agentRef)
@@ -19,6 +25,41 @@ export class Instrument extends InstrumentBase {
     this.ee.on('api-send-rum', (attrs, target) => handle('send-rum', [attrs, target], undefined, this.featureName, this.ee))
 
     this.importAggregator(agentRef, () => import(/* webpackChunkName: "page_view_event-aggregate" */ '../aggregate'))
+  }
+
+  setupInspectionEvents (agentIdentifier) {
+    const dispatch = (evt, name) => {
+      if (!evt) return
+      dispatchGlobalEvent({
+        agentIdentifier,
+        timeStamp: evt.timeStamp,
+        loaded: evt.target.readyState === 'complete',
+        type: 'window',
+        name,
+        data: evt.target.location + ''
+      })
+    }
+
+    onDOMContentLoaded((evt) => {
+      dispatch(evt, 'DOMContentLoaded')
+    })
+
+    onWindowLoad((evt) => {
+      dispatch(evt, 'load')
+    })
+
+    onPopstateChange((evt) => {
+      dispatch(evt, 'navigate')
+    })
+
+    this.ee.on(SESSION_EVENTS.UPDATE, (_, data) => {
+      dispatchGlobalEvent({
+        agentIdentifier,
+        type: 'lifecycle',
+        name: 'session',
+        data
+      })
+    })
   }
 }
 

--- a/tests/assets/inspection-events.html
+++ b/tests/assets/inspection-events.html
@@ -17,7 +17,7 @@
     }
     window.addEventListener('newrelic', ({ detail }) => {
       if (!detail || !detail.agentIdentifier) return
-      const { name, drained, type, feature, data } = detail
+      const { name, drained, type, feature, loaded, timeStamp, data } = detail
 
       if (
         name == 'initialize' &&
@@ -59,7 +59,7 @@
         window.inspectionEvents.harvest = true
       }
 
-      // The API call in this test is called before the agent is loaded, so loaded should be false
+      // The API call in this test is called before the agent is loaded, so drained should be false
       if (
         name === 'api' &&
         drained === false &&
@@ -69,7 +69,63 @@
       ) {
         window.inspectionEvents.api = true
       }
+
+      if (
+        name === 'drain' &&
+        type === 'lifecycle' &&
+        feature
+      ) {
+        window.inspectionEvents.drain = true
+      }
+
+      if (
+        name === 'navigate' &&
+        type === 'window' &&
+        loaded == false &&
+        feature === undefined &&
+        timeStamp &&
+        data
+      ) {
+        window.inspectionEvents.navigate = true
+      }
+
+      if (
+        name === 'load' &&
+        type === 'window' &&
+        loaded == true &&
+        feature === undefined &&
+        timeStamp &&
+        data
+      ) {
+        window.inspectionEvents.windowLoad = true
+      }
+
+      if (
+        name === 'DOMContentLoaded' &&
+        type === 'window' &&
+        loaded == false &&
+        feature === undefined &&
+        timeStamp &&
+        data
+      ) {
+        window.inspectionEvents.domLoad = true
+      }
+
+      if (
+        name === 'session' &&
+        type === 'lifecycle' &&
+        feature === undefined &&
+        data
+      ) {
+        window.inspectionEvents.session = true
+      }
     })
+    window.setTimeout(() => {
+      // Trigger the session event
+      newrelic.setUserId('1')
+      // Trigger the navigation event
+      window.location += '#'
+    }, 2000)
   </script>
   {init} {config} {loader}
 </head>

--- a/tests/assets/inspection-events.html
+++ b/tests/assets/inspection-events.html
@@ -124,7 +124,7 @@
       // Trigger the session event
       newrelic.setUserId('1')
       // Trigger the navigation event
-      window.location += '#'
+      window.location += '#a=1'
     }, 2000)
   </script>
   {init} {config} {loader}

--- a/tests/specs/inspection-events.e2e.js
+++ b/tests/specs/inspection-events.e2e.js
@@ -8,7 +8,8 @@ describe('inspection events', () => {
         () => browser.execute(function () {
           return window?.inspectionEvents?.buffer &&
             window.inspectionEvents.harvest &&
-            window.inspectionEvents.api
+            window.inspectionEvents.api &&
+            window.inspectionEvents.navigate
         }),
         {
           timeout: 30000,
@@ -26,5 +27,10 @@ describe('inspection events', () => {
     expect(inspectionEvents.buffer).toBe(true)
     expect(inspectionEvents.harvest).toBe(true)
     expect(inspectionEvents.api).toBe(true)
+    expect(inspectionEvents.drain).toBe(true)
+    expect(inspectionEvents.navigate).toBe(true)
+    expect(inspectionEvents.windowLoad).toBe(true)
+    expect(inspectionEvents.domLoad).toBe(true)
+    expect(inspectionEvents.session).toBe(true)
   })
 })


### PR DESCRIPTION
Adds new inspection events to the agent. These events include the drain event, window lifecycle events such as navigate, load, DOMContentLoaded, and the session event which emits on changes to the agent's session state.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Adds new inspection events to the agent. These are new events not originally outlined in the CDD. The 'origin' event mentioned in the JIRA ticket is excluded due to too much code effort and not enough of a use case to have it.

drain event: Emits when the agent drains for a particular feature
```
{
    agentIdentifier,
    type: 'lifecycle',
    name: 'drain',
    feature: group
}
```

window lifecycle events:
```
{
    timeStamp: evt.timeStamp,
    loaded: evt.target.document.readyState === 'complete',
    type: 'window',
    name: 'navigate' | 'load' | 'DOMContentLoaded'
    data: evt.target.location + ''
}
```

session event: Emits when the agent's session state changes
```
{
    agentIdentifier,
    type: 'lifecycle',
    name: 'session',
    feature: undefined,
    data: <session state>
}
```

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-377594
Follow-up ticket: https://new-relic.atlassian.net/browse/NR-375666

### Testing

The inspection-events tests were expanded. Open the `inspection-events.html` in the test server to test locally.

Make sure tests pass for this PR.
