### PR TITLE
feat: Add ajaxRequest.id attribute

### DIFF
--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -6,13 +6,14 @@ import { registerHandler } from '../../../common/event-emitter/register-handler'
 import { stringify } from '../../../common/util/stringify'
 import { handle } from '../../../common/event-emitter/handle'
 import { setDenyList, shouldCollectEvent } from '../../../common/deny-list/deny-list'
-import { FEATURE_NAME } from '../constants'
+import { AJAX_ID, FEATURE_NAME } from '../constants'
 import { FEATURE_NAMES } from '../../../loaders/features/features'
 import { AggregateBase } from '../../utils/aggregate-base'
 import { parseGQL } from './gql'
 import { nullable, numeric, getAddStringContext, addCustomAttributes } from '../../../common/serialize/bel-serializer'
 import { gosNREUMOriginals } from '../../../common/window/nreum'
 import { getVersion2Attributes, getVersion2DuplicationAttributes, shouldDuplicate } from '../../../common/v2/utils'
+import { generateUuid } from '../../../common/ids/unique-id'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -91,7 +92,8 @@ export class Aggregate extends AggregateBase {
       type,
       startTime,
       endTime,
-      callbackDuration: metrics.cbTime
+      callbackDuration: metrics.cbTime,
+      [AJAX_ID]: generateUuid() // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
     }
 
     if (ctx.dt) {
@@ -168,7 +170,8 @@ export class Aggregate extends AggregateBase {
       const attrParts = addCustomAttributes({
         ...(jsAttributes || {}),
         ...(event.gql || {}),
-        ...(event.targetAttributes || {}) // used to supply the version 2 attributes, either MFE target or duplication attributes for the main agent app
+        ...(event.targetAttributes || {}), // used to supply the version 2 attributes, either MFE target or duplication attributes for the main agent app
+        [AJAX_ID]: event[AJAX_ID] // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
       }, addString)
 
       fields.unshift(numeric(attrParts.length))

--- a/src/features/ajax/constants.js
+++ b/src/features/ajax/constants.js
@@ -1,7 +1,9 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { FEATURE_NAMES } from '../../loaders/features/features'
 
 export const FEATURE_NAME = FEATURE_NAMES.ajax
+
+export const AJAX_ID = 'ajaxRequest.id'

--- a/src/features/soft_navigations/aggregate/ajax-node.js
+++ b/src/features/soft_navigations/aggregate/ajax-node.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { addCustomAttributes, getAddStringContext, nullable, numeric } from '../../../common/serialize/bel-serializer'
+import { AJAX_ID } from '../../ajax/constants'
 import { NODE_TYPE } from '../constants'
 import { BelNode } from './bel-node'
 
@@ -22,6 +23,7 @@ export class AjaxNode extends BelNode {
     this.spanTimestamp = ajaxEvent.spanTimestamp
     this.gql = ajaxEvent.gql
     this.targetAttributes = ajaxEvent.targetAttributes
+    this[AJAX_ID] = ajaxEvent[AJAX_ID] // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
 
     this.start = ajaxEvent.startTime
     this.end = ajaxEvent.endTime
@@ -55,7 +57,8 @@ export class AjaxNode extends BelNode {
     ]
     let allAttachedNodes = addCustomAttributes({
       ...(this.gql || {}),
-      ...(this.targetAttributes || {})
+      ...(this.targetAttributes || {}),
+      [AJAX_ID]: this[AJAX_ID]
     }, addString)
     this.children.forEach(node => allAttachedNodes.push(node.serialize())) // no children is expected under ajax nodes at this time
 

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -5,6 +5,7 @@ import * as handleModule from '../../../src/common/event-emitter/handle'
 import { Instrument as Ajax } from '../../../src/features/ajax/instrument'
 import { resetAgent, setupAgent } from '../setup-agent'
 import { EventContext } from '../../../src/common/event-emitter/event-context'
+import { AJAX_ID } from '../../../src/features/ajax/constants'
 
 const ajaxArguments = [
   { // params
@@ -131,7 +132,8 @@ describe('prepareHarvest', () => {
       customStringAttribute: 'customStringAttribute',
       customNumAttribute: 2,
       customBooleanAttribute: true,
-      nullCustomAttribute: null
+      nullCustomAttribute: null,
+      [AJAX_ID]: expect.any(String) // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
     }
     fakeAgent.info.jsAttributes = expectedCustomAttributes
 

--- a/tests/components/soft_navigations/api.test.js
+++ b/tests/components/soft_navigations/api.test.js
@@ -1,5 +1,6 @@
 import { Instrument as SoftNav } from '../../../src/features/soft_navigations/instrument'
 import { resetAgent, setupAgent } from '../setup-agent'
+import { AJAX_ID } from '../../../src/features/ajax/constants'
 
 import querypack from '@newrelic/nr-querypack'
 
@@ -330,9 +331,9 @@ test('multiple finished ixns with ajax have correct start/end timestamps (in aja
   ixnContext.associatedInteraction.forceSave = true
   softNavAggregate.ee.emit(`${INTERACTION_API}-end`, [4.56], ixnContext)
 
-  softNavAggregate.ee.emit('ajax', [{ startTime: 2.34, endTime: 5.67 }])
+  softNavAggregate.ee.emit('ajax', [{ startTime: 2.34, endTime: 5.67, [AJAX_ID]: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' }])
   ixnContext.associatedInteraction.children[0].nodeId = 2
-  softNavAggregate.ee.emit('ajax', [{ startTime: 3.45, endTime: 6.78 }])
+  softNavAggregate.ee.emit('ajax', [{ startTime: 3.45, endTime: 6.78, [AJAX_ID]: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb' }])
   ixnContext.associatedInteraction.children[1].nodeId = 3
 
   softNavAggregate.ee.emit(`${INTERACTION_API}-get`, [10])
@@ -342,14 +343,14 @@ test('multiple finished ixns with ajax have correct start/end timestamps (in aja
   ixnContext.associatedInteraction.forceSave = true
   softNavAggregate.ee.emit(`${INTERACTION_API}-end`, [14], ixnContext)
 
-  softNavAggregate.ee.emit('ajax', [{ startTime: 11, endTime: 12 }])
+  softNavAggregate.ee.emit('ajax', [{ startTime: 11, endTime: 12, [AJAX_ID]: 'cccccccc-cccc-cccc-cccc-cccccccccccc' }])
   ixnContext.associatedInteraction.children[0].nodeId = 5
-  softNavAggregate.ee.emit('ajax', [{ startTime: 12, endTime: 13 }])
+  softNavAggregate.ee.emit('ajax', [{ startTime: 12, endTime: 13, [AJAX_ID]: 'dddddddd-dddd-dddd-dddd-dddddddddddd' }])
   ixnContext.associatedInteraction.children[1].nodeId = 6
 
   expect(softNavAggregate.interactionsToHarvest.get().length).toEqual(2)
   // WARN: Double check decoded output & behavior or any introduced bugs before changing the follow line's static string.
-  expect(softNavAggregate.makeHarvestPayload().body).toEqual("bel.7;1,2,1,3,,,'api,'http://localhost/,1,1,,2,!!!!'some_id,'1,!!;2,,1,3,,,,,,,,,,'2,!!!;2,,2,3,,,,,,,,,,'3,!!!;;1,2,9,4,,,'api,'http://localhost/,1,1,,2,!!!!'some_other_id,'4,!!;2,,a,1,,,,,,,,,,'5,!!!;2,,b,1,,,,,,,,,,'6,!!!;")
+  expect(softNavAggregate.makeHarvestPayload().body).toEqual("bel.7;1,2,1,3,,,'api,'http://localhost/,1,1,,2,!!!!'some_id,'1,!!;2,1,1,3,,,,,,,,,,'2,!!!;5,'ajaxRequest.id,'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa;2,1,2,3,,,,,,,,,,'3,!!!;5,'ajaxRequest.id,'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb;;1,2,9,4,,,'api,'http://localhost/,1,1,,2,!!!!'some_other_id,'4,!!;2,1,a,1,,,,,,,,,,'5,!!!;5,'ajaxRequest.id,'cccccccc-cccc-cccc-cccc-cccccccccccc;2,1,b,1,,,,,,,,,,'6,!!!;5,'ajaxRequest.id,'dddddddd-dddd-dddd-dddd-dddddddddddd;")
 })
 
 function getIxnContext (ixn) {

--- a/tests/specs/soft_navigations/xhr.e2e.js
+++ b/tests/specs/soft_navigations/xhr.e2e.js
@@ -29,7 +29,13 @@ describe('XHR SPA Interaction Tracking', () => {
             requestedWith: 'XMLHttpRequest',
             path: '/json',
             nodeId: expect.any(String),
-            children: [],
+            children: [
+              expect.objectContaining({
+                type: 'stringAttribute',
+                key: 'ajaxRequest.id',
+                value: expect.any(String)
+              })
+            ],
             method: 'GET',
             status: 200,
             domain: browser.testHandle.assetServerConfig.host + ':' + browser.testHandle.assetServerConfig.port,
@@ -71,7 +77,13 @@ describe('XHR SPA Interaction Tracking', () => {
             requestedWith: 'XMLHttpRequest',
             path: '/json',
             nodeId: expect.any(String),
-            children: [],
+            children: [
+              expect.objectContaining({
+                type: 'stringAttribute',
+                key: 'ajaxRequest.id',
+                value: expect.any(String)
+              })
+            ],
             method: 'GET',
             status: 200,
             domain: browser.testHandle.assetServerConfig.host + ':' + browser.testHandle.assetServerConfig.port,
@@ -134,7 +146,14 @@ describe('XHR SPA Interaction Tracking', () => {
             requestedWith: 'XMLHttpRequest',
             path: '/echo',
             requestBodySize: 3,
-            responseBodySize: 3
+            responseBodySize: 3,
+            children: [
+              expect.objectContaining({
+                type: 'stringAttribute',
+                key: 'ajaxRequest.id',
+                value: expect.any(String)
+              })
+            ]
           })
         ])
       })
@@ -197,7 +216,14 @@ describe('XHR SPA Interaction Tracking', () => {
             path: expect.stringMatching(/^\/dt\/[\w\d]+/),
             guid: expect.stringMatching(/[\w\d]+/),
             traceId: expect.stringMatching(/[\w\d]+/),
-            timestamp: expect.toBePositive()
+            timestamp: expect.toBePositive(),
+            children: [
+              expect.objectContaining({
+                type: 'stringAttribute',
+                key: 'ajaxRequest.id',
+                value: expect.any(String)
+              })
+            ]
           })
         ])
       })

--- a/tests/unit/features/soft_navigations/aggregate/ajax-node.test.js
+++ b/tests/unit/features/soft_navigations/aggregate/ajax-node.test.js
@@ -28,7 +28,8 @@ const someAjaxEvent = {
     operationName: 'Anonymous',
     operationType: 'QUERY',
     operationFramework: 'GraphQL'
-  }
+  },
+  AJAX_ID: '1234'
 }
 
 let AjaxNode
@@ -78,7 +79,7 @@ test('Ajax serialize output is correct', () => {
   const ajn = new AjaxNode(someAjaxEvent)
 
   expect(ajn.nodeId).toEqual(1)
-  expect(ajn.serialize(0, someAgent)).toEqual("2,3,sg,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL")
+  expect(ajn.serialize(0, someAgent)).toEqual("2,4,sg,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;9,'ajaxRequest.id")
   // The start (and end) timestamp should translate based on "parent" timestamp passed in:
-  expect(ajn.serialize(512, someAgent)).toEqual("2,3,e8,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL")
+  expect(ajn.serialize(512, someAgent)).toEqual("2,4,e8,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;9,'ajaxRequest.id")
 })

--- a/tests/unit/features/soft_navigations/aggregate/ajax-node.test.js
+++ b/tests/unit/features/soft_navigations/aggregate/ajax-node.test.js
@@ -1,4 +1,5 @@
 import { Obfuscator } from '../../../../../src/common/util/obfuscate'
+import { AJAX_ID } from '../../../../../src/features/ajax/constants'
 
 jest.enableAutomock()
 jest.unmock('../../../../../src/features/soft_navigations/aggregate/ajax-node')
@@ -29,7 +30,7 @@ const someAjaxEvent = {
     operationType: 'QUERY',
     operationFramework: 'GraphQL'
   },
-  AJAX_ID: '1234'
+  [AJAX_ID]: '1234'
 }
 
 let AjaxNode
@@ -79,7 +80,7 @@ test('Ajax serialize output is correct', () => {
   const ajn = new AjaxNode(someAjaxEvent)
 
   expect(ajn.nodeId).toEqual(1)
-  expect(ajn.serialize(0, someAgent)).toEqual("2,4,sg,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;9,'ajaxRequest.id")
+  expect(ajn.serialize(0, someAgent)).toEqual("2,4,sg,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;5,'ajaxRequest.id,'1234")
   // The start (and end) timestamp should translate based on "parent" timestamp passed in:
-  expect(ajn.serialize(512, someAgent)).toEqual("2,4,e8,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;9,'ajaxRequest.id")
+  expect(ajn.serialize(512, someAgent)).toEqual("2,4,e8,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;5,'ajaxRequest.id,'1234")
 })

--- a/tests/util/basic-checks.js
+++ b/tests/util/basic-checks.js
@@ -82,25 +82,32 @@ export function checkAjaxEvents ({ query, body }, { specificPath, hasTrace } = {
   expect(body?.length).toBeGreaterThanOrEqual(1)
   body
     .filter(x => !specificPath || (specificPath && x.path === specificPath))
-    .forEach(x => expect(x).toMatchObject({
-      callbackDuration: expect.any(Number),
-      callbackEnd: expect.any(Number),
-      children: expect.any(Array),
-      domain: expect.any(String),
-      end: expect.any(Number),
-      guid: hasTrace ? expect.any(String) : expect.toSatisfy(n => n === null),
-      method: expect.any(String),
-      nodeId: expect.any(String),
-      path: specificPath ? specificPath : expect.any(String),
-      requestBodySize: expect.any(Number),
-      requestedWith: expect.any(String),
-      responseBodySize: expect.any(Number),
-      start: expect.any(Number),
-      status: expect.any(Number),
-      timestamp: hasTrace ? expect.any(Number) : expect.toSatisfy(n => n === null),
-      traceId: hasTrace ? expect.any(String) : expect.toSatisfy(n => n === null),
-      type: expect.any(String)
-    }))
+    .forEach(x => {
+      expect(x).toMatchObject({
+        callbackDuration: expect.any(Number),
+        callbackEnd: expect.any(Number),
+        children: expect.any(Array),
+        domain: expect.any(String),
+        end: expect.any(Number),
+        guid: hasTrace ? expect.any(String) : expect.toSatisfy(n => n === null),
+        method: expect.any(String),
+        nodeId: expect.any(String),
+        path: specificPath ? specificPath : expect.any(String),
+        requestBodySize: expect.any(Number),
+        requestedWith: expect.any(String),
+        responseBodySize: expect.any(Number),
+        start: expect.any(Number),
+        status: expect.any(Number),
+        timestamp: hasTrace ? expect.any(Number) : expect.toSatisfy(n => n === null),
+        traceId: hasTrace ? expect.any(String) : expect.toSatisfy(n => n === null),
+        type: expect.any(String)
+      })
+
+      // AjaxRequest events should always have an 'ajaxRequest.id' custom attribute with a uuid value
+       expect(x.children.find(x => x.type === 'stringAttribute' && x.key === 'ajaxRequest.id')?.value).toEqual(
+        expect.stringMatching(/^[0-9a-zA-Z]{8}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{4}-[0-9a-zA-Z]{12}$/)
+       )
+    })
 }
 
 export function checkAjaxMetrics ({ query, body }, { specificPath, hasTrace, isFetch } = {}) {


### PR DESCRIPTION
Adds a unique identifier to all AjaxRequest events to facilitate direct queries and drilling-down into data in NR1 UIs.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
Adds a unique Id to all AjaxRequest events.
<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-538799
https://source.datanerd.us/docs-eng/attribute-dictionary/pull/179
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
The main test helper that validates AJAX events now includes a check for the id
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
