### PR TITLE
chore: Monkey patch nrWrapper test

### DIFF
--- a/tests/specs/monkey-patched.e2e.js
+++ b/tests/specs/monkey-patched.e2e.js
@@ -25,6 +25,9 @@ describe('monkey-patched globals', () => {
     expect(logs[0][0].includes('New Relic Warning') && logs[0][0].includes('64')).toEqual(true) // 64 is the warning code for monkey-patched globals
     expect(logs[0][1]).toEqual('debug')
 
-    expect(logs.filter(log => log[1].includes('nrWrapper')).length).toEqual(0) // should not have logged anything about nrWrapper
+    expect(logs[1][0].includes('New Relic Warning') && logs[1][0].includes('69')).toEqual(true) // 69 is the warning code for multiple agents on page
+    expect(logs[1][1]).toEqual(null)
+
+    expect(logs.filter(log => log[1]?.includes('nrWrapper')).length).toEqual(0) // should not have logged anything about nrWrapper
   })
 })


### PR DESCRIPTION
Fixed an e2e test related to monkey patching that caused our test suite to fail due to adding the new multi-agent warning code.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Fixes the `should NOT warn if the monkey-patched function is nrWrapper` test in `monkey-patched.e2e.js`. This test needed to be updated to account for the multi-agent warning. [See this PR](https://github.com/newrelic/newrelic-browser-agent/pull/1686) for context.

### Testing

Make sure tests pass.
