### PR TITLE
feat: remove "withCredentials"

### DIFF
--- a/src/common/util/submit-data.js
+++ b/src/common/util/submit-data.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -59,7 +59,7 @@ export function xhrFetch ({
     objHeaders[header.key] = header.value
   }
 
-  return fetch(url, { headers: objHeaders, method, body, credentials: 'include' })
+  return fetch(url, { headers: objHeaders, method, body })
 }
 
 /**
@@ -76,12 +76,6 @@ export function xhr ({ url, body = null, sync, method = 'POST', headers = [{ key
   const request = new XMLHttpRequest()
 
   request.open(method, url, !sync)
-  try {
-    // Set cookie
-    if ('withCredentials' in request) request.withCredentials = true
-  } catch (e) {
-    // do nothing
-  }
 
   headers.forEach(header => {
     request.setRequestHeader(header.key, header.value)

--- a/tests/unit/common/util/submit-data.test.js
+++ b/tests/unit/common/util/submit-data.test.js
@@ -51,12 +51,6 @@ describe('xhr', () => {
       this.open = jest.fn()
       this.send = jest.fn()
       this.setRequestHeader = jest.fn()
-
-      this._withCredentials = false
-      Object.defineProperty(this, 'withCredentials', {
-        get: jest.fn(() => this._withCredentials),
-        set: jest.fn((val) => { this._withCredentials = val })
-      })
     })
   })
 
@@ -65,7 +59,6 @@ describe('xhr', () => {
     const xhr = jest.mocked(global.XMLHttpRequest).mock.instances[0]
 
     expect(result).toBeInstanceOf(XMLHttpRequest)
-    expect(result.withCredentials).toBe(true)
     expect(xhr.open).toHaveBeenCalledWith('POST', url, true)
     expect(xhr.setRequestHeader).toHaveBeenCalledWith('content-type', 'text/plain')
     expect(xhr.send).toHaveBeenCalledWith(null)
@@ -100,33 +93,6 @@ describe('xhr', () => {
 
     expect(xhr.setRequestHeader).not.toHaveBeenCalledWith('content-type', 'text/plain')
     expect(xhr.setRequestHeader).toHaveBeenCalledWith(headers[0].key, headers[0].value)
-  })
-
-  test('should not throw an error if withCredentials is not supported', () => {
-    jest.spyOn(global, 'XMLHttpRequest').mockImplementation(function () {
-      this.prototype = XMLHttpRequest.prototype
-      this.open = jest.fn()
-      this.send = jest.fn()
-      this.setRequestHeader = jest.fn()
-    })
-
-    expect(() => submitData.xhr({ url })).not.toThrow()
-  })
-
-  test('should not throw an error if setRequestHeader throws an error', () => {
-    jest.spyOn(global, 'XMLHttpRequest').mockImplementation(function () {
-      this.prototype = XMLHttpRequest.prototype
-      this.open = jest.fn()
-      this.send = jest.fn()
-      this.setRequestHeader = jest.fn()
-
-      Object.defineProperty(this, 'withCredentials', {
-        get: jest.fn().mockImplementation(() => { throw new Error(faker.lorem.sentence()) }),
-        set: jest.fn().mockImplementation(() => { throw new Error(faker.lorem.sentence()) })
-      })
-    })
-
-    expect(() => submitData.xhr({ url })).not.toThrow()
   })
 })
 


### PR DESCRIPTION
Remove all usage of `withCredentials` or `credentials: 'include'` from agent harvests, as cookies have not been used in the agent since before [v1220](https://github.com/newrelic/newrelic-browser-agent/releases/tag/v1220).
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-538185?atlOrigin=eyJpIjoiZjJkNmRkYTM4OTJkNDk2N2I2OWI2MGExMTlkMGVjMzYiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
