### PR TITLE
feat: Add "long tasks" internal message

### DIFF
--- a/src/common/wrap/wrap-function.js
+++ b/src/common/wrap/wrap-function.js
@@ -76,6 +76,7 @@ export function createWrapperWithEmitter (emitter, always) {
       var originalThis
       var ctx
       var result
+      let thrownError
 
       try {
         originalThis = this
@@ -93,17 +94,28 @@ export function createWrapperWithEmitter (emitter, always) {
       // Warning: start events may mutate args!
       safeEmit(prefix + 'start', [args, originalThis, methodName], ctx, bubble)
 
+      const fnStartTime = performance.now()
       try {
         result = fn.apply(originalThis, args)
         return result
       } catch (err) {
         safeEmit(prefix + 'err', [args, originalThis, err], ctx, bubble)
-
         // rethrow error so we don't effect execution by observing.
-        throw err
+        thrownError = err
+        throw thrownError
       } finally {
-        // happens no matter what.
-        safeEmit(prefix + 'end', [args, originalThis, result], ctx, bubble)
+        const duration = performance.now() - fnStartTime
+        const task = {
+          duration,
+          isLongTask: duration >= 50,
+          methodName,
+          thrownError
+          // could add more properties here later if needed by downstream features
+        }
+        // standalone long task message
+        if (task.isLongTask) safeEmit('long-task', [task], ctx, bubble)
+        // -end message also includes the task execution info
+        safeEmit(prefix + 'end', [args, originalThis, result, task], ctx, bubble)
       }
     }
   }

--- a/tests/assets/long-tasks.html
+++ b/tests/assets/long-tasks.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    {init}{config}
+    <script>
+      NREUM.init.harvest.interval = 30;
+      NREUM.init.logging.enabled = false;
+    </script>
+    {loader}
+  </head>
+  <body>
+    <div>This page executes lots of different FNs that take a short or long amount of syncronous time to execute</div>
+    <pre>
+  The operations behave like this:
+
+    click (anywhere)!
+
+    document.addEventListener (click)
+    ---- SHORT TASK
+    ---- LONG TASK (with setTimeout -- should resolve after short tasks but still be detected!)
+    ---- SHORT TASK (x3)
+    ---- XHR send
+    ---- XHR load callback (Should have an error tied to the long task)
+    ------- SHORT TASK
+    ------- LONG TASK
+    ------- SHORT TASK
+    ------- Promise constructor
+    ----------- LONG TASK
+    ----------- SHORT TASK
+    ------- Promise then callback (async)
+    ----------- SHORT TASK
+    ----------- LONG TASK
+
+    Due to the way syncronous tasks block each other in JS, you may see no activity and then
+     multiple long tasks resolving at the "same time", since they cascade like dominoes when syncronous
+    </pre>
+    <hr />
+    <div id="content"></div>
+    <script type="text/javascript">
+      document.addEventListener(
+        "click",
+        function test () {
+          const contents = document.querySelector("#content");
+          updateDOM("Document Clicked!", true);
+          simulatedShortTask("document addEventListener");
+
+          var xhr = new XMLHttpRequest();
+          xhr.open("POST", "/echo");
+          xhr.send("123");
+
+          simulatedLongTask("document addEventListener", true); // LONG TASK AFFECTING DOC AEL CB
+
+          simulatedShortTask("document addEventListener");
+          simulatedShortTask("document addEventListener");
+          simulatedShortTask("document addEventListener");
+
+          xhr.addEventListener(
+            "load",
+            function () {
+              simulatedShortTask("xhr addEventListener");
+              simulatedLongTask("xhr addEventListener"); // LONG TASK AFFECTING XHR LOAD CB
+              simulatedShortTask("xhr addEventListener");
+
+              a = new Promise((resolve, reject) => {
+                simulatedLongTask("promise constructor"); // LONG TASK AFFECTING PROMISE CONSTRUCTOR
+                simulatedShortTask("promise constructor");
+                resolve();
+              });
+
+              a.then(() => {
+                simulatedShortTask("promise.then");
+                simulatedLongTask("promise.then"); // LONG TASK AFFECTING PROMISE THEN CB
+              });
+
+              throw new Error("I threw an error in the XHR load callback! Fix ME!");
+            },
+            true
+          );
+
+          function simulatedShortTask(name) {
+            const start = performance.now();
+            updateDOM(name + " task started");
+            let i = 0;
+            const loops = getRandomInt(10000, 1000000);
+            while (i < loops) {
+              i++;
+            }
+            const end  = performance.now()
+            updateDOM(name + " duration: " + (end-start).toFixed(4), "green");
+          }
+
+          function simulatedLongTask(name, useSetTimeout) {
+            const start = performance.now();
+            updateDOM(name + " task started");
+            // so as to not let the slow task block rendering for demo purposes
+
+            const executor = useSetTimeout
+              ? (fn) => setTimeout(fn, 0)
+              : function slowHandler(fn) {
+                  fn();
+                };
+
+            executor(reallySlowFn);
+
+            function reallySlowFn() {
+              let i = 0;
+              const loops = getRandomInt(100000000, 5000000000);
+              while (i < loops) {
+                i++;
+              }
+              const end = performance.now()
+              updateDOM("Long task (" + name + ") duration: " + (end-start).toFixed(4), "red");
+            }
+          }
+
+          window.location.hash = Math.random();
+
+          function updateDOM(text, color) {
+            const elem = document.createElement("div");
+            elem.innerHTML = text;
+            elem.style.color = color || "black";
+            contents.appendChild(elem);
+          }
+          function getRandomInt(min, max) {
+            return Math.ceil(Math.floor(Math.random() * (max - min + 1)) + min);
+          }
+        },
+        false
+      );
+    </script>
+  </body>
+</html>

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -804,7 +804,12 @@ describe('API tests', () => {
           expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/wrapLogger/called'])
 
           expectEmitted('wrap-logger-start', [expect.any(Array), expect.any(Object), 'myObservedLogger'])
-          expectEmitted('wrap-logger-end', [['test1'], expect.any(Object), undefined])
+          expectEmitted('wrap-logger-end', [['test1'], expect.any(Object), undefined, expect.objectContaining({
+            duration: expect.any(Number),
+            isLongTask: false,
+            methodName: 'myObservedLogger',
+            thrownError: undefined
+          })])
 
           expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/logging/info/called'])
           expectHandled('log', [expect.any(Number), 'test1', {}, 'INFO', undefined])
@@ -832,7 +837,12 @@ describe('API tests', () => {
           expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/wrapLogger/called'])
 
           expectEmitted('wrap-logger-start', [expect.any(Array), expect.any(Object), randomMethodName])
-          expectEmitted('wrap-logger-end', [['test1'], expect.any(Object), undefined])
+          expectEmitted('wrap-logger-end', [['test1'], expect.any(Object), undefined, expect.objectContaining({
+            duration: expect.any(Number),
+            isLongTask: false,
+            methodName: randomMethodName,
+            thrownError: undefined
+          })])
 
           expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/logging/warn/called'])
           expectHandled('log', [expect.any(Number), 'test1', {}, 'warn', undefined])
@@ -853,7 +863,12 @@ describe('API tests', () => {
           expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/wrapLogger/called'])
 
           expectEmitted('wrap-logger-start', [expect.any(Array), expect.any(Object), randomMethodName])
-          expectEmitted('wrap-logger-end', [['test1', { test2: 2 }, ['test3'], true, 1], expect.any(Object), undefined])
+          expectEmitted('wrap-logger-end', [['test1', { test2: 2 }, ['test3'], true, 1], expect.any(Object), undefined, expect.objectContaining({
+            duration: expect.any(Number),
+            isLongTask: false,
+            methodName: randomMethodName,
+            thrownError: undefined
+          })])
         })
 
         test('wrapped function should still behave as intended', () => {


### PR DESCRIPTION
Add an internal message indicating if a wrapped function qualifies as a "long task".  This is to be used later in agent features to enhance future behaviors.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
1. This PR adds a *new* message through the contextual EE when a long task is detected (>50ms): `long-task`
  - This can be subscribed to by any feature (though none are currently subscribed)
  - The metadata emitted contains task duration and method information, including errors thrown and fn name if supplied
2. The PR also adds the task metadata to the `-end` event, so that multiple pathways are supported for evaluating a task's execution metadata, including tasks that were not "long".
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-414034
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New jest tests have been added, existing tests modified to check for existence of long task metadata.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
