### PR TITLE
chore: fix broken gql test service

### DIFF
--- a/tests/specs/graphql-metadata.e2e.js
+++ b/tests/specs/graphql-metadata.e2e.js
@@ -28,7 +28,7 @@ describe('GraphQL metadata is appended to relevant ajax calls', () => {
       trigger: 'initialPageLoad',
       children: expect.arrayContaining([expect.objectContaining({
         type: 'ajax',
-        domain: 'flyby-router-demo.herokuapp.com:443',
+        domain: expect.stringMatching(/bam-test-1\.nr-local\.net/),
         children: expect.arrayContaining([
           {
             type: 'stringAttribute',
@@ -47,7 +47,7 @@ describe('GraphQL metadata is appended to relevant ajax calls', () => {
     )
     expect(gqlHarvest.request.body).toEqual(expect.arrayContaining([expect.objectContaining({
       type: 'ajax',
-      domain: 'flyby-router-demo.herokuapp.com:443',
+      domain: expect.stringMatching(/bam-test-1\.nr-local\.net/),
       children: expect.arrayContaining([
         {
           type: 'stringAttribute',

--- a/tools/test-builds/library-wrapper/src/apollo-client.js
+++ b/tools/test-builds/library-wrapper/src/apollo-client.js
@@ -10,8 +10,18 @@ const opts = {
 new BrowserAgent(opts)
 
 const client = new ApolloClient({
-  uri: 'https://flyby-router-demo.herokuapp.com/',
-  cache: new InMemoryCache()
+  uri: '/gql',
+  cache: new InMemoryCache(),
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'no-cache',
+      errorPolicy: 'ignore'
+    },
+    query: {
+      fetchPolicy: 'no-cache',
+      errorPolicy: 'all'
+    }
+  }
 })
 var locations = ['id', 'name', 'description']
 window.sendGQL = function (operationName = 'standalone') {

--- a/tools/testing-server/routes/mock-apis.js
+++ b/tools/testing-server/routes/mock-apis.js
@@ -188,6 +188,17 @@ module.exports = fp(async function (fastify, testServer) {
   }, (request, reply) => {
     reply.send({ text: 'hi!' })
   })
+  fastify.post('/gql', {
+    compress: false
+  }, (request, reply) => {
+    reply.send({
+      data: {
+        text: 'hi',
+        locations: 'test locations',
+        description: 'test description'
+      }
+    })
+  })
   fastify.get('/js', {
     compress: false
   }, (request, reply) => {


### PR DESCRIPTION
Point the graphql tests to our internal testing service with a new mocked endpoint instead of relying on a demo service, which has recently gone down and caused test failures.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
`graphql-metadata.e2e.js` should now pass
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
