### PR TITLE
fix: Gql operation type detection logic for Ajax request

### DIFF
--- a/src/features/ajax/aggregate/gql.js
+++ b/src/features/ajax/aggregate/gql.js
@@ -39,7 +39,13 @@ function parseSingleGQL (contents) {
 
   /** parses gql query string and returns [fullmatch, type match, name match] */
   const matches = contents.query.trim().match(/^(query|mutation|subscription)\s?(\w*)/)
-  const operationType = matches?.[1]
+  /** 
+   * Since the regex above expects the operation (query|mutation|subscription) at the start of the query string.
+   * This is not true in every case, especially in the case of a GET request, 
+   * where the client usually sends the query hash, not the full query string.
+   * So, adding a capability where the application can pass the operationType explicitly
+   * **/
+  const operationType = matches?.[1] || contents.operationType
   if (!operationType) return
   const operationName = contents.operationName || matches?.[2] || 'Anonymous'
   return {


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.

Since the regex above expects the operation (query|mutation|subscription) at the start of the query string. This is not true in every case, especially for a GET request, where the client usually sends the query hash rather than the full query string. So, adding a capability where the application can pass the operationType explicitly

---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Consider the below fetch all to a GraphQL server

`
fetch("https://www.test.com/graphql", {
  "headers": {
    "accept": "*/*",
    "accept-language": "en-IN,en-GB;q=0.9,en-US;q=0.8,en;q=0.7",
    "content-type": "application/json"
  },
  "referrer": "https://www.test.com/",
  "body": "{\"operationName\":\"validateUserEntitlement\",\"operation\":\"query\",\"variables\":{\"entityId\":\"140981\"},\"query\":\"\nfragment TestWidget on Test {\n  status\n}\n\nquery TestData() {\n  testWidget() {\n    ...TestWidget\n  }\n}\n",
  "method": "POST"
});
`

Here, the value for `contents.query` is 
`
fragment TestWidget on Test {
  status
}

query TestData() {
  testWidget() {
    ...TestWidget
  }
}
`

Now, if we try to do a regex check on the above query string, it will return undefined

`
const matches = contents.query.trim().match(/^(query|mutation|subscription)\s?(\w*)/)
const operationType = matches?.[1] // this will be undefined
`

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

Make a fetch call similar to the above one from the Newrelic browser client to a GraphQL server, and check if the AjaxRequest is capturing the operation name and operationType in the dashboard or NRQL 

<!-- Please provide detailed steps for testing the changes in this pull request using a developer's local environment. -->
