### PR TITLE
chore: add dropped buffer size SMs

### DIFF
--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -357,3 +357,21 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * Internal/Error/Rrweb-Security-Policy
 <!--- an uncategorized internal error was observed -->
 * Internal/Error/Other
+
+### Event Buffer
+<!-- The number of bytes dropped across all features because an event buffer reached its cap -->
+EventBuffer/Combined/Dropped/Bytes
+<!-- The number of bytes dropped for ajax feature because an event buffer reached its cap -->
+EventBuffer/ajax/Dropped/Bytes
+<!-- The number of bytes dropped for generic events feature because an event buffer reached its cap -->
+EventBuffer/generic_events/Dropped/Bytes
+<!-- The number of bytes dropped for logging feature because an event buffer reached its cap -->
+EventBuffer/logging/Dropped/Bytes
+<!-- The number of bytes dropped for PVE feature because an event buffer reached its cap -->
+EventBuffer/page_view_event/Dropped/Bytes
+<!-- The number of bytes dropped for PVT feature because an event buffer reached its cap -->
+EventBuffer/page_view_timing/Dropped/Bytes
+<!-- The number of bytes dropped for spa feature because an event buffer reached its cap -->
+EventBuffer/spa/Dropped/Bytes
+<!-- The number of bytes dropped for soft_nav feature because an event buffer reached its cap -->
+EventBuffer/soft_navigations/Dropped/Bytes

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -60,13 +60,13 @@ export class AggregateBase extends FeatureBase {
         // Jserror and Metric features uses a singleton EventAggregator instead of a regular EventBuffer.
       case FEATURE_NAMES.jserrors:
       case FEATURE_NAMES.metrics:
-        this.events = this.agentRef.sharedAggregator ??= new EventStoreManager(this.agentRef, EventAggregator, entityGuid, 'shared_aggregator')
+        this.events = this.agentRef.sharedAggregator ??= new EventStoreManager(this.agentRef, EventAggregator, entityGuid, { featureName: 'shared_aggregator' })
         break
         /** All other features get EventBuffer in the ESM by default. Note: PVE is included here, but event buffer will always be empty so future harvests will still not happen by interval or EOL.
     This was necessary to prevent race cond. issues where the event buffer was checked before the feature could "block" itself.
     Its easier to just keep an empty event buffer in place. */
       default:
-        this.events = new EventStoreManager(this.agentRef, EventBuffer, entityGuid, this.featureName)
+        this.events = new EventStoreManager(this.agentRef, EventBuffer, entityGuid, this)
         break
     }
   }

