### PR TITLE
fix: allow child registrations from blocked parents

### DIFF
--- a/src/loaders/api/register.js
+++ b/src/loaders/api/register.js
@@ -136,12 +136,13 @@ function register (agentRef, target, parent) {
      * @returns
      */
   const report = (methodToCall, args, target) => {
-    if (isBlocked()) return
+    /** Even if we are blocked, if registering we should still return a child register API so nested API calls do not throw errors */
+    if (isBlocked() && methodToCall !== register) return
     /** set the timestamp before the async part of waiting for the rum response for better accuracy */
     const timestamp = now()
     handle(SUPPORTABILITY_METRIC_CHANNEL, [`API/register/${methodToCall.name}/called`], undefined, FEATURE_NAMES.metrics, agentRef.ee)
     try {
-      const shouldDuplicate = agentRef.init.api.duplicate_registered_data && methodToCall.name !== 'register'
+      const shouldDuplicate = agentRef.init.api.duplicate_registered_data && methodToCall !== register
       if (shouldDuplicate) {
         let duplicatedArgs = args
         if (args[1] instanceof Object) {

--- a/tests/specs/npm/registered-entity.e2e.js
+++ b/tests/specs/npm/registered-entity.e2e.js
@@ -504,4 +504,68 @@ describe('registered-entity', () => {
       expect(sourceKeys.length).toBe(3)
     })
   })
+
+  it('should not throw errors when parent is blocked; children still record data', async () => {
+    await browser.url(await browser.testHandle.assetURL('test-builds/browser-agent-wrapper/registered-entity.html', { init: { feature_flags: ['register', 'register.jserrors', 'register.generic_events'] } }))
+
+    const { hasErrors } = await browser.execute(function () {
+      let hasErrors = false
+      try {
+        // Blocked parent (invalid id)
+        window.blockedParent = new RegisteredEntity({ id: '', name: 'blocked-parent' })
+
+        // Parent API calls should not throw but should NOT be recorded
+        window.blockedParent.noticeError('PARENT_SHOULD_NOT_RECORD')
+        window.blockedParent.addPageAction('PARENT_SHOULD_NOT_RECORD')
+        window.blockedParent.log('PARENT_SHOULD_NOT_RECORD', { level: 'error' })
+        window.blockedParent.recordCustomEvent('CustomEvent', { val: 'PARENT_SHOULD_NOT_RECORD' })
+
+        // Children should be allowed and record data
+        window.child = window.blockedParent.register({ id: 101, name: 'child' })
+        window.grandchild = window.child.register({ id: 102, name: 'grandchild' })
+
+        window.child.noticeError('CHILD_SHOULD_RECORD')
+        window.child.addPageAction('CHILD_SHOULD_RECORD')
+        window.child.log('CHILD_SHOULD_RECORD', { level: 'error' })
+        window.child.recordCustomEvent('CustomEvent', { val: 'CHILD_SHOULD_RECORD' })
+
+        window.grandchild.noticeError('GRANDCHILD_SHOULD_RECORD')
+        window.grandchild.addPageAction('GRANDCHILD_SHOULD_RECORD')
+        window.grandchild.log('GRANDCHILD_SHOULD_RECORD', { level: 'error' })
+        window.grandchild.recordCustomEvent('CustomEvent', { val: 'GRANDCHILD_SHOULD_RECORD' })
+      } catch (err) {
+        hasErrors = true
+      }
+      return { hasErrors }
+    })
+
+    // No errors thrown creating/using blocked parent and children
+    expect(hasErrors).toBe(false)
+
+    // Errors: children recorded, parent not recorded
+    const errorsHarvests = await mfeErrorsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+    const errorData = errorsHarvests.flatMap(h => h.request.body.err || [])
+    const messages = errorData.map(err => String(err.params.message || ''))
+    expect(messages.some(m => m.includes('PARENT_SHOULD_NOT_RECORD'))).toBe(false)
+    expect(messages.some(m => m.includes('CHILD_SHOULD_RECORD'))).toBe(true)
+    expect(messages.some(m => m.includes('GRANDCHILD_SHOULD_RECORD'))).toBe(true)
+
+    // Insights (PageAction/CustomEvent/Measures): children recorded, parent not recorded
+    const insightsHarvests = await mfeInsightsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+    const insightsData = insightsHarvests.flatMap(h => h.request.body.ins || [])
+    const insightValues = insightsData.map(ins => (ins.val || ins.actionName || ''))
+    expect(insightValues.some(v => v.includes('PARENT_SHOULD_NOT_RECORD'))).toBe(false)
+    expect(insightValues.some(v => v.includes('CHILD_SHOULD_RECORD'))).toBe(true)
+    expect(insightValues.some(v => v.includes('GRANDCHILD_SHOULD_RECORD'))).toBe(true)
+
+    // Logs: children recorded, parent not recorded
+    const logsHarvests = await logsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+    const logsData = logsHarvests.flatMap(h => {
+      try { return JSON.parse(h.request.body)[0]?.logs || [] } catch { return [] }
+    })
+    const logMessages = logsData.map(l => l.message || '')
+    expect(logMessages.some(m => m.includes('PARENT_SHOULD_NOT_RECORD'))).toBe(false)
+    expect(logMessages.some(m => m.includes('CHILD_SHOULD_RECORD'))).toBe(true)
+    expect(logMessages.some(m => m.includes('GRANDCHILD_SHOULD_RECORD'))).toBe(true)
+  })
 })


### PR DESCRIPTION
Allow blocked parent entities to still instantiate a child MFE when registering 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
This was found in E2E testing with NR1, wherein blocked children would throw errors because the API did not exist.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
See these JSEs in NR1 -- https://staging.onenr.io/0LREAD48MRa
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New test has been added demonstrating the desired behavior
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
