### PR TITLE
chore: remove coverage runners

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -25,14 +25,14 @@ jobs:
     with:
       coverage: true
 
-  wdio-coverage:
-    if: github.ref == 'refs/heads/main'
-    name: WDIO coverage
-    uses: ./.github/workflows/wdio-single-browser.yml
-    with:
-      browser-target: chrome@latest
-      coverage: true
-    secrets: inherit
+  # wdio-coverage:
+  #   if: github.ref == 'refs/heads/main'
+  #   name: WDIO coverage
+  #   uses: ./.github/workflows/wdio-single-browser.yml
+  #   with:
+  #     browser-target: chrome@latest
+  #     coverage: true
+  #   secrets: inherit
 
   # Build and publish the latest code from the main branch
   publish-dev-to-s3:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -253,16 +253,16 @@ jobs:
             Checking merge of (${{ fromJSON(needs.find-pull-request.outputs.pull-request-target).head_sha }}) into [${{ fromJSON(needs.find-pull-request.outputs.pull-request-target).base_ref }}](https://github.com/newrelic/newrelic-browser-agent/compare/${{ fromJSON(needs.find-pull-request.outputs.pull-request-target).head_sha }}..${{ fromJSON(needs.find-pull-request.outputs.pull-request-target).base_sha }}) (${{ fromJSON(needs.find-pull-request.outputs.pull-request-target).base_sha }})
           comment_tag: <!-- browser_agent pull request checks -->
 
-  wdio-coverage:
-    name: WDIO coverage
-    if: github.event_name == 'workflow_dispatch'
-    needs: find-pull-request
-    uses: ./.github/workflows/wdio-single-browser.yml
-    with:
-      ref: 'refs/pull/${{ fromJSON(needs.find-pull-request.outputs.pull-request-target).pr_number }}/merge'
-      browser-target: chrome@latest
-      coverage: true
-    secrets: inherit
+  # wdio-coverage:
+  #   name: WDIO coverage
+  #   if: github.event_name == 'workflow_dispatch'
+  #   needs: find-pull-request
+  #   uses: ./.github/workflows/wdio-single-browser.yml
+  #   with:
+  #     ref: 'refs/pull/${{ fromJSON(needs.find-pull-request.outputs.pull-request-target).pr_number }}/merge'
+  #     browser-target: chrome@latest
+  #     coverage: true
+  #   secrets: inherit
 
   wdio:
     name: WDIO
@@ -277,7 +277,8 @@ jobs:
   complete-status-comment-pull-request:
     name: Comment pull request
     if: always() && github.event_name == 'workflow_dispatch' && needs.find-pull-request.result == 'success'
-    needs: [find-pull-request,wdio-coverage,wdio]
+    # needs: [find-pull-request,wdio-coverage,wdio]
+    needs: [find-pull-request,wdio]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
This PR removes the e2e coverage runners (but not the underlying mechanisms that support that behavior), which have been failing and not providing insight.  After some time allowing for evaluation, the underlying mechanisms needed for coverage tests should be removed.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
