### PR TITLE
fix: Add monkey-patching warnings

### DIFF
--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -125,3 +125,5 @@
 `Timestamps must be non-negative and end time cannot be before start time.`
 ### 62 
 `Timestamp must be a unix timestamp greater than the page origin time`
+### 63
+`Required globals have been mutated before being accessed by the browser agent. This can cause issues and should be avoided.`

--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { originTime } from '../constants/runtime'
+import { isNative } from '../util/monkey-patched'
 
 /**
  * Class used to adjust the timestamp of harvested data to New Relic server time. This
@@ -39,6 +40,7 @@ export class TimeKeeper {
   constructor (sessionObj) {
     this.#session = sessionObj
     this.processStoredDiff()
+    isNative(performance.now, Date.now) // will warn the user if these are not native functions.  We need these to be native for time in the agent to be accurate in general.
   }
 
   get ready () {

--- a/src/common/util/monkey-patched.js
+++ b/src/common/util/monkey-patched.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { warn } from './console'
+
+const checked = new Map()
+
+/**
+ * Checks if the provided functions are native functions.
+ * @param {...Function} fns - An array of functions to check if they are native.
+ * @returns {boolean} true if all the expected globals are native, false otherwise
+ */
+export function isNative (...fns) {
+  return fns.every(fn => {
+    if (checked.has(fn)) return checked.get(fn)
+    const isNative = typeof fn === 'function' && fn.toString().includes('[native code]')
+    if (!isNative) {
+      warn(63, fn?.name || fn?.toString())
+    }
+    checked.set(fn, isNative)
+    return isNative
+  })
+}

--- a/src/common/window/nreum.js
+++ b/src/common/window/nreum.js
@@ -4,6 +4,7 @@
  */
 import { globalScope } from '../constants/runtime'
 import { now } from '../timing/now'
+import { isNative } from '../util/monkey-patched'
 
 export const defaults = {
   beacon: 'bam.nr-data.net',
@@ -58,7 +59,7 @@ export function gosNREUMOriginals () {
   if (!nr.o) {
     nr.o = {
       ST: globalScope.setTimeout,
-      SI: globalScope.setImmediate,
+      SI: globalScope.setImmediate || globalScope.setInterval,
       CT: globalScope.clearTimeout,
       XHR: globalScope.XMLHttpRequest,
       REQ: globalScope.Request,
@@ -68,6 +69,7 @@ export function gosNREUMOriginals () {
       FETCH: globalScope.fetch,
       WS: globalScope.WebSocket
     }
+    isNative(...Object.values(nr.o)) // Warns if the originals are not native, which is typically required for the agent to work properly
   }
   return nr
 }

--- a/tests/assets/monkey-patched.html
+++ b/tests/assets/monkey-patched.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    <script>
+      var logs = []
+      // monkey patch the performance API to trigger warnings in the agent
+      var origPerformanceNow = performance.now;
+      performance.now = function (){ 
+        return origPerformanceNow.apply(performance, arguments);}
+
+      // debug will capture the warn() calls for tests
+      var origConsoleDebug = console.debug;
+      console.debug = function debug () {
+        logs.push(arguments)
+        origConsoleDebug.apply(console, arguments);
+      }
+    </script>
+    {init} {config} {loader}
+  </head>
+  <body>Instrumented</body>
+</html>

--- a/tests/components/logging/instrument.test.js
+++ b/tests/components/logging/instrument.test.js
@@ -41,7 +41,6 @@ test('wrapLogger should not re-wrap or overwrite context if called more than onc
   }
   const customAttributes = { args: faker.string.uuid() }
   wrapLogger(loggingInstrument.ee, myLoggerSuite, 'myTestLogger', { customAttributes, level: 'error' })
-  expect(loggingUtilsModule.bufferLog).toHaveBeenCalledTimes(0)
 
   let message = faker.string.uuid()
   myLoggerSuite.myTestLogger(message)

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -418,6 +418,21 @@ describe('NR Server Time', () => {
       expect(subsequentServerTimeDiff).toEqual(initialServerTimeDiff)
       expect(subsequentSession.localStorage.serverTimeDiff).toEqual(initialSession.localStorage.serverTimeDiff)
     })
+
+    it('should warn if the time globals are monkey-patched', async () => {
+      const url = await browser.testHandle.assetURL('monkey-patched.html')
+      await browser.url(url).then(() => browser.waitForAgentLoad())
+
+      const logs = await browser.execute(function () {
+        return window.logs
+      })
+
+      expect(logs[0][0].includes('New Relic Warning') && logs[0][0].includes('63')).toEqual(true) // 63 is the warning code for monkey-patched globals
+      expect(logs[0][1]).toEqual('debug')
+
+      expect(logs[1][0].includes('New Relic Warning') && logs[1][0].includes('63')).toEqual(true) // 63 is the warning code for monkey-patched globals
+      expect(logs[1][1]).toEqual('function (){ \n        return origPerformanceNow.apply(performance, arguments);}')
+    })
   })
 })
 


### PR DESCRIPTION
Added detection and warnings for when expected globals have been monkey-patched before the agent has been executed on the page.  This can cause unexpected behaviors and the intent is to inform customers of this behavior.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Should expect a new warning code when expected globals have been modified before the agent has executed.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-435349
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been updated
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
