### PR TITLE
feat: Warn when more than one agent is running

### DIFF
--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -137,3 +137,5 @@
 `The "spa" feature has been deprecated and disabled. Please use/import "soft_navigations" instead for tracking of BrowserInteraction data.`
 ### 68
 `API has been deregistered and can no longer be used. Call "register" API again with credentials to start over.`
+### 69
+`More than one Browser agent is running on the page`

--- a/src/common/window/nreum.js
+++ b/src/common/window/nreum.js
@@ -1,9 +1,10 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { globalScope } from '../constants/runtime'
 import { now } from '../timing/now'
+import { warn } from '../util/console'
 import { isNative } from '../util/monkey-patched'
 
 export const defaults = {
@@ -82,6 +83,11 @@ export function setNREUMInitializedAgent (id, newAgentInstance) {
     date: new Date()
   }
   nr.initializedAgents[id] = newAgentInstance
+
+  // Warn if using more than one agent, but only once per agent load
+  if (Object.keys(nr.initializedAgents).length === 2) {
+    warn(69)
+  }
 }
 
 /**

--- a/tests/assets/multi-agent.html
+++ b/tests/assets/multi-agent.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!--
+  Copyright 2020 New Relic Corporation.
+  PDX-License-Identifier: Apache-2.0
+-->
+<html>
+  <head>
+    <title>RUM Unit Test</title>
+    <script>
+      window.test = {
+        agentLogCount: 0
+      }
+      console.debug = function (...args) {
+        if (args[0] === "New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#69") window.test.agentLogCount += 1;
+      };
+    </script>
+    {init} {config} {loader} {loader} {loader}
+  </head>
+  <body>This page has multiple Browser agents running on it</body>
+</html>

--- a/tests/specs/multi-agent.e2e.js
+++ b/tests/specs/multi-agent.e2e.js
@@ -1,0 +1,15 @@
+describe('multi-agent', () => {
+  it('emits a single console log warning when more than one agent is on the page', async () => {
+    await browser.url(await browser.testHandle.assetURL('multi-agent.html'))
+
+    // wait for agents to register and log warnings
+    await browser.pause(5000)
+
+    const agentLogCount = await browser.execute(function () {
+      return window.test.agentLogCount
+    })
+
+    // there should only be one agent log warning
+    expect(agentLogCount).toBe(1)
+  })
+})

--- a/tests/specs/npm/multi-agent.e2e.js
+++ b/tests/specs/npm/multi-agent.e2e.js
@@ -18,4 +18,28 @@ describe('multi-agent', () => {
     // a single interaction should have api methods defined on them
     expect(ixn.get).toBeDefined()
   })
+
+  it('emits a single console log warning when more than one agent is on the page', async () => {
+    await browser.url(await browser.testHandle.assetURL('test-builds/browser-agent-wrapper/multi-agent.html'))
+
+    // register two micro agents alongside the main agent
+    await browser.execute(function () {
+      var opts = {
+        info: NREUM.info,
+        init: NREUM.init
+      }
+      window.agent1 = new MicroAgent({ ...opts, info: { ...opts.info, applicationID: 1 } })
+      window.agent2 = new MicroAgent({ ...opts, info: { ...opts.info, applicationID: 2 } })
+    })
+
+    // wait for agents to register and log warnings
+    await browser.pause(5000)
+
+    const agentLogCount = await browser.execute(function () {
+      return window.test.agentLogCount
+    })
+
+    // there should only be one agent log warning
+    expect(agentLogCount).toBe(1)
+  })
 })

--- a/tools/test-builds/browser-agent-wrapper/webpack.config.js
+++ b/tools/test-builds/browser-agent-wrapper/webpack.config.js
@@ -17,6 +17,14 @@ const htmlTemplate = (script) => `<html>
 const multiAgentHtmlTemplate = `<html>
   <head>
     <title>RUM Unit Test</title>
+    <script>
+      window.test = {
+        agentLogCount: 0
+      }
+      console.debug = function (...args) {
+        if (args[0] === "New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#69") window.test.agentLogCount += 1;
+      };
+    </script>
     {init}
     {config}
     <script src="browser-agent.js"></script>

--- a/tools/test-builds/raw-src-wrapper/webpack.config.js
+++ b/tools/test-builds/raw-src-wrapper/webpack.config.js
@@ -17,6 +17,14 @@ const htmlTemplate = (script) => `<html>
 const multiAgentHtmlTemplate = `<html>
   <head>
     <title>RUM Unit Test</title>
+    <script>
+      window.test = {
+        agentLogCount: 0
+      }
+      console.debug = function (...args) {
+        if (args[0] === "New Relic Warning: https://github.com/newrelic/newrelic-browser-agent/blob/main/docs/warning-codes.md#69") window.test.agentLogCount += 1;
+      };
+    </script>
     {init}
     {config}
     <script src="browser-agent.js"></script>


### PR DESCRIPTION
Added a console warning when more than one Browser agent is running on the page.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

When more than one Browser agent is on the page, regardless of what type of agent, we emit a warning code of 69 indicating that multiple agents are on the page. We're doing this to prepare for deprecating micro agent support in the near future.

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-383866

### Testing

Make sure tests pass. There's one for NPM which is browser + micro agent. The regular one is multiple non-micro Browser agents.
