### PR TITLE
Nr 422176 buttons

### DIFF
--- a/src/features/generic_events/aggregate/user-actions/aggregated-user-action.js
+++ b/src/features/generic_events/aggregate/user-actions/aggregated-user-action.js
@@ -19,15 +19,19 @@ export class AggregatedUserAction {
   }
 
   /**
-   * Aggregates the count and maintains the relative MS array for matching events
-   * Will determine if a rage click was observed as part of the aggregation
+   * Update current user action based on new event + selector info.
+   *  - Aggregates the count and maintains the relative MS array for matching events
+   *  - Will determine if a rage click was observed as part of the aggregation
+   *  - Will determine if a dead click has occurred
    * @param {Event} evt
+   * @param {Object} selectorInfo
    * @returns {void}
    */
-  aggregate (evt) {
+  aggregate (evt, selectorInfo = {}) {
     this.count++
     this.relativeMs.push(Math.floor(evt.timeStamp - this.originMs))
     if (this.isRageClick()) this.rageClick = true
+    this.deadClick ||= this.isDeadClick(selectorInfo)
   }
 
   /**
@@ -46,10 +50,11 @@ export class AggregatedUserAction {
    * - clicking on a link that is not interactive = a dead click.
    * - clicking on a span inside a non-interactive link = a dead click.
    * - clicking on a standalone span = not a dead click.
+   * @param {Object} selectorInfo
    * @returns {boolean}
    */
-  isDeadClick (selectorInfo) {
-    const { hasInteractiveElems, hasLink, hasTextbox } = selectorInfo
-    return this.event.type === 'click' && !hasInteractiveElems && (hasLink || hasTextbox)
+  isDeadClick (selectorInfo = {}) {
+    const { hasInteractiveElems, hasButton, hasLink, hasTextbox, ignoreDeadClick } = selectorInfo
+    return this.event.type === 'click' && !hasInteractiveElems && (hasButton || hasLink || hasTextbox) && !ignoreDeadClick
   }
 }

--- a/src/features/generic_events/aggregate/user-actions/interactive-elements.js
+++ b/src/features/generic_events/aggregate/user-actions/interactive-elements.js
@@ -36,7 +36,7 @@ function isButtonOrLink (target) {
 
 export function isInteractiveElement (elem) {
   const tagName = (elem && elem.nodeType === Node.ELEMENT_NODE && elem.tagName?.toLowerCase()) ?? ''
-  return isInteractiveLink(elem, tagName) || isInteractiveTextbox(elem, tagName)
+  return isInteractiveLink(elem, tagName) || isInteractiveButton(elem, tagName) || isInteractiveTextbox(elem, tagName)
 }
 
 /**
@@ -60,4 +60,37 @@ function isInteractiveLink (elem, tagName) {
  */
 function isInteractiveTextbox (elem, tagName) {
   return tagName === 'input' && elem.type.toLowerCase() === 'text' && !elem.readOnly
+}
+
+/**
+ * Checks if the element is an interactive button.
+ * A link is considered interactive if it is part of a form or popover, has an `onclick` handler, or any click event listener(s).
+ *
+ * @param {HTMLElement} elem
+ * @param {tagName} string
+ * @returns {boolean} true only if the element is an interactive button
+ */
+function isInteractiveButton (elem, tagName) {
+  return (tagName === 'button' || (tagName === 'input' && elem.type.toLowerCase() === 'button')) &&
+    (interactiveElems.has(elem) || typeof elem.onclick === 'function' || isPartOfForm(elem) || willUpdatePopover(elem))
+}
+
+function isPartOfForm (buttonElem) {
+  // specified form attribute overrides any ancestor forms
+  if (Object.values(buttonElem.attributes).filter(x => x.nodeName === 'form').length > 0) {
+    return buttonElem.form !== null
+  }
+  return buttonElem.closest('form') !== null
+}
+
+function willUpdatePopover (buttonElem) {
+  const maybePopover = buttonElem.popoverTargetElement
+  if (maybePopover?.nodeType === Node.ELEMENT_NODE) {
+    const targetDisplay = getComputedStyle(maybePopover).display
+    return (buttonElem.popoverTargetAction !== 'hide' && buttonElem.popoverTargetAction !== 'show') ||
+      (buttonElem.popoverTargetAction === 'hide' && targetDisplay === 'block') ||
+      (buttonElem.popoverTargetAction === 'show' && targetDisplay === 'none')
+  }
+
+  return false
 }

--- a/src/features/generic_events/aggregate/user-actions/user-actions-aggregator.js
+++ b/src/features/generic_events/aggregate/user-actions/user-actions-aggregator.js
@@ -33,7 +33,7 @@ export class UserActionsAggregator {
     const aggregationKey = getAggregationKey(evt, selectorInfo.path)
     if (!!aggregationKey && aggregationKey === this.#aggregationKey) {
       // an aggregation exists already, so lets just continue to increment
-      this.#aggregationEvent.aggregate(evt)
+      this.#aggregationEvent.aggregate(evt, selectorInfo)
     } else {
       // return the prev existing one (if there is one)
       const finishedEvent = this.#aggregationEvent

--- a/tests/assets/user-frustrations/instrumented-dead-clicks.html
+++ b/tests/assets/user-frustrations/instrumented-dead-clicks.html
@@ -32,28 +32,162 @@
     <div id="test-area">
       <h1>RUM - Dead Clicks</h1>
       <p>This page is used to test dead clicks instrumentation.</p>
+      <h2>Buttons</h2>
+      <div>
+        <p>Button with a click event handler, added via `addEventListener`.
+          <button id="test-button-with-listener">Click Me</button>
+          <script>
+            document.getElementById('test-button-with-listener').addEventListener('click', function() {
+              console.log('Button clicked, no dead click event should be recorded.');
+            });
+          </script>
+        </p>
+
+        <p>Button with a click event handler, added via `onclick`.
+          <button id="test-button-with-onclick" onclick="console.log('Button clicked, no dead click event should be recorded.');">Click Me</button>
+        </p>
+
+        <p>Button that has a click event handler added, then removed.
+          <button id="do-nothing-button">Do nothing</button>
+          <script>
+            document.getElementById("do-nothing-button").addEventListener("click", doNothingFn)
+            document.getElementById("do-nothing-button").removeEventListener("click", doNothingFn)
+          </script>
+        </p>
+
+        <p>Button with no click handler, no forms
+          <button id="dead-button">Dead button</button>
+        </p>
+
+        <p>Button with listener + span child
+          <button id="button-with-listener-and-span-child">
+            <span id="span-inside-button-with-listener">Button</span>
+          </button>
+          <script>
+            document.getElementById('button-with-listener-and-span-child').addEventListener('click', function() {
+              console.log('button clicked, no dead click event should be recorded.');
+            });
+          </script>
+        </p>
+
+        <p>Dead button +  span child =>
+          <button id="dead-button-with-span-child">
+            <span id="span-inside-dead-button">Dead button</span>
+          </button>
+        </p>
+
+        <fieldset>
+          <legend>Buttons and forms</legend>
+          <p>Button with a form ancestor
+            <form id="form-with-button-child">
+              <input type="checkbox" id="bar1" name="foo" value="bar1" checked />
+              <label for="bar1">bar</label>
+              <button id="button-with-form-ancestor">Button w/ form ancestor</button>
+            </form>
+          </p>
+
+          <p>Button with a related form
+            <form id="form-with-related-button">
+              <input type="checkbox" id="bar2" name="foo" value="bar2" checked />
+              <label for="bar2">bar</label>
+            </form>
+            <button id="button-with-related-form" form="form-with-related-button">Button w/ related form</button>
+          </p>
+
+          <p>Button with an invalid form
+            <form id="form-with-no-valid-button">
+              <input type="checkbox" id="bar3" name="foo" value="bar3" checked />
+              <label for="bar3">bar</label>
+              <button id="button-with-invalid-form" form="does-not-exist">Button w/ non-existent form</button>
+            </form>
+          </p>
+        </fieldset>
+
+        <fieldset>
+          <legend>Buttons and popovers</legend>
+          <p>Button for a popover
+            <button id="button-for-popover" popovertarget="popover-target">Toggle popover</button> <!-- default action is "toggle" -->
+            <button id="button-for-popover-hide" popovertarget="popover-target" popovertargetaction="hide">Hide popover</button>
+            <button id="button-for-popover-show" popovertarget="popover-target" popovertargetaction="show">Show popover</button>
+            <div id="popover-target" popover>This is a popover! </div>
+          </p>
+
+          <p>Button for an invalid popover
+            <button id="button-for-popover-invalid-target" popovertarget="does-not-exist">Button for non-existent popover</button>
+            <button id="button-for-popover-invalid-command" popovertarget="popover-target" popovertargetaction="foo">Button, popovertargetaction = foo</button>
+          </p>
+        </fieldset>
+
+        <fieldset>
+        <legend>Buttons and commands</legend>
+          <p>Button as a command for a dialog
+            <button id="button-for-show-modal-command" commandfor="sample-dialog" command="show-modal">Show modal</button>
+            <button id="button-for-close-already-closed-modal" commandfor="sample-dialog" command="close">Close modal</button> <!-- this will do nothing -->
+            <button id="button-for-request-close-already-closed-modal" commandfor="sample-dialog" command="request-close">Request to close modal</button> <!-- this will do nothing -->
+            <button id="button-for-bad-dialog" commandfor="does-not-exist" command="show-modal">Show non-existent modal</button> <!-- this will do nothing -->
+            <dialog id="sample-dialog" style="border: 1px solid #666; background-color: #ccc;">This is a dialog modal!
+              <p>
+                <button id="button-for-show-modal-again-command" commandfor="sample-dialog" command="show-modal">Show modal</button> <!-- this will do nothing -->
+                <button id="button-for-close-command" commandfor="sample-dialog" command="close">Close modal</button>
+                <button id="button-for-request-close-command" commandfor="sample-dialog" command="request-close">Request to close modal</button>
+                <button id="button-for-bad-command" commandfor="sample-dialog" command="do-nothing">Do nothing</button>
+              </p>
+            </dialog>
+          </p>
+        </fieldset>
+
+      </div>
+
+      <h2>Input, type = "button"</h2>
+      <div>
+        <p>Button with a click event handler, added via `addEventListener`.
+          <input type="button" id="test-input-button-with-listener" value="Click Me"/>
+          <script>
+            document.getElementById('test-input-button-with-listener').addEventListener('click', function() {
+              console.log('Button clicked, no dead click event should be recorded.');
+            });
+          </script>
+        </p>
+
+        <p>Button with a click event handler, added via `onclick`.
+          <input type="button" id="test-input-button-with-onclick" onclick="console.log('Button clicked, no dead click event should be recorded.');"value = "Click Me"/>
+        </p>
+
+        <p>Button that has a click event handler added, then removed.
+          <input type="button" id="do-nothing-input-button" value="Do nothing"/>
+          <script>
+            document.getElementById("do-nothing-input-button").addEventListener("click", doNothingFn)
+            document.getElementById("do-nothing-input-button").removeEventListener("click", doNothingFn)
+          </script>
+        </p>
+
+        <p>Button with no click handler, no forms
+          <input type="button" id="dead-input-button" value="Dead input button" />
+        </p>
+      </div>
+
       <h2>Links</h2>
       <div>
         <p>Link with a click event handler, added via `addEventListener`=>
-        <a id="test-link-with-listener">Link</a>
+          <a id="test-link-with-listener">Link</a>
+          <script>
+            document.getElementById('test-link-with-listener').addEventListener('click', function() {
+              console.log('Link clicked, no dead click event should be recorded.');
+            });
+          </script>
         </p>
-        <script>
-          document.getElementById('test-link-with-listener').addEventListener('click', function() {
-            console.log('Link clicked, no dead click event should be recorded.');
-          });
-        </script>
 
         <p>Link with a click event handler, added via `onclick` =>
-        <a id="test-link-with-onclick" onclick="console.log('Click')">Link</a>
+          <a id="test-link-with-onclick" onclick="console.log('Click')">Link</a>
         </p>
 
         <p>Link that has a click event handler added, then removed. =>
           <a id="do-nothing-link">Link</a>
+          <script>
+            document.getElementById("do-nothing-link").addEventListener("click", doNothingFn)
+            document.getElementById("do-nothing-link").removeEventListener("click", doNothingFn)
+          </script>
         </p>
-        <script>
-          document.getElementById("do-nothing-link").addEventListener("click", doNothingFn)
-          document.getElementById("do-nothing-link").removeEventListener("click", doNothingFn)
-        </script>
 
         <p>Link with href =>
           <a id="test-link-with-href" href="https://www.example.com">Go to Example.com</a>
@@ -112,5 +246,4 @@
       </div>
     </div>
   </body>
-
 </html>

--- a/tests/specs/user-frustrations/dead-clicks.e2e.js
+++ b/tests/specs/user-frustrations/dead-clicks.e2e.js
@@ -151,4 +151,293 @@ describe('User Frustrations - Dead Clicks', () => {
       deadClick: true
     }))
   })
+
+  it('should correctly assess dead clicks on input buttons', async () => {
+    const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testInsRequest }
+    ])
+    await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-dead-clicks.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      // [0] - input button with click listener
+      document.getElementById('test-input-button-with-listener').click()
+      // [1] - input button with onclick
+      document.getElementById('test-input-button-with-onclick').click()
+      // [2] - input button with a handler that was added and removed
+      document.getElementById('do-nothing-input-button').click()
+      // [3] - input button with no handlers and not part of any form
+      document.getElementById('dead-input-button').click()
+      // end previous user action
+      document.getElementById('test-area').click()
+    })
+
+    const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetId: 'test-input-button-with-listener',
+      targetType: 'button'
+    }))
+    expect(actuals[0]).not.toHaveProperty('deadClick')
+
+    expect(actuals[1]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetId: 'test-input-button-with-onclick',
+      targetType: 'button'
+    }))
+    expect(actuals[1]).not.toHaveProperty('deadClick')
+
+    expect(actuals[2]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetId: 'do-nothing-input-button',
+      targetType: 'button',
+      deadClick: true
+    }))
+
+    expect(actuals[3]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetId: 'dead-input-button',
+      targetType: 'button',
+      deadClick: true
+    }))
+  })
+
+  it('should correctly assess dead clicks on button elements', async () => {
+    const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testInsRequest }
+    ])
+    await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-dead-clicks.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      // [0] - button with click listener
+      document.getElementById('test-button-with-listener').click()
+      // [1] - button with onclick
+      document.getElementById('test-button-with-onclick').click()
+      // [2] - button with a handler that was added and removed
+      document.getElementById('do-nothing-button').click()
+      // [3] - button with no handlers and not part of any form
+      document.getElementById('dead-button').click()
+      // [4] - span inside button with listener
+      document.getElementById('span-inside-button-with-listener').click()
+      // [5] - span inside dead button
+      document.getElementById('span-inside-dead-button').click()
+      // end previous user action
+      document.getElementById('test-area').click()
+    })
+
+    const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'test-button-with-listener'
+    }))
+    expect(actuals[0]).not.toHaveProperty('deadClick')
+
+    expect(actuals[1]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'test-button-with-onclick'
+    }))
+    expect(actuals[1]).not.toHaveProperty('deadClick')
+
+    expect(actuals[2]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'do-nothing-button',
+      deadClick: true
+    }))
+
+    expect(actuals[3]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'dead-button',
+      deadClick: true
+    }))
+
+    expect(actuals[4]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'SPAN',
+      targetId: 'span-inside-button-with-listener'
+    }))
+    expect(actuals[4]).not.toHaveProperty('deadClick')
+
+    expect(actuals[5]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'SPAN',
+      targetId: 'span-inside-dead-button',
+      deadClick: true
+    }))
+  })
+
+  it('should correctly assess dead clicks on button elements with forms', async () => {
+    const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testInsRequest }
+    ])
+    await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-dead-clicks.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      // [0] - button with form ancestor
+      document.getElementById('button-with-form-ancestor').click()
+      // [1] - button with a related form
+      document.getElementById('button-with-related-form').click()
+      // [2] - button with an invalid form, overriding form ancestor
+      document.getElementById('button-with-invalid-form').click()
+      // end previous user action
+      document.getElementById('test-area').click()
+    })
+
+    const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-with-form-ancestor'
+    }))
+    expect(actuals[0]).not.toHaveProperty('deadClick')
+
+    expect(actuals[1]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-with-related-form'
+    }))
+    expect(actuals[1]).not.toHaveProperty('deadClick')
+
+    expect(actuals[2]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-with-invalid-form',
+      deadClick: true
+    }))
+  })
+
+  it('should correctly assess dead clicks on popover buttons', async () => {
+    const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testInsRequest }
+    ])
+    await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-dead-clicks.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      // [0] - button to toggle popover
+      document.getElementById('button-for-popover').click() // toggles and opens popover
+      // [1] - button to hide popover that is currently visible
+      document.getElementById('button-for-popover-hide').click() // closes popover
+      // [2] - button to show popover that is currently hidden
+      document.getElementById('button-for-popover-show').click() // opens popover
+      // [3] - button to toggle popover
+      document.getElementById('button-for-popover').click() // toggles and closes popover
+      // [4] - button to hide popover that is already closed
+      document.getElementById('button-for-popover-hide').click() // does nothing = dead click
+
+      // the following clicks will be processed together as one user action
+      // [5] - button first opens popover, then does nothing
+      document.getElementById('button-for-popover-show').click() // opens popover
+      document.getElementById('button-for-popover-show').click() // does nothing = dead click
+
+      // [6] - button with invalid popover command will toggle popover
+      document.getElementById('button-for-popover-invalid-command').click() // toggles and closes popover
+
+      // [7] - button with invalid popover target
+      document.getElementById('button-for-popover-invalid-target').click() // does nothing
+      // end previous user action
+      document.getElementById('test-area').click()
+    })
+
+    const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-popover'
+    }))
+    expect(actuals[0]).not.toHaveProperty('deadClick')
+
+    expect(actuals[1]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-popover-hide'
+    }))
+    expect(actuals[1]).not.toHaveProperty('deadClick')
+
+    expect(actuals[2]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-popover-show'
+    }))
+    expect(actuals[2]).not.toHaveProperty('deadClick')
+
+    expect(actuals[3]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-popover'
+    }))
+    expect(actuals[3]).not.toHaveProperty('deadClick')
+
+    // popover is already closed = dead click
+    expect(actuals[4]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-popover-hide',
+      deadClick: true
+    }))
+
+    // first click opens popover, second click does nothing = dead click
+    expect(actuals[5]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-popover-show',
+      deadClick: true
+    }))
+
+    expect(actuals[6]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-popover-invalid-command'
+    }))
+    expect(actuals[6]).not.toHaveProperty('deadClick')
+
+    // invalid popover target = dead click
+    expect(actuals[7]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-popover-invalid-target',
+      deadClick: true
+    }))
+  })
+
+  it('should ignore buttons with command attribute for dead click detection', async () => {
+    const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testInsRequest }
+    ])
+    await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-dead-clicks.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      // [0] - button with command attribute
+      document.getElementById('button-for-show-modal-command').click()
+      // end previous user action
+      document.getElementById('test-area').click()
+    })
+
+    const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-for-show-modal-command'
+    }))
+    expect(actuals[0]).not.toHaveProperty('deadClick')
+  })
 })

