### PR TITLE
chore: Notify team regarding staging experiment changes

### DIFF
--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -3,8 +3,8 @@
 name: 'Slack Notification'
 
 inputs:
-  dev_channel_url:
-    description: 'Slack API URL for the dev channel'
+  notifications_channel_url:
+    description: 'Slack API URL for the notifications channel'
     required: false
   dem_platform_ops_channel_url:
     description: 'Slack API URL for the dem platform ops release channel'
@@ -22,7 +22,7 @@ runs:
     - name: Send Slack notification
       run: |
         node $GITHUB_ACTION_PATH/index.js \
-          --dev-channel-url "${{ inputs.dev_channel_url }}" \
+          --notifications-channel-url "${{ inputs.notifications_channel_url }}" \
           --dem-platform-ops-channel-url "${{ inputs.dem_platform_ops_channel_url }}" \
           --message "${{ inputs.message }}"
       shell: bash

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -1,0 +1,28 @@
+# This composite action is used to post notifications to Slack channels.
+
+name: 'Slack Notification'
+
+inputs:
+  dev_channel_url:
+    description: 'Slack API URL for the dev channel'
+    required: false
+  dem_platform_ops_channel_url:
+    description: 'Slack API URL for the dem platform ops release channel'
+    required: false
+  message:
+    description: 'The message to post to Slack channels'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
+      shell: bash
+    - name: Send Slack notification
+      run: |
+        node $GITHUB_ACTION_PATH/index.js \
+          --dev-channel-url "${{ inputs.dev_channel_url }}" \
+          --dem-platform-ops-channel-url "${{ inputs.dem_platform_ops_channel_url }}" \
+          --message "${{ inputs.message }}"
+      shell: bash

--- a/.github/actions/slack-notification/args.js
+++ b/.github/actions/slack-notification/args.js
@@ -5,9 +5,9 @@ import { hideBin } from 'yargs/helpers'
 export const args = yargs(hideBin(process.argv))
   .usage('$0 [options]')
 
-  .string('dev-channel-url')
-  .describe('dev-channel-url', 'Webhook URL to slack #browser-agent-dev')
-  .default('dev-channel-url', '')
+  .string('notifications-channel-url')
+  .describe('notifications-channel-url', 'Webhook URL to slack #browser-agent-notifications')
+  .default('notifications-channel-url', '')
 
   .string('dem-platform-ops-channel-url')
   .describe('dem-platform-ops-channel-url', 'Webhook URL to slack #dem-platform-ops')

--- a/.github/actions/slack-notification/args.js
+++ b/.github/actions/slack-notification/args.js
@@ -1,0 +1,20 @@
+import process from 'node:process'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+export const args = yargs(hideBin(process.argv))
+  .usage('$0 [options]')
+
+  .string('dev-channel-url')
+  .describe('dev-channel-url', 'Webhook URL to slack #browser-agent-dev')
+  .default('dev-channel-url', '')
+
+  .string('dem-platform-ops-channel-url')
+  .describe('dem-platform-ops-channel-url', 'Webhook URL to slack #dem-platform-ops')
+  .default('dem-platform-ops-channel-url', '')
+
+  .string('message')
+  .describe('message', 'The message to post to Slack channels')
+  .demandOption('message', 'Message is required')
+
+  .argv

--- a/.github/actions/slack-notification/index.js
+++ b/.github/actions/slack-notification/index.js
@@ -1,0 +1,31 @@
+import { args } from './args.js'
+import chalk from 'chalk'
+
+async function postToSlack (text) {
+  const channels = [
+    args.devChannelUrl,
+    args.demPlatformOpsChannelUrl,
+  ].filter(url => !!url)
+
+  for (const channel of channels) {
+    try {
+      const notificationRequest = await fetch(channel, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ text })
+      })
+
+      if (!notificationRequest.ok) {
+        throw new Error('Notification failed')
+      }
+
+      console.log(chalk.green('Notified Slack Channel'))
+    } catch (error) {
+      console.log(chalk.red(`Failed to post ${text} to Slack`))
+    }
+  }
+}
+
+await postToSlack(args.message)

