### PR TITLE
feat: Add error cause detection

### DIFF
--- a/src/features/jserrors/aggregate/cause-string.js
+++ b/src/features/jserrors/aggregate/cause-string.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * @fileoverview; Extracts the cause string from an error object.
+ */
+
+import { stringify } from '../../../common/util/stringify'
+import { computeStackTrace } from './compute-stack-trace'
+
+/**
+ * Extracts and normalizes a string from an error instance with a cause attribute.
+ * @param {Error} err - The error object to extract the cause from.
+ * @returns {string} The cause string extracted from the error object. Will be an empty string if no cause is present.
+ */
+export function buildCauseString (err) {
+  let causeStackString = ''
+  if (!err?.cause) return causeStackString
+  if (err.cause instanceof Error) causeStackString = computeStackTrace(err.cause).stackString || err.cause.stack
+  else causeStackString = typeof err.cause === 'string' ? err.cause : stringify(err.cause)
+  causeStackString ||= err.cause.toString() // fallback to try the string representation if all else fails
+  return causeStackString
+}

--- a/src/features/jserrors/aggregate/cause-string.js
+++ b/src/features/jserrors/aggregate/cause-string.js
@@ -15,8 +15,12 @@ import { computeStackTrace } from './compute-stack-trace'
 export function buildCauseString (err) {
   let causeStackString = ''
   if (!err?.cause) return causeStackString
-  if (err.cause instanceof Error) causeStackString = computeStackTrace(err.cause).stackString || err.cause.stack
-  else causeStackString = typeof err.cause === 'string' ? err.cause : stringify(err.cause)
+  if (err.cause instanceof Error) {
+    const stackInfo = computeStackTrace(err.cause)
+    causeStackString = stackInfo.stackString || err.cause.stack
+    if (stackInfo.message && !causeStackString.includes(stackInfo.message)) causeStackString = stackInfo.message + '\n' + causeStackString
+    if (stackInfo.name && !causeStackString.includes(stackInfo.name)) causeStackString = stackInfo.name + ': ' + causeStackString
+  } else causeStackString = typeof err.cause === 'string' ? err.cause : stringify(err.cause)
   causeStackString ||= err.cause.toString() // fallback to try the string representation if all else fails
   return causeStackString
 }

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -21,6 +21,7 @@ import { applyFnToProps } from '../../../common/util/traverse'
 import { evaluateInternalError } from './internal-errors'
 import { isContainerAgentTarget } from '../../../common/util/target'
 import { warn } from '../../../common/util/console'
