### PR TITLE
chore: Update browser-agent-2-query account reporting

### DIFF
--- a/.github/actions/build-agent2query/templates/latest-config.js
+++ b/.github/actions/build-agent2query/templates/latest-config.js
@@ -34,4 +34,4 @@ NREUM.init = {
   }
 }
 NREUM.feature_flags = ['soft_nav', 'websockets']
-NREUM.info = { beacon: 'staging-bam-cell.nr-data.net', errorBeacon: 'staging-bam-cell.nr-data.net', licenseKey: '{{{latestLicenseKey}}}', applicationID: '275822177', sa: 1 }
+NREUM.info = { beacon: 'staging-bam-cell.nr-data.net', errorBeacon: 'staging-bam-cell.nr-data.net', licenseKey: '{{{latestLicenseKey}}}', applicationID: '77606036', sa: 1 }

--- a/.github/actions/build-agent2query/templates/released-config.js
+++ b/.github/actions/build-agent2query/templates/released-config.js
@@ -30,8 +30,8 @@ NREUM.init = {
     cookies_enabled: true
   },
   ajax: {
-    deny_list: ['staging-bam-cell.nr-data.net']
+    deny_list: ['bam.nr-data.net']
   }
 }
 NREUM.feature_flags = ['soft_nav', 'websockets']
-NREUM.info = { beacon: 'staging-bam-cell.nr-data.net', errorBeacon: 'staging-bam-cell.nr-data.net', licenseKey: '{{{releasedLicenseKey}}}', applicationID: '275822177', sa: 1 }
+NREUM.info = { beacon: 'bam.nr-data.net', errorBeacon: 'bam.nr-data.net', licenseKey: '{{{releasedLicenseKey}}}', applicationID: '1431909786', sa: 1 }


### PR DESCRIPTION
Updates our browser-agent-2-query app to report to our new A2Q entities instead of a testing entity.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Changing our app reporting from our test app to two separate A2Q apps: latest agent in US staging and released agent in US production. These changes are not customer facing and only affect internal reporting.

After approval and right before merging this PR, we need to change the secrets for A2Q license keys.

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-525777

### Testing

- Tests pass.
- Latest agent should be on app ID 77606036 in US staging beacon.
- Released agent should be on app ID 1431909786 in US production beacon.
