### PR TITLE
chore: Track click handlers of interactive elements

### DIFF
--- a/src/common/wrap/wrap-events.js
+++ b/src/common/wrap/wrap-events.js
@@ -12,6 +12,7 @@ import { ee as baseEE, contextId } from '../event-emitter/contextual-ee'
 import { createWrapperWithEmitter as wfn } from './wrap-function'
 import { getOrSet } from '../util/get-or-set'
 import { globalScope, isBrowserScope } from '../constants/runtime'
+import { interactiveElems } from '../../features/generic_events/aggregate/user-actions/interactive-elements'
 
 const wrapped = {}
 const XHR = globalScope.XMLHttpRequest
@@ -65,10 +66,18 @@ export function wrapEvents (sharedEE) {
     })
 
     this.wrapped = args[1] = wrapped
+
+    if (Array.isArray(args) && args.length && args[0] === 'click') {
+      interactiveElems.add(target, wrapped)
+    }
   })
 
-  ee.on(REMOVE_EVENT_LISTENER + '-start', function (args) {
+  ee.on(REMOVE_EVENT_LISTENER + '-start', function (args, target) {
     args[1] = this.wrapped || args[1]
+
+    if (args[0] === 'click') {
+      interactiveElems.remove(target, args[1])
+    }
   })
 
   function wrapNode (node) {

--- a/src/common/wrap/wrap-events.js
+++ b/src/common/wrap/wrap-events.js
@@ -67,7 +67,7 @@ export function wrapEvents (sharedEE) {
 
     this.wrapped = args[1] = wrapped
 
-    if (Array.isArray(args) && args.length && args[0] === 'click') {
+    if (args[0] === 'click') {
       interactiveElems.add(target, wrapped)
     }
   })

--- a/src/common/wrap/wrap-events.js
+++ b/src/common/wrap/wrap-events.js
@@ -76,7 +76,7 @@ export function wrapEvents (sharedEE) {
     args[1] = this.wrapped || args[1]
 
     if (args[0] === 'click') {
-      interactiveElems.remove(target, args[1])
+      interactiveElems.delete(target, args[1])
     }
   })
 

--- a/src/features/generic_events/aggregate/user-actions/interactive-elements.js
+++ b/src/features/generic_events/aggregate/user-actions/interactive-elements.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+class InteractiveElements {
+  constructor () {
+    this.elements = new WeakMap()
+  }
+
+  add (target, listener) {
+    if (!isInteractiveElement(target)) {
+      return
+    }
+    if (!this.elements.has(target)) {
+      this.elements.set(target, new Set())
+    }
+    this.elements.get(target).add(listener)
+  }
+
+  remove (target, listener) {
+    if (this.elements.has(target)) {
+      const handlers = this.elements.get(target)
+      handlers.delete(listener)
+      if (handlers.size === 0) {
+        this.elements.delete(target)
+      }
+    }
+  }
+
+  has (target) {
+    return this.elements.has(target)
+  }
+
+  get (target) {
+    return this.elements.get(target)
+  }
+}
+
+export const interactiveElems = new InteractiveElements()
+
+function isInteractiveElement (target) {
+  const tagName = (target && target.nodeType === 1 && target.tagName?.toLowerCase()) ?? ''
+  return tagName !== '' &&
+    (tagName === 'button' ||
+      tagName === 'a' ||
+      (tagName === 'input' && target.type === 'button'))
+}

--- a/src/features/generic_events/aggregate/user-actions/interactive-elements.js
+++ b/src/features/generic_events/aggregate/user-actions/interactive-elements.js
@@ -2,37 +2,25 @@
  * Copyright 2020-2025 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-class InteractiveElements {
-  constructor () {
-    this.elements = new WeakMap()
-  }
-
+class InteractiveElements extends WeakMap {
   add (target, listener) {
     if (!isInteractiveElement(target)) {
       return
     }
-    if (!this.elements.has(target)) {
-      this.elements.set(target, new Set())
+    if (!super.has(target)) {
+      super.set(target, new Set())
     }
-    this.elements.get(target).add(listener)
+    super.get(target).add(listener)
   }
 
-  remove (target, listener) {
-    if (this.elements.has(target)) {
-      const handlers = this.elements.get(target)
+  delete (target, listener) {
+    if (super.has(target)) {
+      const handlers = super.get(target)
       handlers.delete(listener)
       if (handlers.size === 0) {
-        this.elements.delete(target)
+        super.delete(target)
       }
     }
-  }
-
-  has (target) {
-    return this.elements.has(target)
-  }
-
-  get (target) {
-    return this.elements.get(target)
   }
 }
 

--- a/src/features/generic_events/aggregate/user-actions/interactive-elements.js
+++ b/src/features/generic_events/aggregate/user-actions/interactive-elements.js
@@ -27,7 +27,7 @@ class InteractiveElements extends WeakMap {
 export const interactiveElems = new InteractiveElements()
 
 function isInteractiveElement (target) {
-  const tagName = (target && target.nodeType === 1 && target.tagName?.toLowerCase()) ?? ''
+  const tagName = (target && target.nodeType === Node.ELEMENT_NODE && target.tagName?.toLowerCase()) ?? ''
   return tagName !== '' &&
     (tagName === 'button' ||
       tagName === 'a' ||

--- a/tests/components/wrappings/wrap-events.test.js
+++ b/tests/components/wrappings/wrap-events.test.js
@@ -411,24 +411,74 @@ describe(' ', () => {
       expect(handlerCallCount).toEqual(3) // should have seen handler calls for neither element
     })
   })
-
-  class ClickerNoHandle {
-    constructor (el) {
-      this.handlerCallCount = 0
-    }
-  }
-  class Clicker extends ClickerNoHandle {
-    handleEvent (event) {
-      this.handlerCallCount++
-    }
-  }
-  function triggerEvent (el, eventName) {
-    const evt = new Event(eventName, { bubbles: true })
-    el.dispatchEvent(evt)
-  }
-  function createAndAddDomElement (tagName = 'div') {
-    var el = document.createElement(tagName)
-    document.body.appendChild(el)
-    return el
-  }
 })
+
+describe('wrap-events', () => {
+  let interactiveElemsAddSpy
+  let interactiveElemsDeleteSpy
+
+  beforeEach(async () => {
+    // import order is important
+    const { interactiveElems } = await import('../../../src/features/generic_events/aggregate/user-actions/interactive-elements')
+    interactiveElemsAddSpy = jest.spyOn(interactiveElems, 'add')
+    interactiveElemsDeleteSpy = jest.spyOn(interactiveElems, 'delete')
+    const { wrapEvents } = await import('../../../src/common/wrap/wrap-events')
+    wrapEvents()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.resetModules()
+  })
+
+  describe('interactiveElems', () => {
+    test('should track when click handling is added via addEventListener', async () => {
+      const elem = createAndAddDomElement('button')
+      elem.addEventListener('click', () => { })
+      expect(interactiveElemsAddSpy).toHaveBeenCalledWith(elem, expect.any(Function))
+    })
+
+    test('should track when click handling is deleted via removeEventListener', async () => {
+      const elem = createAndAddDomElement('button')
+      const handler = () => { }
+      elem.addEventListener('click', handler)
+      elem.removeEventListener('click', handler)
+      expect(interactiveElemsDeleteSpy).toHaveBeenCalledWith(elem, expect.any(Function))
+    })
+
+    test('should not track when non-click handling is added', async () => {
+      const elem = createAndAddDomElement('button')
+      const handler = () => { }
+      elem.addEventListener('mouseover', handler)
+      expect(interactiveElemsAddSpy).not.toHaveBeenCalledWith(elem, handler)
+    })
+
+    test('should not track when non-click handling is deleted', async () => {
+      const elem = createAndAddDomElement('button')
+      const handler = () => { }
+      elem.addEventListener('mouseover', handler)
+      elem.removeEventListener('mouseover', handler)
+      expect(interactiveElemsDeleteSpy).not.toHaveBeenCalledWith(elem, handler)
+    })
+  })
+})
+
+class ClickerNoHandle {
+  constructor (el) {
+    this.handlerCallCount = 0
+  }
+}
+class Clicker extends ClickerNoHandle {
+  handleEvent (event) {
+    this.handlerCallCount++
+  }
+}
+function triggerEvent (el, eventName) {
+  const evt = new Event(eventName, { bubbles: true })
+  el.dispatchEvent(evt)
+}
+function createAndAddDomElement (tagName = 'div') {
+  var el = document.createElement(tagName)
+  document.body.appendChild(el)
+  return el
+}

--- a/tests/components/wrappings/wrap-events.test.js
+++ b/tests/components/wrappings/wrap-events.test.js
@@ -434,13 +434,13 @@ describe('wrap-events', () => {
   describe('interactiveElems', () => {
     test('should track when click handling is added via addEventListener', async () => {
       const elem = createAndAddDomElement('button')
-      elem.addEventListener('click', () => { })
+      elem.addEventListener('click', () => {})
       expect(interactiveElemsAddSpy).toHaveBeenCalledWith(elem, expect.any(Function))
     })
 
     test('should track when click handling is deleted via removeEventListener', async () => {
       const elem = createAndAddDomElement('button')
-      const handler = () => { }
+      const handler = () => {}
       elem.addEventListener('click', handler)
       elem.removeEventListener('click', handler)
       expect(interactiveElemsDeleteSpy).toHaveBeenCalledWith(elem, expect.any(Function))
@@ -448,14 +448,14 @@ describe('wrap-events', () => {
 
     test('should not track when non-click handling is added', async () => {
       const elem = createAndAddDomElement('button')
-      const handler = () => { }
+      const handler = () => {}
       elem.addEventListener('mouseover', handler)
       expect(interactiveElemsAddSpy).not.toHaveBeenCalledWith(elem, handler)
     })
 
     test('should not track when non-click handling is deleted', async () => {
       const elem = createAndAddDomElement('button')
-      const handler = () => { }
+      const handler = () => {}
       elem.addEventListener('mouseover', handler)
       elem.removeEventListener('mouseover', handler)
       expect(interactiveElemsDeleteSpy).not.toHaveBeenCalledWith(elem, handler)

--- a/tests/unit/features/generic_events/aggregate/user-actions/interactive-elements.test.js
+++ b/tests/unit/features/generic_events/aggregate/user-actions/interactive-elements.test.js
@@ -1,0 +1,47 @@
+import { interactiveElems } from '../../../../../../src/features/generic_events/aggregate/user-actions/interactive-elements'
+
+describe('Interactive Elements', () => {
+  const lookup = interactiveElems
+  it('should keep references for button', async () => {
+    const button = document.createElement('button')
+    const listener = () => {}
+    lookup.add(button, listener)
+    expect(lookup.has(button)).toBeTrue()
+    expect(lookup.get(button).size).toBe(1)
+  })
+
+  it('should keep references for input, type=button', async () => {
+    const button = document.createElement('input')
+    button.type = 'button'
+    const listener = () => {}
+    lookup.add(button, listener)
+    expect(lookup.has(button)).toBeTrue()
+    expect(lookup.get(button).size).toBe(1)
+  })
+
+  it('should keep references for a', async () => {
+    const link = document.createElement('a')
+    const listener = () => {}
+    lookup.add(link, listener)
+    expect(lookup.has(link)).toBeTrue()
+    expect(lookup.get(link).size).toBe(1)
+  })
+
+  it('should not keep references for non-interactive elements', async () => {
+    const span = document.createElement('span')
+    const listener = () => {}
+    lookup.add(span, listener)
+    expect(lookup.has(span)).toBeFalse()
+  })
+
+  it('should remove entry when listener is removed', async () => {
+    const button = document.createElement('button')
+    const listener = () => {}
+    lookup.add(button, listener)
+    expect(lookup.has(button)).toBeTrue()
+    expect(lookup.get(button).size).toBe(1)
+
+    lookup.remove(button, listener)
+    expect(lookup.has(button)).toBeFalse()
+  })
+})

--- a/tests/unit/features/generic_events/aggregate/user-actions/interactive-elements.test.js
+++ b/tests/unit/features/generic_events/aggregate/user-actions/interactive-elements.test.js
@@ -34,14 +34,14 @@ describe('Interactive Elements', () => {
     expect(lookup.has(span)).toBeFalse()
   })
 
-  it('should remove entry when listener is removed', async () => {
+  it('should delete entry when listener is deleted', async () => {
     const button = document.createElement('button')
     const listener = () => {}
     lookup.add(button, listener)
     expect(lookup.has(button)).toBeTrue()
     expect(lookup.get(button).size).toBe(1)
 
-    lookup.remove(button, listener)
+    lookup.delete(button, listener)
     expect(lookup.has(button)).toBeFalse()
   })
 })


### PR DESCRIPTION
Extends `wrap-events` to track which buttons and links have click event handlers. 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

This is a first step towards helping track dead clicks on interactive elements, which are mainly buttons and links at the moment. Any click event handlers added via `addEventListener` for buttons and links will be stored in a lookup, key = element reference, value = handler function reference.  The lookup can be used later on to verify if a user click is going to "do something" vs. is a dead click.

### Related Issue(s)

[NR-422169](https://new-relic.atlassian.net/browse/NR-422169)

### Testing

- Added unit tests for InteractiveElements 


[NR-422169]: https://new-relic.atlassian.net/browse/NR-422169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