### PR TITLE
fix: Address issue keeping distributed traces from being disabled

### DIFF
--- a/src/features/ajax/instrument/distributed-tracing.js
+++ b/src/features/ajax/instrument/distributed-tracing.js
@@ -94,7 +94,7 @@ export class DT {
   // return true if DT is enabled and the origin is allowed, either by being
   // same-origin, or included in the allowed list
   shouldGenerateTrace (parsedOrigin) {
-    return this.agentRef.init?.distributed_tracing && this.isAllowedOrigin(parsedOrigin)
+    return this.agentRef.init?.distributed_tracing?.enabled && this.isAllowedOrigin(parsedOrigin)
   }
 
   isAllowedOrigin (parsedOrigin) {

--- a/tests/specs/ajax/distributed-tracing.e2e.js
+++ b/tests/specs/ajax/distributed-tracing.e2e.js
@@ -8,8 +8,18 @@ const assetServerTraceTest = function (request) {
 
 const testCases = [
   {
-    name: 'no headers added when feature is not enabled',
+    name: 'no headers added when configuration is null',
     configuration: null,
+    sameOrigin: true,
+    addRouterToAllowedOrigins: false,
+    newrelicHeader: false,
+    traceContextHeaders: false
+  },
+  {
+    name: 'no headers added when configuration exists but is not enabled',
+    configuration: {
+      enabled: false
+    },
     sameOrigin: true,
     addRouterToAllowedOrigins: false,
     newrelicHeader: false,


### PR DESCRIPTION
Addressed a bug where the agent was able to capture distributed traces, even when `distributed_tracing: false` was supplied in the configuration.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
[NR-432936](https://new-relic.atlassian.net/browse/NR-432936)
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New test has been added to ensure the `.disabled` field is checked
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->


[NR-432936]: https://new-relic.atlassian.net/browse/NR-432936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