### PR TITLE
fix: memoize promise context propagation to avoid safari hangs

### DIFF
--- a/tests/components/wrappings/wrap-promise.test.js
+++ b/tests/components/wrappings/wrap-promise.test.js
@@ -77,6 +77,22 @@ test('Promise then chains are kept separate and distinct', async () => {
   await promise
 })
 
+test('Propagation caches resolved parent context once per chain', async () => {
+  const sentinelCtx = {}
+  const parentPromise = new Promise(resolve => resolve('parent'))
+  const parentStore = promiseEE.context(parentPromise)
+  parentStore.getCtx = jest.fn(() => sentinelCtx)
+
+  const childPromise = parentPromise.then(() => {})
+  const childStore = promiseEE.context(childPromise)
+
+  expect(childStore.getCtx()).toBe(sentinelCtx)
+  expect(childStore.getCtx()).toBe(sentinelCtx)
+  expect(parentStore.getCtx).toHaveBeenCalledTimes(1)
+
+  await childPromise
+})
+
 const thrownError = new Error('123')
 test('A promise constructor exception can be caught', async () => {
   await new Promise(function (resolve, reject) {


### PR DESCRIPTION
Caching the resolved SPA context for wrapped Promises prevents from re-traversing long promise chains on every propagation, eliminating the freeze on Safari and keeping third-party promise-heavy workflows responsive (e.g. with `html2pdf.js`).

### Overview

- Cache the resolved context once inside [wrap-promise](https://github.com/newrelic/newrelic-browser-agent/blob/796d970ce69e4130b6c71ef798c0a68820ffb033/src/common/wrap/wrap-promise.js) propagation handlers so downstream `.then` chains no longer walk the entire parent chain.
- Add a regression test that ensures the parent context is only resolved once per chain and that subsequent accesses reuse the cached value.

### Related Issue(s)

- Repro sandbox: [CodeSandbox](https://codesandbox.io/p/devbox/broken-river-46523k?workspaceId=ws_38qrSMMjqQpsmcCa3FfJkv)
- Preview: [https://46523k-5173.csb.app/](https://46523k-5173.csb.app/) (Press `Export as PDF` in Safari on iOS or macOS)

### Testing

Added a regression test in [wrap-promise.test.js](https://github.com/newrelic/newrelic-browser-agent/blob/796d970ce69e4130b6c71ef798c0a68820ffb033/tests/components/wrappings/wrap-promise.test.js) that validates context caching prevents repeated parent traversal in long promise chains.
