### PR TITLE
feat: Add dead click detection via DOM mutations

### DIFF
--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -84,7 +84,8 @@ export class Aggregate extends AggregateBase {
                   if (canTrustTargetAttribute(field)) acc[targetAttrName(field)] = String(target[field]).trim().slice(0, 128)
                   return acc
                 }, {})),
-                ...aggregatedUserAction.nearestTargetFields
+                ...aggregatedUserAction.nearestTargetFields,
+                ...(agentRef.init.feature_flags.includes('user_frustrations') && aggregatedUserAction.deadClick && { deadClick: true })
               })
 
               /**

--- a/src/features/generic_events/aggregate/user-actions/aggregated-user-action.js
+++ b/src/features/generic_events/aggregate/user-actions/aggregated-user-action.js
@@ -15,6 +15,7 @@ export class AggregatedUserAction {
     this.rageClick = undefined
     this.nearestTargetFields = nearestTargetFields
     this.currentUrl = cleanURL('' + location)
+    this.deadClick = false
   }
 
   /**

--- a/src/features/generic_events/constants.js
+++ b/src/features/generic_events/constants.js
@@ -12,6 +12,8 @@ export const OBSERVED_WINDOW_EVENTS = ['focus', 'blur']
 export const RAGE_CLICK_THRESHOLD_EVENTS = 4
 export const RAGE_CLICK_THRESHOLD_MS = 1000
 
+export const FRUSTRATION_TIMEOUT_MS = 2000
+
 export const RESERVED_EVENT_TYPES = ['PageAction', 'UserAction', 'BrowserPerformance']
 
 export const FEATURE_FLAGS = {

--- a/tests/specs/user-frustrations/dead-clicks.e2e.js
+++ b/tests/specs/user-frustrations/dead-clicks.e2e.js
@@ -1,0 +1,51 @@
+import { testInsRequest } from '../../../tools/testing-server/utils/expect-tests'
+
+const loaderTypes = ['full', 'spa'] // 'rum' is excluded as UserActions is not supported
+
+describe('User Frustrations - Dead Clicks', () => {
+  loaderTypes.forEach(loaderType => {
+    it('should decorate dead clicks - ' + loaderType, async () => {
+      const [insightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+        { test: testInsRequest }
+      ])
+      await browser.url(await browser.testHandle.assetURL('test-builds/vite-react-wrapper/index.html'))
+        .then(() => browser.waitForAgentLoad())
+
+      await browser.execute(function () {
+        const USER_TIMEOUT = 2000
+        const commands = [
+          // [0] - span with no click handler
+          () => { document.getElementById('do-nothing-span').click() },
+          // [1] - DOM mutation as a result of handlers fired via event delegation
+          () => { document.getElementById('sample-trigger').click() },
+          // end previous user action, using two actions to help "pad" UA harvests due to race between events and harvest cycle
+          () => { document.getElementById('dummy-span-1').click() },
+          () => { document.getElementById('dummy-span-2').click() }
+        ]
+        const cmdCount = commands.length
+        for (let i = 0; i < cmdCount; i++) {
+          const buffer = 20 * i
+
+          setTimeout(() => {
+            commands[i].call()
+          }, USER_TIMEOUT * (i) + buffer)
+        }
+      })
+
+      const [insightsHarvest] = await insightsCapture.waitForResult({ totalCount: 3, timeout: 20000 })
+      const actualInsHarvests = insightsHarvest?.request.body.ins.filter(x => x.action === 'click')
+      expect(actualInsHarvests[0]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'SPAN',
+        targetId: 'do-nothing-span',
+        deadClick: true
+      }))
+      expect(actualInsHarvests[1]).toMatchObject(expect.objectContaining({
+        eventType: 'UserAction',
+        targetTag: 'BUTTON',
+        targetId: 'sample-trigger'
+      }))
+      expect(actualInsHarvests[1]).not.toHaveProperty('deadClick')
+    })
+  })
+})

--- a/tools/test-builds/vite-react-wrapper/.env
+++ b/tools/test-builds/vite-react-wrapper/.env
@@ -1,0 +1,1 @@
+VITE_SCRIPT_SRC=src/main.tsx

--- a/tools/test-builds/vite-react-wrapper/index.html
+++ b/tools/test-builds/vite-react-wrapper/index.html
@@ -6,10 +6,22 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
     {init}
     {config}
+    <script>
+      NREUM.init.feature_flags = ['user_frustrations']
+      NREUM.init.harvest.interval = 5
+    </script>
     <title>Vite Template</title>
+    <style>
+      .popover-content {
+        background-color: #fff;
+        border: 2px solid #00f;
+        padding: .5em;
+      }
+    </style>
   </head>
   <body>
-    <div id="app"></div>
-    <script type="module" src="src/main.tsx"></script>
+    {loader}
+    <div id="app">App</div>
+    <script type="module" src="%VITE_SCRIPT_SRC%"></script>
   </body>
 </html>

--- a/tools/test-builds/vite-react-wrapper/package.json
+++ b/tools/test-builds/vite-react-wrapper/package.json
@@ -4,19 +4,21 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.293.0.tgz",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "@newrelic/browser-agent": "file:../../../temp/newrelic-browser-agent-1.294.0.tgz",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-popper": "^1.3.2"
   },
   "scripts": {
     "start": "vite",
     "test:types-resolver": "tsc --project tsconfig.types-resolver.json",
     "prebuild": "npm run test:types-resolver",
-    "build": "tsc && vite build"
+    "build": "tsc && vite build",
+    "build:local": "VITE_SCRIPT_SRC=src/local-e2e-main.tsx npm run build"
   },
   "devDependencies": {
     "@types/react": "*",
-    "@types/react-dom": "*",
+    "@types/react-dom": "^17.0.2",
     "@vitejs/plugin-react-swc": "3.2.0",
     "typescript": "4.9.5",
     "vite": "4.2.0"

--- a/tools/test-builds/vite-react-wrapper/src/App.css
+++ b/tools/test-builds/vite-react-wrapper/src/App.css
@@ -1,0 +1,8 @@
+html {
+  color-scheme: light dark;
+  font-family: system-ui;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}

--- a/tools/test-builds/vite-react-wrapper/src/App.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/App.tsx
@@ -1,3 +1,38 @@
-export function App() {
-  return <div>Vite React</div>;
+import React from 'react';
+import './App.css';
+import SampleTrigger from './SampleTrigger';
+import Popover from './Popover';
+import PopoverTrigger from './PopoverTrigger';
+import PopoverBody from './PopoverBody';
+
+export default function App() {
+  const [clickCount, updateClickCount] = React.useState(0);
+  return (
+    <>
+      <h1>Vite React</h1>
+      <div>
+        <span id={"dummy-span-1"}></span>
+        <span id={"dummy-span-2"}></span>
+        <p><strong>Click count: { clickCount } </strong></p>
+        <p>Span with a click event handler, added via `onclick` ={'>'}
+          <span id="span-with-onclick" onClick={() => { updateClickCount(clickCount + 1)}} className="non-interactive-element">Span </span>
+        </p>
+        <p>Span with no handlers ={'>'}
+          <span id="do-nothing-span" className="non-interactive-element">Span</span>
+        </p>
+      </div>
+      <hr/>
+      <Popover>
+        <PopoverTrigger>
+          <SampleTrigger id="sample-trigger" title="Sample Trigger"/>
+        </PopoverTrigger>
+        <PopoverBody>
+          <div className="popover-content">
+            <p>This is the content of the popover.</p>
+            <p>You can add more elements here.</p>
+          </div>
+        </PopoverBody>
+      </Popover>
+    </>
+  );
 }

--- a/tools/test-builds/vite-react-wrapper/src/Popover.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/Popover.tsx
@@ -1,0 +1,234 @@
+import React, { cloneElement, createRef, PureComponent } from "react";
+import ReferenceCurrentRef from "./ReferenceCurrentRef";
+import { PopoverBodyContext, PopoverTriggerContext } from "./popover-context";
+
+type Props = {
+  children: any;
+  onChange?: (evt: Event, opened: boolean) => void;
+  opened?: boolean;
+};
+type State = {
+    opened: boolean;
+    triggerNode: HTMLElement | null;
+    triggerRef: any;
+    bodyNode: HTMLElement | null;
+    bodyRef: any;
+}
+export default class Popover extends PureComponent<Props, State> {
+    _sectionRefs: {};
+    _fallbackBodyRef: React.RefObject<unknown>;
+    _fallbackTriggerRef: React.RefObject<unknown>;
+    _onClickDelegated: any;
+
+    static getDerivedStateFromProps({ opened }: { opened?: boolean}) {
+            if (typeof opened === 'boolean') {
+                return {
+                    opened,
+                };
+            }
+
+            return null;
+        }
+
+        constructor(props: Props) {
+            super(props);
+
+            this.state = {
+                opened: false,
+                triggerNode: null,
+                triggerRef: null,
+                bodyNode: null,
+                bodyRef: null,
+            };
+
+            this._sectionRefs = {};
+
+            this._fallbackBodyRef = createRef();
+            this._fallbackTriggerRef = createRef();
+
+            this._onActionOutside = this._onActionOutside.bind(this);
+            this._onClick = this._onClick.bind(this);
+            this._setBodyNode = this._setBodyNode.bind(this);
+            this._setBodyRef = this._setBodyRef.bind(this);
+            this._setTriggerNode = this._setTriggerNode.bind(this);
+            this._setTriggerRef = this._setTriggerRef.bind(this);
+            this._setOpenedState = this._setOpenedState.bind(this);
+            this._delegateTriggerHandler = this._delegateTriggerHandler.bind(this);
+
+            this._onClickDelegated = this._delegateTriggerHandler(this._onClick);
+        }
+
+        componentWillUnmount() {
+            const oldRef = this.state.triggerNode;
+
+            // Clean up properly so there aren't any event handler leaks
+            if (oldRef) {
+                const oldWindow = oldRef.ownerDocument.defaultView;
+                oldWindow?.removeEventListener('click', this._onActionOutside);
+                oldWindow?.removeEventListener('click', this._onClickDelegated);
+            }
+        }
+
+        _delegateTriggerHandler(handler: (evt: Event) => void) {
+            return (evt: Event) => {
+                if (this.state.triggerNode && this.state.triggerNode.contains(evt.target as HTMLElement)) {
+                    return handler(evt);
+                }
+            };
+        }
+
+        _focusTrigger() {
+            this.state.triggerRef?.focus();
+        }
+
+        _isControlled() {
+            return typeof this.props.opened === 'boolean';
+        }
+
+        _onActionOutside(evt: Event) {
+            if (!this.state.opened) {
+                return;
+            }
+
+            for (let node: ParentNode | null = evt.target as ParentNode; node; node = node.parentNode) {
+                if (node === this.state.triggerNode || node === this.state.bodyNode) {
+                    return;
+                }
+            }
+
+            if (this._isControlled()) {
+                this.props.onChange?.(evt, false);
+            } else {
+                this.state.bodyRef.close(evt);
+            }
+        }
+
+        _onClick(evt: Event) {
+            const { bodyRef, opened } = this.state;
+
+            if (!evt.defaultPrevented) {
+                if (this._isControlled()) {
+                    this.props.onChange?.(evt, !opened);
+                } else {
+                    bodyRef.toggle(evt, !opened);
+                }
+            }
+        }
+
+        _setBodyNode(newRef: HTMLElement | null) {
+            const oldRef = this.state.bodyNode;
+
+            if (oldRef === newRef) {
+                return;
+            }
+
+            this.setState({ bodyNode: newRef });
+        }
+
+        _setBodyRef(bodyRef: HTMLElement | null) {
+            this.setState({ bodyRef });
+        }
+
+
+        _setOpenedState(evt: Event, opened: boolean) {
+            if (this._isControlled()) {
+                this.props.onChange?.(evt, opened);
+
+                return;
+            }
+
+            if (typeof opened === 'undefined') {
+                this.setState((prevState) => {
+                    return {
+                        opened: !prevState.opened,
+                    };
+                });
+
+                return;
+            }
+
+            this.setState({ opened });
+        }
+
+        _setTriggerNode(newRef: HTMLElement | null) {
+            const oldRef = this.state.triggerNode;
+
+            if (oldRef === newRef) {
+                return;
+            }
+
+            if (oldRef) {
+                const oldWindow = oldRef.ownerDocument.defaultView;
+
+                oldWindow?.removeEventListener('click', this._onActionOutside);
+                oldWindow?.removeEventListener('click', this._onClickDelegated);
+            }
+
+            if (newRef) {
+                const newWindow = newRef.ownerDocument.defaultView;
+
+                newWindow?.addEventListener('click', this._onActionOutside);
+                newWindow?.addEventListener('click', this._onClickDelegated);
+            }
+
+            this.setState({ triggerNode: newRef });
+        }
+
+        _setTriggerRef(triggerRef: HTMLElement | null) {
+            this.setState({ triggerRef });
+        }
+
+        renderBody() {
+            const { children } = this.props;
+
+            const context = {
+                opened: this.state.opened,
+                setOpenedState: this._setOpenedState,
+                setBodyNode: this._setBodyNode,
+                triggerNode: this.state.triggerNode,
+                triggerRef: this.state.triggerRef
+            };
+
+            return (
+                <PopoverBodyContext.Provider value={context}>
+                    <ReferenceCurrentRef refSetter={this._setBodyRef}>
+                        {cloneElement(children[1], {
+                            ref: children[1].ref || this._fallbackBodyRef,
+                        })}
+                    </ReferenceCurrentRef>
+                </PopoverBodyContext.Provider>
+            );
+        }
+
+        renderTrigger() {
+            const { children } = this.props;
+
+            const isControlled = this._isControlled();
+
+            const context = {
+                controlled: isControlled,
+                opened: this.state.opened,
+                setTriggerNode: this._setTriggerNode,
+            };
+
+            return (
+                <PopoverTriggerContext.Provider value={context}>
+                    <ReferenceCurrentRef refSetter={this._setTriggerRef}>
+                        {cloneElement(children[0], {
+                            ref: children[0].ref || this._fallbackTriggerRef,
+                        })}
+                    </ReferenceCurrentRef>
+                </PopoverTriggerContext.Provider>
+            );
+        }
+
+        render() {
+            return (
+                <>
+                    {this.renderTrigger()}
+                    {this.renderBody()}
+                </>
+            );
+        }
+
+}

--- a/tools/test-builds/vite-react-wrapper/src/PopoverBody.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/PopoverBody.tsx
@@ -1,0 +1,266 @@
+import React, { createRef, PureComponent } from 'react';
+import { createPortal } from 'react-dom';
+import { Popper } from 'react-popper';
+
+import ReferenceElement from './ReferenceElement';
+
+import { PopoverBodyContext, PopoverListContext } from './popover-context';
+
+const popperModifiers = new WeakMap();
+
+const PLACEMENT_TYPE = {
+    TOP_START: 'top-start',
+    TOP_END: 'top-end',
+    BOTTOM_START: 'bottom-start',
+    BOTTOM_END: 'bottom-end',
+    RIGHT_START: 'right-start',
+    RIGHT_END: 'right-end',
+    LEFT_START: 'left-start',
+    LEFT_END: 'left-end',
+};
+const DEFAULT_PLACEMENT = PLACEMENT_TYPE.BOTTOM_START;
+
+type Prop = {
+    children: any;
+    className?: string;
+    onClose?: (event: React.MouseEvent) => void;
+    onOpen?: (event: React.MouseEvent) => void;
+    onToggle?: (event: React.MouseEvent, opened: boolean) => void;
+    placementType?: string;
+    style?: React.CSSProperties;
+}
+
+function isOverflownHorizontal(element: HTMLElement) {
+    return element.scrollWidth > element.clientWidth;
+}
+
+function isOverflownVertical(element: HTMLElement) {
+    return element.scrollHeight > element.clientHeight;
+}
+
+export function getScrollParent(base: HTMLElement, boundaryElement: HTMLElement) {
+    let node: HTMLElement | null = null;
+
+    if (base) {
+        const { defaultView, body } = base.ownerDocument;
+
+        for (
+            node = base;
+            node && node !== boundaryElement && node !== body;
+            node = node.parentNode as HTMLElement
+        ) {
+            if (node.nodeType !== Node.ELEMENT_NODE) {
+                continue;
+            }
+
+            // Partially extracted and adapted from PopperJS internal logic
+            // ("getScrollParent" method).
+          if (defaultView) {
+            const {overflow, overflowX, overflowY} = defaultView.getComputedStyle(node);
+            const all = overflow + overflowY + overflowX;
+
+            if (
+              node.hasAttribute('data-boundary-container') ||
+              // If scroll is forced, use this node.
+              /(?:scroll|overlay)/.test(all) ||
+              // If scroll is "auto", ensure it's really scrolling before using it.
+              (/auto/.test(all) && (isOverflownHorizontal(node) || isOverflownVertical(node)))
+            ) {
+              break;
+            }
+          }
+        }
+    }
+
+    return node || boundaryElement;
+}
+
+/**
+ * @nr1-docs
+ *
+ * Child element of the `<Popover>` component.
+ *
+ * Contains the content of the Popover overlay.
+ */
+export default class PopoverBody extends PureComponent<Prop> {
+    static PLACEMENT_TYPE = PLACEMENT_TYPE;
+
+    _setOpenedState: ((event: React.MouseEvent, opened: boolean) => void) | null = null;
+    _bodyRef: any;
+
+    constructor(props: Prop) {
+        super(props);
+
+        this._getStyle = this._getStyle.bind(this);
+
+        this._bodyRef = createRef();
+
+        this.open = this.open.bind(this);
+        this.close = this.close.bind(this);
+        this.toggle = this.toggle.bind(this);
+    }
+
+    /**
+     * Closes the Popover body.
+     */
+    close(event: React.MouseEvent) {
+        const { onClose, onToggle } = this.props;
+
+        this._setOpenedState?.(event, false);
+        onClose?.(event);
+        onToggle?.(event, false);
+    }
+
+    /**
+     * Opens the Popover body.
+     */
+    open(event: React.MouseEvent) {
+        const { onOpen, onToggle } = this.props;
+
+        this._setOpenedState?.(event, true);
+        onOpen?.(event);
+        onToggle?.(event, true);
+    }
+
+    /**
+     * Toggles the Popover body.
+     */
+    toggle(event: React.MouseEvent, opened: boolean) {
+        const { onClose, onOpen, onToggle } = this.props;
+
+        this._setOpenedState?.(event, opened);
+
+        if (opened) {
+            onOpen?.(event);
+        } else {
+            onClose?.(event);
+        }
+
+        onToggle?.(event, opened);
+    }
+
+    _getPopperModifiers(boundariesElement: any, allowPopperToEscapeBoundary: boolean) {
+        const offset = {
+            enabled: true,
+            offset: `0, 6`,
+        };
+
+        if (
+            boundariesElement &&
+            !popperModifiers.has(boundariesElement) &&
+            !allowPopperToEscapeBoundary
+        ) {
+            const boundaryModifiers = {
+                flip: {
+                    boundariesElement,
+                    flipVariationsByContent: true,
+                    order: 250, // Execute before "preventOverflow".
+                },
+
+                preventOverflow: {
+                    boundariesElement,
+                },
+            };
+
+            popperModifiers.set(boundariesElement, {
+                offset,
+                ...boundaryModifiers,
+            });
+        }
+
+        // Only apply the offset for poppers that can escape, otherwise apply the full set of modifiers (which includes boundary configuration)
+        return allowPopperToEscapeBoundary ? { offset } : popperModifiers.get(boundariesElement);
+    }
+
+    _getStyle(popoverBodyStyle: any) {
+        const { style } = this.props;
+
+        return {
+            ...popoverBodyStyle,
+            ...style,
+        };
+    }
+
+    renderBody(portalTargetRef: any, boundaryRef: any) {
+        const { children } = this.props;
+
+        return (
+            <PopoverBodyContext.Consumer>
+                {(contextValue) => {
+                    const {
+                        opened,
+                        triggerNode,
+                        setBodyNode,
+                        triggerRef,
+                        setOpenedState,
+                    } = contextValue as {
+                        opened: any;
+                        triggerNode: any;
+                        setBodyNode: any;
+                        triggerRef: any;
+                        setOpenedState: any;
+                    };
+
+                    this._setOpenedState = setOpenedState;
+
+                    if (!triggerNode) {
+                        return null;
+                    }
+
+                    const boundaryElement = getScrollParent(
+                        triggerNode,
+                        boundaryRef || portalTargetRef || triggerNode.ownerDocument.body
+                    );
+
+                    return createPortal(
+                        <Popper
+                            modifiers={this._getPopperModifiers(
+                                boundaryElement,
+                                false
+                            )}
+                            placement={DEFAULT_PLACEMENT as any}
+                            referenceElement={triggerNode}
+                        >
+                            {({ ref, style }) => {
+                                if (!opened) {
+                                    return null;
+                                }
+
+                                const context = {
+                                    triggerRef,
+                                    triggerNode,
+                                    bodyRef: this,
+                                };
+
+                                return (
+                                    <ReferenceElement refSetter={setBodyNode}>
+                                        <div
+                                            ref={ref}
+                                            style={this._getStyle(style)}
+                                        >
+                                            <div
+                                                ref={this._bodyRef}
+                                            >
+                                                <PopoverListContext.Provider value={context}>
+                                                    {children}
+                                                </PopoverListContext.Provider>
+                                            </div>
+                                        </div>
+                                    </ReferenceElement>
+                                );
+                            }}
+                        </Popper>,
+
+                        portalTargetRef || triggerNode.ownerDocument.body
+                    );
+                }}
+            </PopoverBodyContext.Consumer>
+        );
+    }
+
+    render() {
+        return (
+            this.renderBody(null, null)
+        );
+    }
+}

