### PR TITLE
chore: Notify staging deploys from main

### DIFF
--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -3,8 +3,8 @@
 name: 'Slack Notification'
 
 inputs:
-  dev_channel_url:
-    description: 'Slack API URL for the dev channel'
+  notifications_channel_url:
+    description: 'Slack API URL for the notifications channel'
     required: false
   dem_platform_ops_channel_url:
     description: 'Slack API URL for the dem platform ops release channel'
@@ -22,7 +22,7 @@ runs:
     - name: Send Slack notification
       run: |
         node $GITHUB_ACTION_PATH/index.js \
-          --dev-channel-url "${{ inputs.dev_channel_url }}" \
+          --notifications-channel-url "${{ inputs.notifications_channel_url }}" \
           --dem-platform-ops-channel-url "${{ inputs.dem_platform_ops_channel_url }}" \
           --message "${{ inputs.message }}"
       shell: bash

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -1,0 +1,28 @@
+# This composite action is used to post notifications to Slack channels.
+
+name: 'Slack Notification'
+
+inputs:
+  dev_channel_url:
+    description: 'Slack API URL for the dev channel'
+    required: false
+  dem_platform_ops_channel_url:
+    description: 'Slack API URL for the dem platform ops release channel'
+    required: false
+  message:
+    description: 'The message to post to Slack channels'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
+      shell: bash
+    - name: Send Slack notification
+      run: |
+        node $GITHUB_ACTION_PATH/index.js \
+          --dev-channel-url "${{ inputs.dev_channel_url }}" \
+          --dem-platform-ops-channel-url "${{ inputs.dem_platform_ops_channel_url }}" \
+          --message "${{ inputs.message }}"
+      shell: bash

--- a/.github/actions/slack-notification/args.js
+++ b/.github/actions/slack-notification/args.js
@@ -5,9 +5,9 @@ import { hideBin } from 'yargs/helpers'
 export const args = yargs(hideBin(process.argv))
   .usage('$0 [options]')
 
-  .string('dev-channel-url')
-  .describe('dev-channel-url', 'Webhook URL to slack #browser-agent-dev')
-  .default('dev-channel-url', '')
+  .string('notifications-channel-url')
+  .describe('notifications-channel-url', 'Webhook URL to slack #browser-agent-notifications')
+  .default('notifications-channel-url', '')
 
   .string('dem-platform-ops-channel-url')
   .describe('dem-platform-ops-channel-url', 'Webhook URL to slack #dem-platform-ops')

--- a/.github/actions/slack-notification/args.js
+++ b/.github/actions/slack-notification/args.js
@@ -1,0 +1,20 @@
+import process from 'node:process'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+export const args = yargs(hideBin(process.argv))
+  .usage('$0 [options]')
+
+  .string('dev-channel-url')
+  .describe('dev-channel-url', 'Webhook URL to slack #browser-agent-dev')
+  .default('dev-channel-url', '')
+
+  .string('dem-platform-ops-channel-url')
+  .describe('dem-platform-ops-channel-url', 'Webhook URL to slack #dem-platform-ops')
+  .default('dem-platform-ops-channel-url', '')
+
+  .string('message')
+  .describe('message', 'The message to post to Slack channels')
+  .demandOption('message', 'Message is required')
+
+  .argv

--- a/.github/actions/slack-notification/index.js
+++ b/.github/actions/slack-notification/index.js
@@ -1,0 +1,31 @@
+import { args } from './args.js'
+import chalk from 'chalk'
+
+async function postToSlack (text) {
+  const channels = [
+    args.devChannelUrl,
+    args.demPlatformOpsChannelUrl,
+  ].filter(url => !!url)
+
+  for (const channel of channels) {
+    try {
+      const notificationRequest = await fetch(channel, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ text })
+      })
+
+      if (!notificationRequest.ok) {
+        throw new Error('Notification failed')
+      }
+
+      console.log(chalk.green('Notified Slack Channel'))
+    } catch (error) {
+      console.log(chalk.red(`Failed to post ${text} to Slack`))
+    }
+  }
+}
+
+await postToSlack(args.message)

