### PR TITLE
feat: Add error click detection for buttons and links

### DIFF
--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -64,6 +64,11 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 <!--- GenericEvents harvest had too many nodes and sent early --->
 * GenericEvents/Harvest/Max/Seen
 
+### User Actions
+* UserAction/RageClick/Seen
+* UserAction/DeadClick/Seen
+* UserAction/ErrorClick/Seen
+
 ### Session
 <!--- Session has ended due to max time limit reached --->
 * Session/Expired/Seen

--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -65,8 +65,11 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * GenericEvents/Harvest/Max/Seen
 
 ### User Actions
+<!-- A user action has been detected as a rage click --->
 * UserAction/RageClick/Seen
+<!-- A user action has been detected as a dead click --->
 * UserAction/DeadClick/Seen
+<!-- A user action has been detected as an error click --->
 * UserAction/ErrorClick/Seen
 
 ### Session

--- a/src/common/wrap/wrap-function.js
+++ b/src/common/wrap/wrap-function.js
@@ -103,6 +103,9 @@ export function createWrapperWithEmitter (emitter, always) {
       } catch (err) {
         fnEndTime = performance.now()
         safeEmit(prefix + 'err', [args, originalThis, err], ctx, bubble)
+        if (args[0]?.type === 'click') {
+          safeEmit('ua-click-err', [args, originalThis, err], ctx, bubble)
+        }
         // rethrow error so we don't effect execution by observing.
         thrownError = err
         throw thrownError

--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -93,7 +93,7 @@ export class Aggregate extends AggregateBase {
                   return acc
                 }, {})),
                 ...aggregatedUserAction.nearestTargetFields,
