### PR TITLE
chore: Fix typos in code comments and descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Before instrumenting your app using the NPM package, a Browser App should be con
 
 For best results, import and instantiate the `BrowserAgent` class as close to the top of the `head` element of your app's HTML output as possible. The specific location and method will vary based on your application's architecture or framework. See [Library Support](#library-support) for more information.
 
-Populate the `options` parameter using configuration values found in the the *Copy/Paste JavaScript* box in your browser app's *Application settings* page in New Relic.
+Populate the `options` parameter using configuration values found in the *Copy/Paste JavaScript* box in your browser app's *Application settings* page in New Relic.
 
 ```javascript
 import { BrowserAgent } from '@newrelic/browser-agent/loaders/browser-agent'

--- a/src/common/drain/drain.js
+++ b/src/common/drain/drain.js
@@ -128,7 +128,7 @@ function drainGroup (agentIdentifier, group, activateGroup = true) {
 
 /**
  * Processes the specified event using all relevant handler functions associated with a particular feature, based on
- * whether the the handler is meant to apply to events of this type. (Event type is a descriptive string set at the
+ * whether the handler is meant to apply to events of this type. (Event type is a descriptive string set at the
  * time an event is originally created by instrumentation, as with calls to the `handle` method.)
  * @param {*} evt - A single event to be emitted to (processed by) eligible handler functions.
  * @param {*} groupHandlers - A set of handler functions associated with a particular feature's event-group.

--- a/src/common/harvest/harvester.js
+++ b/src/common/harvest/harvester.js
@@ -35,7 +35,7 @@ export class Harvester {
         if (typeof aggregateInst.harvestOpts.beforeUnload === 'function') aggregateInst.harvestOpts.beforeUnload()
       })
       this.initializedAggregates.forEach(aggregateInst => this.triggerHarvestFor(aggregateInst, { isFinalHarvest: true }))
-      /* This callback should run in bubble phase, so that that CWV api, like "onLCP", is called before the final harvest so that emitted timings are part of last outgoing. */
+      /* This callback should run in bubble phase, so that CWV api, like "onLCP", is called before the final harvest so that emitted timings are part of last outgoing. */
     }, false)
   }
 

--- a/src/features/jserrors/aggregate/index.js
+++ b/src/features/jserrors/aggregate/index.js
@@ -99,7 +99,7 @@ export class Aggregate extends AggregateBase {
   /**
    *
    * @param {Error|UncaughtError} err The error instance to be processed
-   * @param {number} time the relative ms (to origin) timestamp of occurence
+   * @param {number} time the relative ms (to origin) timestamp of occurrence
    * @param {boolean=} internal if the error was "caught" and deemed "internal" before reporting to the jserrors feature
    * @param {object=} customAttributes  any custom attributes to be included in the error payload
    * @param {boolean=} hasReplay a flag indicating if the error occurred during a replay session

--- a/src/features/soft_navigations/aggregate/initial-page-load-interaction.js
+++ b/src/features/soft_navigations/aggregate/initial-page-load-interaction.js
@@ -28,13 +28,13 @@ export class InitialPageLoadInteraction extends Interaction {
   get navTiming () {
     if (!navTimingValues.length) return
     /*
-    1. we initialize the seperator to ',' (seperates the nodeType id from the first value)
+    1. we initialize the separator to ',' (separates the nodeType id from the first value)
     2. we initialize the navTiming node to 'b' (the nodeType id)
-    3. if the value is present, we add the seperator followed by the value;
+    3. if the value is present, we add the separator followed by the value;
        otherwise:
-        - we add null seperator ('!') to the navTimingNode
-        - we set the seperator to an empty string since we already wrote it above
-      the reason for writing the null seperator instead of setting the seperator
+        - we add null separator ('!') to the navTimingNode
+        - we set the separator to an empty string since we already wrote it above
+      the reason for writing the null separator instead of setting the separator
       is to ensure we still write it if the null is the last navTiming value.
     */
     let seperator = ','

--- a/src/features/utils/feature-base.js
+++ b/src/features/utils/feature-base.js
@@ -14,7 +14,7 @@ export class FeatureBase {
     /** @type {string} */
     this.featureName = featureName
     /**
-     * Blocked can be used to prevent aggregation and harvest after inititalization time of the feature.
+     * Blocked can be used to prevent aggregation and harvest after initialization time of the feature.
      * This can currently happen if RUM response setToken flag is 0, which is tied to ingest account entitlement info.
      * @type {boolean}
      */

--- a/tools/testing-server/plugins/agent-injector/loader-transform.js
+++ b/tools/testing-server/plugins/agent-injector/loader-transform.js
@@ -57,7 +57,7 @@ async function getLoaderScript (scriptType, loaderFilePath, nonce, injectionDela
 
 /**
  * Transforms requests for HTML files that contain the \{loader\} string with the
- * built loader JS. By default, the full loader will be used but can be overriden
+ * built loader JS. By default, the full loader will be used but can be overridden
  * by passing the loader query param.
  */
 module.exports = function (request, reply, testServer) {

--- a/tools/wdio/args.mjs
+++ b/tools/wdio/args.mjs
@@ -19,7 +19,7 @@ const args = yargs(hideBin(process.argv))
   .alias('b', 'browsers')
   .describe(
     'b',
-    'a comma seperated list of browsers with an optional semver range. (eg. chrome@>39)'
+    'a comma separated list of browsers with an optional semver range. (eg. chrome@>39)'
   )
 
   .number('concurrent')
@@ -48,7 +48,7 @@ const args = yargs(hideBin(process.argv))
   .default('t', 85000)
 
   .number('session-timeout')
-  .describe('session-timeout', 'timout in ms for LambdaTest browser session')
+  .describe('session-timeout', 'timeout in ms for LambdaTest browser session')
   .default('session-timeout', 120000)
 
   .boolean('d')


### PR DESCRIPTION
Fixes minor typos in code comments and descriptions.
---

### Overview
  This PR corrects typos found across the codebase in comments, JSDoc, CLI descriptions, and documentation:
  
  - `occurence` → `occurrence` in JSDoc for jserrors aggregate (`src/features/jserrors/aggregate/index.js`)
  - `inititalization` → `initialization` in JSDoc for FeatureBase (`src/features/utils/feature-base.js`)
  - `overriden` → `overridden` in comment for loader-transform plugin (`tools/testing-server/plugins/agent-injector/loader-transform.js`)
  - `timout` → `timeout` in CLI argument description (`tools/wdio/args.mjs`)
  - `seperated` → `separated` in CLI argument description (`tools/wdio/args.mjs`)
  - `seperator` / `seperates` → `separator` / `separates` in navTiming comment (`src/features/soft_navigations/aggregate/initial-page-load-interaction.js`)
  - Removed doubled word `the the` → `the` (`src/common/drain/drain.js`, `README.md`)
  - Removed doubled word `that that` → `that` (`src/common/harvest/harvester.js`)

### Related Issue(s)

N/A

### Testing

No functional changes — only comment and description string corrections. No testing required beyond verifying the diff.