--- a/.github/actions/slack-notification/index.js
+++ b/.github/actions/slack-notification/index.js
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 
 async function postToSlack (text) {
   const channels = [
-    args.devChannelUrl,
+    args.notificationsChannelUrl,
     args.demPlatformOpsChannelUrl,
   ].filter(url => !!url)
 
@@ -18,12 +18,12 @@ async function postToSlack (text) {
       })
 
       if (!notificationRequest.ok) {
-        throw new Error('Notification failed')
+        throw new Error('Notification failed for channel ' + channel)
       }
 
-      console.log(chalk.green('Notified Slack Channel'))
+      console.log(chalk.green('Successfully notified channel ' + channel))
     } catch (error) {
-      console.log(chalk.red(`Failed to post ${text} to Slack`))
+      console.log(chalk.red(`Failed to post ${text} to ` + channel))
     }
   }
 }

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -70,4 +70,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: Removed experiment in environment \\`'${{ inputs.nr_environment }}'\\` for branch \\`'${{ steps.clean-branch-name.outputs.results }}'\\`."
+          message: ":test_tube: Removed Browser Agent experiment in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\`. See Delete Experiment workflow at https://github.com/newrelic/newrelic-browser-agent/actions/workflows/delete-experiment.yml."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -51,7 +51,7 @@ jobs:
 
   # Notify about experiments in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'dev' }}