--- a/tools/test-builds/vite-react-wrapper/src/PopoverTrigger.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/PopoverTrigger.tsx
@@ -1,0 +1,75 @@
+import React, { cloneElement, createRef, PureComponent } from 'react';
+
+import { PopoverTriggerContext } from './popover-context';
+import ReferenceCurrentRef from './ReferenceCurrentRef';
+import ReferenceElement from './ReferenceElement';
+
+type Prop = {
+    children: any
+}
+/**
+ * Child element of the `<Popover>` component.
+ *
+ * Controls the opening/closing of the Popover overlay.
+ */
+export default class PopoverTrigger extends PureComponent<Prop> {
+    static defaultProps = {};
+    _triggerRef: any;
+    _fallbackRef: any;
+
+    constructor(props: Prop) {
+        super(props);
+
+        this._triggerRef = null;
+        this._fallbackRef = createRef();
+    }
+
+    /**
+     * Focus the PopoverTrigger children.
+     */
+    focus() {
+        if (typeof this._triggerRef?.focus === 'function') this._triggerRef.focus();
+    }
+
+    renderTrigger(triggerProps: any) {
+        const { children } = this.props;
+
+        if (
+            typeof children === 'string' ||
+            typeof children === 'number' ||
+            typeof children === 'boolean'
+        ) {
+            return <div ref={this._fallbackRef}>{children}</div>;
+        }
+
+        if (typeof children === 'function') {
+            const triggerElement = children(triggerProps);
+
+            return cloneElement(triggerElement, {
+                ref: triggerElement.ref || this._fallbackRef,
+            });
+        }
+
+        return cloneElement(children, {
+            ref: children.ref || this._fallbackRef,
+        });
+    }
+
+    render() {
+        return (
+            <PopoverTriggerContext.Consumer>
+                {(context: any) => (
+                    <ReferenceElement refSetter={context.setTriggerNode}>
+                        <ReferenceCurrentRef
+                            refSetter={(ref: HTMLElement | null) => {
+                                this._triggerRef = ref;
+                            }}
+                        >
+                            {this.renderTrigger({ opened: context.opened, controlled: context.controlled })}
+                        </ReferenceCurrentRef>
+                    </ReferenceElement>
+                )}
+            </PopoverTriggerContext.Consumer>
+        );
+    }
+}

