### PR TITLE
feat: Associate JSErrors and AjaxRequest to extended soft nav interactions

### DIFF
--- a/src/features/soft_navigations/aggregate/interaction.js
+++ b/src/features/soft_navigations/aggregate/interaction.js
@@ -115,12 +115,12 @@ export class Interaction extends BelNode {
   /**
    * Given a timestamp, determine if it falls within this interaction's span, i.e. if this was the active interaction during that time.
    * For in-progress interactions, this only compares the time with the start of span. Cancelled interactions are not considered active at all.
+   * Pending-finish interactions are also considered still active wrt assigning ajax or jserrors to them during the wait period.
    * @param {DOMHighResTimeStamp} timestamp
    * @returns True or false boolean.
    */
   isActiveDuring (timestamp) {
-    if (this.status === INTERACTION_STATUS.IP) return this.start <= timestamp
-    if (this.status === INTERACTION_STATUS.PF) return this.start <= timestamp && timestamp < this.domTimestamp // for now, ajax & jserror that occurs during long task & pending-finish ixn await periods will not be tied to the ixn
+    if (this.status === INTERACTION_STATUS.IP || this.status === INTERACTION_STATUS.PF) return this.start <= timestamp
     return (this.status === INTERACTION_STATUS.FIN && this.start <= timestamp && timestamp < this.end)
   }
 

--- a/tests/components/ajax/with-softnav.test.js
+++ b/tests/components/ajax/with-softnav.test.js
@@ -1,0 +1,90 @@
+import { EventContext } from '../../../src/common/event-emitter/event-context'
+import { Instrument as Ajax } from '../../../src/features/ajax/instrument'
+import { Instrument as SoftNav } from '../../../src/features/soft_navigations/instrument'
+import { FEATURE_NAMES } from '../../../src/loaders/features/features'
+import { resetAgent, setupAgent } from '../setup-agent'
+
+let mainAgent
+const params = {
+  method: 'PUT',
+  status: 200,
+  host: 'https://example.com',
+  hostname: 'example.com',
+  pathname: '/pathname'
+}
+const metrics = {
+  txSize: 128,
+  rxSize: 256,
+  cbTime: 5
+}
+
+beforeAll(() => {
+  mainAgent = setupAgent({
+    agentOverrides: {
+      runSoftNavOverSpa: true
+    },
+    init: {
+      feature_flags: ['soft_nav'],
+      ajax: { enabled: true },
+      soft_navigations: { enabled: true }
+    }
+  })
+})
+let ajaxAggregate, softNavAggregate, context
+beforeEach(async () => {
+  const ajaxInstrument = new Ajax(mainAgent)
+  const softNavInstrument = new SoftNav(mainAgent)
+  await Promise.all([ajaxInstrument.onAggregateImported, softNavInstrument.onAggregateImported])
+  ajaxAggregate = ajaxInstrument.featAggregate
+  softNavAggregate = softNavInstrument.featAggregate
+
+  context = new EventContext()
+  ajaxAggregate.ee.emit('rumresp', [{ spa: 1 }]) // both features share the same ee event so this activate & drain both; ajax needs no flag
+  await new Promise(process.nextTick)
+  ajaxAggregate.agentRef.features[FEATURE_NAMES.softNav] = true // currently this is required for ajax to switch to softnav behavior
+
+  softNavAggregate.initialPageLoadInteraction.done(1) // so that IPL doesn't muddy the ixn seeking logic
+  softNavAggregate.events.clear()
+})
+afterEach(() => {
+  resetAgent(mainAgent.agentIdentifier)
+})
+
+test('on interaction finish, ajax within time span are associated, others standalone', () => {
+  softNavAggregate.ee.emit('newUIEvent', [{ type: 'keydown', timeStamp: 100 }])
+  softNavAggregate.ee.emit('newURL', [150, 'new_location'])
+  ajaxAggregate.storeXhr(params, metrics, 175, 225, 'XMLHttpRequest', context) // ensure xhr happening during default heuristics are associated
+  softNavAggregate.ee.emit('newDom', [200])
+  expect(softNavAggregate.interactionInProgress).toBeTruthy()
+
+  ajaxAggregate.storeXhr(params, metrics, 250, 350, 'fetch', context) // ensure xhr happening during wait window for actualized long tasks are associated
+  ajaxAggregate.storeXhr(params, metrics, 325, 400, 'XMLHttpRequest', context) // this one should fall outside the final interaction span and be standalone
+  expect(ajaxAggregate.events.get()[0].data.length).toEqual(0)
+
+  softNavAggregate.interactionInProgress.customEnd = 300 // simulate a long task extending the interaction end time (pretend there's some delay (waiting window) before ixn gets finalized)
+  softNavAggregate.interactionInProgress.done()
+  expect(ajaxAggregate.events.get()[0].data.length).toEqual(1)
+  expect(ajaxAggregate.events.get()[0].data[0]).toEqual(expect.objectContaining({ startTime: 325, endTime: 400 })) // the 3rd one that falls outside ixn span
+
+  expect(softNavAggregate.events.get()[0].data.length).toEqual(1)
+  const ixn = softNavAggregate.events.get()[0].data[0]
+  expect(ixn.end).toEqual(300)
+  expect(ixn.children.length).toEqual(2)
+  expect(ixn.children[0]).toEqual(expect.objectContaining({ start: 175, end: 225 }))
+  expect(ixn.children[1]).toEqual(expect.objectContaining({ start: 250, end: 350 }))
+})
+
+test('on spa API .end(), ajax prior to call is associated and post-call is standalone', () => {
+  softNavAggregate.ee.emit('newUIEvent', [{ type: 'keydown', timeStamp: 100 }])
+  softNavAggregate.ee.emit('newURL', [150, 'new_location'])
+  softNavAggregate.ee.emit('newDom', [200])
+
+  ajaxAggregate.storeXhr(params, metrics, 250, 299, 'fetch', context)
+  softNavAggregate.interactionInProgress.done(300, true) // simulate API call to .end() at 300, this would occur in order
+  ajaxAggregate.storeXhr(params, metrics, 301, 350, 'fetch', context)
+
+  expect(ajaxAggregate.events.get()[0].data.length).toEqual(1)
+  const ixn = softNavAggregate.events.get()[0].data[0]
+  expect(ixn.end).toEqual(300)
+  expect(ixn.children.length).toEqual(1)
+})

--- a/tests/components/jserrors/with-softnav.test.js
+++ b/tests/components/jserrors/with-softnav.test.js
@@ -1,0 +1,69 @@
+import { Instrument as JsErrors } from '../../../src/features/jserrors/instrument'
+import { Instrument as SoftNav } from '../../../src/features/soft_navigations/instrument'
+import { FEATURE_NAMES } from '../../../src/loaders/features/features'
+import { resetAgent, setupAgent } from '../setup-agent'
+
+let mainAgent
+beforeAll(() => {
+  mainAgent = setupAgent({
+    agentOverrides: {
+      runSoftNavOverSpa: true
+    },
+    init: {
+      feature_flags: ['soft_nav'],
+      jserrors: { enabled: true },
+      soft_navigations: { enabled: true }
+    }
+  })
+})
+let jserrorsAggregate, softNavAggregate
+beforeEach(async () => {
+  const jserrorsInstrument = new JsErrors(mainAgent)
+  const softNavInstrument = new SoftNav(mainAgent)
+  await Promise.all([jserrorsInstrument.onAggregateImported, softNavInstrument.onAggregateImported])
+  jserrorsAggregate = jserrorsInstrument.featAggregate
+  softNavAggregate = softNavInstrument.featAggregate
+
+  jserrorsAggregate.ee.emit('rumresp', [{ err: 1, spa: 1 }]) // both features share the same ee event so this activate & drain both
+  await new Promise(process.nextTick)
+  jserrorsAggregate.agentRef.features[FEATURE_NAMES.softNav] = true // currently this is required for jserrors to switch to softnav behavior
+  softNavAggregate.initialPageLoadInteraction.done(1) // so that IPL doesn't muddy the ixn seeking logic
+})
+afterEach(() => {
+  resetAgent(mainAgent.agentIdentifier)
+})
+
+test('on interaction cancel, buffered jserrors are flushed as standalone', () => {
+  softNavAggregate.ee.emit('newUIEvent', [{ type: 'keydown', timeStamp: 100 }])
+  expect(softNavAggregate.interactionInProgress).toBeTruthy()
+  const ixnId = softNavAggregate.interactionInProgress.id
+
+  jserrorsAggregate.storeError(new Error('test error'), 200)
+  expect(jserrorsAggregate.bufferedErrorsUnderSpa[ixnId].length).toEqual(1)
+
+  softNavAggregate.interactionInProgress.done()
+  expect(softNavAggregate.interactionInProgress).toBeNull()
+  expect(jserrorsAggregate.bufferedErrorsUnderSpa[ixnId]).toBeUndefined()
+  expect(jserrorsAggregate.events.get(jserrorsAggregate.harvestOpts)[0].data?.err.length).toEqual(1)
+})
+
+test('on interaction finish, jserrors within time span are associated, others standalone', () => {
+  softNavAggregate.ee.emit('newUIEvent', [{ type: 'keydown', timeStamp: 100 }])
+  softNavAggregate.ee.emit('newURL', [150, 'new_location'])
+  jserrorsAggregate.storeError(new Error('test1'), 175) // ensure errors happening during default heuristics are associated
+  softNavAggregate.ee.emit('newDom', [200])
+  expect(softNavAggregate.interactionInProgress).toBeTruthy()
+  const ixnId = softNavAggregate.interactionInProgress.id
+
+  jserrorsAggregate.storeError(new Error('test2'), 250) // ensure errors happening during wait window for actualized long tasks are associated
+  softNavAggregate.interactionInProgress.customEnd = 300 // simulate a long task extending the interaction end time
+  jserrorsAggregate.storeError(new Error('test3'), 350) // this one should fall outside the final interaction span and be standalone
+  expect(jserrorsAggregate.bufferedErrorsUnderSpa[ixnId].length).toEqual(3)
+
+  softNavAggregate.interactionInProgress.done()
+  const errsHarvested = jserrorsAggregate.events.get(jserrorsAggregate.harvestOpts)[0].data?.err.map(jseEvent => jseEvent.params)
+  expect(errsHarvested[0]).toEqual(expect.objectContaining({ message: 'test1', browserInteractionId: ixnId }))
+  expect(errsHarvested[1]).toEqual(expect.objectContaining({ message: 'test2', browserInteractionId: ixnId }))
+  expect(errsHarvested[2].message).toEqual('test3')
+  expect(errsHarvested[2].browserInteractionId).toBeUndefined()
+})


### PR DESCRIPTION
`JavascriptError` and `AjaxRequest` events will be correctly tied to `BrowserInteraction` when long tasks do/does not happen and extend the interaction. Ultimately, events that start before the final end time of an interaction will be associated to it, inclusive of long tasks.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

(3 of 3 modifying soft navigation heuristic.) During the waiting window of an interaction monitoring for long tasks, JS errors and network requests still occur, and will initially be associated with the interaction that's "pending finish". In the event that there's ultimately no long task, those jse & ajax falling within this window are freed from ixn association and returned to their standalone features. On contrary, if a long task does occur which extends the interaction, they too will become part of the interaction. In other words, association remains faithful to the final time span of the interaction.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-438511
https://new-relic.atlassian.net/browse/NR-452609

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
