### PR TITLE
fix: Remove event buffer inspection event

### DIFF
--- a/src/features/utils/event-store-manager.js
+++ b/src/features/utils/event-store-manager.js
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { DEFAULT_KEY, MAX_PAYLOAD_SIZE } from '../../common/constants/agent-constants'
-import { dispatchGlobalEvent } from '../../common/dispatch/global-event'
-import { activatedFeatures } from '../../common/util/feature-flags'
 import { isContainerAgentTarget } from '../../common/util/target'
 /**
  * This layer allows multiple browser entity apps, or "target", to each have their own segregated storage instance.
@@ -70,14 +68,6 @@ export class EventStoreManager {
    * @returns {boolean} True if the event was successfully added
    */
   add (event, targetEntityGuid) {
-    dispatchGlobalEvent({
-      agentIdentifier: this.agentRef.agentIdentifier,
-      drained: !!activatedFeatures?.[this.agentRef.agentIdentifier],
-      type: 'data',
-      name: 'buffer',
-      feature: this.featureAgg.featureName,
-      data: event
-    })
     return this.#getEventStore(targetEntityGuid).add(event)
   }
 

--- a/tests/assets/inspection-events.html
+++ b/tests/assets/inspection-events.html
@@ -11,7 +11,6 @@
     window.inspectionEvents = {
       initialize: false,
       load: false,
-      buffer: false,
       harvest: false,
       api: false,
     }
@@ -37,16 +36,6 @@
         data
       ) {
         window.inspectionEvents.load = true
-      }
-
-      if (
-        name === 'buffer' &&
-        drained === true &&
-        type === 'data' &&
-        feature &&
-        data
-      ) {
-        window.inspectionEvents.buffer = true
       }
 
       if (

--- a/tests/specs/inspection-events.e2e.js
+++ b/tests/specs/inspection-events.e2e.js
@@ -6,8 +6,7 @@ describe('inspection events', () => {
       .then(() => browser.waitForAgentLoad())
       .then(() => browser.waitUntil(
         () => browser.execute(function () {
-          return window?.inspectionEvents?.buffer &&
-            window.inspectionEvents.harvest &&
+          return window.inspectionEvents.harvest &&
             window.inspectionEvents.api &&
             window.inspectionEvents.navigate
         }),
@@ -24,7 +23,6 @@ describe('inspection events', () => {
 
     expect(inspectionEvents.initialize).toBe(true)
     expect(inspectionEvents.load).toBe(true)
-    expect(inspectionEvents.buffer).toBe(true)
     expect(inspectionEvents.harvest).toBe(true)
     expect(inspectionEvents.api).toBe(true)
     expect(inspectionEvents.drain).toBe(true)


### PR DESCRIPTION
Removes the event buffer inspection event to avoid a memory leak on using console.log with the `newrelic` window event listener.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Inspection events can cause an endless loop if a console log is detected and reported in the callback, causing a memory leak. To remedy this, we remove the buffer event as it is not worth the risk to customer applications.

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-444882

### Testing

Make sure tests pass, especially inspection events tests.
