### PR TITLE
fix uncontrolled data used in path expression loader-transform

### DIFF
--- a/tools/testing-server/plugins/agent-injector/loader-transform.js
+++ b/tools/testing-server/plugins/agent-injector/loader-transform.js
@@ -23,11 +23,15 @@ async function getLoaderContent (loaderFilePath) {
 }
 
 function getLoaderFilePath (request, testServer, webpath) {
-  const loader = request.query.loader || testServer.config.loader
+  const validLoaders = ['default', 'custom']; // Define an allowlist of valid loader names
+  const loader = request.query.loader || testServer.config.loader;
+  if (!validLoaders.includes(loader)) {
+    throw new Error(`Invalid loader specified: ${loader}`);
+  }
   return path.join(
     webpath ? '/build/' : paths.builtAssetsDir,
     `nr-loader-${loader}.min.js`
-  )
+  );
 }
 
 async function getLoaderScript (scriptType, loaderFilePath, nonce, injectionDelay) {


### PR DESCRIPTION
https://github.com/newrelic/newrelic-browser-agent/blob/39c9fb5a1ff1eec62327271c003af39d9617bbcb/tools/testing-server/plugins/agent-injector/loader-transform.js#L18-L18
https://github.com/newrelic/newrelic-browser-agent/blob/39c9fb5a1ff1eec62327271c003af39d9617bbcb/tools/testing-server/plugins/agent-injector/loader-transform.js#L26-L30


Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.



Fix the `loader-transform:feat` need to validate and sanitize the `loader` value before using it to construct the file path. Since the `loader` value is used to determine a specific file name, we can use an allowlist approach to restrict it to a predefined set of valid loader names. This ensures that only expected and safe file paths are constructed.

1. Define an allowlist of valid loader names (e.g., `['default', 'custom']`).
2. Validate the `loader` value against this allowlist in the `getLoaderFilePath` function.
3. If the `loader` value is invalid, throw an error or use a default value.

## References
- [npm@sanitize-filename](https://www.npmjs.com/package/sanitize-filename).
- [93757c2e3678016f4159520e67e85a82](https://gist.github.com/odaysec/93757c2e3678016f4159520e67e85a82)