--- a/tools/test-builds/vite-react-wrapper/src/ReferenceCurrentRef.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/ReferenceCurrentRef.tsx
@@ -1,0 +1,30 @@
+
+import { PureComponent } from 'react';
+
+type Prop = {
+    children: any;
+    refSetter: (ref: HTMLElement | null) => void;
+}
+export default class ReferenceCurrentRef extends PureComponent<Prop> {
+
+    static defaultProps = {};
+
+    componentDidMount() {
+        this._setRef();
+    }
+
+    componentDidUpdate() {
+        this._setRef();
+    }
+
+    _setRef() {
+        const { children } = this.props;
+        const ref = children.ref && children.ref.current;
+
+        this.props.refSetter(ref);
+    }
+
+    render() {
+        return this.props.children;
+    }
+}

--- a/tools/test-builds/vite-react-wrapper/src/ReferenceElement.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/ReferenceElement.tsx
@@ -1,0 +1,100 @@
+import { PureComponent } from 'react';
+import { findDOMNode } from 'react-dom';
+
+type Prop = {
+    children: any;
+    refSetter: (node: Element | Text | null) => void;
+};
+
+type State = {
+    refNode: Element | Text | null;
+}
+
+export default class ReferenceElement extends PureComponent<Prop, State> {
+    static defaultProps = {};
+    events: Map<any, any>;
+
+    constructor(props: Prop) {
+        super(props);
+
+        this._addEventListeners = this._addEventListeners.bind(this);
+        this.events = new Map();
+
+        this.state = {
+            refNode: null,
+        };
+    }
+
+    componentDidMount() {
+        this._setRefNode(findDOMNode(this));
+    }
+
+    componentDidUpdate() {
+        this._setRefNode(findDOMNode(this));
+    }
+
+    componentWillUnmount() {
+        this._removeEventListeners();
+    }
+
+    _addEventListeners() {
+        const { refNode } = this.state;
+
+        if (!refNode) {
+            return;
+        }
+
+        for (const propName of Object.keys(this.props)) {
+            if (propName.startsWith('on')) {
+                const eventName = propName.replace(/^on/, '').toLowerCase();
+
+                const handler = this._onEvent.bind(this, propName);
+
+                this.events.set(eventName, handler);
+
+                refNode.addEventListener(eventName, handler);
+            }
+        }
+    }
+
+    _onEvent(propName: any, evt: Event) {
+        // @ts-ignore
+      const prop = this.props[propName];
+
+        prop && prop(evt);
+    }
+
+    _removeEventListeners() {
+        const { refNode } = this.state;
+
+        if (!refNode) {
+            return;
+        }
+
+        for (const [eventName, handler] of this.events) {
+            refNode.removeEventListener(eventName, handler);
+        }
+
+        this.events.clear();
+    }
+
+    /* eslint-disable-next-line react/no-find-dom-node */
+    _setRefNode(node: any) {
+        if (node !== this.state.refNode) {
+            this._removeEventListeners();
+            this.setState({ refNode: node }, this._addEventListeners);
+        }
+
+        this.props.refSetter(node);
+    }
+
+    render() {
+        const { children } = this.props;
+
+        if ((typeof children === 'string' && children.length) || typeof children === 'number') {
+            return <span>{children}</span>;
+        }
+
+        return children;
+    }
+}

