### PR TITLE
chore: remove override to allow full adoption of early harvest

### DIFF
--- a/.github/actions/build-ab/templates/released.js
+++ b/.github/actions/build-ab/templates/released.js
@@ -12,7 +12,6 @@ window.NREUM={
         'bam-cell.nr-data.net'
       ]
     },
-    harvest: {interval: 5},
     session_replay: {
       enabled: true,
       fix_stylesheets: false,


### PR DESCRIPTION
Remove the harvest interval override, which allows NR1 to fully adopt the "early harvest" changes.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