--- a/tests/specs/user-frustrations/dead-clicks.e2e.js
+++ b/tests/specs/user-frustrations/dead-clicks.e2e.js
@@ -22,32 +22,22 @@ describe('User Frustrations - Dead Clicks', () => {
       })
 
       const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
-      expect(insightsHarvest.request.body.ins).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'DIV',
-            targetId: 'test-area'
-          }),
-          expect.not.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'DIV',
-            targetId: 'test-area',
-            deadClick: true
-          }),
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'SPAN',
-            targetId: 'do-nothing-span'
-          }),
-          expect.not.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'SPAN',
-            targetId: 'do-nothing-span',
-            deadClick: true
-          })
-        ]))
+      const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+      expect(actuals[0]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'DIV',
+        targetId: 'test-area'
+      }))
+      expect(actuals[0]).not.toHaveProperty('deadClick')
+
+      expect(actuals[1]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'SPAN',
+        targetId: 'do-nothing-span'
+      }))
+      expect(actuals[1]).not.toHaveProperty('deadClick')
     })
+
     it(`should correctly assess dead clicks on links for ${loaderType} loader`, async () => {
       const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
         { test: testInsRequest }
@@ -76,71 +66,54 @@ describe('User Frustrations - Dead Clicks', () => {
 
       const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
 
-      expect(insightsHarvest.request.body.ins).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'A',
-            targetId: 'dead-link',
-            deadClick: true
-          }),
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'A',
-            targetId: 'do-nothing-link',
-            deadClick: true
-          }),
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'A',
-            targetId: 'test-link-with-listener'
-          }),
-          expect.not.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'A',
-            targetId: 'test-link-with-listener',
-            deadClick: true
-          }),
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'A',
-            targetId: 'test-link-with-onclick'
-          }),
-          expect.not.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'A',
-            targetId: 'test-link-with-onclick',
-            deadClick: true
-          }),
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'A',
-            targetId: 'test-link-with-href'
-          }),
-          expect.not.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'A',
-            targetId: 'test-link-with-href',
-            deadClick: true
-          }),
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'SPAN',
-            targetId: 'span-inside-link-with-listener'
-          }),
-          expect.not.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'SPAN',
-            targetId: 'span-inside-link-with-listener',
-            deadClick: true
-          }),
-          expect.objectContaining({
-            eventType: 'UserAction',
-            targetTag: 'SPAN',
-            targetId: 'span-inside-dead-link',
-            deadClick: true
-          })
-        ]))
+      const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+      expect(actuals[0]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'dead-link',
+        deadClick: true
+      }))
+      expect(actuals[1]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'do-nothing-link',
+        deadClick: true
+      }))
+
+      expect(actuals[2]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'test-link-with-listener'
+      }))
+      expect(actuals[2]).not.toHaveProperty('deadClick')
+
+      expect(actuals[3]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'test-link-with-onclick'
+      }))
+      expect(actuals[3]).not.toHaveProperty('deadClick')
+
+      expect(actuals[4]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'test-link-with-href'
+      }))
+      expect(actuals[4]).not.toHaveProperty('deadClick')
+
+      expect(actuals[5]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'SPAN',
+        targetId: 'span-inside-link-with-listener'
+      }))
+      expect(actuals[5]).not.toHaveProperty('deadClick')
+
+      expect(actuals[6]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'SPAN',
+        targetId: 'span-inside-dead-link',
+        deadClick: true
+      }))
     })
   })
 
