### PR TITLE
fix: fix custom attribute race condition precedence

### DIFF
--- a/src/features/utils/agent-session.js
+++ b/src/features/utils/agent-session.js
@@ -25,7 +25,8 @@ export function setupAgentSession (agentRef) {
   // Retrieve & re-add all of the persisted setCustomAttribute|setUserId k-v from previous page load(s), if any was stored.
   const customSessionData = agentRef.runtime.session.state.custom
   if (customSessionData) {
-    agentRef.info.jsAttributes = { ...agentRef.info.jsAttributes, ...customSessionData }
+    /** stored attributes from previous page should not take precedence over attributes stored on this page via API before the page load */
+    agentRef.info.jsAttributes = { ...customSessionData, ...agentRef.info.jsAttributes }
   }
 
   const sharedEE = ee.get(agentRef.agentIdentifier)

--- a/tests/assets/api/custom-attribute-persist-random.html
+++ b/tests/assets/api/custom-attribute-persist-random.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>setCustomAttribute API Test</title>
+    {init}
+    {config}
+    {loader}
+  </head>
+  <body>
+    <script>
+        // should change persistent value both locallly and in LS
+        window.value = Math.random()
+        newrelic.setCustomAttribute('testing', window.value, true)
+        window.addEventListener('load', function() {
+          newrelic.setCustomAttribute('testing-load', window.value, true)
+        })
+    </script>
+  </body>
+</html>

--- a/tests/specs/api.e2e.js
+++ b/tests/specs/api.e2e.js
@@ -376,6 +376,67 @@ describe('newrelic api', () => {
 
       expect(rumResultAfterUnset[2].request.body).not.toHaveProperty('ja') // 3rd page load does not retain custom attribute after unsetting (set to null)
     })
+
+    it('can change persisted attribute during load race, page memory and LS', async () => {
+      const rumCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testRumRequest })
+      const testUrl = await browser.testHandle.assetURL('api/custom-attribute-persist-random.html', {
+        init: {
+          privacy: { cookies_enabled: true }
+        }
+      })
+
+      const [rumResult, randomValue] = await Promise.all([
+        rumCapture.waitForResult({ totalCount: 1 }),
+        browser.url(testUrl)
+          .then(() => browser.waitForAgentLoad())
+          .then(() => browser.execute(function () { return window.value }))
+      ])
+
+      expect(rumResult[0].request.body.ja).toEqual({ testing: randomValue, 'testing-load': randomValue }) // initial page load has custom attribute
+
+      const session = await browser.execute(function () {
+        return localStorage.getItem('NRBA_SESSION')
+      })
+      expect(JSON.parse(session).custom.testing).toEqual(randomValue) // initial page load has custom attribute in memory
+      expect(JSON.parse(session).custom['testing-load']).toEqual(randomValue) // initial page load has custom attribute in memory
+
+      expect((await browser.execute(function () {
+        return Object.values(newrelic.initializedAgents)[0].info.jsAttributes.testing
+      }))).toEqual(randomValue) // initial page load has custom attribute in JS memory
+
+      expect((await browser.execute(function () {
+        return Object.values(newrelic.initializedAgents)[0].info.jsAttributes['testing-load']
+      }))).toEqual(randomValue) // initial page load has custom attribute in JS memory
+
+      await browser.testHandle.assetURL('api/custom-attribute-persist-random.html', {
+        init: {
+          privacy: { cookies_enabled: true }
+        }
+      })
+
+      const [rumResultAfterNavigate, randomValueAfterNavigate] = await Promise.all([
+        rumCapture.waitForResult({ totalCount: 2 }),
+        browser.url(testUrl)
+          .then(() => browser.waitForAgentLoad())
+          .then(() => browser.execute(function () { return window.value }))
+      ])
+
+      expect(rumResultAfterNavigate[1].request.body.ja).toEqual({ testing: randomValueAfterNavigate, 'testing-load': randomValueAfterNavigate }) // 2nd page load has new random value
+      expect(rumResultAfterNavigate[1].request.body.ja).not.toEqual({ testing: randomValue, 'testing-load': randomValueAfterNavigate }) // 2nd page load value is not first load value
+
+      const sessionAfterNavigate = await browser.execute(function () {
+        return localStorage.getItem('NRBA_SESSION')
+      })
+      expect(JSON.parse(sessionAfterNavigate).custom.testing).toEqual(randomValueAfterNavigate) // initial page load has custom attribute in memory
+      expect(JSON.parse(sessionAfterNavigate).custom['testing-load']).toEqual(randomValueAfterNavigate) // initial page load has custom attribute in memory
+
+      expect((await browser.execute(function () {
+        return Object.values(newrelic.initializedAgents)[0].info.jsAttributes.testing
+      }))).toEqual(randomValueAfterNavigate) // initial page load has custom attribute in JS memory
+      expect((await browser.execute(function () {
+        return Object.values(newrelic.initializedAgents)[0].info.jsAttributes['testing-load']
+      }))).toEqual(randomValueAfterNavigate) // initial page load has custom attribute in JS memory
+    })
   })
 
   describe('setUserId()', () => {


### PR DESCRIPTION
Addressed a race condition that occurred between the local storage module reading and writing custom attributes locally and the API updating custom attributes in page memory. 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Local Storage attributes should *NOT* take precedence over attributes set on the current page via API, when the page first loads.  That was causing new attributes to be overwritten with old values.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-403008?atlOrigin=eyJpIjoiNzMyNzczMTMyOGQzNDlmMGIzNTRiYTVlMGYyZjgzYjIiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added that confirm the correct behavior is applied on racing page loads.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
