### PR TITLE
feat: Enhance SPA API to support targetPageLoad option

### DIFF
--- a/src/features/soft_navigations/aggregate/index.js
+++ b/src/features/soft_navigations/aggregate/index.js
@@ -30,7 +30,6 @@ export class Aggregate extends AggregateBase {
       this.initialPageLoadInteraction.forceSave = true // unless forcibly ignored, iPL always finish by default
       const ixn = this.initialPageLoadInteraction
       this.events.add(ixn) // add the iPL ixn to the buffer for harvest
-      this.initialPageLoadInteraction = null
     })
 
     loadTime.subscribe(({ value: loadEventTime }) => {
@@ -230,16 +229,19 @@ export class Aggregate extends AggregateBase {
     const INTERACTION_API = 'api-ixn-'
     const thisClass = this
 
-    registerHandler(INTERACTION_API + 'get', function (time, { waitForEnd } = {}) {
+    registerHandler(INTERACTION_API + 'get', function (time, { waitForEnd, targetPageLoad } = {}) {
       // In here, 'this' refers to the EventContext specific to per InteractionHandle instance spawned by each .interaction() api call.
       // Each api call aka IH instance would therefore retain a reference to either the in-progress interaction *at the time of the call* OR a new api-started interaction.
-      this.associatedInteraction = thisClass.getInteractionFor(time)
-      if (this.associatedInteraction?.trigger === IPL_TRIGGER_NAME) this.associatedInteraction = null // the api get-interaction method cannot target IPL
-      if (!this.associatedInteraction) {
+      if (targetPageLoad) this.associatedInteraction = thisClass.initialPageLoadInteraction // this option only grabs the IPL, no frills
+      else {
+        this.associatedInteraction = thisClass.getInteractionFor(time)
+        if (this.associatedInteraction?.trigger === IPL_TRIGGER_NAME) this.associatedInteraction = null // the api get-interaction method cannot target IPL
+        if (!this.associatedInteraction) {
         // This new api-driven interaction will be the target of any subsequent .interaction() call, until it is closed by EITHER .end() OR the regular url>dom change process.
-        this.associatedInteraction = thisClass.interactionInProgress = new Interaction(API_TRIGGER_NAME, Math.floor(time), thisClass.latestRouteSetByApi)
-        thisClass.domObserver.observe(document.body, { attributes: true, childList: true, subtree: true, characterData: true }) // start observing for DOM changes like a regular UI-driven interaction
-        thisClass.setClosureHandlers()
+          this.associatedInteraction = thisClass.interactionInProgress = new Interaction(API_TRIGGER_NAME, Math.floor(time), thisClass.latestRouteSetByApi)
+          thisClass.domObserver.observe(document.body, { attributes: true, childList: true, subtree: true, characterData: true }) // start observing for DOM changes like a regular UI-driven interaction
+          thisClass.setClosureHandlers()
+        }
       }
       if (waitForEnd === true) {
         this.associatedInteraction.keepOpenUntilEndApi = true

--- a/src/loaders/api-base.js
+++ b/src/loaders/api-base.js
@@ -197,6 +197,7 @@ export class ApiBase {
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/interaction/}
    * @param {Object} [opts] Options to configure the new or existing interaction with
    * @param {boolean} [opts.waitForEnd=false] To forcibly keep the interaction open until the `.end` method is called on its handle, set to true. Defaults to false. After an interaction is earmarked with this, it cannot be undone.
+    * @param {boolean} [opts.targetPageLoad=false] If true, bind this API handle to the initial page load interaction forcibly instead of creating or targeting a soft navigation interaction.
    * @returns {InteractionInstance} An API object that is bound to a specific BrowserInteraction event. Each time this method is called for the same BrowserInteraction, a new object is created, but it still references the same interaction.
    *  - Note: Does not apply to MicroAgent
    *  - Deprecation Notice: interaction.createTracer is deprecated.  See https://docs.newrelic.com/eol/2024/04/eol-04-24-24-createtracer/ for more information.

--- a/tests/components/api.test.js
+++ b/tests/components/api.test.js
@@ -1179,6 +1179,15 @@ describe('API tests', () => {
         expectHandled('api-ixn-get', [expect.toBeNumber(), expect.any(Object)])
       })
 
+      test('should forward interaction options to get handler', () => {
+        const opts = { waitForEnd: true, targetPageLoad: true }
+        agent.interaction(opts)
+
+        expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/interaction/called'])
+        expectHandled(SUPPORTABILITY_METRIC_CHANNEL, ['API/get/called'])
+        expectHandled('api-ixn-get', [expect.toBeNumber(), opts])
+      })
+
       test('should return an object containing the SPA interaction API methods', () => {
         const interaction = agent.interaction()
 

--- a/tests/components/soft_navigations/aggregate.test.js
+++ b/tests/components/soft_navigations/aggregate.test.js
@@ -66,7 +66,8 @@ test('processes interaction heuristics', async () => {
 
   const loadTimeSubscriber = jest.mocked(loadTimeModule.loadTime.subscribe).mock.calls[0][0]
   loadTimeSubscriber({ value: 123 })
-  expect(softNavAggregate.initialPageLoadInteraction).toBeNull()
+  expect(softNavAggregate.initialPageLoadInteraction).toBeTruthy()
+  expect(softNavAggregate.initialPageLoadInteraction.status).toEqual(INTERACTION_STATUS.FIN)
   expect(softNavAggregate.interactionsToHarvest.get().length).toEqual(1)
 
   softNavAggregate.ee.emit('newURL', [234, 'new_location'])
@@ -371,7 +372,7 @@ test('calling done on the initialPageLoad actually closes it correctly', () => {
   let endTime = performance.now()
   let ipl = softNavAggregate.initialPageLoadInteraction
   softNavAggregate.initialPageLoadInteraction.done(endTime)
-  expect(softNavAggregate.initialPageLoadInteraction).toBeNull()
+  expect(softNavAggregate.initialPageLoadInteraction).toBe(ipl)
   expect(ipl.end).toEqual(endTime)
   expect(ipl.status).toEqual(INTERACTION_STATUS.FIN)
   expect(softNavAggregate.interactionsToHarvest.get()).toEqual([ipl])

--- a/tests/components/soft_navigations/api.test.js
+++ b/tests/components/soft_navigations/api.test.js
@@ -70,6 +70,41 @@ test('.interaction gets current or creates new api ixn', () => {
   expect(softNavAggregate.interactionInProgress.cancellationTimer).toBeUndefined()
 })
 
+test('.interaction with targetPageLoad binds to retained IPL without opening api ixn', () => {
+  const fakeIpl = {
+    trigger: 'initialPageLoad',
+    isActiveDuring: () => true
+  }
+  softNavAggregate.initialPageLoadInteraction = fakeIpl
+
+  const defaultIxn = mainAgent.interaction()
+  expect(getIxnContext(defaultIxn).associatedInteraction.trigger).toEqual('api') // default interaction() still cannot target iPL
+  defaultIxn.end()
+
+  const iplIxn = mainAgent.interaction({ targetPageLoad: true })
+  expect(getIxnContext(iplIxn).associatedInteraction).toBe(fakeIpl)
+  expect(softNavAggregate.interactionInProgress).toBeNull()
+})
+
+test('.interaction creates new api ixn when IPL is finished, while targetPageLoad still returns finished IPL', () => {
+  const finishedIpl = {
+    trigger: 'initialPageLoad',
+    status: 'finished',
+    isActiveDuring: () => false
+  }
+  softNavAggregate.initialPageLoadInteraction = finishedIpl
+
+  const apiIxn = mainAgent.interaction()
+  const apiCtx = getIxnContext(apiIxn)
+  expect(apiCtx.associatedInteraction.trigger).toEqual('api')
+  expect(softNavAggregate.interactionInProgress).toBe(apiCtx.associatedInteraction)
+
+  const iplIxn = mainAgent.interaction({ targetPageLoad: true })
+  expect(getIxnContext(iplIxn).associatedInteraction).toBe(finishedIpl)
+  expect(getIxnContext(iplIxn).associatedInteraction.status).toEqual('finished')
+  expect(softNavAggregate.interactionInProgress).toBe(apiCtx.associatedInteraction)
+})
+
 test('.interaction returns a different new context for every call', () => {
   const ixn1 = mainAgent.interaction()
   const ixn2 = mainAgent.interaction()

--- a/tests/dts/api.test-d.ts
+++ b/tests/dts/api.test-d.ts
@@ -26,7 +26,7 @@ expectType<MicroAgent>(microAgent)
     type?: string;
   }) => any>(agent.addToTrace)
   expectType<(name: string) => any>(agent.setCurrentRouteName)
-  expectType<(opts?: { waitForEnd?: boolean }) => InteractionInstance>(agent.interaction)
+  expectType<(opts?: { waitForEnd?: boolean, targetPageLoad?: boolean }) => InteractionInstance>(agent.interaction)
 
   // Base Agent APIs
   expectType<(name: string, attributes?: object) => any>(agent.addPageAction)
@@ -49,7 +49,7 @@ expectType<MicroAgent>(microAgent)
   expectType<(accept: boolean | null) => any>(agent.consent)
 
   // SPA APIs
-  expectType<(opts?: { waitForEnd?: boolean }) => InteractionInstance>(agent.interaction)
+  expectType<(opts?: { waitForEnd?: boolean, targetPageLoad?: boolean }) => InteractionInstance>(agent.interaction)
   expectType<(value: string) => InteractionInstance>(agent.interaction().actionText)
   expectType<(name: string, callback?: ((...args: any[]) => any)) => (...args: any) => any>(agent.interaction().createTracer)
   expectType<() => InteractionInstance>(agent.interaction().end)


### PR DESCRIPTION
Allow the SPA API to target and work on the `initialPageLoad` type `BrowserInteraction` event. A new option is added to `.interaction` that now binds the returned handle to the initial page load interaction at any point in time.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Example:
```js
newrelic.interaction({ targetPageLoad: true }).setName('My Home Page')
```

Resolves #1756 

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-555406

Docs PR: https://github.com/newrelic/docs-website/pull/23890

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
