### PR TITLE
fix: Fix .finished API timeSinceLoad value

### DIFF
--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -123,3 +123,5 @@
 `Session trace aborted`
 ### 61
 `Timestamps must be non-negative and end time cannot be before start time.`
+### 62 
+`Timestamp must be a unix timestamp greater than the page origin time`

--- a/src/loaders/api-base.js
+++ b/src/loaders/api-base.js
@@ -144,7 +144,7 @@ export class ApiBase {
   /**
    * Records an additional time point as "finished" in a session trace and adds a page action.
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/finished/}
-   * @param {number} [timeStamp] Defaults to the current time of the call. If used, this marks the time that the page is "finished" according to your own criteria.
+   * @param {number} [timeStamp] integer (UNIX time) - Defaults to the current time of the call. If used, this marks the time that the page is "finished" according to your own criteria.
    */
   finished (timeStamp) {
     return this.#callMethod(FINISHED, timeStamp)

--- a/src/loaders/api/finished.js
+++ b/src/loaders/api/finished.js
@@ -11,10 +11,11 @@ import { ADD_PAGE_ACTION, FINISHED, prefix } from './constants'
 import { setupAPI } from './sharedHandlers'
 
 export function setupFinishedAPI (agent) {
-  setupAPI(FINISHED, function (time = Date.now()) {
-    if (time < originTime) warn(62, time)
-    handle(CUSTOM_METRIC_CHANNEL, [FINISHED, { time }], undefined, FEATURE_NAMES.metrics, agent.ee)
-    agent.addToTrace({ name: FINISHED, start: time, origin: 'nr' })
-    handle(prefix + ADD_PAGE_ACTION, [time - originTime, FINISHED], undefined, FEATURE_NAMES.genericEvents, agent.ee)
+  setupAPI(FINISHED, function (unixTime = Date.now()) {
+    const relativeTime = unixTime - originTime
+    if (relativeTime < 0) warn(62, unixTime)
+    handle(CUSTOM_METRIC_CHANNEL, [FINISHED, { time: relativeTime }], undefined, FEATURE_NAMES.metrics, agent.ee)
+    agent.addToTrace({ name: FINISHED, start: unixTime, origin: 'nr' })
+    handle(prefix + ADD_PAGE_ACTION, [relativeTime, FINISHED], undefined, FEATURE_NAMES.genericEvents, agent.ee)
   }, agent)
 }

--- a/src/loaders/api/finished.js
+++ b/src/loaders/api/finished.js
@@ -4,16 +4,17 @@
  */
 import { originTime } from '../../common/constants/runtime'
 import { handle } from '../../common/event-emitter/handle'
-import { now } from '../../common/timing/now'
+import { warn } from '../../common/util/console'
 import { CUSTOM_METRIC_CHANNEL } from '../../features/metrics/constants'
 import { FEATURE_NAMES } from '../features/features'
 import { ADD_PAGE_ACTION, FINISHED, prefix } from './constants'
 import { setupAPI } from './sharedHandlers'
 
 export function setupFinishedAPI (agent) {
-  setupAPI(FINISHED, function (time = now()) {
+  setupAPI(FINISHED, function (time = Date.now()) {
+    if (time < originTime) warn(62, time)
     handle(CUSTOM_METRIC_CHANNEL, [FINISHED, { time }], undefined, FEATURE_NAMES.metrics, agent.ee)
-    agent.addToTrace({ name: FINISHED, start: time + originTime, origin: 'nr' })
-    handle(prefix + ADD_PAGE_ACTION, [time, FINISHED], undefined, FEATURE_NAMES.genericEvents, agent.ee)
+    agent.addToTrace({ name: FINISHED, start: time, origin: 'nr' })
+    handle(prefix + ADD_PAGE_ACTION, [time - originTime, FINISHED], undefined, FEATURE_NAMES.genericEvents, agent.ee)
   }, agent)
 }

--- a/tests/assets/api/finished.html
+++ b/tests/assets/api/finished.html
@@ -13,6 +13,7 @@
   <body>
     Api test!
     <script>
+      window.calledAt = performance.now();
       newrelic.finished()
     </script>
   </body>

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -132,14 +132,13 @@ describe('API tests', () => {
 
     describe('finished', () => {
       test('should execute as expected', async () => {
-        const time = Date.now()
         const n = now()
         agent.finished()
         expectHandled('storeSupportabilityMetrics', ['API/finished/called'])
 
         expectHandled('storeEventMetrics', ['finished', { time: expect.any(Number) }])
         const storeEventMetricsCall = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'storeEventMetrics')
-        expect(Math.abs(storeEventMetricsCall[1][1].time - time)).toBeLessThanOrEqual(1) // should be unix timestamp
+        expect(Math.abs(storeEventMetricsCall[1][1].time - n)).toBeLessThanOrEqual(1) // should be unix timestamp
 
         expectHandled('storeSupportabilityMetrics', ['API/addToTrace/called'])
 
@@ -162,7 +161,7 @@ describe('API tests', () => {
 
         expectHandled('storeEventMetrics', ['finished', { time: expect.any(Number) }])
         const storeEventMetricsCall = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'storeEventMetrics')
-        expect(Math.abs(storeEventMetricsCall[1][1].time - time)).toBeLessThanOrEqual(1) // should be unix timestamp
+        expect(Math.abs(storeEventMetricsCall[1][1].time - (n + 1000))).toBeLessThanOrEqual(1) // should be unix timestamp
 
         expectHandled('storeSupportabilityMetrics', ['API/addToTrace/called'])
 

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -22,6 +22,7 @@ import { setupSetApplicationVersionAPI } from '../../src/loaders/api/setApplicat
 import { setupStartAPI } from '../../src/loaders/api/start'
 import { setTopLevelCallers } from '../../src/loaders/api/topLevelCallers'
 import { gosCDN } from '../../src/common/window/nreum'
+import { now } from '../../src/common/timing/now'
 
 jest.retryTimes(0)
 
@@ -131,12 +132,56 @@ describe('API tests', () => {
 
     describe('finished', () => {
       test('should execute as expected', async () => {
+        const time = Date.now()
+        const n = now()
         agent.finished()
         expectHandled('storeSupportabilityMetrics', ['API/finished/called'])
-        expectHandled('storeEventMetrics', ['finished', { time: expect.toBeNumber() }])
+
+        expectHandled('storeEventMetrics', ['finished', { time: expect.any(Number) }])
+        const storeEventMetricsCall = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'storeEventMetrics')
+        expect(Math.abs(storeEventMetricsCall[1][1].time - time)).toBeLessThanOrEqual(1) // should be unix timestamp
+
         expectHandled('storeSupportabilityMetrics', ['API/addToTrace/called'])
+
         expectHandled('bstApi', [{ e: expect.toBeNumber(), n: 'finished', o: 'nr', s: expect.toBeNumber(), t: 'api' }])
-        expectHandled('api-addPageAction', [expect.toBeNumber(), 'finished'])
+        const bstApiCall = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'bstApi')
+        expect(Math.abs(bstApiCall[1][0].s - (n))).toBeLessThanOrEqual(1) // should be unix timestamp
+        expect(Math.abs(bstApiCall[1][0].e - (n))).toBeLessThanOrEqual(1) // should be unix timestamp
+
+        expectHandled('api-addPageAction', [expect.any(Number), 'finished']) // unix timestamp
+        const addPageActionCall = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'api-addPageAction')
+        expect(addPageActionCall[1][0]).toBeLessThan(10000) // should be relative timestamp
+        expect(Math.abs(addPageActionCall[1][0] - n)).toBeLessThanOrEqual(1) // should be relative timestamp, account for rounding errors
+      })
+
+      test('should allow argument as expected', async () => {
+        const time = Date.now() + 1000
+        const n = now()
+        agent.finished(time)
+        expectHandled('storeSupportabilityMetrics', ['API/finished/called'])
+
+        expectHandled('storeEventMetrics', ['finished', { time: expect.any(Number) }])
+        const storeEventMetricsCall = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'storeEventMetrics')
+        expect(Math.abs(storeEventMetricsCall[1][1].time - time)).toBeLessThanOrEqual(1) // should be unix timestamp
+
+        expectHandled('storeSupportabilityMetrics', ['API/addToTrace/called'])
+
+        expectHandled('bstApi', [{ e: expect.toBeNumber(), n: 'finished', o: 'nr', s: expect.toBeNumber(), t: 'api' }])
+        const bstApiCall = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'bstApi')
+        expect(Math.abs(bstApiCall[1][0].s - (n + 1000))).toBeLessThanOrEqual(1) // should be unix timestamp
+        expect(Math.abs(bstApiCall[1][0].e - (n + 1000))).toBeLessThanOrEqual(1) // should be unix timestamp
+
+        expectHandled('api-addPageAction', [expect.any(Number), 'finished']) // unix timestamp
+        const addPageActionCall = handleModule.handle.mock.calls.find(callArr => callArr[0] === 'api-addPageAction')
+        expect(addPageActionCall[1][0]).toBeLessThan(10000) // should be relative timestamp
+        expect(Math.abs(addPageActionCall[1][0] - (n + 1000))).toBeLessThanOrEqual(1) // should be relative timestamp, account for rounding errors
+      })
+
+      test('should warn for bad arg', async () => {
+        const debugSpy = jest.spyOn(console, 'debug')
+        const n = now()
+        agent.finished(n)
+        expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining('New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#62'), n)
       })
     })
 

--- a/tests/specs/api.e2e.js
+++ b/tests/specs/api.e2e.js
@@ -252,16 +252,20 @@ describe('newrelic api', () => {
     it('records a PageAction when called before RUM message', async () => {
       const insCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInsRequest })
 
-      const [insResult] = await Promise.all([
+      const [insResult, calledAt] = await Promise.all([
         insCapture.waitForResult({ totalCount: 1 }),
         browser.url(await browser.testHandle.assetURL('api/finished.html'))
           .then(() => browser.waitForAgentLoad())
+          .then(() => browser.execute(function () {
+            return window.calledAt
+          }))
       ])
 
       const pageActions = insResult[0].request.body.ins.filter(evt => evt.eventType === 'PageAction')
       expect(pageActions).toBeDefined()
       expect(pageActions.length).toEqual(1) // exactly 1 PageAction was submitted
       expect(pageActions[0].actionName).toEqual('finished') // PageAction has actionName = finished
+      expect(Math.abs((pageActions[0].timeSinceLoad * 1000) - calledAt)).toBeLessThanOrEqual(1)
     })
   })
 


### PR DESCRIPTION
Fixes an issue where the `finished` api was creating a `timeSinceLoad` value for PageAction data as the unix timestamp instead of a relative time value in seconds from the page origin.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
#1502 
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been updated to check that page actions create the correct timeSincePageLoad values
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
