### PR TITLE
chore: replace SR_EVENT_EMITTER_TYPES with direct constants

### DIFF
--- a/src/features/session_replay/aggregate/index.js
+++ b/src/features/session_replay/aggregate/index.js
@@ -7,7 +7,7 @@
  */
 
 import { registerHandler } from '../../../common/event-emitter/register-handler'
-import { ABORT_REASONS, FEATURE_NAME, QUERY_PARAM_PADDING, RRWEB_EVENT_TYPES, SR_EVENT_EMITTER_TYPES, TRIGGERS } from '../constants'
+import { ABORT_REASONS, ERROR_DURING_REPLAY, FEATURE_NAME, QUERY_PARAM_PADDING, RRWEB_EVENT_TYPES, TRIGGERS } from '../constants'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { sharedChannel } from '../../../common/constants/shared-channel'
 import { obj as encodeObj } from '../../../common/url/encode'
@@ -21,6 +21,7 @@ import { now } from '../../../common/timing/now'
 import { MAX_PAYLOAD_SIZE } from '../../../common/constants/agent-constants'
 import { cleanURL } from '../../../common/url/clean-url'
 import { canEnableSessionTracking } from '../../utils/feature-gates'
+import { PAUSE_REPLAY } from '../../../loaders/api/constants'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -77,11 +78,11 @@ export class Aggregate extends AggregateBase {
       this.mode = data.sessionReplayMode
     })
 
-    registerHandler(SR_EVENT_EMITTER_TYPES.PAUSE, () => {
+    registerHandler(PAUSE_REPLAY, () => {
       this.forceStop(this.mode === MODE.FULL)
     }, this.featureName, this.ee)
 
-    registerHandler(SR_EVENT_EMITTER_TYPES.ERROR_DURING_REPLAY, e => {
+    registerHandler(ERROR_DURING_REPLAY, e => {
       this.handleError(e)
     }, this.featureName, this.ee)
 

--- a/src/features/session_replay/constants.js
+++ b/src/features/session_replay/constants.js
@@ -7,11 +7,7 @@ import { FEATURE_NAMES } from '../../loaders/features/features'
 
 export const FEATURE_NAME = FEATURE_NAMES.sessionReplay
 
-export const SR_EVENT_EMITTER_TYPES = {
-  RECORD: 'recordReplay',
-  PAUSE: 'pauseReplay',
-  ERROR_DURING_REPLAY: 'errorDuringReplay'
-}
+export const ERROR_DURING_REPLAY = 'errorDuringReplay'
 
 export const AVG_COMPRESSION = 0.12
 export const RRWEB_EVENT_TYPES = {

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -10,9 +10,10 @@ import { handle } from '../../../common/event-emitter/handle'
 import { DEFAULT_KEY, MODE, PREFIX } from '../../../common/session/constants'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { hasReplayPrerequisite, isPreloadAllowed } from '../shared/utils'
-import { FEATURE_NAME, SR_EVENT_EMITTER_TYPES, TRIGGERS } from '../constants'
+import { ERROR_DURING_REPLAY, FEATURE_NAME, TRIGGERS } from '../constants'
 import { setupRecordReplayAPI } from '../../../loaders/api/recordReplay'
 import { setupPauseReplayAPI } from '../../../loaders/api/pauseReplay'
+import { RECORD_REPLAY } from '../../../loaders/api/constants'
 
 export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
@@ -34,7 +35,7 @@ export class Instrument extends InstrumentBase {
     } catch (err) { }
 
     if (hasReplayPrerequisite(agentRef.init)) {
-      this.ee.on(SR_EVENT_EMITTER_TYPES.RECORD, () => this.#apiStartOrRestartReplay())
+      this.ee.on(RECORD_REPLAY, () => this.#apiStartOrRestartReplay())
     }
 
     if (this.#canPreloadRecorder(session)) {
@@ -50,7 +51,7 @@ export class Instrument extends InstrumentBase {
       if (this.blocked) return
       if (this.agentRef.runtime.isRecording) {
         this.errorNoticed = true
-        handle(SR_EVENT_EMITTER_TYPES.ERROR_DURING_REPLAY, [e], undefined, this.featureName, this.ee)
+        handle(ERROR_DURING_REPLAY, [e], undefined, this.featureName, this.ee)
       }
     })
   }

--- a/tests/components/session_replay/aggregate.test.js
+++ b/tests/components/session_replay/aggregate.test.js
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
-import { SR_EVENT_EMITTER_TYPES } from '../../../src/features/session_replay/constants'
+import { ERROR_DURING_REPLAY } from '../../../src/features/session_replay/constants'
 import { IDEAL_PAYLOAD_SIZE, MAX_PAYLOAD_SIZE } from '../../../src/common/constants/agent-constants'
 import { MODE, SESSION_EVENTS } from '../../../src/common/session/constants'
 import { FEATURE_NAMES } from '../../../src/loaders/features/features'
@@ -166,7 +166,7 @@ describe('Session Replay Sample -> Mode Behaviors', () => {
 
 describe('Session Replay Error Mode Behaviors', () => {
   test('an error BEFORE rrweb import starts running in ERROR from beginning (when not preloaded)', async () => {
-    ee.get(mainAgent.agentIdentifier).emit(SR_EVENT_EMITTER_TYPES.ERROR_DURING_REPLAY, ['test1'], undefined, FEATURE_NAMES.sessionReplay, ee.get(mainAgent.agentIdentifier))
+    ee.get(mainAgent.agentIdentifier).emit(ERROR_DURING_REPLAY, ['test1'], undefined, FEATURE_NAMES.sessionReplay, ee.get(mainAgent.agentIdentifier))
 
     const sessionReplayInstrument = new SessionReplay(mainAgent)
     await new Promise(process.nextTick)
@@ -184,7 +184,7 @@ describe('Session Replay Error Mode Behaviors', () => {
 
     expect(sessionReplayAggregate.mode).toEqual(MODE.ERROR)
 
-    ee.get(mainAgent.agentIdentifier).emit(SR_EVENT_EMITTER_TYPES.ERROR_DURING_REPLAY, ['test1'], undefined, FEATURE_NAMES.sessionReplay, ee.get(mainAgent.agentIdentifier))
+    ee.get(mainAgent.agentIdentifier).emit(ERROR_DURING_REPLAY, ['test1'], undefined, FEATURE_NAMES.sessionReplay, ee.get(mainAgent.agentIdentifier))
 
     expect(sessionReplayAggregate.mode).toEqual(MODE.FULL)
   })


### PR DESCRIPTION
Chore
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Just reducing 2 places where the exact same constant string is used down to 1 definition so it's easier to track the link between API and where it's handled in SR feature.

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
