### PR TITLE
fix: Fix exceptions for null bodies arising from empty harvests

### DIFF
--- a/src/common/harvest/harvester.js
+++ b/src/common/harvest/harvester.js
@@ -112,7 +112,7 @@ const warnings = {}
   * @param {NetworkSendSpec} param0 Specification for sending data
   * @returns {boolean} True if a network call was made. Note that this does not mean or guarantee that it was successful.
   */
-function send (agentRef, { endpoint, targetApp, payload, localOpts = {}, submitMethod, cbFinished, raw, featureName }) {
+export function send (agentRef, { endpoint, targetApp, payload, localOpts = {}, submitMethod, cbFinished, raw, featureName }) {
   if (!agentRef.info.errorBeacon) return false
 
   let { body, qs } = cleanPayload(payload)
@@ -218,7 +218,7 @@ function send (agentRef, { endpoint, targetApp, payload, localOpts = {}, submitM
 function cleanPayload (payload = {}) {
   const clean = (input) => {
     if ((typeof Uint8Array !== 'undefined' && input instanceof Uint8Array) || Array.isArray(input)) return input
-    if (typeof input === 'string') return input.length > 0 ? input : null
+    if (typeof input === 'string') return input
     return Object.entries(input || {}).reduce((accumulator, [key, value]) => {
       if ((typeof value === 'number') ||
           (typeof value === 'string' && value.length > 0) ||


### PR DESCRIPTION
A change has been made to enforce that all cleaned payloads ensure a valid output. Before, an empty string passing through the body cleaning process could throw an error as the mechanism would return the body as null.  Now empty strings will pass through untouched, allowing further processing to apply successfully. 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-450681?atlOrigin=eyJpIjoiYzQ3YjY2OTQ0N2EzNDViODliZWVhYmVkOWUxZTc1ZjAiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