+    if: ${{ inputs.nr_environment == 'staging' }}
     needs: [delete-experiment-on-s3, republish-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -70,4 +70,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: Removed Browser Agent experiment in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\`. See Delete Experiment workflow at https://github.com/newrelic/newrelic-browser-agent/actions/workflows/delete-experiment.yml."
+          message: ":red-x: Removed browser agent experiment in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\`. See <https://github.com/newrelic/newrelic-browser-agent/actions/workflows/delete-experiment.yml|Delete Experiment> workflow."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -68,5 +68,6 @@ jobs:
       - name: Send Slack notifications
         uses: ./.github/actions/slack-notification
         with:
+          notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
           message: ":test_tube: Removed experiment in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -51,7 +51,7 @@ jobs:
 
   # Notify about experiments in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'staging' }}
+    if: ${{ inputs.nr_environment == 'dev' }}
     needs: [ delete-experiment-on-s3 ]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -52,7 +52,7 @@ jobs:
   # Notify about experiments in Slack
   send-slack-notifications:
     if: ${{ inputs.nr_environment == 'dev' }}
-    needs: [ delete-experiment-on-s3 ]
+    needs: [delete-experiment-on-s3, republish-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -48,3 +48,25 @@ jobs:
     needs: [delete-experiment-on-s3]
     uses: ./.github/workflows/publish-dev.yml
     secrets: inherit
+
+  # Notify about experiments in Slack
+  send-slack-notifications:
+    if: ${{ inputs.nr_environment == 'staging' }}
+    needs: [ delete-experiment-on-s3 ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Clean branch name
+        id: clean-branch-name
+        run: echo "results=$(echo '${{ github.ref }}' | sed 's/refs\/heads\///g' | sed 's/[^[:alnum:].-]/-/g')" >> $GITHUB_OUTPUT
+      - name: Send Slack notifications
+        uses: ./.github/actions/slack-notification
+        with:
+          dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
+          message: ":test_tube: Removed experiment in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -4,9 +4,6 @@
 
 name: Delete Experiment
 
-permissions:
-  contents: read
-
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -70,4 +70,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: Removed experiment in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."
+          message: ":test_tube: Removed experiment in environment \\`'${{ inputs.nr_environment }}'\\` for branch \\`'${{ steps.clean-branch-name.outputs.results }}'\\`."

--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -4,6 +4,9 @@
 
 name: Delete Experiment
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -283,6 +283,7 @@ jobs:
   create-staging-change-tracking:
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [publish-dev-to-s3]
+    continue-on-error: true
     runs-on: Browser-Agent-Assigned-IP-Linux
     timeout-minutes: 5
     defaults:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -29,10 +29,27 @@ jobs:
     with:
       coverage: true
 
-  # Build and publish the latest code from the main branch
-  publish-dev-to-s3:
+  # Gate job to check if tests passed before proceeding with deployment
+  build-gate:
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [jest-tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check tests status
+        run: |
+          if [ "${{ needs.jest-tests.result }}" == "success" ]; then
+            echo "✅ Tests passed, proceeding with deployment"
+          elif [ "${{ needs.jest-tests.result }}" == "skipped" ]; then
+            echo "⏭️ Tests were skipped, proceeding with deployment"
+          else
+            echo "❌ Unexpected test result: ${{ needs.jest-tests.result }}"
+            exit 1
+          fi
+
+  # Build and publish the latest code from the main branch
+  publish-dev-to-s3:
+    needs: [build-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -221,7 +238,6 @@ jobs:
 
   # Rebuild and publish the dev environment A/B script
   publish-dev-ab:
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [publish-dev-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -251,7 +267,6 @@ jobs:
 
   # Rebuild and publish the staging environment A/B script
   publish-staging-ab:
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [publish-dev-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -282,7 +297,6 @@ jobs:
   # Create change tracking events for staging environment
   create-staging-change-tracking:
     environment: staging
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [publish-dev-to-s3]
     continue-on-error: true
     runs-on: Browser-Agent-Assigned-IP-Linux

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -105,7 +105,7 @@ jobs:
           asset_path: ${{ join(fromJson(steps.s3-upload.outputs.results).*.Key, ' ') }}
         # This step creates a new Change Tracking Marker
       - name: New Relic Application Deployment Marker
-        continue-on-error: true    
+        continue-on-error: true
         uses: newrelic/deployment-marker-action@v2.3.0
         with:
           apiKey: ${{ secrets.INTERNAL_STAGING_INGEST_LICENSE_KEY }}
@@ -114,7 +114,7 @@ jobs:
           version: "${{ github.ref_name }}"
           user: "${{ github.actor }}"
       - name: Get local stats
-        continue-on-error: true    
+        continue-on-error: true
         id: get-stats
         shell: bash
         run: |
@@ -122,7 +122,7 @@ jobs:
           full=$(cat ./build/nr-full-standard.stats.json); echo "full=$full" >> $GITHUB_OUTPUT;
           spa=$(cat ./build/nr-spa-standard.stats.json); echo "spa=$spa" >> $GITHUB_OUTPUT;
       - name: Report lite size to NR
-        continue-on-error: true    
+        continue-on-error: true
         uses: newrelic-apps/capture-build-size@v1.0.1
         with:
           nr-api-key: ${{ secrets.INTERNAL_STAGING_INGEST_LICENSE_KEY }}
@@ -144,7 +144,7 @@ jobs:
           trigger: 'publish-dev'
           traverse: true
       - name: Report spa size to NR
-        continue-on-error: true    
+        continue-on-error: true
         uses: newrelic-apps/capture-build-size@v1.0.1
         with:
           nr-api-key: ${{ secrets.INTERNAL_STAGING_INGEST_LICENSE_KEY }}
@@ -379,4 +379,35 @@ jobs:
           user: ${{ github.actor }}
           groupId: '${{ github.run_id }}-${{ github.sha }}'
 
+  # Notify about new staging deploy in Slack
+  send-slack-notifications:
+    if: github.event_name != 'workflow_call' # skip for delete-experiment (avoids double notices + no PR)
+    needs: [publish-staging-ab]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Get PR Description
+        id: get-pr-description
+        run: |
+          PR_NUMBER=$(git log -1 --pretty=%B | grep -oP '(?<=#)\d+' | head -1)
 
+          if [ -n "$PR_NUMBER" ]; then
+            PR_TITLE=$(gh pr view $PR_NUMBER --json title --jq '.title')
+            echo "text=PR #$PR_NUMBER: $PR_TITLE" >> $GITHUB_OUTPUT
+          else
+            echo "text=Manual deployment from main" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Send Slack notifications
+        uses: ./.github/actions/slack-notification
+        with:
+          notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
+          dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
+          message: ":tada: Published browser agent <https://github.com/newrelic/newrelic-browser-agent/commits/main/|main> latest in staging. ${{ steps.get-pr-description.outputs.text }}. Sent from this <https://github.com/newrelic/newrelic-browser-agent/actions/workflows/publish-dev.yml|workflow>."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -182,4 +182,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: New experiment published in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."
+          message: ":test_tube: New experiment published in environment \\`'${{ inputs.nr_environment }}'\\` for branch \\`'${{ steps.clean-branch-name.outputs.results }}'\\`."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -181,4 +181,4 @@ jobs:
         with:
           dev_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_DEV_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: New experiment published in environment `${{ inputs.nr_environment }}` for branch `${{ steps.clean-branch-name.outputs.results }}`."
+          message: ":test_tube: New experiment published in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -163,7 +163,7 @@ jobs:
 
   # Notify about new experiment in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'staging' }}
+    if: ${{ inputs.nr_environment == 'dev' }}
     needs: [publish-experiment-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -163,8 +163,8 @@ jobs:
 
   # Notify about new experiment in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'dev' }}
-    needs: [publish-experiment-to-s3]
+    if: ${{ inputs.nr_environment == 'dev' && inputs.publish_ab_script == true }}
+    needs: [publish-experiment-to-s3, publish-ab]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -163,6 +163,7 @@ jobs:
 
   # Notify about new experiment in Slack
   send-slack-notifications:
+    if: ${{ inputs.nr_environment == 'staging' }}
     needs: [publish-experiment-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -163,7 +163,7 @@ jobs:
 
   # Notify about new experiment in Slack
   send-slack-notifications:
-    if: ${{ inputs.nr_environment == 'dev' && inputs.publish_ab_script == true }}
+    if: ${{ inputs.nr_environment == 'staging' && inputs.publish_ab_script == true }}
     needs: [publish-experiment-to-s3, publish-ab]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -182,4 +182,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: Browser Agent experiment published in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\` See Publish Experiment workflow at https://github.com/newrelic/newrelic-browser-agent/actions/workflows/publish-experiment.yml."
+          message: ":test_tube: Published browser agent experiment in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\`. See <https://github.com/newrelic/newrelic-browser-agent/actions/workflows/publish-experiment.yml|Publish Experiment> workflow."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -105,7 +105,7 @@ jobs:
     if: ${{ inputs.publish_ab_script == true }}
     needs: [publish-experiment-to-s3]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -182,4 +182,4 @@ jobs:
         with:
           notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
-          message: ":test_tube: New experiment published in environment \\`'${{ inputs.nr_environment }}'\\` for branch \\`'${{ steps.clean-branch-name.outputs.results }}'\\`."
+          message: ":test_tube: Browser Agent experiment published in \\`${{ inputs.nr_environment }}\\` for branch \\`${{ steps.clean-branch-name.outputs.results }}\\` See Publish Experiment workflow at https://github.com/newrelic/newrelic-browser-agent/actions/workflows/publish-experiment.yml."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -160,3 +160,25 @@ jobs:
           commit: ${{ github.sha }}
           user: ${{ github.actor }}
           groupId: '${{ github.run_id }}-${{ github.sha }}'
+
+  # Notify about new experiment in Slack
+  send-slack-notifications:
+    needs: [publish-experiment-to-s3]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            ref: ${{ github.ref }}
+      - name: Clean branch name
+        id: clean-branch-name
+        run: echo "results=$(echo '${{ github.ref }}' | sed 's/refs\/heads\///g' | sed 's/[^[:alnum:].-]/-/g')" >> $GITHUB_OUTPUT
+      - name: Send Slack notifications
+        uses: ./.github/actions/slack-notification
+        with:
+          dev_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_DEV_WEBHOOK_URL }}
+          dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
+          message: ":test_tube: New experiment published in environment `${{ inputs.nr_environment }}` for branch `${{ steps.clean-branch-name.outputs.results }}`."

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -180,6 +180,6 @@ jobs:
       - name: Send Slack notifications
         uses: ./.github/actions/slack-notification
         with:
-          dev_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_DEV_WEBHOOK_URL }}
+          notifications_channel_url: ${{ secrets.SLACK_BROWSER_AGENT_NOTIFICATIONS_WEBHOOK_URL }}
           dem_platform_ops_channel_url: ${{ secrets.SLACK_DEM_PLATFORM_OPS_WEBHOOK_URL }}
           message: ":test_tube: New experiment published in environment \`'${{ inputs.nr_environment }}'\` for branch \`'${{ steps.clean-branch-name.outputs.results }}'\`."


### PR DESCRIPTION
Send Slack notifications for when there are staging deployments from the main branch.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-526518

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