+import { buildCauseString } from './cause-string'
 
 /**
  * @typedef {import('./compute-stack-trace.js').StackInfo} StackInfo
@@ -140,19 +141,7 @@ export class Aggregate extends AggregateBase {
 
     var canonicalStackString = this.buildCanonicalStackString(stackInfo)
 
-    let causeStackString = ''
-    if (err.cause) {
-      if (err.cause instanceof Error) {
-        try {
-          causeStackString = computeStackTrace(err.cause).stackString
-        } catch (e) {
-          // If we can't compute the stack trace for the cause, try to capture the string output
-          causeStackString = err.cause.toString()
-        }
-      } else {
-        causeStackString = typeof err.cause === 'string' ? err.cause : stringify(err.cause)
-      }
-    }
+    const causeStackString = buildCauseString(err)
 
     const params = {
       stackHash: stringHashCode(canonicalStackString),

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -140,10 +140,22 @@ export class Aggregate extends AggregateBase {
 
     var canonicalStackString = this.buildCanonicalStackString(stackInfo)
 
+    let causeStackString = ''
+    if (err.cause) {
+      if (err.cause instanceof Error) {
+        const causeStack = computeStackTrace(err.cause)
+        // canonicalCauseString = err.message + ' ' + this.buildCanonicalStackString(causeStack)
+        causeStackString = causeStack.stackString
+      } else {
+        causeStackString = typeof err.cause === 'string' ? err.cause : stringify(err.cause)
+      }
+    }
+
     const params = {
       stackHash: stringHashCode(canonicalStackString),
       exceptionClass: stackInfo.name,
-      request_uri: globalScope?.location.pathname
+      request_uri: globalScope?.location.pathname,
+      ...(causeStackString && { cause: causeStackString })
     }
     if (stackInfo.message) params.message = '' + stackInfo.message
     // Notice if filterOutput isn't false|undefined OR our specified object, this func would've returned already (so it's unnecessary to req-check group).

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -143,9 +143,12 @@ export class Aggregate extends AggregateBase {
     let causeStackString = ''
     if (err.cause) {
       if (err.cause instanceof Error) {
-        const causeStack = computeStackTrace(err.cause)
-        // canonicalCauseString = err.message + ' ' + this.buildCanonicalStackString(causeStack)
-        causeStackString = causeStack.stackString
+        try {
+          causeStackString = computeStackTrace(err.cause).stackString
+        } catch (e) {
+          // If we can't compute the stack trace for the cause, try to capture the string output
+          causeStackString = err.cause.toString()
+        }
       } else {
         causeStackString = typeof err.cause === 'string' ? err.cause : stringify(err.cause)
       }

--- a/src/features/jserrors/shared/cast-error.js
+++ b/src/features/jserrors/shared/cast-error.js
@@ -25,7 +25,8 @@ export function castError (error) {
     error?.filename || error?.sourceURL,
     error?.lineno || error?.line,
     error?.colno || error?.col,
-    error?.__newrelic
+    error?.__newrelic,
+    error?.cause
   )
 }
 
@@ -65,7 +66,7 @@ export function castPromiseRejectionEvent (promiseRejectionEvent) {
    */
 export function castErrorEvent (errorEvent) {
   if (errorEvent.error instanceof SyntaxError && !/:\d+$/.test(errorEvent.error.stack?.trim())) {
-    const error = new UncaughtError(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno, errorEvent.error.__newrelic)
+    const error = new UncaughtError(errorEvent.message, errorEvent.filename, errorEvent.lineno, errorEvent.colno, errorEvent.error.__newrelic, errorEvent.cause)
     error.name = SyntaxError.name
     return error
   }

--- a/tests/assets/js-error-cause.html
+++ b/tests/assets/js-error-cause.html
@@ -11,25 +11,37 @@
 <body>
 This page throws an error with a cause
 
+<script>
+  window.errorCauseMessage = 'This is the cause of the test error';
+</script>
+
 <!-- error with error cause -->
 <script>
   throw new Error('error with error cause', {
-    cause: new Error('This is the cause of the test error')
+    cause: new Error(window.errorCauseMessage)
   })
 </script>
 
 <!-- error with string cause -->
 <script>
   throw new Error('error with string cause', {
-    cause: 'This is the cause of the test error'
+    cause: window.errorCauseMessage
   })
 </script>
 
 <!-- error with non-string cause -->
 <script>
   throw new Error('error with non-string cause', {
-    cause: 123
+    cause: { toJSON: function(){ return window.errorCauseMessage; } }
   })
 </script>
+
+<!-- error with cause that can't be stringified -->
+<script>
+  throw new Error('error with cause that can\'t be stringified', {
+    cause: { toString: function(){ return window.errorCauseMessage; }, toJSON: function(){ throw new Error('cannot stringify cause'); } }
+  })
+</script>
+
 </body>
 </html>

--- a/tests/assets/js-error-cause.html
+++ b/tests/assets/js-error-cause.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+<head>
+  <title>RUM Unit Test</title>
+  {init} {config} {loader}
+</head>
+<body>
+This page throws an error with a cause
+
+<!-- error with error cause -->
+<script>
+  throw new Error('error with error cause', {
+    cause: new Error('This is the cause of the test error')
+  })
+</script>
+
+<!-- error with string cause -->
+<script>
+  throw new Error('error with string cause', {
+    cause: 'This is the cause of the test error'
+  })
+</script>
+
+<!-- error with non-string cause -->
+<script>
+  throw new Error('error with non-string cause', {
+    cause: 123
+  })
+</script>
+</body>
+</html>

--- a/tests/specs/err/error-payload.e2e.js
+++ b/tests/specs/err/error-payload.e2e.js
@@ -1,6 +1,5 @@
-/* globals errorFn, noticeErrorFn, browserMatch */
+/* globals errorFn, noticeErrorFn */
 const { testErrorsRequest } = require('../../../tools/testing-server/utils/expect-tests')
-const { onlySafari, onlyFirefox } = require('../../../tools/browser-matcher/common-matchers.mjs')
 
 describe('error payloads', () => {
   let errorsCapture
@@ -139,9 +138,8 @@ describe('error payloads', () => {
 
     const errorCause = errorResults[0].request.body.err.find(x => x.params.message === 'error with error cause').params.cause
     expect(errorCause.match(/<inline>:[0-9]+:[0-9]+/).length).toEqual(1)
-    if (browserMatch(onlyFirefox)) expect(errorCause).toContain('@<inline>')
-    else if (browserMatch(onlySafari)) expect(errorCause).toContain('global code')
-    else expect(errorCause).toContain(errorCauseMessage)
+    expect(errorCause).toContain(errorCauseMessage)
+    expect(errorCause).toContain('Error: ')
 
     const stringCause = errorResults[0].request.body.err.find(x => x.params.message === 'error with string cause').params.cause
     expect(stringCause).toContain(errorCauseMessage)

--- a/tests/specs/err/error-payload.e2e.js
+++ b/tests/specs/err/error-payload.e2e.js
@@ -128,4 +128,18 @@ describe('error payloads', () => {
 
     expect(errorResults).toEqual([])
   })
+
+  it('cause is captured when present', async () => {
+    const [errorResults] = await Promise.all([
+      errorsCapture.waitForResult({ totalCount: 1 }), // should not harvest an error (neither the noticeError call or an error from calling the API with no arg)
+      browser.url(await browser.testHandle.assetURL('js-error-cause.html')) // Setup expects before loading the page
+    ])
+
+    // error cause is captured in the params
+    expect(errorResults[0].request.body.err[0].params.cause).toEqual('Error: This is the cause of the test error\n    at <inline>:18:12')
+    // string cause is captured in the params
+    expect(errorResults[0].request.body.err[1].params.cause).toEqual('This is the cause of the test error')
+    // non-string cause is captured in the params
+    expect(errorResults[0].request.body.err[2].params.cause).toEqual('123')
+  })
 })

--- a/tests/unit/features/jserrors/aggregate/cause-string.test.js
+++ b/tests/unit/features/jserrors/aggregate/cause-string.test.js
@@ -1,0 +1,46 @@
+import { buildCauseString } from '../../../../../src/features/jserrors/aggregate/cause-string'
+import * as computeStackTraceModule from '../../../../../src/features/jserrors/aggregate/compute-stack-trace'
+
+describe('buildCauseString', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('returns an empty string when no cause is present', () => {
+    const err = new Error('Test error without cause')
+    expect(buildCauseString(err)).toBe('')
+  })
+
+  it('returns the computed stack string of the cause if it is an Error', () => {
+    const cause = new Error('This is the cause')
+    const err = new Error('Test error with cause', { cause })
+    expect(buildCauseString(err)).toContain(computeStackTraceModule.computeStackTrace(cause).stackString)
+  })
+
+  it('returns the stack string of the cause if it is an Error that cant be computed', () => {
+    const cause = new Error('This is the cause')
+    const err = new Error('Test error with cause', { cause })
+    jest.spyOn(computeStackTraceModule, 'computeStackTrace').mockReturnValue({ stackString: '' })
+    expect(buildCauseString(err)).toContain(cause.stack)
+  })
+
+  it('returns the string representation of a string cause', () => {
+    const err = new Error('Test error with string cause', { cause: 'This is a string cause' })
+    expect(buildCauseString(err)).toBe('This is a string cause')
+  })
+
+  it('returns the string representation of a (stringifyable) non-string cause', () => {
+    const err = new Error('Test error with non-string cause', { cause: { toJSON: () => 'Non-string cause' } })
+    expect(buildCauseString(err)).toBe(JSON.stringify('Non-string cause'))
+  })
+
+  it('returns the string representation of a (non-stringifyable) non-string cause', () => {
+    const err = new Error('Test error with non-string cause', { cause: { toJSON: () => { throw new Error() }, toString: () => 'Non-string cause' } })
+    expect(buildCauseString(err)).toBe('Non-string cause')
+  })
+
+  it('returns the string representation of a complex object as a fallback', () => {
+    const err = new Error('Test error with complex object as cause', { cause: { key: 'value' } })
+    expect(buildCauseString(err)).toContain('"key":"value"')
+  })
+})

--- a/tests/unit/features/jserrors/shared/cast-error.test.js
+++ b/tests/unit/features/jserrors/shared/cast-error.test.js
@@ -8,6 +8,7 @@ describe('cast-error', () => {
     err.filename = 'filename'
     err.lineno = 'lineno'
     err.colno = 'colno'
+    err.cause = 'cause'
   })
 
   describe('castError', () => {
@@ -114,7 +115,7 @@ describe('cast-error', () => {
       const castedError = castPromiseRejectionEvent({ reason: err })
       expect(castedError).toMatchObject({
         name: 'UncaughtError',
-        message: 'Unhandled Promise Rejection: {"filename":"filename","lineno":"lineno","colno":"colno"}',
+        message: 'Unhandled Promise Rejection: {"filename":"filename","lineno":"lineno","colno":"colno","cause":"cause"}',
         sourceURL: 'filename',
         line: 'lineno',
         column: 'colno'

--- a/tools/browser-matcher/common-matchers.mjs
+++ b/tools/browser-matcher/common-matchers.mjs
@@ -62,6 +62,10 @@ export const onlyChromium = new SpecMatcher()
 export const onlyFirefox = new SpecMatcher()
   .include('firefox')
 
+export const onlySafari = new SpecMatcher()
+  .include('safari')
+  .include('ios')
+
 export const supportsFirstPaint = new SpecMatcher()
   .include('android')
   .include('chrome')

--- a/tools/browsers-lists/lt-mobile-supported.json
+++ b/tools/browsers-lists/lt-mobile-supported.json
@@ -1,7 +1,7 @@
 {
   "ios": [
     {
-      "device_name": "iPhone 16",
+      "device_name": "iPhone 16 Pro",
       "version": "26.0",
       "platformName": "ios"
     },


### PR DESCRIPTION
Detect and report the cause attribute on captured JavaScriptError events.  If the cause is an instance of an Error, the stack trace will be captured, otherwise the stringified contents of the cause will be reported. This will be queryable in JavaScriptError events under the attribute `cause`.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-414116?atlOrigin=eyJpIjoiODY2NDUxZTIwMTUxNGQ0YWFkMDU0M2JmMDkxNzBkOWYiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added to validate the various cause cases.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
