### PR TITLE
fix: Improve accuracy in standalone AjaxRequest event start times

### DIFF
--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -143,7 +143,7 @@ export class Aggregate extends AggregateBase {
       const event = eventBuffer[i]
       // ajax nodes are relative to the first node (or page origin if no previous node), so we need to calculate the relative start time
       const relativeStartTime = event.startTime - firstTimestamp
-      firstTimestamp ||= event.startTime
+      if (i === 0) firstTimestamp = event.startTime
 
       const fields = [
         numeric(relativeStartTime),

--- a/tests/assets/spa/dt/xhr-dt-crossorigin-load.html
+++ b/tests/assets/spa/dt/xhr-dt-crossorigin-load.html
@@ -22,13 +22,17 @@
       window.rawTimes.push(Math.floor(performance.now()))
       xhr.send()
 
-      for (var i = 0; i < 10; i++) {
-        var xhr = new XMLHttpRequest()
+      let offset = 100
+      for (var i = 0; i < 3; i++) {
+        setTimeout(function () {
+          var xhr = new XMLHttpRequest()
 
-        var url = '/json'
-        xhr.open('GET', url)
-        window.rawTimes.push(Math.floor(performance.now()))
-        xhr.send()
+          var url = '/json'
+          xhr.open('GET', url)
+          window.rawTimes.push(Math.floor(performance.now()))
+          xhr.send()
+        }, offset)
+        offset += 100
       }
     </script>
   </body>

--- a/tests/assets/spa/dt/xhr-dt-sameorigin-load.html
+++ b/tests/assets/spa/dt/xhr-dt-sameorigin-load.html
@@ -22,13 +22,17 @@
       window.rawTimes.push(Math.floor(performance.now()))
       xhr.send()
 
-      for (var i = 0; i < 10; i++) {
-        var xhr = new XMLHttpRequest()
+      let offset = 100
+      for (var i = 0; i < 3; i++) {
+        setTimeout(function () {
+          var xhr = new XMLHttpRequest()
 
-        var url = '/json'
-        xhr.open('GET', url)
-        window.rawTimes.push(Math.floor(performance.now()))
-        xhr.send()
+          var url = '/json'
+          xhr.open('GET', url)
+          window.rawTimes.push(Math.floor(performance.now()))
+          xhr.send()
+        }, offset)
+        offset += 100
       }
     </script>
   </body>

--- a/tests/specs/ajax/distributed-tracing.e2e.js
+++ b/tests/specs/ajax/distributed-tracing.e2e.js
@@ -275,7 +275,7 @@ function validateTraceTime (harvest = {}, rawTimes = []) {
     expect(event.end).toBeGreaterThan(event.start)
     // For all but the first event, validate the time difference is in rawTimes
     // Example: event[1].start - event[0].start should be in rawTimes
-    if (idx !== 0) validateRawTimes(event.start - events[0].start)
+    if (idx !== 0) validateRawTimes(event.start)
 
     // For each child of type 'ajax', validate its timing
     // Example: child = { type: 'ajax', start: 110, end: 120, timestamp: 23456789, ... }


### PR DESCRIPTION
Adjusts a problem in the agent where start times of certain standalone AjaxRequest event payloads were reported relative to the page origin instead of relative to the first event in the payload, causing discrepancies when visualizing in NR1.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Standalone ajax nodes indexed 1+ in BEL7.2 event arrays must reference the first node in the series as the relative timestamp.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-479069?atlOrigin=eyJpIjoiMzc5NzA3YjE0ZGE0NGFhMjhiNjU3NThmN2E0ZTI4MDgiLCJwIjoiamlyYS1zbGFjay1pbnQifQ
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added to validate the timestamps are correct before sending.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