-                ...(this.#runUserFrustrations && aggregatedUserAction.deadClick && { deadClick: aggregatedUserAction.deadClick }),
+                ...(this.#runUserFrustrations && aggregatedUserAction.deadClick && { deadClick: true }),
                 ...(this.#runUserFrustrations && aggregatedUserAction.isErrorClick(this.#clickErrorEvents) && { errorClick: true })
               }
               this.addEvent(userActionEvent)

--- a/src/features/generic_events/aggregate/user-actions/aggregated-user-action.js
+++ b/src/features/generic_events/aggregate/user-actions/aggregated-user-action.js
@@ -30,7 +30,7 @@ export class AggregatedUserAction {
    */
   aggregate (evt, selectorInfo = {}) {
     this.count++
-    this.events.push(evt)
+    if (this.hasInteractiveElems && evt.type === 'click') this.events.push(evt)
     this.relativeMs.push(Math.floor(evt.timeStamp - this.originMs))
     if (this.isRageClick()) this.rageClick = true
     this.deadClick ||= this.isDeadClick(selectorInfo)
@@ -42,7 +42,7 @@ export class AggregatedUserAction {
    */
   isRageClick () {
     const len = this.relativeMs.length
-    return (this.events[0]?.type === 'click' && len >= RAGE_CLICK_THRESHOLD_EVENTS && this.relativeMs[len - 1] - this.relativeMs[len - RAGE_CLICK_THRESHOLD_EVENTS] < RAGE_CLICK_THRESHOLD_MS)
+    return (this.events[0].type === 'click' && len >= RAGE_CLICK_THRESHOLD_EVENTS && this.relativeMs[len - 1] - this.relativeMs[len - RAGE_CLICK_THRESHOLD_EVENTS] < RAGE_CLICK_THRESHOLD_MS)
   }
 
   /**
@@ -57,7 +57,7 @@ export class AggregatedUserAction {
    */
   isDeadClick (selectorInfo = {}) {
     const { hasInteractiveElems, hasButton, hasLink, hasTextbox, ignoreDeadClick } = selectorInfo
-    return this.events[0]?.type === 'click' && !hasInteractiveElems && (hasButton || hasLink || hasTextbox) && !ignoreDeadClick
+    return this.events[0].type === 'click' && !hasInteractiveElems && (hasButton || hasLink || hasTextbox) && !ignoreDeadClick
   }
 
   isErrorClick (clickErrorEvents = new Set()) {

--- a/src/features/generic_events/aggregate/user-actions/interactive-elements.js
+++ b/src/features/generic_events/aggregate/user-actions/interactive-elements.js
@@ -4,22 +4,18 @@
  */
 class InteractiveElements extends WeakMap {
   add (target, listener) {
-    if (!isButtonOrLink(target)) {
-      return
+    if (isButtonOrLink(target)) {
+      const handlers = super.get(target) || new Set()
+      handlers.add(listener)
+      super.set(target, handlers)
     }
-    if (!super.has(target)) {
-      super.set(target, new Set())
-    }
-    super.get(target).add(listener)
   }
 
   delete (target, listener) {
-    if (super.has(target)) {
-      const handlers = super.get(target)
+    const handlers = super.get(target)
+    if (handlers) {
       handlers.delete(listener)
-      if (handlers.size === 0) {
-        super.delete(target)
-      }
+      if (handlers.size === 0) super.delete(target)
     }
   }
 }
@@ -27,70 +23,6 @@ class InteractiveElements extends WeakMap {
 export const interactiveElems = new InteractiveElements()
 
 function isButtonOrLink (target) {
-  const tagName = (target && target.nodeType === Node.ELEMENT_NODE && target.tagName?.toLowerCase()) ?? ''
-  return tagName !== '' &&
-    (tagName === 'button' ||
-      tagName === 'a' ||
-      (tagName === 'input' && target.type === 'button'))
-}
-
-export function isInteractiveElement (elem) {
-  const tagName = (elem && elem.nodeType === Node.ELEMENT_NODE && elem.tagName?.toLowerCase()) ?? ''
-  return isInteractiveLink(elem, tagName) || isInteractiveButton(elem, tagName) || isInteractiveTextbox(elem, tagName)
-}
-
-/**
- * Checks if the element is an interactive link.
- * A link is considered interactive if it has an `href` attribute, an `onclick` handler, or any click event listener(s).
- * @param {HTMLElement} elem
- * @param {tagName} string
- * @returns {boolean} true only if the element is an interactive link
- */
-function isInteractiveLink (elem, tagName) {
-  return tagName === 'a' &&
-    (elem.hasAttribute('href') || interactiveElems.has(elem) || typeof elem.onclick === 'function')
-}
-
-/**
- * Checks if the element is an interactive textbox.
- * A textbox is considered interactive if it is not read-only.
- * @param {HTMLElement} elem
- * @param {tagName} string
- * @returns {boolean} true only if the element is an interactive textbox
- */
-function isInteractiveTextbox (elem, tagName) {
-  return tagName === 'input' && elem.type.toLowerCase() === 'text' && !elem.readOnly
-}
-
-/**
- * Checks if the element is an interactive button.
- * A link is considered interactive if it is part of a form or popover, has an `onclick` handler, or any click event listener(s).
- *
- * @param {HTMLElement} elem
- * @param {tagName} string
- * @returns {boolean} true only if the element is an interactive button
- */
-function isInteractiveButton (elem, tagName) {
-  return (tagName === 'button' || (tagName === 'input' && elem.type.toLowerCase() === 'button')) &&
-    (interactiveElems.has(elem) || typeof elem.onclick === 'function' || isPartOfForm(elem) || willUpdatePopover(elem))
-}
-
-function isPartOfForm (buttonElem) {
-  // specified form attribute overrides any ancestor forms
-  if (Object.values(buttonElem.attributes).filter(x => x.nodeName === 'form').length > 0) {
-    return buttonElem.form !== null
-  }
-  return buttonElem.closest('form') !== null
-}
-
-function willUpdatePopover (buttonElem) {
-  const maybePopover = buttonElem.popoverTargetElement
-  if (maybePopover?.nodeType === Node.ELEMENT_NODE) {
-    const targetDisplay = getComputedStyle(maybePopover).display
-    return (buttonElem.popoverTargetAction !== 'hide' && buttonElem.popoverTargetAction !== 'show') ||
-      (buttonElem.popoverTargetAction === 'hide' && targetDisplay === 'block') ||
-      (buttonElem.popoverTargetAction === 'show' && targetDisplay === 'none')
-  }
-
-  return false
+  const tagName = target?.tagName?.toLowerCase()
+  return tagName === 'button' || tagName === 'a' || (tagName === 'input' && target.type === 'button')
 }

--- a/src/features/generic_events/aggregate/user-actions/interactive-utils.js
+++ b/src/features/generic_events/aggregate/user-actions/interactive-utils.js
@@ -13,7 +13,7 @@ export function isInteractiveElement (elem) {
  * Checks if the element is an interactive link.
  * A link is considered interactive if it has an `href` attribute, an `onclick` handler, or any click event listener(s).
  * @param {HTMLElement} elem
- * @param {tagName} string
+ * @param {string} tagName
  * @returns {boolean} true only if the element is an interactive link
  */
 function isInteractiveLink (elem, tagName) {
@@ -25,7 +25,7 @@ function isInteractiveLink (elem, tagName) {
  * Checks if the element is an interactive textbox.
  * A textbox is considered interactive if it is not read-only.
  * @param {HTMLElement} elem
- * @param {tagName} string
+ * @param {string} tagName
  * @returns {boolean} true only if the element is an interactive textbox
  */
 function isInteractiveTextbox (elem, tagName) {
@@ -40,7 +40,7 @@ function isInteractiveTextbox (elem, tagName) {
  * - has any click event listener(s)
  *
  * @param {HTMLElement} elem
- * @param {tagName} string
+ * @param {string} tagName
  * @returns {boolean} true only if the element is an interactive button
  */
 function isInteractiveButton (elem, tagName) {

--- a/src/features/generic_events/aggregate/user-actions/interactive-utils.js
+++ b/src/features/generic_events/aggregate/user-actions/interactive-utils.js
@@ -5,7 +5,7 @@
 import { interactiveElems } from './interactive-elements'
 
 export function isInteractiveElement (elem) {
-  const tagName = (elem && elem.nodeType === Node.ELEMENT_NODE && elem.tagName?.toLowerCase()) ?? ''
+  const tagName = elem?.nodeType === Node.ELEMENT_NODE ? elem.tagName?.toLowerCase() : ''
   return isInteractiveLink(elem, tagName) || isInteractiveButton(elem, tagName) || isInteractiveTextbox(elem, tagName)
 }
 
@@ -29,7 +29,7 @@ function isInteractiveLink (elem, tagName) {
  * @returns {boolean} true only if the element is an interactive textbox
  */
 function isInteractiveTextbox (elem, tagName) {
-  return tagName === 'input' && elem.type.toLowerCase() === 'text' && !elem.readOnly
+  return tagName === 'input' && elem.type?.toLowerCase() === 'text' && !elem.readOnly
 }
 
 /**
@@ -44,25 +44,24 @@ function isInteractiveTextbox (elem, tagName) {
  * @returns {boolean} true only if the element is an interactive button
  */
 function isInteractiveButton (elem, tagName) {
-  return (tagName === 'button' || (tagName === 'input' && elem.type.toLowerCase() === 'button')) &&
+  return (tagName === 'button' || (tagName === 'input' && elem.type?.toLowerCase() === 'button')) &&
     (interactiveElems.has(elem) || typeof elem.onclick === 'function' || isPartOfForm(elem) || willUpdatePopover(elem))
 }
 
 function isPartOfForm (buttonElem) {
   // specified form attribute overrides any ancestor forms
-  if (Object.values(buttonElem.attributes).filter(x => x.nodeName === 'form').length > 0) {
-    return buttonElem.form !== null
-  }
-  return buttonElem.closest('form') !== null
+  const formAttr = buttonElem.attributes?.form
+  return formAttr ? buttonElem.form !== null : buttonElem.closest('form') !== null
 }
 
 function willUpdatePopover (buttonElem) {
   const maybePopover = buttonElem.popoverTargetElement
   if (maybePopover?.nodeType === Node.ELEMENT_NODE) {
-    const targetDisplay = getComputedStyle(maybePopover).display
-    return (buttonElem.popoverTargetAction !== 'hide' && buttonElem.popoverTargetAction !== 'show') ||
-      (buttonElem.popoverTargetAction === 'hide' && targetDisplay === 'block') ||
-      (buttonElem.popoverTargetAction === 'show' && targetDisplay === 'none')
+    const display = getComputedStyle(maybePopover).display
+    const action = buttonElem.popoverTargetAction
+    return (action !== 'hide' && action !== 'show') ||
+      (action === 'hide' && display === 'block') ||
+      (action === 'show' && display === 'none')
   }
 
   return false

--- a/src/features/generic_events/aggregate/user-actions/interactive-utils.js
+++ b/src/features/generic_events/aggregate/user-actions/interactive-utils.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { interactiveElems } from './interactive-elements'
+
+export function isInteractiveElement (elem) {
+  const tagName = (elem && elem.nodeType === Node.ELEMENT_NODE && elem.tagName?.toLowerCase()) ?? ''
+  return isInteractiveLink(elem, tagName) || isInteractiveButton(elem, tagName) || isInteractiveTextbox(elem, tagName)
+}
+
+/**
+ * Checks if the element is an interactive link.
+ * A link is considered interactive if it has an `href` attribute, an `onclick` handler, or any click event listener(s).
+ * @param {HTMLElement} elem
+ * @param {tagName} string
+ * @returns {boolean} true only if the element is an interactive link
+ */
+function isInteractiveLink (elem, tagName) {
+  return tagName === 'a' &&
+    (elem.hasAttribute('href') || interactiveElems.has(elem) || typeof elem.onclick === 'function')
+}
+
+/**
+ * Checks if the element is an interactive textbox.
+ * A textbox is considered interactive if it is not read-only.
+ * @param {HTMLElement} elem
+ * @param {tagName} string
+ * @returns {boolean} true only if the element is an interactive textbox
+ */
+function isInteractiveTextbox (elem, tagName) {
+  return tagName === 'input' && elem.type.toLowerCase() === 'text' && !elem.readOnly
+}
+
+/**
+ * Checks if the element is an interactive button.
+ * A link is considered interactive if
+ * - it is part of a form or popover,
+ * - has an `onclick` handler, or
+ * - has any click event listener(s)
+ *
+ * @param {HTMLElement} elem
+ * @param {tagName} string
+ * @returns {boolean} true only if the element is an interactive button
+ */
+function isInteractiveButton (elem, tagName) {
+  return (tagName === 'button' || (tagName === 'input' && elem.type.toLowerCase() === 'button')) &&
+    (interactiveElems.has(elem) || typeof elem.onclick === 'function' || isPartOfForm(elem) || willUpdatePopover(elem))
+}
+
+function isPartOfForm (buttonElem) {
+  // specified form attribute overrides any ancestor forms
+  if (Object.values(buttonElem.attributes).filter(x => x.nodeName === 'form').length > 0) {
+    return buttonElem.form !== null
+  }
+  return buttonElem.closest('form') !== null
+}
+
+function willUpdatePopover (buttonElem) {
+  const maybePopover = buttonElem.popoverTargetElement
+  if (maybePopover?.nodeType === Node.ELEMENT_NODE) {
+    const targetDisplay = getComputedStyle(maybePopover).display
+    return (buttonElem.popoverTargetAction !== 'hide' && buttonElem.popoverTargetAction !== 'show') ||
+      (buttonElem.popoverTargetAction === 'hide' && targetDisplay === 'block') ||
+      (buttonElem.popoverTargetAction === 'show' && targetDisplay === 'none')
+  }
+
+  return false
+}

--- a/src/features/generic_events/aggregate/user-actions/selector-path.js
+++ b/src/features/generic_events/aggregate/user-actions/selector-path.js
@@ -46,15 +46,12 @@ export const analyzeElemPath = (elem, targetFields = []) => {
 
       const tagName = elem.tagName.toLowerCase()
       result.hasLink ||= tagName === 'a'
-      result.hasTextbox ||= tagName === 'input' && elem.type.toLowerCase() === 'text'
-      result.hasButton ||= tagName === 'button' || (tagName === 'input' && elem.type.toLowerCase() === 'button')
-
+      result.hasTextbox ||= tagName === 'input' && elem.type?.toLowerCase() === 'text'
+      result.hasButton ||= tagName === 'button' || (tagName === 'input' && elem.type?.toLowerCase() === 'button')
       // Evaluation of buttons used for commands is not yet supported and will be ignored for dead click detection
-      if (tagName === 'button') {
-        result.ignoreDeadClick ||= Object.values(elem.attributes).some(x => x.nodeName === 'command')
-      }
-
+      result.ignoreDeadClick ||= tagName === 'button' && Object.values(elem.attributes).some(x => x.nodeName === 'command')
       result.hasInteractiveElems ||= isInteractiveElement(elem)
+
       pathSelector = selector
       elem = elem.parentNode
     }

--- a/src/features/generic_events/aggregate/user-actions/selector-path.js
+++ b/src/features/generic_events/aggregate/user-actions/selector-path.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isInteractiveElement } from './interactive-elements'
+import { isInteractiveElement } from './interactive-utils'
 
 /**
  * Generates a CSS selector path for the given element, if possible

--- a/tests/assets/user-frustrations/instrumented-error-clicks.html
+++ b/tests/assets/user-frustrations/instrumented-error-clicks.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2025 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html lang="en">
+  <head>
+    <title>RUM - Dead Clicks</title>
+    {init} {config}
+    <script>
+      NREUM.init.feature_flags = ['user_frustrations']
+      // disable cookies to help e2e test events are wrapped in generic events instrument phase
+      NREUM.init.privacy.cookies_enabled = false
+      localStorage.clear()
+    </script>
+    {loader}
+    <style>
+      a {
+        color: blue;
+        cursor: pointer;
+        text-decoration: underline;
+      }
+      .non-interactive-element {
+        color: red;
+      }
+      .example-container {
+        border: 10px solid black;
+        border-radius: 2em;
+        padding: 10px;
+        margin-bottom: 1em;
+        background-color: #BDF7D7;
+
+        h2 {
+          margin-top: 0.5em;
+        }
+      }
+      .link-examples {
+        display: flex;
+        gap: 0.5em;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="test-area">
+      <h1>RUM - Error Clicks</h1>
+      <p>This page is used to test error clicks instrumentation.</p>
+      <div class="example-container">
+        <h2>Buttons</h2>
+        <div>
+          <p>Button with a click event handler, added via `addEventListener`.
+            <button id="button-with-listener">Button</button>
+            <button id="button-with-listener-error">Button w/ error</button>
+            <script>
+              document.getElementById('button-with-listener').addEventListener('click', function() {
+                console.log('Button clicked, no dead click event should be recorded.');
+              });
+              document.getElementById('button-with-listener-error').addEventListener('click', function() {
+                console.log('Button clicked, no dead click event should be recorded.');
+                throw new Error('This is a test error');
+              });
+            </script>
+          </p>
+
+          <p>Button with a click event handler, added via `onclick`.
+            <button id="button-with-onclick" onclick="console.log('Button clicked, no dead click event should be recorded.')">Button</button>
+            <button id="button-with-onclick-error" onclick="console.log('Button clicked, no dead click event should be recorded.'); throw new Error('Test error')">Button w/ onclick error</button>
+          </p>
+
+          <p>Button with listener + span child
+            <button id="button-with-listener-and-span-child">
+              <span id="span-inside-button-with-listener">Button</span>
+            </button>
+            <button id="button-with-listener-error-and-span-child">
+              <span id="span-inside-button-with-listener-error">Button w/ error</span>
+            </button>
+            <script>
+              document.getElementById('button-with-listener-and-span-child').addEventListener('click', function() {
+                console.log('button clicked, no dead click event should be recorded.');
+              });
+              document.getElementById('button-with-listener-error-and-span-child').addEventListener('click', function() {
+                console.log('button clicked, no dead click event should be recorded.');
+                throw new Error('This is a test error');
+              });
+            </script>
+          </p>
+
+          <p>Button with onclick listener + span child
+            <button id="button-with-onclick-and-span-child" onclick="console.log('Button clicked, no dead click event should be recorded.')">
+              <span id="span-inside-button-with-onclick">Button</span>
+            </button>
+            <button id="button-with-onclick-error-and-span-child" onclick="console.log('Button clicked, no dead click event should be recorded.'); throw new Error('Test error')">
+              <span id="span-inside-button-with-onclick-error">Button w/ onclick error</span>
+            </button>
+          </p>
+        </div>
+      </div>
+
+      <div class="example-container">
+        <h2>Input, type = "button"</h2>
+        <div>
+          <p>Input button with a click event handler, added via `addEventListener`.
+            <input type="button" id="input-button-with-listener" value="Button"/>
+            <input type="button" id="input-button-with-listener-error" value="Button w/ error"/>
+            <script>
+              document.getElementById('input-button-with-listener').addEventListener('click', function() {
+                console.log('Button clicked, no dead click event should be recorded.');
+              });
+              document.getElementById('input-button-with-listener-error').addEventListener('click', function() {
+                console.log('Button clicked, no dead click event should be recorded.');
+                throw new Error('This is a test error');
+              });
+            </script>
+          </p>
+
+          <p>Input button with a click event handler, added via `onclick`.
+            <input type="button" id="input-button-with-onclick" onclick="console.log('Button clicked, no dead click event should be recorded.')" value = "Button"/>
+            <input type="button" id="input-button-with-onclick-error" onclick="console.log('Button clicked, no dead click event should be recorded.'); throw new Error('Test error')" value = "Button w/ onclick error"/>
+          </p>
+        </div>
+      </div>
+
+      <div class="example-container">
+        <h2>Links</h2>
+        <div>
+          <p class="link-examples">Link with a click event handler, added via `addEventListener`=>
+            <a id="link-with-listener">Link,</a>
+            <a id="link-with-listener-error">Link w/ error</a>
+            <script>
+              document.getElementById('link-with-listener').addEventListener('click', function() {
+                console.log('Link clicked, no dead click event should be recorded.');
+              });
+              document.getElementById('link-with-listener-error').addEventListener('click', function() {
+                console.log('Link clicked, no dead click event should be recorded.');
+                throw new Error('This is a test error');
+              });
+            </script>
+          </p>
+
+          <p class="link-examples">Link with a click event handler, added via `onclick` =>
+            <a id="link-with-onclick" onclick="console.log('Click')">Link,</a>
+            <a id="link-with-onclick-error" onclick="console.log('Click'); throw new Error('Test error')">Link w/ error</a>
+          </p>
+
+          <p class="link-examples">Link with a click event handler +  span child =>
+            <a id="link-with-listener-and-span-child">
+              <span id="span-inside-link-with-listener">Link</span>,
+            </a>
+            <a id="link-with-listener-error-and-span-child">
+              <span id="span-inside-link-with-listener-error">Link w/ error</span>
+            </a>
+            <script>
+              document.getElementById('link-with-listener-and-span-child').addEventListener('click', function() {
+                console.log('Link clicked, no dead click event should be recorded.');
+              });
+              document.getElementById('link-with-listener-error-and-span-child').addEventListener('click', function() {
+                console.log('Link clicked, no dead click event should be recorded.');
+                throw new Error('This is a test error');
+              });
+            </script>
+          </p>
+        </div>
+      </div>
+
+      <div class="example-container">
+        <h2>Other Elements</h2>
+        <div>
+          <p>Span with a click event handler, added via `addEventListener` =>
+            <!-- should not be added to listener map -->
+            <span id="span-with-listener-error" class="non-interactive-element">Span w/ error</span>
+            <script>
+              document.getElementById("span-with-listener-error").addEventListener('click', function() {
+                console.log('Span clicked')
+                throw new Error('This is a test error');
+              })
+            </script>
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/components/generic_events/aggregate/index.test.js
+++ b/tests/components/generic_events/aggregate/index.test.js
@@ -315,6 +315,8 @@ describe('sub-features', () => {
   test('should remove stale errors after user action is buffered', () => {
     const removeStaleErrorSpy = jest.spyOn(genericEventsAggregate, 'removeStaleErrors')
     const target = document.createElement('button')
+    const someForm = document.createElement('form')
+    someForm.appendChild(target)
     target.id = 'myBtn'
 
     Array.of(

--- a/tests/components/generic_events/aggregate/index.test.js
+++ b/tests/components/generic_events/aggregate/index.test.js
@@ -316,15 +316,15 @@ describe('sub-features', () => {
     const removeStaleErrorSpy = jest.spyOn(genericEventsAggregate, 'removeStaleErrors')
     const target = document.createElement('button')
     target.id = 'myBtn'
-    const clickEvent1 = { timeStamp: 100, type: 'click', target }
-    const clickEvent2 = { timeStamp: 200, type: 'click', target }
-    const clickEvent3 = { timeStamp: 300, type: 'click', target }
-    genericEventsAggregate.ee.emit('ua', [clickEvent1])
-    genericEventsAggregate.ee.emit('ua-click-err', [clickEvent1])
-    genericEventsAggregate.ee.emit('ua', [clickEvent2])
-    genericEventsAggregate.ee.emit('ua-click-err', [clickEvent2])
-    genericEventsAggregate.ee.emit('ua', [clickEvent3])
-    genericEventsAggregate.ee.emit('ua-click-err', [clickEvent3])
+
+    Array.of(
+      { timeStamp: 100, type: 'click', target },
+      { timeStamp: 200, type: 'click', target },
+      { timeStamp: 300, type: 'click', target }
+    ).forEach(event => {
+      genericEventsAggregate.ee.emit('ua', [event])
+      genericEventsAggregate.ee.emit('ua-click-err', [event])
+    })
 
     // blur event to trigger aggregation to stop and add to harvest buffer
     genericEventsAggregate.ee.emit('ua', [{ timeStamp: 1000, type: 'blur', target: window }])

--- a/tests/specs/user-frustrations/error-clicks.e2e.js
+++ b/tests/specs/user-frustrations/error-clicks.e2e.js
@@ -1,0 +1,229 @@
+import { testInsRequest } from '../../../tools/testing-server/utils/expect-tests'
+
+const loaderTypes = ['full', 'spa'] // 'rum' is excluded as UserActions is not supported
+describe('User Frustrations - Error Clicks', () => {
+  it('should not decorate error clicks on non-interactive elements', async () => {
+    const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testInsRequest }
+    ])
+    await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-error-clicks.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      // [1] - span with listener error
+      document.getElementById('span-with-listener-error').click()
+      // end previous user action
+      document.getElementById('test-area').click()
+    })
+
+    const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'SPAN',
+      targetId: 'span-with-listener-error'
+    }))
+    expect(actuals[0]).not.toHaveProperty('errorClick')
+  })
+
+  loaderTypes.forEach(loaderType => {
+    it('should correctly assess error clicks for links', async () => {
+      const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+        { test: testInsRequest }
+      ])
+      await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-error-clicks.html'))
+        .then(() => browser.waitForAgentLoad())
+
+      await browser.execute(function () {
+        // [0] - link with listener, no error
+        document.getElementById('link-with-listener').click()
+        // [1] - link with listener error
+        document.getElementById('link-with-listener-error').click()
+        // [2] - link with onclick, no error
+        document.getElementById('link-with-onclick').click()
+        // [3] - link with onclick error
+        document.getElementById('link-with-onclick-error').click()
+        // [4] - span inside link with listener, no error
+        document.getElementById('span-inside-link-with-listener').click()
+        // [5] - span inside link with listener error
+        document.getElementById('span-inside-link-with-listener-error').click()
+        // end previous user action
+        document.getElementById('test-area').click()
+      })
+
+      const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+      const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+      expect(actuals[0]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'link-with-listener'
+      }))
+      expect(actuals[0]).not.toHaveProperty('errorClick')
+      expect(actuals[1]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'link-with-listener-error',
+        errorClick: true
+      }))
+      expect(actuals[2]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'link-with-onclick'
+      }))
+      expect(actuals[2]).not.toHaveProperty('errorClick')
+      // currently unable to tie errors from onclick with click event/user action
+      expect(actuals[3]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'A',
+        targetId: 'link-with-onclick-error'
+      }))
+      expect(actuals[3]).not.toHaveProperty('errorClick')
+      expect(actuals[4]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'SPAN',
+        targetId: 'span-inside-link-with-listener'
+      }))
+      expect(actuals[4]).not.toHaveProperty('errorClick')
+      expect(actuals[5]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'SPAN',
+        targetId: 'span-inside-link-with-listener-error',
+        errorClick: true
+      }))
+    })
+  })
+
+  it('should correctly assess error clicks for buttons', async () => {
+    const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testInsRequest }
+    ])
+    await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-error-clicks.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      // [0] - button with listener, no error
+      document.getElementById('button-with-listener').click()
+      // [1] - button with listener error
+      document.getElementById('button-with-listener-error').click()
+      // [2] - button with onclick, no error
+      document.getElementById('button-with-onclick').click()
+      // [3] - button with onclick error
+      document.getElementById('button-with-onclick-error').click()
+      // [4] - span inside button with listener, no error
+      document.getElementById('span-inside-button-with-listener').click()
+      // [5] - span inside button with listener error
+      document.getElementById('span-inside-button-with-listener-error').click()
+      // [6] - span inside button with onclick, no error
+      document.getElementById('span-inside-button-with-onclick').click()
+      // [7] - span inside button with onclick error
+      document.getElementById('span-inside-button-with-onclick-error').click()
+      // end previous user action
+      document.getElementById('test-area').click()
+    })
+
+    const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-with-listener'
+    }))
+    expect(actuals[0]).not.toHaveProperty('errorClick')
+    expect(actuals[1]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-with-listener-error',
+      errorClick: true
+    }))
+    expect(actuals[2]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-with-onclick'
+    }))
+    expect(actuals[2]).not.toHaveProperty('errorClick')
+    // currently unable to tie errors from onclick with click event/user action
+    expect(actuals[3]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'BUTTON',
+      targetId: 'button-with-onclick-error'
+    }))
+    expect(actuals[3]).not.toHaveProperty('errorClick')
+    expect(actuals[4]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'SPAN',
+      targetId: 'span-inside-button-with-listener'
+    }))
+    expect(actuals[4]).not.toHaveProperty('errorClick')
+    expect(actuals[5]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'SPAN',
+      targetId: 'span-inside-button-with-listener-error',
+      errorClick: true
+    }))
+    expect(actuals[6]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'SPAN',
+      targetId: 'span-inside-button-with-onclick'
+    }))
+    expect(actuals[6]).not.toHaveProperty('errorClick')
+    // currently unable to tie errors from onclick with click event/user action
+    expect(actuals[7]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'SPAN',
+      targetId: 'span-inside-button-with-onclick-error'
+    }))
+    expect(actuals[7]).not.toHaveProperty('errorClick')
+  })
+  it('should correctly assess error clicks for input buttons', async () => {
+    const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testInsRequest }
+    ])
+    await browser.url(await browser.testHandle.assetURL('user-frustrations/instrumented-error-clicks.html'))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      // [0] - input button with listener, no error
+      document.getElementById('input-button-with-listener').click()
+      // [1] - button with listener error
+      document.getElementById('input-button-with-listener-error').click()
+      // [2] - button with onclick, no error
+      document.getElementById('input-button-with-onclick').click()
+      // [3] - button with onclick error
+      document.getElementById('input-button-with-onclick-error').click()
+      // end previous user action
+      document.getElementById('test-area').click()
+    })
+
+    const [insightsHarvest] = await insightsCapture.waitForResult({ timeout: 10000 })
+    const actuals = insightsHarvest.request.body.ins.filter(x => x.action === 'click')
+    expect(actuals[0]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetType: 'button',
+      targetId: 'input-button-with-listener'
+    }))
+    expect(actuals[0]).not.toHaveProperty('errorClick')
+    expect(actuals[1]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetId: 'input-button-with-listener-error',
+      targetType: 'button',
+      errorClick: true
+    }))
+    expect(actuals[2]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetType: 'button',
+      targetId: 'input-button-with-onclick'
+    }))
+    expect(actuals[2]).not.toHaveProperty('errorClick')
+    // currently unable to tie errors from onclick with click event/user action
+    expect(actuals[3]).toMatchObject(expect.objectContaining({
+      eventType: 'UserAction',
+      targetTag: 'INPUT',
+      targetType: 'button',
+      targetId: 'input-button-with-onclick-error'
+    }))
+    expect(actuals[3]).not.toHaveProperty('errorClick')
+  })
+})

--- a/tests/unit/features/generic_events/aggregate/user-actions/aggregated-user-action.test.js
+++ b/tests/unit/features/generic_events/aggregate/user-actions/aggregated-user-action.test.js
@@ -13,7 +13,7 @@ describe('AggregatedUserAction', () => {
   })
 
   test('should initialize with correct values', () => {
-    expect(aggregatedUserAction.event).toBe(evt)
+    expect(aggregatedUserAction.events[0]).toBe(evt)
     expect(aggregatedUserAction.count).toBe(1)
     expect(aggregatedUserAction.originMs).toBe(1000)
     expect(aggregatedUserAction.relativeMs).toEqual([0])
@@ -58,17 +58,6 @@ describe('AggregatedUserAction - Dead Click Detection', () => {
     evt = { type: 'click', timeStamp: 1000 }
   })
 
-  function generateAggregatedUserAction (evt, selectorInfo = {
-    path: 'dummy value',
-    hasInteractiveElems: false,
-    hasLink: false,
-    hasTextbox: false,
-    hasButton: false,
-    ignoreDeadClick: false
-  }) {
-    return new AggregatedUserAction(evt, selectorInfo)
-  }
-
   test('should correctly assess not a dead click - no interactive elems', () => {
     const userClickOnDeadlink = generateAggregatedUserAction(evt, undefined)
     expect(userClickOnDeadlink.deadClick).toBe(false)
@@ -98,3 +87,38 @@ describe('AggregatedUserAction - Dead Click Detection', () => {
     expect(userClickOnDeadlink.deadClick).toBe(false)
   })
 })
+
+describe('AggregatedUserAction - Error Click Detection', () => {
+  test('should detect error click when hasInteractiveElems and contains error events', () => {
+    const mockClickEvent = { type: 'click' }
+    const clickErrorEvents = new Set([mockClickEvent])
+    const userAction = new AggregatedUserAction(mockClickEvent, { hasInteractiveElems: true })
+
+    expect(userAction.isErrorClick(clickErrorEvents)).toBe(true)
+  })
+  test('should not detect error click when hasInteractiveElems is false', () => {
+    const mockClickEvent = { type: 'click' }
+    const clickErrorEvents = new Set([mockClickEvent])
+    const userAction = new AggregatedUserAction(mockClickEvent, { hasInteractiveElems: false })
+
+    expect(userAction.isErrorClick(clickErrorEvents)).toBe(false)
+  })
+  test('should not detect error click when event does not have error', () => {
+    const mockClickEvent = { type: 'click' }
+    const clickErrorEvents = new Set()
+    const userAction = new AggregatedUserAction(mockClickEvent, { hasInteractiveElems: true })
+
+    expect(userAction.isErrorClick(clickErrorEvents)).toBe(false)
+  })
+})
+
+function generateAggregatedUserAction (evt, selectorInfo = {
+  path: 'dummy value',
+  hasInteractiveElems: false,
+  hasLink: false,
+  hasTextbox: false,
+  hasButton: false,
+  ignoreDeadClick: false
+}) {
+  return new AggregatedUserAction(evt, selectorInfo)
+}

--- a/tests/unit/features/generic_events/aggregate/user-actions/interactive-elements.test.js
+++ b/tests/unit/features/generic_events/aggregate/user-actions/interactive-elements.test.js
@@ -1,4 +1,5 @@
-import { interactiveElems, isInteractiveElement } from '../../../../../../src/features/generic_events/aggregate/user-actions/interactive-elements'
+import { interactiveElems } from '../../../../../../src/features/generic_events/aggregate/user-actions/interactive-elements'
+import { isInteractiveElement } from '../../../../../../src/features/generic_events/aggregate/user-actions/interactive-utils'
 
 describe('Interactive Elements - lookup for elem click event listeners', () => {
   const lookup = interactiveElems

--- a/tests/unit/features/generic_events/aggregate/user-actions/user-actions-aggregator.test.js
+++ b/tests/unit/features/generic_events/aggregate/user-actions/user-actions-aggregator.test.js
@@ -20,7 +20,7 @@ describe('UserActionsAggregator', () => {
 
     const output = aggregator.process(evt2)
     expect(output).toBeInstanceOf(AggregatedUserAction)
-    expect(output.event).toEqual(evt) // not evt2, it returns the processed event (evt)
+    expect(output.events[0]).toEqual(evt) // not evt2, it returns the processed event (evt)
     expect(output.count).toEqual(1)
   })
 


### PR DESCRIPTION
Part three of user frustrations - error clicks. Adds error click detection for buttons and links.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

An error click is essentially a user click that's triggered a JavaScript error, which can lead to user frustrations.  In this PR, we implement the detection of error clicks for buttons and links.  There are some limitations to the current implementation:
- Only errors from event listeners added via `addEventListener` are detected via try/catch
  - Errors coming from `onclick` handlers are currently not wrapped by the agent and subsequently not associated with user actions
  - Errors from asynchronous calls are currently not associated with user actions 

Also added User Action supportability metrics.  Angler PR - https://source.datanerd.us/agents/angler/pull/714

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-425403 (error click)
https://new-relic.atlassian.net/browse/NR-422178 (SM)

### Testing

- Manually tested using error-clicks.html
- Added unit/integration/e2e tests
