### PR TITLE
chore: re-expose generic events

### DIFF
--- a/.github/actions/build-ab/templates/released.js
+++ b/.github/actions/build-ab/templates/released.js
@@ -1,7 +1,7 @@
 // config
 window.NREUM={
   init: {
-    feature_flags: ['register', 'register.jserrors'], // add generic events flag once the consumer(s) support it
+    feature_flags: ['register', 'register.jserrors', 'register.generic_events'],
     distributed_tracing: {
       enabled: true
     },


### PR DESCRIPTION
This re-exposes generic events to all builds per request of @newrelic/dempla for consumer validation
---