### PR TITLE
chore: Explicitly grant write in release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
Bump token used in release please workflow
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->
Sample error message
```
Invalid workflow file: .github/workflows/release-please.yml#L35 
The workflow is not valid. .github/workflows/release-please.yml (Line: 35, Col: 3): 
Error calling workflow 'newrelic/newrelic-browser-agent/.github/workflows/npm-operations.yml@<commit_id>'. 
The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
