### PR TITLE
fix: Calculate first and last timestamps from raw data

### DIFF
--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -278,14 +278,14 @@ export class Aggregate extends AggregateBase {
   /**
    * returns the timestamps for the earliest and latest nodes in the provided array, even if out of order
    * @param {Object[]} [nodes] - the nodes to evaluate
-   * @returns {{ firstEvent: number|undefined, lastEvent: number|undefined }} - the earliest and latest nodes. Defaults to undefined if no nodes are provided or if no timestamps are found in the nodes.
+   * @returns {{ firstEvent: Object|undefined, lastEvent: Object|undefined }} - the earliest and latest nodes. Defaults to undefined if no nodes are provided or if no timestamps are found in the nodes.
    */
   getFirstAndLastNodes (nodes = []) {
     const output = { firstEvent: nodes[0], lastEvent: nodes[nodes.length - 1] }
     nodes.forEach(node => {
       const timestamp = node?.timestamp
-      if (!output.firstEvent?.timestamp || (timestamp || Infinity) < output.firstEvent.timestamp) output.firstEvent.timestamp = timestamp
-      if (!output.lastEvent?.timestamp || (timestamp || -Infinity) > output.lastEvent.timestamp) output.lastEvent.timestamp = timestamp
+      if (!output.firstEvent?.timestamp || (timestamp || Infinity) < output.firstEvent.timestamp) output.firstEvent = node
+      if (!output.lastEvent?.timestamp || (timestamp || -Infinity) > output.lastEvent.timestamp) output.lastEvent = node
     })
     return output
   }

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -278,7 +278,7 @@ export class Aggregate extends AggregateBase {
   /**
    * returns the timestamps for the earliest and latest nodes in the provided array, even if out of order
    * @param {Object[]} [nodes] - the nodes to evaluate
-   * @returns {{ firstEventTimestamp: number|undefined, lastEventTimestamp: number|undefined }} - the corrected timestamps for the earliest and latest nodes
+   * @returns {{ firstEvent: number|undefined, lastEvent: number|undefined }} - the earliest and latest nodes. Defaults to undefined if no nodes are provided or if no timestamps are found in the nodes.
    */
   getFirstAndLastNodes (nodes = []) {
     const output = { firstEvent: nodes[0], lastEvent: nodes[nodes.length - 1] }

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -275,6 +275,21 @@ export class Aggregate extends AggregateBase {
     return this.timeKeeper.correctAbsoluteTimestamp(node.timestamp)
   }
 
+  /**
+   * returns the timestamps for the earliest and latest nodes in the provided array, even if out of order
+   * @param {Object[]} [nodes] - the nodes to evaluate
+   * @returns {{ firstEventTimestamp: number|undefined, lastEventTimestamp: number|undefined }} - the corrected timestamps for the earliest and latest nodes
+   */
+  getFirstAndLastNodes (nodes = []) {
+    const output = { firstEvent: nodes[0], lastEvent: nodes[nodes.length - 1] }
+    nodes.forEach(node => {
+      const timestamp = node?.timestamp
+      if (!output.firstEvent?.timestamp || (timestamp || Infinity) < output.firstEvent.timestamp) output.firstEvent.timestamp = timestamp
+      if (!output.lastEvent?.timestamp || (timestamp || -Infinity) > output.lastEvent.timestamp) output.lastEvent.timestamp = timestamp
+    })
+    return output
+  }
+
   getHarvestContents (recorderEvents) {
     recorderEvents ??= this.recorder.getEvents()
     let events = recorderEvents.events
@@ -301,11 +316,10 @@ export class Aggregate extends AggregateBase {
 
     const relativeNow = now()
 
-    const firstEventTimestamp = this.getCorrectedTimestamp(events[0]) // from rrweb node
-    const lastEventTimestamp = this.getCorrectedTimestamp(events[events.length - 1]) // from rrweb node
+    const { firstEvent, lastEvent } = this.getFirstAndLastNodes(events)
     // from rrweb node || from when the harvest cycle started
-    const firstTimestamp = firstEventTimestamp || Math.floor(this.timeKeeper.correctAbsoluteTimestamp(recorderEvents.cycleTimestamp))
-    const lastTimestamp = lastEventTimestamp || Math.floor(this.timeKeeper.correctRelativeTimestamp(relativeNow))
+    const firstTimestamp = this.getCorrectedTimestamp(firstEvent) || Math.floor(this.timeKeeper.correctAbsoluteTimestamp(recorderEvents.cycleTimestamp))
+    const lastTimestamp = this.getCorrectedTimestamp(lastEvent) || Math.floor(this.timeKeeper.correctRelativeTimestamp(relativeNow))
 
     const agentMetadata = agentRuntime.appMetadata?.agents?.[0] || {}
 

--- a/tests/components/session_replay/aggregate.test.js
+++ b/tests/components/session_replay/aggregate.test.js
@@ -321,6 +321,74 @@ describe('Session Replay Harvest Behaviors', () => {
     expect(sessionReplayAggregate.blocked).toEqual(true)
     expect(sessionReplayAggregate.mode).toEqual(MODE.OFF)
   })
+
+  test('provides correct first and last timestamps, even when out of order', async () => {
+    const now = performance.now()
+    sessionReplayAggregate.timeKeeper = {
+      correctAbsoluteTimestamp: jest.fn().mockImplementation(timestamp => timestamp),
+      correctRelativeTimestamp: jest.fn().mockImplementation(timestamp => timestamp)
+    }
+
+    const newrelic_events = [
+      { __newrelic: true, timestamp: 500 },
+      { __newrelic: true, timestamp: 1500 },
+      { __newrelic: true, timestamp: 1000 }
+    ]
+
+    const stock_events = [
+      { timestamp: 500 },
+      { timestamp: 1500 },
+      { timestamp: 1000 }
+    ]
+
+    const undefined_events = [
+      { },
+      { },
+      { }
+    ]
+
+    const newrelic_recorderEvents = {
+      cycleTimestamp: 2000,
+      events: newrelic_events
+    }
+
+    const stock_recorderEvents = {
+      cycleTimestamp: 2000,
+      events: stock_events
+    }
+
+    const undefined_recorderEvents = {
+      cycleTimestamp: 2000,
+      events: undefined_events
+    }
+
+    const newrelicTimestamps = sessionReplayAggregate.getFirstAndLastNodes(newrelic_events)
+    expect(newrelicTimestamps.firstEvent.timestamp).toEqual(500)
+    expect(newrelicTimestamps.lastEvent.timestamp).toEqual(1500)
+
+    const newrelicHarvestContents = sessionReplayAggregate.getHarvestContents(newrelic_recorderEvents)
+    expect(newrelicHarvestContents.qs.attributes.includes('replay.firstTimestamp=500')).toEqual(true)
+    expect(newrelicHarvestContents.qs.attributes.includes('replay.lastTimestamp=1500')).toEqual(true)
+
+    const stockTimestamps = sessionReplayAggregate.getFirstAndLastNodes(stock_events)
+    expect(stockTimestamps.firstEvent.timestamp).toEqual(500)
+    expect(stockTimestamps.lastEvent.timestamp).toEqual(1500)
+
+    const stockHarvestContents = sessionReplayAggregate.getHarvestContents(stock_recorderEvents)
+    expect(stockHarvestContents.qs.attributes.includes('replay.firstTimestamp=500')).toEqual(true)
+    expect(stockHarvestContents.qs.attributes.includes('replay.lastTimestamp=1500')).toEqual(true)
+
+    const undefinedTimestamps = sessionReplayAggregate.getFirstAndLastNodes(undefined_events)
+    expect(undefinedTimestamps.firstEvent.timestamp).toEqual(undefined)
+    expect(undefinedTimestamps.lastEvent.timestamp).toEqual(undefined)
+
+    const undefinedHarvestContents = sessionReplayAggregate.getHarvestContents(undefined_recorderEvents)
+
+    const attrs = Object.fromEntries(new URLSearchParams(undefinedHarvestContents.qs.attributes))
+    expect(attrs['replay.firstTimestamp']).toEqual('2000') // cycleTimestamp is used as first timestamp
+    expect(Number(attrs['replay.lastTimestamp'])).toEqual(expect.any(Number))
+    expect(Number(attrs['replay.lastTimestamp'])).toBeGreaterThan(now) // last timestamp should be greater than the start time of this test
+  })
 })
 
 function createAnyQueryMatcher () {


### PR DESCRIPTION
Ensure the agent manually calculates the first and last timestamps of a SessionReplay payload before harvesting to help improve consistency on the UI replayer.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-428135?atlOrigin=eyJpIjoiNWZiYmZjM2UxMDJkNDQyMzg3ZDVkOGMxOWFmZDkwYzEiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
new unit test has been added to validate the new method.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