--- a/src/features/utils/event-buffer.js
+++ b/src/features/utils/event-buffer.js
@@ -12,10 +12,13 @@ export class EventBuffer {
   #rawBytesBackup
 
   /**
-   * @param {number} maxPayloadSize
+   * Creates an event buffer that can hold feature-processed events.
+   * @param {Number} maxPayloadSize The maximum size of the payload that can be stored in this buffer.
+   * @param {Object} [featureAgg] - the feature aggregate instance
    */
-  constructor (maxPayloadSize = MAX_PAYLOAD_SIZE) {
+  constructor (maxPayloadSize = MAX_PAYLOAD_SIZE, featureAgg) {
     this.maxPayloadSize = maxPayloadSize
+    this.featureAgg = featureAgg
   }
 
   isEmpty () {
@@ -41,7 +44,12 @@ export class EventBuffer {
    */
   add (event) {
     const addSize = stringify(event)?.length || 0 // (estimate) # of bytes a directly stringified event it would take to send
-    if (this.#rawBytes + addSize > this.maxPayloadSize) return false
+    if (this.#rawBytes + addSize > this.maxPayloadSize) {
+      const smTag = inject => `EventBuffer/${inject}/Dropped/Bytes`
+      this.featureAgg?.reportSupportabilityMetric(smTag(this.featureAgg.featureName), addSize) // bytes dropped for this feature will aggregate with this metric tag
+      this.featureAgg?.reportSupportabilityMetric(smTag('Combined'), addSize) // all bytes dropped across all features will aggregate with this metric tag
+      return false
+    }
     this.#buffer.push(event)
     this.#rawBytes += addSize
     return true

--- a/src/features/utils/event-store-manager.js
+++ b/src/features/utils/event-store-manager.js
@@ -2,7 +2,7 @@
  * Copyright 2020-2025 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { DEFAULT_KEY } from '../../common/constants/agent-constants'
+import { DEFAULT_KEY, MAX_PAYLOAD_SIZE } from '../../common/constants/agent-constants'
 import { dispatchGlobalEvent } from '../../common/dispatch/global-event'
 import { activatedFeatures } from '../../common/util/feature-flags'
 import { isContainerAgentTarget } from '../../common/util/target'
@@ -15,14 +15,14 @@ export class EventStoreManager {
    * @param {object} agentRef - reference to base agent class
    * @param {EventBuffer|EventAggregator} storageClass - the type of storage to use in this manager; 'EventBuffer' (1), 'EventAggregator' (2)
    * @param {string} [defaultEntityGuid] - the entity guid to use as the default storage instance; if not provided, a new one is created
-   * @param {string} featureName - the name of the feature this manager is for; used for event dispatching
+   * @param {Object} featureAgg - the feature aggregate instance that initialized this manager
    */
-  constructor (agentRef, storageClass, defaultEntityGuid, featureName) {
+  constructor (agentRef, storageClass, defaultEntityGuid, featureAgg) {
     this.agentRef = agentRef
     this.entityManager = agentRef.runtime.entityManager
     this.StorageClass = storageClass
-    this.appStorageMap = new Map([[DEFAULT_KEY, new this.StorageClass()]])
-    this.featureName = featureName
+    this.appStorageMap = new Map([[DEFAULT_KEY, new this.StorageClass(MAX_PAYLOAD_SIZE, featureAgg)]])
+    this.featureAgg = featureAgg
     this.setEventStore(defaultEntityGuid)
   }
 
@@ -42,7 +42,7 @@ export class EventStoreManager {
     /** if the target is the container agent, SHARE the default storage -- otherwise create a new event store */
     const eventStorage = (isContainerAgentTarget(this.entityManager.get(targetEntityGuid), this.agentRef))
       ? this.appStorageMap.get(DEFAULT_KEY)
-      : new this.StorageClass()
+      : new this.StorageClass(MAX_PAYLOAD_SIZE, this.featureAgg.featureAgg)
     this.appStorageMap.set(targetEntityGuid, eventStorage)
   }
 
@@ -75,7 +75,7 @@ export class EventStoreManager {
       drained: !!activatedFeatures?.[this.agentRef.agentIdentifier],
       type: 'data',
       name: 'buffer',
-      feature: this.featureName,
+      feature: this.featureAgg.featureName,
       data: event
     })
     return this.#getEventStore(targetEntityGuid).add(event)

--- a/tests/unit/features/utils/aggregate-base.test.js
+++ b/tests/unit/features/utils/aggregate-base.test.js
@@ -160,18 +160,18 @@ test('does not initialized Aggregator more than once with multiple features', as
   pveAgg.processEntities(mockRumResp1.app.agents, { licenseKey: '1', applicationID: '1' })
 
   expect(EventStoreManager).toHaveBeenCalledTimes(1)
-  expect(EventStoreManager).toHaveBeenCalledWith(mainAgent, EventBuffer, '12345', FEATURE_NAMES.pageViewEvent) // 2 = initialize EventAggregator
+  expect(EventStoreManager).toHaveBeenCalledWith(mainAgent, EventBuffer, '12345', pveAgg) // 2 = initialize EventAggregator
   expect(mainAgent.runtime.entityManager).toBeTruthy()
   expect(mainAgent.sharedAggregator).toBeUndefined()
 
   new AggregateBase(mainAgent, FEATURE_NAMES.jserrors) // this feature should be using the shared aggregator, so it will set it now
   expect(EventStoreManager).toHaveBeenCalledTimes(2)
-  expect(EventStoreManager).toHaveBeenCalledWith(mainAgent, EventAggregator, '12345', 'shared_aggregator') // 2 = initialize EventAggregator
+  expect(EventStoreManager).toHaveBeenCalledWith(mainAgent, EventAggregator, '12345', { featureName: 'shared_aggregator' }) // 2 = initialize EventAggregator
   expect(mainAgent.sharedAggregator).toBeTruthy()
 
-  new AggregateBase(mainAgent, FEATURE_NAMES.pageViewTiming) // PVT should use its own EventStoreManager
+  const pvtAgg = new AggregateBase(mainAgent, FEATURE_NAMES.pageViewTiming) // PVT should use its own EventStoreManager
   expect(EventStoreManager).toHaveBeenCalledTimes(3)
-  expect(EventStoreManager).toHaveBeenCalledWith(mainAgent, EventBuffer, '12345', FEATURE_NAMES.pageViewTiming) // 1 = initialize EventBuffer
+  expect(EventStoreManager).toHaveBeenCalledWith(mainAgent, EventBuffer, '12345', pvtAgg) // 1 = initialize EventBuffer
 })
 
 test('does initialize separate Aggregators with multiple agents', async () => {

--- a/tests/unit/features/utils/event-store-manager.test.js
+++ b/tests/unit/features/utils/event-store-manager.test.js
@@ -35,9 +35,9 @@ describe('EventStoreManager', () => {
   })
 
   test('has agentIdentifier and featureName defined', () => {
-    const store = new EventStoreManager(mockAgentRef, EventBuffer, mockAgentRef.runtime.appMetadata.agents[0].entityGuid, 'test')
+    const store = new EventStoreManager(mockAgentRef, EventBuffer, mockAgentRef.runtime.appMetadata.agents[0].entityGuid, { featureName: 'test' })
     expect(store.agentIdentifier).toEqual(mockAgentRef.agentIdentifier)
-    expect(store.featureName).toEqual('test')
+    expect(store.featureAgg.featureName).toEqual('test')
   })
 
   test('calls the underlying StorgeClass add, get, isEmpty methods', () => {


### PR DESCRIPTION
This PR adds new SMs for cases where the event buffer is dropping data due to max size
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Please see the changes to `supportability-metrics.md` to see the relevant tags that will be created in Angler.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-422717
A new PR to Angler is to be made and linked here to create lookups for the new tags --> https://source.datanerd.us/agents/angler/pull/706
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
N/A
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