--- a/.github/actions/slack-notification/index.js
+++ b/.github/actions/slack-notification/index.js
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 
 async function postToSlack (text) {
   const channels = [
-    args.devChannelUrl,
+    args.notificationsChannelUrl,
     args.demPlatformOpsChannelUrl,
   ].filter(url => !!url)
 
@@ -18,12 +18,12 @@ async function postToSlack (text) {
       })
 
       if (!notificationRequest.ok) {
-        throw new Error('Notification failed')
+        throw new Error('Notification failed for channel ' + channel)
       }
 
-      console.log(chalk.green('Notified Slack Channel'))
+      console.log(chalk.green('Successfully notified channel ' + channel))
     } catch (error) {
-      console.log(chalk.red(`Failed to post ${text} to Slack`))
+      console.log(chalk.red(`Failed to post ${text} to ` + channel))
     }
   }
 }

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -70,4 +70,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: Removed experiment in environment \\`'${{ inputs.nr_environment }}'\\` for branch \\`'${{ steps.clean-branch-name.outputs.results }}'\\`."
+          message: ":test_tube: Removed Browser Agent experiment in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\`. See Delete Experiment workflow at https://github.com/newrelic/newrelic-browser-agent/actions/workflows/delete-experiment.yml."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -51,7 +51,7 @@ jobs:
 
   # Notify about experiments in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'dev' }}
