### PR TITLE
feat: Adjust timestamps for clock skew due to machine sleep

### DIFF
--- a/src/common/timing/time-keeper.js
+++ b/src/common/timing/time-keeper.js
@@ -40,7 +40,12 @@ export class TimeKeeper {
    */
   #ready = false
 
-  #reportedDrift = false
+  /**
+   * The total measured drift in milliseconds. Represents how much performance.now()
+   * has fallen behind Date.now(), which is used to correct timestamp conversions.
+   * @type {number}
+   */
+  #measuredDrift = 0
 
   constructor (sessionObj) {
     this.#session = sessionObj
@@ -49,7 +54,6 @@ export class TimeKeeper {
   }
 
   #detectDrift () {
-    if (this.#reportedDrift) return
     try {
       // Drift detection: measures if performance.now() and Date.now() have become desynchronized
       // This can happen when a machine sleeps and the performance timer freezes while Date continues
@@ -60,8 +64,13 @@ export class TimeKeeper {
       // Note: localTimeDiff (server time offset) is NOT part of drift - that's a legitimate offset
       const drift = (Date.now() - originTime) - performance.now()
       if (drift > 1000) {
-        this.#reportedDrift = true
-        handle(SUPPORTABILITY_METRIC_CHANNEL, ['Generic/TimeKeeper/ClockDrift/Detected', drift], undefined, FEATURE_NAMES.metrics, this.#session.agentRef.ee)
+        // Check if this is new drift (increase of >1000ms from last measurement)
+        const newDrift = drift - this.#measuredDrift
+        if (newDrift > 1000) {
+          // Update measured drift and report it
+          this.#measuredDrift = drift
+          if (this.#session) handle(SUPPORTABILITY_METRIC_CHANNEL, ['Generic/TimeKeeper/ClockDrift/Detected', drift], undefined, FEATURE_NAMES.metrics, this.#session.agentRef.ee)
+        }
       }
     } catch (err) {
       // Silently ignore drift detection errors to avoid breaking normal operation
@@ -116,7 +125,8 @@ export class TimeKeeper {
    */
   convertRelativeTimestamp (relativeTime) {
     this.#detectDrift()
-    return originTime + relativeTime
+    // Add measured drift to compensate for performance.now() falling behind
+    return originTime + relativeTime + this.#measuredDrift
   }
 
   /**
@@ -127,7 +137,8 @@ export class TimeKeeper {
    */
   convertAbsoluteTimestamp (timestamp) {
     this.#detectDrift()
-    return timestamp - originTime
+    // Subtract measured drift since we're converting from absolute to relative
+    return timestamp - originTime - this.#measuredDrift
   }
 
   /**

--- a/tests/assets/clock-drift-simulation.html
+++ b/tests/assets/clock-drift-simulation.html
@@ -7,36 +7,41 @@
   <head>
     <title>Clock Drift Simulation</title>
     <script>
-      // Save original performance.now
+      // Save original performance.now and Date.now
       var origPerformanceNow = performance.now.bind(performance);
       var origDateNow = Date.now.bind(Date);
       
       // Capture the initial values at page load
       var frozenPerformanceValue = null;
-      var freezeStartTime = null;
+      var mockDateOffset = 0;
       
-      // Function to simulate clock drift by freezing performance.now()
-      window.simulateClockFreeze = function(durationMs) {
-        if (!frozenPerformanceValue) {
-          frozenPerformanceValue = origPerformanceNow();
-          freezeStartTime = origDateNow();
+      // Function to simulate clock drift by freezing performance.now() and advancing Date.now()
+      window.simulateClockFreeze = function(driftDurationMs) {
+        return new Promise(resolve => {
+          // Freeze performance.now() at current value on first call, or keep it frozen
+          if (frozenPerformanceValue === null) {
+            frozenPerformanceValue = origPerformanceNow();
+            
+            // Override performance.now to return frozen value
+            performance.now = function() {
+              return frozenPerformanceValue;
+            };
+            
+            console.log('Clock frozen at performance.now() =', frozenPerformanceValue);
+          }
           
-          // Override performance.now to return frozen value
-          performance.now = function() {
-            return frozenPerformanceValue;
+          // Advance Date.now() by the drift amount (instant, no waiting)
+          mockDateOffset += driftDurationMs;
+          
+          Date.now = function() {
+            return origDateNow() + mockDateOffset;
           };
           
-          console.log('Clock frozen at performance.now() =', frozenPerformanceValue);
-          console.log('Date will continue advancing, creating drift');
-        }
-        
-        return new Promise(resolve => {
-          setTimeout(() => {
-            const actualElapsed = origDateNow() - freezeStartTime;
-            const drift = actualElapsed; // performance stayed frozen
-            console.log('Drift created:', drift, 'ms');
-            resolve(drift);
-          }, durationMs);
+          console.log('Date.now() advanced by', driftDurationMs, 'ms (total offset:', mockDateOffset, 'ms)');
+          console.log('Drift created:', mockDateOffset, 'ms');
+          
+          // Resolve immediately - no actual waiting
+          resolve(mockDateOffset);
         });
       };
       
@@ -44,8 +49,9 @@
       window.unfreezeClocks = function() {
         if (frozenPerformanceValue !== null) {
           performance.now = origPerformanceNow;
+          Date.now = origDateNow;
           frozenPerformanceValue = null;
-          freezeStartTime = null;
+          mockDateOffset = 0;
           console.log('Clocks unfrozen');
         }
       };

--- a/tests/specs/clock-drift-detection.e2e.js
+++ b/tests/specs/clock-drift-detection.e2e.js
@@ -1,10 +1,12 @@
-import { testSupportMetricsRequest } from '../../tools/testing-server/utils/expect-tests'
+import { testSupportMetricsRequest, testInsRequest } from '../../tools/testing-server/utils/expect-tests'
 
 describe('Clock Drift Detection', () => {
   let supportabilityMetricsCapture
+  let insightsCapture
 
   beforeEach(async () => {
     supportabilityMetricsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testSupportMetricsRequest })
+    insightsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testInsRequest })
   })
 
   afterEach(async () => {
@@ -12,44 +14,183 @@ describe('Clock Drift Detection', () => {
   })
 
   it('should detect drift when performance.now() freezes while Date.now() continues', async () => {
-    await browser.url(await browser.testHandle.assetURL('clock-drift-simulation.html', { loader: 'rum' }))
+    await browser.url(await browser.testHandle.assetURL('clock-drift-simulation.html', { loader: 'spa' }))
       .then(() => browser.waitForAgentLoad())
 
-    // Simulate a 2-second clock freeze (drift)
-    await browser.executeAsync(function (done) {
-      window.simulateClockFreeze(2000).then(done)
-    })
-
-    // Trigger drift detection by calling TimeKeeper methods
+    // Wait for the initial RUM call to complete so TimeKeeper is ready
     await browser.execute(function () {
       const agent = Object.values(newrelic.initializedAgents)[0]
       const timeKeeper = agent.runtime.timeKeeper
-
-      // Call a method that triggers drift detection
-      timeKeeper.convertRelativeTimestamp(performance.now())
+      // Ensure TimeKeeper is initialized by waiting for it to be ready
+      return new Promise((resolve) => {
+        const checkReady = () => {
+          if (timeKeeper.ready) {
+            resolve()
+          } else {
+            setTimeout(checkReady, 10)
+          }
+        }
+        checkReady()
+      })
     })
 
-    // Navigate away to trigger final harvest with supportability metrics
-    const [metricsHarvests] = await Promise.all([
-      supportabilityMetricsCapture.waitForResult({ totalCount: 1 }),
+    // Capture timestamps before drift
+    const beforeDrift = await browser.execute(function () {
+      const agent = Object.values(newrelic.initializedAgents)[0]
+      const timeKeeper = agent.runtime.timeKeeper
+      const perfNow = performance.now()
+      const dateNow = Date.now()
+
+      // Add a page action before the drift with timing data
+      newrelic.addPageAction('beforeDrift', {
+        perfNow,
+        dateNow,
+        convertedTimestamp: timeKeeper.convertRelativeTimestamp(perfNow)
+      })
+
+      return {
+        perfNow,
+        dateNow,
+        convertedTimestamp: timeKeeper.convertRelativeTimestamp(perfNow)
+      }
+    })
+
+    // Simulate a 4-hour clock freeze (drift) - realistic machine sleep scenario
+    await browser.execute(function () {
+      return window.simulateClockFreeze(14400000)
+    })
+
+    // Trigger drift detection and capture corrected timestamps
+    const afterDrift = await browser.execute(function () {
+      const agent = Object.values(newrelic.initializedAgents)[0]
+      const timeKeeper = agent.runtime.timeKeeper
+
+      // Log to verify the freeze worked
+      const perfNow = performance.now()
+      const dateNow = Date.now()
+
+      // Trigger drift detection multiple times to ensure it fires
+      for (let i = 0; i < 5; i++) {
+        timeKeeper.convertRelativeTimestamp(perfNow)
+        timeKeeper.convertAbsoluteTimestamp(dateNow)
+      }
+
+      // Call a method that triggers drift detection
+      const convertedTimestamp = timeKeeper.convertRelativeTimestamp(perfNow)
+      const convertedAbsolute = timeKeeper.convertAbsoluteTimestamp(dateNow)
+
+      // Add a page action after the drift with timing data
+      newrelic.addPageAction('afterDrift', {
+        perfNow,
+        dateNow,
+        convertedTimestamp,
+        convertedAbsolute
+      })
+
+      return {
+        perfNow,
+        dateNow,
+        convertedTimestamp,
+        convertedAbsolute
+      }
+    })
+
+    // Verify that timestamps are corrected for drift
+    // After drift, Date.now() has advanced ~4 hours more than performance.now()
+    // The converted timestamp should add the drift to compensate
+    const expectedDrift = Math.floor((afterDrift.dateNow - beforeDrift.dateNow) - (afterDrift.perfNow - beforeDrift.perfNow))
+    expect(expectedDrift).toBeGreaterThan(14000000) // ~4 hours
+
+    // The converted timestamp should be close to Date.now() because it includes drift correction
+    const timestampDifference = Math.abs(afterDrift.convertedTimestamp - afterDrift.dateNow)
+    expect(timestampDifference).toBeLessThan(100) // Allow small tolerance for execution time
+
+    // convertAbsoluteTimestamp should give us back approximately performance.now() (subtracting drift)
+    const absoluteDifference = Math.abs(afterDrift.convertedAbsolute - afterDrift.perfNow)
+    expect(absoluteDifference).toBeLessThan(100)
+
+    // Small delay to ensure page actions are buffered
+    await browser.pause(100)
+
+    // Unfreeze clocks before triggering harvest to avoid timer issues
+    await browser.execute(function () {
+      window.unfreezeClocks()
+    })
+
+    // Trigger harvest by navigating away
+    const [insightsHarvests, metricsHarvests] = await Promise.all([
+      insightsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      supportabilityMetricsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
       browser.url(await browser.testHandle.assetURL('/'))
     ])
 
+    // Verify page action timestamps
+    expect(insightsHarvests).toBeDefined()
+    expect(insightsHarvests.length).toBeGreaterThan(0)
+
+    const allInsights = insightsHarvests[0].request.body.ins
+    // Filter to only PageAction events (exclude UserAction like blur)
+    const pageActions = allInsights.filter(event => event.eventType === 'PageAction')
+    expect(pageActions).toHaveLength(2)
+
+    // Find the before and after page actions
+    const beforeAction = pageActions.find(pa => pa.actionName === 'beforeDrift')
+    const afterAction = pageActions.find(pa => pa.actionName === 'afterDrift')
+
+    expect(beforeAction).toBeDefined()
+    expect(afterAction).toBeDefined()
+
+    // Verify the page action attributes are close to what we captured
+    // Note: perfNow might differ slightly between beforeDrift capture and the freeze point
+    expect(Math.abs(beforeAction.perfNow - beforeDrift.perfNow)).toBeLessThan(500) // Allow up to 500ms for execution time
+    expect(Math.abs(beforeAction.dateNow - beforeDrift.dateNow)).toBeLessThan(500)
+    expect(Math.abs(beforeAction.convertedTimestamp - beforeDrift.convertedTimestamp)).toBeLessThan(500)
+
+    // After drift, perfNow should be frozen (same value in page action as captured)
+    expect(Math.abs(afterAction.perfNow - afterDrift.perfNow)).toBeLessThan(1)
+    expect(Math.abs(afterAction.dateNow - afterDrift.dateNow)).toBeLessThan(1)
+    expect(Math.abs(afterAction.convertedTimestamp - afterDrift.convertedTimestamp)).toBeLessThan(1)
+    expect(Math.abs(afterAction.convertedAbsolute - afterDrift.convertedAbsolute)).toBeLessThan(1)
+
+    // The before-drift page action timestamp should be close to its dateNow
+    // (no drift correction needed since drift hadn't happened yet)
+    const beforeActionDiff = Math.abs(beforeAction.timestamp - beforeAction.dateNow)
+    expect(beforeActionDiff).toBeLessThan(1000) // Allow 1 second tolerance due to network time for wdio tests
+
+    // The after-drift page action timestamp should be close to its dateNow
+    // It should be corrected to current time, NOT 4 hours behind
+    const afterActionDiff = Math.abs(afterAction.timestamp - afterAction.dateNow)
+    expect(afterActionDiff).toBeLessThan(1000) // Should be corrected to current time
+
+    // Verify the difference between the two page actions is approximately the drift amount
+    const timeDiffBetweenActions = afterAction.timestamp - beforeAction.timestamp
+    expect(timeDiffBetweenActions).toBeGreaterThan(14000000) // Should be ~4 hours apart
+
+    // Also verify using the captured dateNow values
+    const dateDiff = afterAction.dateNow - beforeAction.dateNow
+    expect(dateDiff).toBeGreaterThan(14000000) // Date.now() advanced ~4 hours
+
+    // perfNow increased slightly before freezing, but stayed frozen after
+    // The key is that Date.now advanced much more than perfNow
+    const perfDiff = afterAction.perfNow - beforeAction.perfNow
+    expect(perfDiff).toBeLessThan(1000) // Should be minimal (just wdio network + execution time before freeze)
+    expect(dateDiff - perfDiff).toBeGreaterThan(14000000) // The drift amount
+
+    // Verify the supportability metric was reported
+    expect(metricsHarvests.length).toBeGreaterThan(0)
     const supportabilityMetrics = metricsHarvests[0].request.body.sm
 
-    // Look for the drift detection metric
     const driftMetric = supportabilityMetrics.find(sm =>
       sm.params.name === 'Generic/TimeKeeper/ClockDrift/Detected'
     )
-
     expect(driftMetric).toBeDefined()
-    expect(driftMetric.stats.t).toBeGreaterThan(1000) // Drift value should be > 1000ms
+    expect(driftMetric.stats.t).toBeGreaterThan(14400000) // Should report ~4 hours of drift
   })
 
   it('should NOT detect drift with normal server time offset', async () => {
     // Load page with 1-hour server offset to verify it doesn't trigger drift detection
     await browser.url(await browser.testHandle.assetURL('instrumented.html', {
-      loader: 'rum',
+      loader: 'spa',
       init: {
         app: { nrServerTime: Date.now() + 3600000 } // 1 hour in the future
       }
@@ -69,17 +210,172 @@ describe('Clock Drift Detection', () => {
 
     // Navigate away to trigger final harvest
     const [metricsHarvests] = await Promise.all([
-      supportabilityMetricsCapture.waitForResult({ totalCount: 1 }),
-      browser.refresh()
+      supportabilityMetricsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      browser.url(await browser.testHandle.assetURL('/'))
     ])
 
     const supportabilityMetrics = metricsHarvests[0].request.body.sm
 
-    // Check that NO drift was detected
+    // Check that NO drift was detected (no 'Generic/TimeKeeper/ClockDrift/Detected' metric)
     const driftMetric = supportabilityMetrics.find(sm =>
       sm.params.name === 'Generic/TimeKeeper/ClockDrift/Detected'
     )
+    expect(driftMetric).toBeUndefined()
+  })
 
-    expect(driftMetric).toBeUndefined() // Should NOT detect drift from server offset
+  it('should handle multiple drift events and continue correcting timestamps', async () => {
+    await browser.url(await browser.testHandle.assetURL('clock-drift-simulation.html', { loader: 'spa' }))
+      .then(() => browser.waitForAgentLoad())
+
+    // Add initial page action before any drift
+    const initial = await browser.execute(function () {
+      const perfNow = performance.now()
+      const dateNow = Date.now()
+
+      newrelic.addPageAction('initial', {
+        perfNow,
+        dateNow
+      })
+
+      return { perfNow, dateNow }
+    })
+
+    // First drift event: 4 hours
+    await browser.execute(function () {
+      return window.simulateClockFreeze(14400000)
+    })
+
+    const afterFirstDrift = await browser.execute(function () {
+      const agent = Object.values(newrelic.initializedAgents)[0]
+      const timeKeeper = agent.runtime.timeKeeper
+      const perfNow = performance.now()
+      const dateNow = Date.now()
+      const convertedTimestamp = timeKeeper.convertRelativeTimestamp(perfNow)
+
+      // Add page action after first drift
+      newrelic.addPageAction('afterFirstDrift', {
+        perfNow,
+        dateNow,
+        convertedTimestamp
+      })
+
+      return {
+        perfNow,
+        dateNow,
+        convertedTimestamp
+      }
+    })
+
+    // Verify first drift correction
+    // Note: Some drift may accumulate during test execution, so allow reasonable tolerance
+    const firstDriftCheck = Math.abs(afterFirstDrift.convertedTimestamp - afterFirstDrift.dateNow)
+    expect(firstDriftCheck).toBeLessThan(500) // Allow tolerance for execution time and wdio overhead
+
+    // Second drift event: another 2 hours
+    await browser.execute(function () {
+      return window.simulateClockFreeze(7200000)
+    })
+
+    const afterSecondDrift = await browser.execute(function () {
+      const agent = Object.values(newrelic.initializedAgents)[0]
+      const timeKeeper = agent.runtime.timeKeeper
+      const perfNow = performance.now()
+      const dateNow = Date.now()
+      const convertedTimestamp = timeKeeper.convertRelativeTimestamp(perfNow)
+
+      // Add page action after second drift
+      newrelic.addPageAction('afterSecondDrift', {
+        perfNow,
+        dateNow,
+        convertedTimestamp
+      })
+
+      return {
+        perfNow,
+        dateNow,
+        convertedTimestamp
+      }
+    })
+
+    // Verify second drift correction (cumulative ~6 hours total drift)
+    // Note: Some drift may accumulate during test execution, so allow reasonable tolerance
+    const secondDriftCheck = Math.abs(afterSecondDrift.convertedTimestamp - afterSecondDrift.dateNow)
+    expect(secondDriftCheck).toBeLessThan(500) // Allow tolerance for execution time and wdio overhead
+
+    // Small delay to ensure page actions are buffered
+    await browser.pause(100)
+
+    // Unfreeze clocks before triggering harvest to avoid timer issues
+    await browser.execute(function () {
+      window.unfreezeClocks()
+    })
+
+    // Trigger harvest by navigating away
+    const [insightsHarvests, metricsHarvests] = await Promise.all([
+      insightsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      supportabilityMetricsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      browser.url(await browser.testHandle.assetURL('/'))
+    ])
+
+    // Verify page actions were collected with correct timestamps
+    expect(insightsHarvests).toBeDefined()
+    expect(insightsHarvests.length).toBeGreaterThan(0)
+
+    const allInsights = insightsHarvests[0].request.body.ins
+    // Filter to only PageAction events (exclude UserAction like blur)
+    const pageActions = allInsights.filter(event => event.eventType === 'PageAction')
+    expect(pageActions.length).toBeGreaterThanOrEqual(3)
+
+    const initialAction = pageActions.find(pa => pa.actionName === 'initial')
+    const firstDriftAction = pageActions.find(pa => pa.actionName === 'afterFirstDrift')
+    const secondDriftAction = pageActions.find(pa => pa.actionName === 'afterSecondDrift')
+
+    expect(initialAction).toBeDefined()
+    expect(firstDriftAction).toBeDefined()
+    expect(secondDriftAction).toBeDefined()
+
+    // Verify attributes are close to captured values (allow for execution time)
+    expect(Math.abs(initialAction.perfNow - initial.perfNow)).toBeLessThan(500)
+    expect(Math.abs(initialAction.dateNow - initial.dateNow)).toBeLessThan(500)
+
+    expect(Math.abs(firstDriftAction.perfNow - afterFirstDrift.perfNow)).toBeLessThan(1)
+    expect(Math.abs(firstDriftAction.dateNow - afterFirstDrift.dateNow)).toBeLessThan(1)
+    expect(Math.abs(firstDriftAction.convertedTimestamp - afterFirstDrift.convertedTimestamp)).toBeLessThan(1)
+
+    expect(Math.abs(secondDriftAction.perfNow - afterSecondDrift.perfNow)).toBeLessThan(1)
+    expect(Math.abs(secondDriftAction.dateNow - afterSecondDrift.dateNow)).toBeLessThan(1)
+    expect(Math.abs(secondDriftAction.convertedTimestamp - afterSecondDrift.convertedTimestamp)).toBeLessThan(1)
+
+    // perfNow should stay approximately frozen after first drift (allowing for small execution time before freeze)
+    expect(Math.abs(firstDriftAction.perfNow - initialAction.perfNow)).toBeLessThan(1000)
+    expect(Math.abs(secondDriftAction.perfNow - firstDriftAction.perfNow)).toBeLessThan(10) // Very close after frozen
+
+    // dateNow should advance with each drift
+    const dateDiff1 = firstDriftAction.dateNow - initialAction.dateNow
+    expect(dateDiff1).toBeGreaterThan(14000000) // ~4 hours
+
+    const dateDiff2 = secondDriftAction.dateNow - firstDriftAction.dateNow
+    expect(dateDiff2).toBeGreaterThan(7000000) // ~2 hours
+
+    // Page action timestamps should reflect the drift-corrected time
+    const actionTimeDiff1 = firstDriftAction.timestamp - initialAction.timestamp
+    expect(actionTimeDiff1).toBeGreaterThan(14000000) // ~4 hours
+
+    const actionTimeDiff2 = secondDriftAction.timestamp - firstDriftAction.timestamp
+    expect(actionTimeDiff2).toBeGreaterThan(7000000) // ~2 hours
+
+    // Verify supportability metrics were reported
+    expect(metricsHarvests.length).toBeGreaterThan(0)
+    const supportabilityMetrics = metricsHarvests[0].request.body.sm
+
+    // Should have reported drift detection (at least once, possibly twice)
+    const driftMetrics = supportabilityMetrics.filter(sm =>
+      sm.params.name === 'Generic/TimeKeeper/ClockDrift/Detected'
+    )
+
+    expect(driftMetrics.length).toBeGreaterThan(0)
+    // Count should be at least 1 (may report both drift events or aggregate them)
+    const totalCount = driftMetrics.reduce((sum, metric) => sum + metric.stats.c, 0)
+    expect(totalCount).toBeGreaterThanOrEqual(1)
   })
 })

--- a/tests/specs/clock-drift-detection.e2e.js
+++ b/tests/specs/clock-drift-detection.e2e.js
@@ -58,11 +58,9 @@ describe('Clock Drift Detection', () => {
     })
 
     // Simulate a 4-hour clock freeze (drift) - realistic machine sleep scenario
-    const freezeResult = await browser.execute(function () {
+    await browser.execute(function () {
       return window.simulateClockFreeze(14400000)
     })
-
-    console.log('Clock freeze result:', freezeResult)
 
     // Trigger drift detection and capture corrected timestamps
     const afterDrift = await browser.execute(function () {
@@ -246,11 +244,9 @@ describe('Clock Drift Detection', () => {
     })
 
     // First drift event: 4 hours
-    const firstFreezeResult = await browser.execute(function () {
+    await browser.execute(function () {
       return window.simulateClockFreeze(14400000)
     })
-
-    console.log('First clock freeze result:', firstFreezeResult)
 
     const afterFirstDrift = await browser.execute(function () {
       const agent = Object.values(newrelic.initializedAgents)[0]

--- a/tests/specs/clock-drift-detection.e2e.js
+++ b/tests/specs/clock-drift-detection.e2e.js
@@ -1,4 +1,5 @@
 import { testSupportMetricsRequest, testInsRequest } from '../../tools/testing-server/utils/expect-tests'
+import { notFirefox } from '../../tools/browser-matcher/common-matchers.mjs'
 
 describe('Clock Drift Detection', () => {
   let supportabilityMetricsCapture
@@ -13,7 +14,8 @@ describe('Clock Drift Detection', () => {
     await browser.destroyAgentSession()
   })
 
-  it('should detect drift when performance.now() freezes while Date.now() continues', async () => {
+  // Firefox doesn't maintain performance.now() overrides across browser.execute() calls, so we can't reliably simulate clock drift
+  it.withBrowsersMatching(notFirefox)('should detect drift when performance.now() freezes while Date.now() continues', async () => {
     await browser.url(await browser.testHandle.assetURL('clock-drift-simulation.html', { loader: 'spa' }))
       .then(() => browser.waitForAgentLoad())
 
@@ -56,9 +58,11 @@ describe('Clock Drift Detection', () => {
     })
 
     // Simulate a 4-hour clock freeze (drift) - realistic machine sleep scenario
-    await browser.execute(function () {
+    const freezeResult = await browser.execute(function () {
       return window.simulateClockFreeze(14400000)
     })
+
+    console.log('Clock freeze result:', freezeResult)
 
     // Trigger drift detection and capture corrected timestamps
     const afterDrift = await browser.execute(function () {
@@ -223,7 +227,8 @@ describe('Clock Drift Detection', () => {
     expect(driftMetric).toBeUndefined()
   })
 
-  it('should handle multiple drift events and continue correcting timestamps', async () => {
+  // Firefox doesn't allow performance.now() overrides so we can't reliably simulate clock drift
+  it.withBrowsersMatching(notFirefox)('should handle multiple drift events and continue correcting timestamps', async () => {
     await browser.url(await browser.testHandle.assetURL('clock-drift-simulation.html', { loader: 'spa' }))
       .then(() => browser.waitForAgentLoad())
 
@@ -241,9 +246,11 @@ describe('Clock Drift Detection', () => {
     })
 
     // First drift event: 4 hours
-    await browser.execute(function () {
+    const firstFreezeResult = await browser.execute(function () {
       return window.simulateClockFreeze(14400000)
     })
+
+    console.log('First clock freeze result:', firstFreezeResult)
 
     const afterFirstDrift = await browser.execute(function () {
       const agent = Object.values(newrelic.initializedAgents)[0]

--- a/tests/unit/common/timing/time-keeper.test.js
+++ b/tests/unit/common/timing/time-keeper.test.js
@@ -23,7 +23,10 @@ beforeEach(() => {
   }
   session = {
     read: jest.fn(),
-    write: jest.fn()
+    write: jest.fn(),
+    agentRef: {
+      ee: eventEmitter
+    }
   }
   serverTime = 1706213061000
 
@@ -277,5 +280,176 @@ describe('session entity integration', () => {
     expect(sessionTimeKeeper.ready).toEqual(false)
 
     expect(session.write).not.toHaveBeenCalled()
+  })
+})
+
+describe('clock drift detection and correction', () => {
+  let mockPerformanceNow
+  let mockDateNow
+  let handleModule
+
+  beforeEach(() => {
+    // Use real timers for drift detection tests
+    jest.useRealTimers()
+
+    mockPerformanceNow = jest.spyOn(performance, 'now')
+    mockDateNow = jest.spyOn(Date, 'now')
+
+    // Mock the handle module
+    handleModule = require('../../../../src/common/event-emitter/handle')
+    jest.spyOn(handleModule, 'handle').mockImplementation(() => {})
+
+    // Setup TimeKeeper with server time
+    timeKeeper.processRumRequest({}, startTime, endTime, new Date(serverTime) - 0)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.useFakeTimers({ now: originTime })
+  })
+
+  test('should detect drift when performance.now() falls behind Date.now()', () => {
+    // Initially no drift
+    mockPerformanceNow.mockReturnValue(1000)
+    mockDateNow.mockReturnValue(originTime + 1000)
+
+    timeKeeper.convertRelativeTimestamp(1000)
+    expect(handleModule.handle).not.toHaveBeenCalled()
+
+    // Simulate 2-second drift (performance.now frozen while Date.now advanced)
+    mockPerformanceNow.mockReturnValue(1000) // Frozen at 1000
+    mockDateNow.mockReturnValue(originTime + 3000) // Advanced 2000ms more
+
+    timeKeeper.convertRelativeTimestamp(1000)
+
+    // Should detect drift
+    expect(handleModule.handle).toHaveBeenCalledWith(
+      expect.any(String),
+      ['Generic/TimeKeeper/ClockDrift/Detected', 2000],
+      undefined,
+      expect.any(String),
+      expect.anything()
+    )
+  })
+
+  test('should NOT detect drift below 1000ms threshold', () => {
+    // Small drift under threshold
+    mockPerformanceNow.mockReturnValue(1000)
+    mockDateNow.mockReturnValue(originTime + 1500) // Only 500ms drift
+
+    timeKeeper.convertRelativeTimestamp(1000)
+
+    expect(handleModule.handle).not.toHaveBeenCalled()
+  })
+
+  test('should NOT apply correction when performance.now() is ahead of Date.now()', () => {
+    // Simulate negative drift - performance ahead of Date (unusual scenario)
+    mockPerformanceNow.mockReturnValue(5000)
+    mockDateNow.mockReturnValue(originTime + 2000) // Date is behind performance
+
+    timeKeeper.convertRelativeTimestamp(5000)
+
+    // Should NOT detect drift (we only detect positive drift)
+    expect(handleModule.handle).not.toHaveBeenCalled()
+
+    // Timestamp should be converted without any drift correction
+    const convertedTimestamp = timeKeeper.convertRelativeTimestamp(5000)
+    expect(convertedTimestamp).toEqual(originTime + 5000) // No drift adjustment
+  })
+
+  test('should correct timestamps after drift is detected', () => {
+    // Initially no drift
+    mockPerformanceNow.mockReturnValue(1000)
+    mockDateNow.mockReturnValue(originTime + 1000)
+
+    const beforeDriftTimestamp = timeKeeper.convertRelativeTimestamp(1000)
+    expect(beforeDriftTimestamp).toEqual(originTime + 1000)
+
+    // Simulate 2-second drift
+    mockPerformanceNow.mockReturnValue(1000) // Frozen
+    mockDateNow.mockReturnValue(originTime + 3000) // Advanced 2000ms
+
+    const afterDriftTimestamp = timeKeeper.convertRelativeTimestamp(1000)
+    // Should add the 2000ms drift correction
+    expect(afterDriftTimestamp).toEqual(originTime + 1000 + 2000)
+  })
+
+  test('should correct convertAbsoluteTimestamp after drift is detected', () => {
+    // Simulate 2-second drift
+    mockPerformanceNow.mockReturnValue(1000)
+    mockDateNow.mockReturnValue(originTime + 3000)
+
+    // Trigger drift detection
+    timeKeeper.convertRelativeTimestamp(1000)
+
+    // Convert absolute back to relative - should subtract the drift
+    const absoluteTime = originTime + 3000
+    const relativeTime = timeKeeper.convertAbsoluteTimestamp(absoluteTime)
+
+    // Should return approximately performance.now() (1000ms)
+    expect(relativeTime).toEqual(1000)
+  })
+
+  test('should handle multiple drift events cumulatively', () => {
+    // First drift event: 2 seconds
+    mockPerformanceNow.mockReturnValue(1000)
+    mockDateNow.mockReturnValue(originTime + 3000)
+
+    timeKeeper.convertRelativeTimestamp(1000)
+    expect(handleModule.handle).toHaveBeenCalledWith(
+      expect.any(String),
+      ['Generic/TimeKeeper/ClockDrift/Detected', 2000],
+      undefined,
+      expect.any(String),
+      expect.anything()
+    )
+
+    const afterFirstDrift = timeKeeper.convertRelativeTimestamp(1000)
+    expect(afterFirstDrift).toEqual(originTime + 3000)
+
+    // Second drift event: another 1.5 seconds (cumulative 3.5s total)
+    mockPerformanceNow.mockReturnValue(1000) // Still frozen
+    mockDateNow.mockReturnValue(originTime + 4500)
+
+    timeKeeper.convertRelativeTimestamp(1000)
+
+    // Should detect the new drift (increase of 1500ms)
+    expect(handleModule.handle).toHaveBeenCalledWith(
+      expect.any(String),
+      ['Generic/TimeKeeper/ClockDrift/Detected', 3500],
+      undefined,
+      expect.any(String),
+      expect.anything()
+    )
+
+    const afterSecondDrift = timeKeeper.convertRelativeTimestamp(1000)
+    expect(afterSecondDrift).toEqual(originTime + 4500)
+  })
+
+  test('should NOT report same drift multiple times', () => {
+    // Simulate drift
+    mockPerformanceNow.mockReturnValue(1000)
+    mockDateNow.mockReturnValue(originTime + 3000)
+
+    timeKeeper.convertRelativeTimestamp(1000)
+    expect(handleModule.handle).toHaveBeenCalledTimes(1)
+
+    // Call again with same drift - should not report again
+    timeKeeper.convertRelativeTimestamp(1000)
+    expect(handleModule.handle).toHaveBeenCalledTimes(1) // Still only 1 call
+  })
+
+  test('should apply drift correction to correctRelativeTimestamp', () => {
+    // Simulate drift
+    mockPerformanceNow.mockReturnValue(1000)
+    mockDateNow.mockReturnValue(originTime + 3000)
+
+    const correctedTimestamp = timeKeeper.correctRelativeTimestamp(1000)
+
+    // Should convert relative to absolute (with drift), then correct to server time
+    // convertRelativeTimestamp(1000) = originTime + 1000 + 2000 (drift)
+    // correctAbsoluteTimestamp applies server offset on top of that
+    const expectedServerCorrected = originTime + 3000 - timeKeeper.localTimeDiff
+    expect(correctedTimestamp).toEqual(expectedServerCorrected)
   })
 })

--- a/tools/browser-matcher/common-matchers.mjs
+++ b/tools/browser-matcher/common-matchers.mjs
@@ -57,6 +57,13 @@ export const notSafari = new SpecMatcher()
   .include('firefox')
   .include('ios')
 
+export const notFirefox = new SpecMatcher()
+  .include('android')
+  .include('chrome')
+  .include('edge')
+  .include('ios')
+  .include('safari')
+
 export const onlyChrome = new SpecMatcher()
   .include('chrome')
 


### PR DESCRIPTION
Certain linux and apple hardware can freeze the performance API clocks when entering deep sleep, which can cause inaccurate timestamps on New Relic events upon awakening. This introduces a new change which attempts to correct clock skew caused by frozen machines.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
NR-543627

This has a followup ticket to audit the agent implementation -- https://new-relic.atlassian.net/browse/NR-559496
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
New tests have been added to validate the skew correction behaviors
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
