### PR TITLE
chore: Fix hidden deps between component tests

### DIFF
--- a/tests/components/generic_events/aggregate/index.test.js
+++ b/tests/components/generic_events/aggregate/index.test.js
@@ -56,32 +56,29 @@ test('should warn if invalid event is provide', async () => {
 })
 
 test('should harvest early if will exceed 1mb', async () => {
-  mainAgent.runtime.harvester.triggerHarvestFor = jest.fn()
-  expect(mainAgent.runtime.harvester.triggerHarvestFor).toHaveBeenCalledTimes(0)
+  const triggerHarvestSpy = jest.spyOn(mainAgent.runtime.harvester, 'triggerHarvestFor').mockImplementation(() => {})
+  expect(triggerHarvestSpy).toHaveBeenCalledTimes(0)
   genericEventsAggregate.ee.emit('rumresp', [{ ins: 1 }])
   await new Promise(process.nextTick)
-  expect(mainAgent.runtime.harvester.triggerHarvestFor).toHaveBeenCalledTimes(1)
+  expect(triggerHarvestSpy).toHaveBeenCalledTimes(1)
 
   genericEventsAggregate.addEvent({ name: 'test', eventType: 'x'.repeat(15000) })
 
-  expect(mainAgent.runtime.harvester.triggerHarvestFor).toHaveBeenCalledTimes(1)
+  expect(triggerHarvestSpy).toHaveBeenCalledTimes(1)
   genericEventsAggregate.addEvent({ name: 1000, eventType: 'x'.repeat(100000) })
-  expect(mainAgent.runtime.harvester.triggerHarvestFor).toHaveBeenCalledTimes(2)
-
-  mainAgent.runtime.harvester.triggerHarvestFor.mockRestore()
+  expect(triggerHarvestSpy).toHaveBeenCalledTimes(2)
+  triggerHarvestSpy.mockRestore()
 })
 
 test('should not harvest if single event will exceed 1mb', async () => {
   genericEventsAggregate.ee.emit('rumresp', [{ ins: 1 }])
-
   await new Promise(process.nextTick)
+  const triggerHarvestSpy = jest.spyOn(mainAgent.runtime.harvester, 'triggerHarvestFor').mockImplementation(() => {})
 
-  mainAgent.runtime.harvester.triggerHarvestFor = jest.fn()
   genericEventsAggregate.addEvent({ name: 'test', eventType: 'x'.repeat(1000000) })
 
-  expect(mainAgent.runtime.harvester.triggerHarvestFor).not.toHaveBeenCalled()
-
-  mainAgent.runtime.harvester.triggerHarvestFor.mockRestore()
+  expect(triggerHarvestSpy).toHaveBeenCalledTimes(0)
+  triggerHarvestSpy.mockRestore()
 })
 
 describe('sub-features', () => {
@@ -234,7 +231,8 @@ describe('sub-features', () => {
   test('should record marks when enabled', async () => {
     mainAgent.init.performance.capture_marks = true
     mainAgent.info.jsAttributes = { globalFoo: 'globalBar' }
-    const mockPerformanceObserver = jest.fn(cb => ({
+    const origGlobalPO = global.PerformanceObserver
+    global.PerformanceObserver = jest.fn(cb => ({
       observe: () => {
         const callCb = () => {
           // eslint-disable-next-line
@@ -251,12 +249,14 @@ describe('sub-features', () => {
       disconnect: jest.fn()
     }))
 
-    global.PerformanceObserver = mockPerformanceObserver
     global.PerformanceObserver.supportedEntryTypes = ['mark']
 
     const { Aggregate } = await import('../../../../src/features/generic_events/aggregate')
     genericEventsAggregate = new Aggregate(mainAgent)
     expect(genericEventsAggregate.events?.[0]).toBeUndefined()
+
+    // temporarily swap out triggerHarvestFor so the buffer doesn't get emptied before we can check
+    const triggerHarvestSpy = jest.spyOn(mainAgent.runtime.harvester, 'triggerHarvestFor').mockImplementation(() => {})
 
     genericEventsAggregate.ee.emit('rumresp', [{ ins: 1 }])
     await new Promise(process.nextTick)
@@ -269,12 +269,16 @@ describe('sub-features', () => {
       entryType: 'mark',
       entryDetail: JSON.stringify({ foo: 'bar' })
     })
+
+    triggerHarvestSpy.mockRestore()
+    global.PerformanceObserver = origGlobalPO
   })
 
   test('should record measures when enabled', async () => {
     mainAgent.init.performance = { capture_measures: true, capture_detail: true, resources: { enabled: false, asset_types: [], first_party_domains: [], ignore_newrelic: true } }
     mainAgent.info.jsAttributes = { globalFoo: 'globalBar' }
-    const mockPerformanceObserver = jest.fn(cb => ({
+    const origGlobalPO = global.PerformanceObserver
+    global.PerformanceObserver = jest.fn(cb => ({
       observe: () => {
         const callCb = () => {
           // eslint-disable-next-line
@@ -291,12 +295,14 @@ describe('sub-features', () => {
       disconnect: jest.fn()
     }))
 
-    global.PerformanceObserver = mockPerformanceObserver
     global.PerformanceObserver.supportedEntryTypes = ['measure']
 
     const { Aggregate } = await import('../../../../src/features/generic_events/aggregate')
     genericEventsAggregate = new Aggregate(mainAgent)
     expect(genericEventsAggregate.events?.[0]).toBeUndefined()
+
+    // temporarily swap out triggerHarvestFor so the buffer doesn't get emptied before we can check
+    const triggerHarvestSpy = jest.spyOn(mainAgent.runtime.harvester, 'triggerHarvestFor').mockImplementation(() => {})
 
     genericEventsAggregate.ee.emit('rumresp', [{ ins: 1 }])
     await new Promise(process.nextTick)
@@ -309,5 +315,8 @@ describe('sub-features', () => {
       entryType: 'measure',
       'entryDetail.foo': 'bar'
     })
+
+    triggerHarvestSpy.mockRestore()
+    global.PerformanceObserver = origGlobalPO
   })
 })


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Discovered while investigating a Jest test [failure](https://github.com/newrelic/newrelic-browser-agent/actions/runs/17276249751) in another PR.

- Switched to spies to allow `triggerHarvestFor` to run for other tests
- Restored PO to not trigger extra BrowserPerformance entries in later tests

**Issue 1**
`should record marks when enabled` + `should record measures when enabled` tests would fail when run as standalone tests but pass if run as part of the component test

The mock restore wasn't taking effect in the `'should harvest early if will exceed 1mb'` and `'should not harvest if single event will exceed 1mb'` tests.

(in this screenshot, the `'should harvest early if will exceed 1mb'` and `'should not harvest if single event will exceed 1mb'` tests have been commented out, showing the hidden dependency)
<img width="860" height="336" alt="Screenshot 2025-08-27 at 3 44 30 PM" src="https://github.com/user-attachments/assets/1afa414d-6270-4bac-8c89-d4525cf334f1" />

**Issue 2**
Initially I ran the added `user_frustrations` tests as a standalone set and they passed.  When the CI pipeline ran the component test suite, they failed.  There were extra BrowserPerformance entries being created.


### Related Issue(s)

### Testing

- Tested the failing tests as standalone: `should record marks when enabled`, `should record measures when enabled`
- Tested the overall generic_events agg component test suite
- Tested the component test passes in the `NR-443293-network-requests` branch after applying the same fix.
<img width="1016" height="623" alt="Screenshot 2025-08-27 at 4 10 20 PM" src="https://github.com/user-attachments/assets/ebd18e17-df12-455b-a667-4885065c8b6f" />