+    if: ${{ inputs.nr_environment == 'staging' }}
     needs: [delete-experiment-on-s3, republish-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -70,4 +70,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: Removed Browser Agent experiment in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\`. See Delete Experiment workflow at https://github.com/newrelic/newrelic-browser-agent/actions/workflows/delete-experiment.yml."
+          message: ":red-x: Removed browser agent experiment in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\`. See <https://github.com/newrelic/newrelic-browser-agent/actions/workflows/delete-experiment.yml|Delete Experiment> workflow."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -68,5 +68,6 @@ jobs:
       - name: Send Slack notifications
         uses: ./.github/actions/slack-notification
         with:
+          notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
           message: ":test_tube: Removed experiment in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -51,7 +51,7 @@ jobs:
 
   # Notify about experiments in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'staging' }}
+    if: ${{ inputs.nr_environment == 'dev' }}
     needs: [ delete-experiment-on-s3 ]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -52,7 +52,7 @@ jobs:
   # Notify about experiments in Slack
   send-slack-notifications:
     if: ${{ inputs.nr_environment == 'dev' }}
-    needs: [ delete-experiment-on-s3 ]
+    needs: [delete-experiment-on-s3, republish-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -48,3 +48,25 @@ jobs:
     needs: [delete-experiment-on-s3]
     uses: ./.github/workflows/publish-dev.yml
     secrets: inherit
+
+  # Notify about experiments in Slack
+  send-slack-notifications:
+    if: ${{ inputs.nr_environment == 'staging' }}
+    needs: [ delete-experiment-on-s3 ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Clean branch name
+        id: clean-branch-name
+        run: echo "results=$(echo '${{ github.ref }}' | sed 's/refs\/heads\///g' | sed 's/[^[:alnum:].-]/-/g')" >> $GITHUB_OUTPUT
+      - name: Send Slack notifications
+        uses: ./.github/actions/slack-notification
+        with:
+          dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
+          message: ":test_tube: Removed experiment in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -4,9 +4,6 @@
 
 name: Delete Experiment
 
-permissions:
-  contents: read
-
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -70,4 +70,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: Removed experiment in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."
+          message: ":test_tube: Removed experiment in environment \\`'${{ inputs.nr_environment }}'\\` for branch \\`'${{ steps.clean-branch-name.outputs.results }}'\\`."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -4,6 +4,9 @@
 
 name: Delete Experiment
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -283,6 +283,7 @@ jobs:
   create-staging-change-tracking:
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [publish-dev-to-s3]
+    continue-on-error: true
     runs-on: Browser-Agent-Assigned-IP-Linux
     timeout-minutes: 5
     defaults:

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -182,4 +182,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: New experiment published in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."
+          message: ":test_tube: New experiment published in environment \\`'${{ inputs.nr_environment }}'\\` for branch \\`'${{ steps.clean-branch-name.outputs.results }}'\\`."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -181,4 +181,4 @@ jobs:
         with:
           dev_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_DEV_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: New experiment published in environment `${{ inputs.nr_environment }}` for branch `${{ steps.clean-branch-name.outputs.results }}`."
+          message: ":test_tube: New experiment published in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -163,7 +163,7 @@ jobs:
 
   # Notify about new experiment in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'staging' }}
+    if: ${{ inputs.nr_environment == 'dev' }}
     needs: [publish-experiment-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -163,8 +163,8 @@ jobs:
 
   # Notify about new experiment in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'dev' }}
-    needs: [publish-experiment-to-s3]
+    if: ${{ inputs.nr_environment == 'dev' && inputs.publish_ab_script == true }}
+    needs: [publish-experiment-to-s3, publish-ab]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -163,6 +163,7 @@ jobs:
 
   # Notify about new experiment in Slack
   send-slack-notifications:
+    if: ${{ inputs.nr_environment == 'staging' }}
     needs: [publish-experiment-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -163,7 +163,7 @@ jobs:
 
   # Notify about new experiment in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'dev' && inputs.publish_ab_script == true }}
+    if: ${{ inputs.nr_environment == 'staging' && inputs.publish_ab_script == true }}
     needs: [publish-experiment-to-s3, publish-ab]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -182,4 +182,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: Browser Agent experiment published in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\` See Publish Experiment workflow at https://github.com/newrelic/newrelic-browser-agent/actions/workflows/publish-experiment.yml."
+          message: ":test_tube: Published browser agent experiment in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\`. See <https://github.com/newrelic/newrelic-browser-agent/actions/workflows/publish-experiment.yml|Publish Experiment> workflow."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -182,4 +182,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: New experiment published in environment \\`'${{ inputs.nr_environment }}'\\` for branch \\`'${{ steps.clean-branch-name.outputs.results }}'\\`."
+          message: ":test_tube: Browser Agent experiment published in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\` See Publish Experiment workflow at https://github.com/newrelic/newrelic-browser-agent/actions/workflows/publish-experiment.yml."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -160,3 +160,25 @@ jobs:
           commit: ${{ github.sha }}
           user: ${{ github.actor }}
           groupId: '${{ github.run_id }}-${{ github.sha }}'
+
+  # Notify about new experiment in Slack
+  send-slack-notifications:
+    needs: [publish-experiment-to-s3]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            ref: ${{ github.ref }}
+      - name: Clean branch name
+        id: clean-branch-name
+        run: echo "results=$(echo '${{ github.ref }}' | sed 's/refs\/heads\///g' | sed 's/[^[:alnum:].-]/-/g')" >> $GITHUB_OUTPUT
+      - name: Send Slack notifications
+        uses: ./.github/actions/slack-notification
+        with:
+          dev_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_DEV_WEBHOOK_URL }}
+          dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
+          message: ":test_tube: New experiment published in environment `${{ inputs.nr_environment }}` for branch `${{ steps.clean-branch-name.outputs.results }}`."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -180,6 +180,6 @@ jobs:
       - name: Send Slack notifications
         uses: ./.github/actions/slack-notification
         with:
-          dev_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_DEV_WEBHOOK_URL }}
+          notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
           message: ":test_tube: New experiment published in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."


### PR DESCRIPTION
Sends notifications to specified channels whenever experiments are deployed to or removed from staging
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-526518

### Testing

Tested with staging environment + Slack channels to ensure the notifications would work.