--- a/tools/test-builds/vite-react-wrapper/src/SampleTrigger.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/SampleTrigger.tsx
@@ -1,0 +1,37 @@
+import React, { createRef, PureComponent } from "react";
+
+interface SampleTriggerProps {
+  id: string;
+  title: string;
+}
+
+export default class SampleTrigger extends PureComponent<SampleTriggerProps> {
+  _rootRef: any;
+  _buttonRef: any;
+
+  constructor(props: SampleTriggerProps) {
+    super(props);
+
+    this._rootRef = createRef();
+    this._buttonRef = createRef();
+  }
+
+  render() {
+    const { id, title } = this.props;
+    return (
+      <div
+        ref={this._rootRef}
+        className="wnd-DropdownTrigger"
+      >
+        <button ref={this._buttonRef} id={id} type="button">
+          <span>
+            <span>{title}</span>
+            <span style={{ fontSize: '8px', marginLeft: '8px', display: 'inline-block', height: '1em', width: '1em' }}>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8" focusable="false">
+                <path fillRule="evenodd" d="M6.6 2L4 4.7 1.4 2l-.8.8L4 6.1l3.4-3.3-.8-.8z" clipRule="evenodd"></path></svg></span>
+          </span>
+        </button>
+      </div>
+    );
+  }
+}

--- a/tools/test-builds/vite-react-wrapper/src/local-e2e-main.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/local-e2e-main.tsx
@@ -1,6 +1,3 @@
-// Make sure newrelic is the first thing imported
-import "./newrelic";
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';

--- a/tools/test-builds/vite-react-wrapper/src/popover-context.tsx
+++ b/tools/test-builds/vite-react-wrapper/src/popover-context.tsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+export const PopoverTriggerContext = createContext({});
+export const PopoverBodyContext = createContext({});
+export const PopoverListContext = createContext({});


### PR DESCRIPTION
Add dead click detection via DOM mutations on user clicks.
---

### Overview
For a given user click action, start a dead click eval window for 2s.  
- If there's any DOM mutation during that time, then it is NOT a dead click.  
- If there're no DOM mutations within the eval window, then it will be marked as a dead click.  
- If another user action started before the eval window ends, then it is also considered NOT a dead click. 

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-443292

### Testing

- Added dead-clicks unit and e2e tests
- Manually tested on local test-server 
