### PR TITLE
chore: Patch delete-experiment workflow

### DIFF
--- a/.github/workflows/delete-experiment.yml
+++ b/.github/workflows/delete-experiment.yml
@@ -52,6 +52,8 @@ jobs:
     needs: [delete-experiment-on-s3]
     uses: ./.github/workflows/publish-dev.yml
     secrets: inherit
+    with:
+      skip_publish_notification: true
 
   # Notify about experiments in Slack
   send-slack-notifications:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -49,6 +49,7 @@ jobs:
 
   # Build and publish the latest code from the main branch
   publish-dev-to-s3:
+    if: needs.check-jest-tests.result == 'success'
     needs: [check-jest-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -238,6 +239,7 @@ jobs:
 
   # Rebuild and publish the dev environment A/B script
   publish-dev-ab:
+    if: needs.publish-dev-to-s3.result == 'success'
     needs: [publish-dev-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -267,6 +269,7 @@ jobs:
 
   # Rebuild and publish the staging environment A/B script
   publish-staging-ab:
+    if: needs.publish-dev-to-s3.result == 'success'
     needs: [publish-dev-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -296,6 +299,7 @@ jobs:
 
   # Create change tracking events for staging environment
   create-staging-change-tracking:
+    if: needs.publish-dev-to-s3.result == 'success'
     environment: staging
     needs: [publish-dev-to-s3]
     continue-on-error: true

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -32,7 +32,7 @@ jobs:
   # Build and publish the latest code from the main branch
   publish-dev-to-s3:
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    needs: [check-jest-tests]
+    needs: [jest-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -29,27 +29,9 @@ jobs:
     with:
       coverage: true
 
-  # Check if the deployment should proceed (only if tests passing or skipped)
-  check-jest-tests:
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    needs: [jest-tests]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Check tests status
-        run: |
-          if [ "${{ needs.jest-tests.result }}" == "success" ]; then
-            echo "✅ Tests passed, proceeding with deployment"
-          elif [ "${{ needs.jest-tests.result }}" == "skipped" ]; then
-            echo "⏭️ Tests were skipped, proceeding with deployment"
-          else
-            echo "❌ Unexpected test result: ${{ needs.jest-tests.result }}"
-            exit 1
-          fi
-
   # Build and publish the latest code from the main branch
   publish-dev-to-s3:
-    if: needs.check-jest-tests.result == 'success'
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [check-jest-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -239,7 +221,7 @@ jobs:
 
   # Rebuild and publish the dev environment A/B script
   publish-dev-ab:
-    if: needs.publish-dev-to-s3.result == 'success'
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [publish-dev-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -269,7 +251,7 @@ jobs:
 
   # Rebuild and publish the staging environment A/B script
   publish-staging-ab:
-    if: needs.publish-dev-to-s3.result == 'success'
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: [publish-dev-to-s3]
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -299,7 +281,7 @@ jobs:
 
   # Create change tracking events for staging environment
   create-staging-change-tracking:
-    if: needs.publish-dev-to-s3.result == 'success'
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     environment: staging
     needs: [publish-dev-to-s3]
     continue-on-error: true
@@ -389,7 +371,7 @@ jobs:
 
   # Notify about new staging deploy in Slack
   send-slack-notifications:
-    if: github.event_name != 'workflow_call' # skip for delete-experiment (avoids double notices + no PR)
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure') && github.event_name != 'workflow_call' # skip for delete-experiment (avoids double notices + no PR)
     needs: [publish-staging-ab]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -7,6 +7,11 @@ name: Publish Dev
 
 on:
   workflow_call:
+    inputs:
+      skip_publish_notification:
+        description: 'Skip sending published agent Slack notification'
+        type: boolean
+        default: false
   workflow_dispatch:
   push:
     branches:
@@ -371,7 +376,7 @@ jobs:
 
   # Notify about new staging deploy in Slack
   send-slack-notifications:
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure') && github.event_name != 'workflow_call' # skip for delete-experiment (avoids double notices + no PR)
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure') && !inputs.skip_publish_notification
     needs: [publish-staging-ab]
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Prevent skipping the `publish-dev-to-s3` job when executing the delete-experiment workflow.  
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Need to explicitly check and ensure there are no failures in previous jobs as we go along the chain of jobs.
Also fixed the condition to skip duplicate Slack notification when running delete-experiment workflow.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-526518

### Testing

Troubleshot the workflow: https://github.com/newrelic/newrelic-browser-agent/actions/runs/24267224141