@@ -162,28 +135,20 @@ describe('User Frustrations - Dead Clicks', () => {
     })
 
     const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
-    expect(insightsHarvest.request.body.ins).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          eventType: 'UserAction',
-          targetTag: 'INPUT',
-          targetId: 'normal-textbox',
-          targetType: 'text'
-        }),
-        expect.not.objectContaining({
-          eventType: 'UserAction',
-          targetTag: 'INPUT',
-          targetId: 'normal-textbox',
-          targetType: 'text',
-          deadClick: true
-        }),
-        expect.objectContaining({
-          eventType: 'UserAction',
-          targetTag: 'INPUT',
-          targetId: 'readonly-textbox',
-          targetType: 'text',
-          deadClick: true
-        })
-      ]))
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetId: 'normal-textbox',
+      targetType: 'text'
+    }))
+    expect(actuals[0]).not.toHaveProperty('deadClick')
+    expect(actuals[1]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetId: 'readonly-textbox',
+      targetType: 'text',
+      deadClick: true
+    }))
   })
 })

--- a/tests/unit/features/generic_events/aggregate/user-actions/interactive-elements.test.js
+++ b/tests/unit/features/generic_events/aggregate/user-actions/interactive-elements.test.js
@@ -1,4 +1,4 @@
-import { interactiveElems } from '../../../../../../src/features/generic_events/aggregate/user-actions/interactive-elements'
+import { interactiveElems, isInteractiveElement } from '../../../../../../src/features/generic_events/aggregate/user-actions/interactive-elements'
 
 describe('Interactive Elements - lookup for elem click event listeners', () => {
   const lookup = interactiveElems
@@ -44,5 +44,189 @@ describe('Interactive Elements - lookup for elem click event listeners', () => {
 
     lookup.delete(button, listener)
     expect(lookup.has(button)).toBeFalse()
+  })
+})
+
+describe('isInteractiveElement - links', () => {
+  it('should return true for link with href', () => {
+    const link = document.createElement('a')
+    link.href = 'https://example.com'
+    expect(isInteractiveElement(link)).toBe(true)
+  })
+
+  it('should return true for link with onclick', () => {
+    const link = document.createElement('a')
+    link.onclick = () => {}
+    expect(isInteractiveElement(link)).toBe(true)
+  })
+
+  it('should return true for link with click event listener', () => {
+    const link = document.createElement('a')
+    const listener = () => {}
+    interactiveElems.add(link, listener)
+    expect(isInteractiveElement(link)).toBe(true)
+
+    // clean up
+    interactiveElems.delete(link, listener)
+  })
+
+  it('should return false for non-interactive link without href or click handler', () => {
+    const link = document.createElement('a')
+    expect(isInteractiveElement(link)).toBe(false)
+  })
+})
+
+describe('isInteractiveElement - textboxes', () => {
+  it('should return true for normal textbox', () => {
+    const input = document.createElement('input')
+    input.type = 'text'
+    expect(isInteractiveElement(input)).toBe(true)
+  })
+  it('should return false for readonly textbox', () => {
+    const input = document.createElement('input')
+    input.type = 'text'
+    input.readOnly = true
+    expect(isInteractiveElement(input)).toBe(false)
+  })
+})
+
+describe('isInteractiveElement - buttons', () => {
+  it('should return true for button with onclick', () => {
+    const button = document.createElement('button')
+    button.onclick = () => {}
+    expect(isInteractiveElement(button)).toBe(true)
+  })
+  it('should return true for button with click event listener', () => {
+    const button = document.createElement('button')
+    const listener = () => {}
+    interactiveElems.add(button, listener)
+    expect(isInteractiveElement(button)).toBe(true)
+
+    // clean up
+    interactiveElems.delete(button, listener)
+  })
+  it('should return false for button without onclick or click event listener, and not associated with anything else', () => {
+    const button = document.createElement('button')
+    expect(isInteractiveElement(button)).toBe(false)
+  })
+  it('should return true for button that is a descendant of a form', () => {
+    const form = document.createElement('form')
+    const button = document.createElement('button')
+    form.appendChild(button)
+    document.body.appendChild(form)
+    expect(isInteractiveElement(button)).toBe(true)
+  })
+  it('should return true for button that is associated with a form', () => {
+    const form = document.createElement('form')
+    form.id = 'test-form'
+    const button = document.createElement('button')
+    button.setAttribute('form', 'test-form') // associate button with form
+    document.body.appendChild(button)
+    document.body.appendChild(form)
+    expect(isInteractiveElement(button)).toBe(true)
+  })
+  it('should return false for button with a form ancestor and a bad override form value', () => {
+    const form = document.createElement('form')
+    form.id = 'test-form'
+    const button = document.createElement('button')
+    button.setAttribute('form', 'does-not-exist')
+    form.appendChild(button)
+    document.body.appendChild(form)
+    expect(isInteractiveElement(button)).toBe(false)
+  })
+  it('should return true for button associated with a popover', () => {
+    const button = document.createElement('button')
+    const popover = document.createElement('div')
+    button.popoverTargetElement = popover // simulate a popover association
+    expect(isInteractiveElement(button)).toBe(true)
+  })
+  it('should return true for button that will show a popover, if popover is currently hidden', () => {
+    const button = document.createElement('button')
+    const popover = document.createElement('div')
+    popover.style.display = 'none' // simulate a hidden popover
+    button.popoverTargetElement = popover
+    button.popoverTargetAction = 'show' // simulate action to show popover
+    expect(isInteractiveElement(button)).toBe(true)
+  })
+  it('should return false for button that will show a popover, if popover is already visible', () => {
+    const button = document.createElement('button')
+    const popover = document.createElement('div')
+    popover.style.display = 'block' // simulate a visible popover
+    button.popoverTargetElement = popover
+    button.popoverTargetAction = 'show' // simulate action to show popover
+    expect(isInteractiveElement(button)).toBe(false)
+  })
+  it('should return true for button that will hide a popover, if popover is currently visible', () => {
+    const button = document.createElement('button')
+    const popover = document.createElement('div')
+    popover.style.display = 'block' // simulate a visible popover
+    button.popoverTargetElement = popover
+    button.popoverTargetAction = 'hide' // simulate action to hide popover
+    expect(isInteractiveElement(button)).toBe(true)
+  })
+  it('should return false for button that will hide a popover, if popover is already hidden', () => {
+    const button = document.createElement('button')
+    const popover = document.createElement('div')
+    popover.style.display = 'none' // simulate a hidden popover
+    button.popoverTargetElement = popover
+    button.popoverTargetAction = 'hide' // simulate action to hide popover
+    expect(isInteractiveElement(button)).toBe(false)
+  })
+  it('should return true for button associated with toggling a popover', () => {
+    const button = document.createElement('button')
+    const popover = document.createElement('div')
+    button.popoverTargetElement = popover // simulate a popover association
+
+    button.popoverTargetAction = 'toggle' // simulate action to toggle popover
+    popover.style.display = 'none' // simulate a hidden popover
+    expect(isInteractiveElement(button)).toBe(true)
+    popover.style.display = 'block' // simulate a visible popover
+    expect(isInteractiveElement(button)).toBe(true)
+
+    button.popoverTargetAction = 'foo' // any value other than 'hide' or 'show' will toggle popover
+    popover.style.display = 'none' // simulate a hidden popover
+    expect(isInteractiveElement(button)).toBe(true)
+    popover.style.display = 'block' // simulate a visible popover
+    expect(isInteractiveElement(button)).toBe(true)
+  })
+  it('should return false for button with a popover target that does not exist', () => {
+    const button = document.createElement('button')
+    button.popoverTargetElement = null // simulate a non-existent popover
+    expect(isInteractiveElement(button)).toBe(false)
+  })
+
+  // Note: Currently, buttons used for commands are not explicitly handled and will not be considered interactive.
+  it('should return false for button associated with a command', () => {
+    const button = document.createElement('button')
+
+    // simulate a command association
+    button.setAttribute('commandfor', 'some-dialog')
+    button.setAttribute('command', 'close')
+
+    expect(isInteractiveElement(button)).toBe(false)
+  })
+})
+
+describe('isInteractiveElement - input buttons', () => {
+  it('should return true for input button with onclick', () => {
+    const input = document.createElement('input')
+    input.type = 'button'
+    input.onclick = () => {}
+    expect(isInteractiveElement(input)).toBe(true)
+  })
+  it('should return true for input button with click event listener', () => {
+    const input = document.createElement('input')
+    input.type = 'button'
+    const listener = () => {}
+    interactiveElems.add(input, listener)
+    expect(isInteractiveElement(input)).toBe(true)
+
+    // clean up
+    interactiveElems.delete(input, listener)
+  })
+  it('should return false for input button without onclick or click event listener', () => {
+    const input = document.createElement('input')
+    input.type = 'button'
+    expect(isInteractiveElement(input)).toBe(false)
   })
 })


### PR DESCRIPTION
Part two of dead click detection for buttons.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

In this PR, we implement the detection of dead clicks for buttons, which currently covers the following usage:
- click event handlers, including `onclick`
- forms
- popovers

Usage of buttons for commands is currently not detected as dead clicks.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-422176

### Testing

- Added buttons to dead-clicks e2e test
- Shore up unit test for interactive-elements
