### PR TITLE
fix: Obfuscate custom attributes for logs added after PVE

### DIFF
--- a/src/features/logging/aggregate/index.js
+++ b/src/features/logging/aggregate/index.js
@@ -116,7 +116,7 @@ export class Aggregate extends AggregateBase {
       common: {
         /** Attributes in the `common` section are added to `all` logs generated in the payload */
         attributes: {
-          ...this.agentRef.info.jsAttributes, // user-provided custom attributes
+          ...(applyFnToProps(this.agentRef.info.jsAttributes, this.obfuscator.obfuscateString.bind(this.obfuscator), 'string')),
           ...(this.harvestEndpointVersion === 1 && {
             'entity.guid': this.agentRef.runtime.appMetadata.agents[0].entityGuid,
             appId: this.agentRef.info.applicationID

--- a/tests/specs/obfuscate.e2e.js
+++ b/tests/specs/obfuscate.e2e.js
@@ -47,6 +47,13 @@ describe('obfuscate rules', () => {
   })
 
   it('should apply to all payloads', async () => {
+    await browser.url(await browser.testHandle.assetURL('obfuscate-pii.html', config))
+      .then(() => browser.waitForAgentLoad())
+    await browser.execute(function () {
+      // test log custom attributes added after PVE
+      newrelic.setCustomAttribute('foo', 'foo pii')
+      console.log('Test')
+    })
     const [rumHarvests, timingEventsHarvests, ajaxEventsHarvests, errorsHarvests, insightsHarvests, tracesHarvests, interactionEventsHarvests, logsHarvests] = await Promise.all([
       rumCapture.waitForResult({ timeout: 10000 }),
       timingEventsCapture.waitForResult({ timeout: 10000 }),
@@ -55,9 +62,7 @@ describe('obfuscate rules', () => {
       insightsCapture.waitForResult({ timeout: 10000 }),
       tracesCapture.waitForResult({ timeout: 10000 }),
       interactionEventsCapture.waitForResult({ timeout: 10000 }),
-      logsCapture.waitForResult({ timeout: 10000 }),
-      browser.url(await browser.testHandle.assetURL('obfuscate-pii.html', config))
-        .then(() => browser.waitForAgentLoad())
+      logsCapture.waitForResult({ timeout: 10000 })
     ])
 
     expect(rumHarvests.length).toBeGreaterThan(0)
@@ -89,7 +94,7 @@ describe('obfuscate rules', () => {
       checkPayload(harvest.request.body)
       checkPayload(harvest.request.query)
     })
-    expect(logsHarvests.length).toBeGreaterThan(0)
+    expect(logsHarvests.length).toBe(2)
     logsHarvests.forEach(harvest => {
       checkPayload(harvest.request.body)
       checkPayload(harvest.request.query)


### PR DESCRIPTION
Extends obfuscation to cover custom attributes on logging events added after the initial RUM/PageViewEvent harvest.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview


### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-472374

### Testing

Updated obfuscated.e2e.js to cover the scenario.
