### PR TITLE
feat: remove newrelic meta attribute

### DIFF
--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -18,7 +18,6 @@ import { MODE, SESSION_EVENTS, SESSION_EVENT_TYPES } from '../../../common/sessi
 import { stringify } from '../../../common/util/stringify'
 import { stylesheetEvaluator } from '../shared/stylesheet-evaluator'
 import { now } from '../../../common/timing/now'
-import { buildNRMetaNode } from '../shared/utils'
 import { MAX_PAYLOAD_SIZE } from '../../../common/constants/agent-constants'
 import { cleanURL } from '../../../common/url/clean-url'
 import { canEnableSessionTracking } from '../../utils/feature-gates'
@@ -94,8 +93,7 @@ export class Aggregate extends AggregateBase {
         }
         return
       }
-      this.drain()
-      this.initializeRecording(srMode)
+      this.initializeRecording(srMode).then(() => { this.drain() })
     }).then(() => {
       if (this.mode === MODE.OFF) {
         this.recorder?.stopRecording() // stop any conservative preload recording launched by instrument
@@ -121,7 +119,7 @@ export class Aggregate extends AggregateBase {
   }
 
   handleError (e) {
-    if (this.recorder) this.recorder.currentBufferTarget.hasError = true
+    if (this.recorder) this.recorder.events.hasError = true
     // run once
     if (this.mode === MODE.ERROR && globalScope?.document.visibilityState === 'visible') {
       this.switchToFull()
@@ -171,10 +169,10 @@ export class Aggregate extends AggregateBase {
 
     if (!this.recorder) {
       try {
-      // Do not change the webpackChunkName or it will break the webpack nrba-chunking plugin
+        // Do not change the webpackChunkName or it will break the webpack nrba-chunking plugin
         const { Recorder } = (await import(/* webpackChunkName: "recorder" */'../shared/recorder'))
         this.recorder = new Recorder(this)
-        this.recorder.currentBufferTarget.hasError = this.errorNoticed
+        this.recorder.events.hasError = this.errorNoticed
       } catch (err) {
         return this.abort(ABORT_REASONS.IMPORT)
       }
@@ -188,11 +186,6 @@ export class Aggregate extends AggregateBase {
     // FULL mode records AND reports from the beginning, while ERROR mode only records (but does not report).
     // ERROR mode will do this until an error is thrown, and then switch into FULL mode.
     // The makeHarvestPayload should ensure that no payload is returned if we're not in FULL mode...
-
-    // If theres preloaded events and we are in full mode, just harvest immediately to clear up space and for consistency
-    if (this.mode === MODE.FULL && this.recorder?.getEvents().type === 'preloaded') {
-      this.prepUtils().then(() => this.agentRef.runtime.harvester.triggerHarvestFor(this))
-    }
 
     await this.prepUtils()
 
@@ -231,24 +224,10 @@ export class Aggregate extends AggregateBase {
 
     let len = 0
     if (!!this.gzipper && !!this.u8) {
-      payload.body = this.gzipper(this.u8(`[${payload.body.map(({ __serialized, ...e }) => {
-        if (e.__newrelic && __serialized) return __serialized
-        const output = { ...e }
-        if (!output.__newrelic) {
-          output.__newrelic = buildNRMetaNode(e.timestamp, this.timeKeeper)
-          output.timestamp = this.timeKeeper.correctAbsoluteTimestamp(e.timestamp)
-        }
-        return stringify(output)
-      }).join(',')}]`))
+      payload.body = this.gzipper(this.u8(`[${payload.body.map(({ __serialized }) => (__serialized)).join(',')}]`))
       len = payload.body.length
     } else {
-      payload.body = payload.body.map(({ __serialized, ...node }) => {
-        if (node.__newrelic) return node
-        const output = { ...node }
-        output.__newrelic = buildNRMetaNode(node.timestamp, this.timeKeeper)
-        output.timestamp = this.timeKeeper.correctAbsoluteTimestamp(node.timestamp)
-        return output
-      })
+      payload.body = payload.body.map(({ __serialized, ...node }) => ({ ...node }))
       len = stringify(payload.body).length
     }
 
@@ -267,12 +246,6 @@ export class Aggregate extends AggregateBase {
     }
 
     return [payloadOutput]
-  }
-
-  getCorrectedTimestamp (node) {
-    if (!node?.timestamp) return
-    if (node.__newrelic) return node.timestamp
-    return this.timeKeeper.correctAbsoluteTimestamp(node.timestamp)
   }
 
   /**
@@ -318,8 +291,8 @@ export class Aggregate extends AggregateBase {
 
     const { firstEvent, lastEvent } = this.getFirstAndLastNodes(events)
     // from rrweb node || from when the harvest cycle started
-    const firstTimestamp = this.getCorrectedTimestamp(firstEvent) || Math.floor(this.timeKeeper.correctAbsoluteTimestamp(recorderEvents.cycleTimestamp))
-    const lastTimestamp = this.getCorrectedTimestamp(lastEvent) || Math.floor(this.timeKeeper.correctRelativeTimestamp(relativeNow))
+    const firstTimestamp = firstEvent?.timestamp || Math.floor(this.timeKeeper.correctAbsoluteTimestamp(recorderEvents.cycleTimestamp))
+    const lastTimestamp = lastEvent?.timestamp || Math.floor(this.timeKeeper.correctRelativeTimestamp(relativeNow))
 
     const agentMetadata = agentRuntime.appMetadata?.agents?.[0] || {}
 

--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -227,7 +227,7 @@ export class Aggregate extends AggregateBase {
       payload.body = this.gzipper(this.u8(`[${payload.body.map(({ __serialized }) => (__serialized)).join(',')}]`))
       len = payload.body.length
     } else {
-      payload.body = payload.body.map(({ __serialized, ...node }) => ({ ...node }))
+      for (let idx in payload.body) delete payload.body[idx].__serialized
       len = stringify(payload.body).length
     }
 

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -78,7 +78,7 @@ export class Instrument extends InstrumentBase {
 
       // If startReplay() has been used by this point, we must record in full mode regardless of session preload:
       // Note: recorder starts here with w/e the mode is at this time, but this may be changed later (see #apiStartOrRestartReplay else-case)
-      this.recorder ??= new Recorder({ mode: this.#mode, agentIdentifier: this.agentIdentifier, trigger, ee: this.ee, agentRef: this.#agentRef })
+      this.recorder ??= new Recorder({ ...this, mode: this.#mode, trigger, agentRef: this.#agentRef, timeKeeper: this.#agentRef.runtime.timeKeeper }) // if TK exists due to deferred state, pass it
       this.recorder.startRecording()
       this.abortHandler = this.recorder.stopRecording
     } catch (err) {

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -10,7 +10,7 @@ import { handle } from '../../../common/event-emitter/handle'
 import { DEFAULT_KEY, MODE, PREFIX } from '../../../common/session/constants'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { hasReplayPrerequisite, isPreloadAllowed } from '../shared/utils'
-import { FEATURE_NAME, SR_EVENT_EMITTER_TYPES, TRIGGERS } from '../constants'
+import { FEATURE_NAME, SR_EVENT_EMITTER_TYPES } from '../constants'
 import { setupRecordReplayAPI } from '../../../loaders/api/recordReplay'
 import { setupPauseReplayAPI } from '../../../loaders/api/pauseReplay'
 
@@ -69,7 +69,7 @@ export class Instrument extends InstrumentBase {
   /**
    * This func is use for early pre-load recording prior to replay feature (agg) being loaded onto the page. It should only setup once, including if already called and in-progress.
    */
-  async #preloadStartRecording (trigger) {
+  async #preloadStartRecording () {
     if (this.#alreadyStarted) return
     this.#alreadyStarted = true
 
@@ -78,7 +78,7 @@ export class Instrument extends InstrumentBase {
 
       // If startReplay() has been used by this point, we must record in full mode regardless of session preload:
       // Note: recorder starts here with w/e the mode is at this time, but this may be changed later (see #apiStartOrRestartReplay else-case)
-      this.recorder ??= new Recorder({ ...this, mode: this.#mode, trigger, agentRef: this.#agentRef, timeKeeper: this.#agentRef.runtime.timeKeeper }) // if TK exists due to deferred state, pass it
+      this.recorder ??= new Recorder({ ...this, mode: this.#mode, agentRef: this.#agentRef, timeKeeper: this.#agentRef.runtime.timeKeeper }) // if TK exists due to deferred state, pass it
       this.recorder.startRecording()
       this.abortHandler = this.recorder.stopRecording
     } catch (err) {
@@ -95,7 +95,7 @@ export class Instrument extends InstrumentBase {
       if (this.featAggregate.mode !== MODE.FULL) this.featAggregate.initializeRecording(MODE.FULL, true)
     } else { // pre-load
       this.#mode = MODE.FULL
-      this.#preloadStartRecording(TRIGGERS.API)
+      this.#preloadStartRecording()
       // There's a race here wherein either:
       // a. Recorder has not been initialized, and we've set the enforced mode, so we're good, or;
       // b. Record has been initialized, possibly with the "wrong" mode, so we have to correct that + restart.

--- a/src/features/session_replay/shared/recorder-events.js
+++ b/src/features/session_replay/shared/recorder-events.js
@@ -26,8 +26,8 @@ export class RecorderEvents {
     this.inlinedAllStylesheets = shouldInlineStylesheets
   }
 
-  add (event) {
-    this.#events.add(event)
+  add (event, evaluatedSize) {
+    this.#events.add(event, evaluatedSize)
   }
 
   get events () {

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -163,7 +163,8 @@ export class Recorder {
     // snapshot event
     this.events.hasSnapshot ||= this.hasSeenSnapshot ||= event.type === RRWEB_EVENT_TYPES.FullSnapshot
 
-    this.events.add(event)
+    //* dont let the EventBuffer class double evaluate the event data size, it's a performance burden and we have special reasons to do it outside the event buffer */
+    this.events.add(event, eventBytes)
 
     // We are making an effort to try to keep payloads manageable for unloading.  If they reach the unload limit before their interval,
     // it will send immediately.  This often happens on the first snapshot, which can be significantly larger than the other payloads.

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -150,7 +150,7 @@ export class Recorder {
     /** The estimated size of the payload after compression */
     const payloadSize = this.getPayloadSize(eventBytes)
     // Checkout events are flags by the recording lib that indicate a fullsnapshot was taken every n ms. These are important
-    // to help reconstruct the100 replay later and must be included.  While waiting and buffering for errors to come through,
+    // to help reconstruct the replay later and must be included.  While waiting and buffering for errors to come through,
     // each time we see a new checkout, we can drop the old data.
     // we need to check for meta because rrweb will flag it as checkout twice, once for meta, then once for snapshot
     if (this.parent.mode === MODE.ERROR && isCheckout && event.type === RRWEB_EVENT_TYPES.Meta) {

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -11,19 +11,15 @@ import { stylesheetEvaluator } from './stylesheet-evaluator'
 import { handle } from '../../../common/event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
-import { buildNRMetaNode, customMasker } from './utils'
+import { customMasker } from './utils'
 import { IDEAL_PAYLOAD_SIZE } from '../../../common/constants/agent-constants'
-import { AggregateBase } from '../../utils/aggregate-base'
 import { warn } from '../../../common/util/console'
 import { single } from '../../../common/util/invoke'
+import { registerHandler } from '../../../common/event-emitter/register-handler'
+
+const RRWEB_DATA_CHANNEL = 'rrweb-data'
 
 export class Recorder {
-  /** Each page mutation or event will be stored (raw) in this array. This array will be cleared on each harvest */
-  #events
-  /** Backlog used for a 2-part sliding window to guarantee a 15-30s buffer window */
-  #backloggedEvents
-  /** array of recorder events -- Will be filled only if forced harvest was triggered and harvester does not exist */
-  #preloaded
   /** flag that if true, blocks events from being "stored".  Only set to true when a full snapshot has incomplete nodes (only stylesheets ATM) */
   #fixing = false
 
@@ -34,47 +30,38 @@ export class Recorder {
     this.parent = parent
     /** A flag that can be set to false by failing conversions to stop the fetching process */
     this.shouldFix = this.parent.agentRef.init.session_replay.fix_stylesheets
-    /** Event Buffers */
-    this.#events = new RecorderEvents(this.shouldFix)
-    this.#backloggedEvents = new RecorderEvents(this.shouldFix)
-    this.#preloaded = [new RecorderEvents(this.shouldFix)]
-    /** The pointer to the current bucket holding rrweb events */
-    this.currentBufferTarget = this.#events
-    /** Only set to true once a snapshot node has been processed.  Used to block preload harvests from sending before we know we have a snapshot */
+
+    /** Each page mutation or event will be stored (raw) in this array. This array will be cleared on each harvest */
+    this.events = new RecorderEvents(this.shouldFix)
+    /** Backlog used for a 2-part sliding window to guarantee a 15-30s buffer window */
+    this.backloggedEvents = new RecorderEvents(this.shouldFix)
+    /** Only set to true once a snapshot node has been processed.  Used to block harvests from sending before we know we have a snapshot */
     this.hasSeenSnapshot = false
     /** Hold on to the last meta node, so that it can be re-inserted if the meta and snapshot nodes are broken up due to harvesting */
     this.lastMeta = false
     /** The method to stop recording. This defaults to a noop, but is overwritten once the recording library is imported and initialized */
     this.stopRecording = () => { this.parent.agentRef.runtime.isRecording = false }
+
+    registerHandler(RRWEB_DATA_CHANNEL, (event, isCheckout) => { this.audit(event, isCheckout) }, this.parent.featureName, this.parent.ee)
   }
 
   getEvents () {
-    if (this.#preloaded[0]?.events.length) {
-      return {
-        ...this.#preloaded[0],
-        events: this.#preloaded[0].events,
-        payloadBytesEstimation: this.#preloaded[0].payloadBytesEstimation,
-        type: 'preloaded'
-      }
-    }
     return {
-      events: [...this.#backloggedEvents.events, ...this.#events.events].filter(x => x),
+      events: [...this.backloggedEvents.events, ...this.events.events].filter(x => x),
       type: 'standard',
-      cycleTimestamp: Math.min(this.#backloggedEvents.cycleTimestamp, this.#events.cycleTimestamp),
-      payloadBytesEstimation: this.#backloggedEvents.payloadBytesEstimation + this.#events.payloadBytesEstimation,
-      hasError: this.#backloggedEvents.hasError || this.#events.hasError,
-      hasMeta: this.#backloggedEvents.hasMeta || this.#events.hasMeta,
-      hasSnapshot: this.#backloggedEvents.hasSnapshot || this.#events.hasSnapshot,
-      inlinedAllStylesheets: (!!this.#backloggedEvents.events.length && this.#backloggedEvents.inlinedAllStylesheets) || this.#events.inlinedAllStylesheets
+      cycleTimestamp: Math.min(this.backloggedEvents.cycleTimestamp, this.events.cycleTimestamp),
+      payloadBytesEstimation: this.backloggedEvents.payloadBytesEstimation + this.events.payloadBytesEstimation,
+      hasError: this.backloggedEvents.hasError || this.events.hasError,
+      hasMeta: this.backloggedEvents.hasMeta || this.events.hasMeta,
+      hasSnapshot: this.backloggedEvents.hasSnapshot || this.events.hasSnapshot,
+      inlinedAllStylesheets: (!!this.backloggedEvents.events.length && this.backloggedEvents.inlinedAllStylesheets) || this.events.inlinedAllStylesheets
     }
   }
 
-  /** Clears the buffer (this.#events), and resets all payload metadata properties */
+  /** Clears the buffer (this.events), and resets all payload metadata properties */
   clearBuffer () {
-    if (this.#preloaded[0]?.events.length) this.#preloaded.shift()
-    else if (this.parent.mode === MODE.ERROR) this.#backloggedEvents = this.#events
-    else this.#backloggedEvents = new RecorderEvents(this.shouldFix)
-    this.#events = new RecorderEvents(this.shouldFix)
+    this.backloggedEvents = (this.parent.mode === MODE.ERROR) ? this.events : new RecorderEvents(this.shouldFix)
+    this.events = new RecorderEvents(this.shouldFix)
   }
 
   /** Begin recording using configured recording lib */
@@ -87,7 +74,7 @@ export class Recorder {
     let stop
     try {
       stop = recorder({
-        emit: this.audit.bind(this),
+        emit: (event, isCheckout) => { handle(RRWEB_DATA_CHANNEL, [event, isCheckout], undefined, this.parent.featureName, this.parent.ee) },
         blockClass: block_class,
         ignoreClass: ignore_class,
         maskTextClass: mask_text_class,
@@ -126,7 +113,7 @@ export class Recorder {
     /** only run the full fixing behavior (more costly) if fix_stylesheets is configured as on (default behavior) */
     if (!this.shouldFix) {
       if (incompletes > 0) {
-        this.currentBufferTarget.inlinedAllStylesheets = false
+        this.events.inlinedAllStylesheets = false
         this.#warnCSSOnce()
         handle(SUPPORTABILITY_METRIC_CHANNEL, [missingInlineSMTag + 'Skipped', incompletes], undefined, FEATURE_NAMES.metrics, this.parent.ee)
       }
@@ -138,7 +125,7 @@ export class Recorder {
       /** wait for the evaluator to download/replace the incompletes' src code and then take a new snap */
       stylesheetEvaluator.fix().then((failedToFix) => {
         if (failedToFix > 0) {
-          this.currentBufferTarget.inlinedAllStylesheets = false
+          this.events.inlinedAllStylesheets = false
           this.shouldFix = false
         }
         handle(SUPPORTABILITY_METRIC_CHANNEL, [missingInlineSMTag + 'Failed', failedToFix], undefined, FEATURE_NAMES.metrics, this.parent.ee)
@@ -152,25 +139,18 @@ export class Recorder {
     if (!this.#fixing) this.store(event, isCheckout)
   }
 
-  /** Store a payload in the buffer (this.#events).  This should be the callback to the recording lib noticing a mutation */
+  /** Store a payload in the buffer (this.events).  This should be the callback to the recording lib noticing a mutation */
   store (event, isCheckout) {
-    if (!event) return
+    if (!event || this.parent.blocked) return
 
-    if (!(this.parent instanceof AggregateBase) && this.#preloaded.length) this.currentBufferTarget = this.#preloaded[this.#preloaded.length - 1]
-    else this.currentBufferTarget = this.#events
-
-    if (this.parent.blocked) return
-
-    if (this.parent.timeKeeper?.ready && !event.__newrelic) {
-      event.__newrelic = buildNRMetaNode(event.timestamp, this.parent.timeKeeper)
-      event.timestamp = this.parent.timeKeeper.correctAbsoluteTimestamp(event.timestamp)
-    }
+    /** because we've waited until draining to process the buffered rrweb events, we can guarantee the timekeeper exists */
+    event.timestamp = this.parent.timeKeeper.correctAbsoluteTimestamp(event.timestamp)
     event.__serialized = stringify(event)
     const eventBytes = event.__serialized.length
     /** The estimated size of the payload after compression */
     const payloadSize = this.getPayloadSize(eventBytes)
     // Checkout events are flags by the recording lib that indicate a fullsnapshot was taken every n ms. These are important
-    // to help reconstruct the replay later and must be included.  While waiting and buffering for errors to come through,
+    // to help reconstruct the100 replay later and must be included.  While waiting and buffering for errors to come through,
     // each time we see a new checkout, we can drop the old data.
     // we need to check for meta because rrweb will flag it as checkout twice, once for meta, then once for snapshot
     if (this.parent.mode === MODE.ERROR && isCheckout && event.type === RRWEB_EVENT_TYPES.Meta) {
@@ -179,26 +159,17 @@ export class Recorder {
     }
 
     // meta event
-    if (event.type === RRWEB_EVENT_TYPES.Meta) {
-      this.currentBufferTarget.hasMeta = true
-    }
+    this.events.hasMeta ||= event.type === RRWEB_EVENT_TYPES.Meta
     // snapshot event
-    if (event.type === RRWEB_EVENT_TYPES.FullSnapshot) {
-      this.currentBufferTarget.hasSnapshot = true
-      this.hasSeenSnapshot = true
-    }
-    this.currentBufferTarget.add(event)
+    this.events.hasSnapshot ||= this.hasSeenSnapshot ||= event.type === RRWEB_EVENT_TYPES.FullSnapshot
+
+    this.events.add(event)
 
     // We are making an effort to try to keep payloads manageable for unloading.  If they reach the unload limit before their interval,
     // it will send immediately.  This often happens on the first snapshot, which can be significantly larger than the other payloads.
-    if (((event.type === RRWEB_EVENT_TYPES.FullSnapshot && this.currentBufferTarget.hasMeta) || payloadSize > IDEAL_PAYLOAD_SIZE) && this.parent.mode === MODE.FULL) {
-      // if we've made it to the ideal size of ~64kb before the interval timer, we should send early.
-      if (this.parent instanceof AggregateBase) {
-        this.parent.agentRef.runtime.harvester.triggerHarvestFor(this.parent)
-      } else {
-        // we are still in "preload" and it triggered a "stop point".  Make a new set, which will get pointed at on next cycle
-        this.#preloaded.push(new RecorderEvents(this.shouldFix))
-      }
+    if (((this.events.hasSnapshot && this.events.hasMeta) || payloadSize > IDEAL_PAYLOAD_SIZE) && this.parent.mode === MODE.FULL) {
+      // if we've made it to the ideal size of ~16kb before the interval timer, we should send early.
+      this.parent.agentRef.runtime.harvester.triggerHarvestFor(this.parent)
     }
   }
 
@@ -213,13 +184,13 @@ export class Recorder {
   }
 
   clearTimestamps () {
-    this.currentBufferTarget.cycleTimestamp = undefined
+    this.events.cycleTimestamp = undefined
   }
 
   /** Estimate the payload size */
   getPayloadSize (newBytes = 0) {
     // the query param padding constant gives us some padding for the other metadata to be safely injected
-    return this.estimateCompression(this.currentBufferTarget.payloadBytesEstimation + newBytes) + QUERY_PARAM_PADDING
+    return this.estimateCompression(this.events.payloadBytesEstimation + newBytes) + QUERY_PARAM_PADDING
   }
 
   /** Extensive research has yielded about an 88% compression factor on these payloads.

--- a/src/features/session_replay/shared/utils.js
+++ b/src/features/session_replay/shared/utils.js
@@ -4,7 +4,6 @@
  */
 import { gosNREUMOriginals } from '../../../common/window/nreum'
 import { canEnableSessionTracking } from '../../utils/feature-gates'
-import { originTime } from '../../../common/constants/runtime'
 
 export function hasReplayPrerequisite (agentInit) {
   return !!gosNREUMOriginals().o.MO && // Session Replay cannot work without Mutation Observer
@@ -14,18 +13,6 @@ export function hasReplayPrerequisite (agentInit) {
 
 export function isPreloadAllowed (agentInit) {
   return agentInit?.session_replay.preload === true && hasReplayPrerequisite(agentInit)
-}
-
-export function buildNRMetaNode (timestamp, timeKeeper) {
-  const correctedTimestamp = timeKeeper.correctAbsoluteTimestamp(timestamp)
-  return {
-    originalTimestamp: timestamp,
-    correctedTimestamp,
-    timestampDiff: timestamp - correctedTimestamp,
-    originTime,
-    correctedOriginTime: timeKeeper.correctedOriginTime,
-    originTimeDiff: Math.floor(originTime - timeKeeper.correctedOriginTime)
-  }
 }
 
 export function customMasker (text, element) {

--- a/src/features/utils/event-buffer.js
+++ b/src/features/utils/event-buffer.js
@@ -40,10 +40,11 @@ export class EventBuffer {
   /**
    * Add feature-processed event to our buffer. If this event would cause our total raw size to exceed the set max payload size, it is dropped.
    * @param {any} event - any primitive type or object
+   * @param {number} [evaluatedSize] - the evalated size of the event, if already done so before storing in the event buffer
    * @returns {Boolean} true if successfully added; false otherwise
    */
-  add (event) {
-    const addSize = stringify(event)?.length || 0 // (estimate) # of bytes a directly stringified event it would take to send
+  add (event, evaluatedSize) {
+    const addSize = evaluatedSize || stringify(event)?.length || 0 // (estimate) # of bytes a directly stringified event it would take to send
     if (this.#rawBytes + addSize > this.maxPayloadSize) {
       const smTag = inject => `EventBuffer/${inject}/Dropped/Bytes`
       this.featureAgg?.reportSupportabilityMetric(smTag(this.featureAgg.featureName), addSize) // bytes dropped for this feature will aggregate with this metric tag

--- a/tests/components/session_replay/instrument.test.js
+++ b/tests/components/session_replay/instrument.test.js
@@ -9,8 +9,14 @@ beforeAll(() => {
   mainAgent = setupAgent({
     init: {
       session_replay: { preload: false, enabled: true }
+    },
+    runtime: {
+      timeKeeper: {
+        correctAbsoluteTimestamp: jest.fn(x => x)
+      }
     }
   })
+  jest.spyOn(mainAgent.runtime.harvester, 'triggerHarvestFor').mockImplementation(() => Promise.resolve())
   savedInitialSession = mainAgent.runtime.session
 })
 

--- a/tests/components/setup-agent.js
+++ b/tests/components/setup-agent.js
@@ -91,6 +91,8 @@ function resetAgentEventEmitter (agentIdentifier) {
   ]
 
   listeners.forEach(([type, fn]) => eventEmitter.removeEventListener(type, fn))
+
+  eventEmitter.backlog = {}
 }
 
 function resetAggregator (agentIdentifier) {

--- a/tests/specs/nr-server-time.e2e.js
+++ b/tests/specs/nr-server-time.e2e.js
@@ -88,21 +88,6 @@ describe('NR Server Time', () => {
         .then(() => browser.getPageTime())
     ])
 
-    replayData.body.forEach(x => {
-      expect(x.__newrelic).toMatchObject({
-        originalTimestamp: expect.any(Number),
-        correctedTimestamp: expect.any(Number),
-        timestampDiff: expect.any(Number),
-        originTime: expect.any(Number),
-        correctedOriginTime: expect.any(Number),
-        originTimeDiff: expect.any(Number)
-      })
-      expect(x.__newrelic.timestampDiff - x.__newrelic.originTimeDiff).toBeLessThanOrEqual(1) //  account for rounding error
-      testTimeExpectations(x.__newrelic.correctedTimestamp, {
-        originTime: x.__newrelic.originTime,
-        correctedOriginTime: x.__newrelic.correctedOriginTime
-      }, true)
-    })
     const attrs = decodeAttributes(replayData.query.attributes)
     const firstTimestamp = attrs['replay.firstTimestamp']
     testTimeExpectations(firstTimestamp, timeKeeper, true)
@@ -122,21 +107,6 @@ describe('NR Server Time', () => {
         .then(() => browser.waitForSessionReplayRecording())
         .then(() => browser.getPageTime())
     ])
-    replayData.body.forEach(x => {
-      expect(x.__newrelic).toMatchObject({
-        originalTimestamp: expect.any(Number),
-        correctedTimestamp: expect.any(Number),
-        timestampDiff: expect.any(Number),
-        originTime: expect.any(Number),
-        correctedOriginTime: expect.any(Number),
-        originTimeDiff: expect.any(Number)
-      })
-      expect(x.__newrelic.timestampDiff - x.__newrelic.originTimeDiff).toBeLessThanOrEqual(1) //  account for rounding error
-      testTimeExpectations(x.__newrelic.correctedTimestamp, {
-        originTime: x.__newrelic.originTime,
-        correctedOriginTime: x.__newrelic.correctedOriginTime
-      }, true)
-    })
     const attrs = decodeAttributes(replayData.query.attributes)
     const firstTimestamp = attrs['replay.firstTimestamp']
     testTimeExpectations(firstTimestamp, timeKeeper, false)

--- a/tests/specs/session-replay/sr-api.e2e.js
+++ b/tests/specs/session-replay/sr-api.e2e.js
@@ -20,10 +20,11 @@ describe('Replay API', () => {
   it('pauseReplay called before page load stops the replay', async () => {
     await browser.enableSessionReplay(100, 0)
     await browser.url(await browser.testHandle.assetURL('rrweb-api-pause-before-load.html', srConfig()))
-      .then(() => browser.waitForSessionReplayRecording())
+      .then(() => browser.waitForFeatureAggregate('session_replay'))
 
+    await browser.pause(1000) // give time for the features to drain fully
     await expect(getSR()).resolves.toMatchObject({
-      recording: true,
+      recording: false,
       initialized: true,
       events: expect.any(Array),
       mode: 0

--- a/tests/unit/features/session_replay/shared/recorder.test.js
+++ b/tests/unit/features/session_replay/shared/recorder.test.js
@@ -13,6 +13,9 @@ describe('recorder', () => {
         },
         runtime: {}
       },
+      timeKeeper: {
+        correctAbsoluteTimestamp: jest.fn(x => x)
+      },
       ee: {
         emit: () => {}
       }

--- a/tests/unit/features/session_replay/shared/utils.test.js
+++ b/tests/unit/features/session_replay/shared/utils.test.js
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker'
 import * as sessionReplaySharedUtils from '../../../../../src/features/session_replay/shared/utils'
 import * as runtimeConstantsModule from '../../../../../src/common/constants/runtime'
 import * as featureGatesModule from '../../../../../src/features/utils/feature-gates'
@@ -40,27 +39,6 @@ test('hasReplayPrerequisite should return false when replay prerequisites are no
   jest.mocked(nreumModule.gosNREUMOriginals).mockReturnValue({ o: { } })
 
   expect(sessionReplaySharedUtils.hasReplayPrerequisite({ session_trace: { enabled: true }, privacy: { cookies_enabled: true } })).toEqual(false)
-})
-
-describe('buildNRMetaNode', () => {
-  let timekeeper
-
-  beforeEach(() => {
-    timekeeper = {
-      correctAbsoluteTimestamp: jest.fn()
-    }
-  })
-
-  test('should use the timekeeper to correct the timestamp', async () => {
-    const timestamp = faker.date.anytime().getTime()
-    const expected = faker.date.anytime().getTime()
-    jest.spyOn(timekeeper, 'correctAbsoluteTimestamp').mockReturnValue(expected)
-
-    const metadata = sessionReplaySharedUtils.buildNRMetaNode(timestamp, timekeeper)
-
-    expect(metadata.originalTimestamp).toEqual(timestamp)
-    expect(metadata.correctedTimestamp).toEqual(expected)
-  })
 })
 
 describe('customMasker', () => {


### PR DESCRIPTION
Remove the reporting of the __newrelic meta attribute from outgoing replay payloads.  This is being conducted as a measure to help save billable bytes for customers and reduce cost of use for Session Replay functionalities.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This PR removes the __newrelic attribute from outgoing payloads, but as a byproduct of that, a number of internal mechanisms were able to be changed, simplified, or removed in a sort of "domino effect" to reduce build burden and performance impacts on enduser machines:
1. The agent now uses the contextual ee to buffer preloaded recording data.
2. Because the agent can buffer the data until the features are fully initialized (by way of the ee), it can now: 
  - assume that the timekeeper should always exist when processing rrweb data.
  - get rid of the need for separate buffers for preload vs standard datasets
  - remove the requirement to loop through preload harvests at startup
3. Because the timekeeper can be assumed to exist, we no longer need to "correct" timestamps at harvest time
4. Because we don't need to correct timestamps at harvest time, we no longer need to pass the `__newrelic` object around internally, so it was just completely removed.

See the following visuals around the changes to the buffer mechanics here that kick off the "domino" effect.
### before the change
<img width="1254" height="630" alt="before" src="https://github.com/user-attachments/assets/570734f3-968f-4039-81db-6e949dd21208" />


### after the change
<img width="1447" height="639" alt="after" src="https://github.com/user-attachments/assets/4dcc8968-3def-456d-8e8e-df45754be586" />

### Related Issue(s)
NR-446285
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
many unit and e2e tests have been added/modified to adjust for the lack of the __newrelic node.  Existing tests should continue to pass.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
