### PR TITLE
feat: add interim session behavior

### DIFF
--- a/tests/components/session-entity.test.js
+++ b/tests/components/session-entity.test.js
@@ -190,7 +190,7 @@ describe('isNew', () => {
     expect(sessionInstance.value).not.toEqual(value)
   })
 
-  test('is true if existing session is not interim', () => {
+  test('is false if existing session is not interim', () => {
     storage.set(`${PREFIX}_${key}`, { ...model, interim: false, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
     const sessionInstance = new SessionEntity({ agentIdentifier, key, storage })
     expect(sessionInstance.isNew).toEqual(false)

--- a/tests/components/session-helpers.js
+++ b/tests/components/session-helpers.js
@@ -41,5 +41,6 @@ export const model = {
   loggingMode: 0,
   serverTimeDiff: null,
   custom: {},
-  numOfResets: 0
+  numOfResets: 0,
+  interim: false
 }

--- a/tests/specs/util/helpers.js
+++ b/tests/specs/util/helpers.js
@@ -24,7 +24,8 @@ export function buildExpectedSessionState (additionalExpectations) {
     sessionReplaySentFirstChunk: expect.any(Boolean),
     sessionTraceMode: expect.any(Number),
     loggingMode: expect.any(Number),
-    numOfResets: expect.any(Number)
+    numOfResets: expect.any(Number),
+    interim: expect.any(Boolean)
   }, additionalExpectations)
 }
 


### PR DESCRIPTION
Introduces a change to session behavior wherein if a session expires **live** on the page, the new session is flagged as "interim". This flag controls behavior in the agent where the next **hard** page load will trigger a new fresh session to start, which will allow new sampling decisions for session replay, session trace and logging features.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This is innovation work to stabilize session behavior to alleviate customer complaints around not being able to capture logs, traces or replays after a session has reset on a page.  Currently, these features are only re-initialized for a specific user after a dead expiration is observed (while the page is not being observed by the agent). A nice side-effect of this work is this provides us and customers a sure-fire (but internal) way to debug and reset their sessions in a way that the next page load will trigger sampling

```javascript
Object.values(newrelic.initializedAgents)[0].runtime.session.reset(true)
```

### Related Issue(s)
See [this thread](https://newrelic.slack.com/archives/G019T80B1EJ/p1757082558448299) for context around the innovation work

<img width="1087" height="487" alt="interim" src="https://github.com/user-attachments/assets/24db3ba3-4edf-43c4-ac97-7934522b0112" />

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added to validate that interim sessions can spawn new sessions on the next page load.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
