### PR TITLE
feat: Improve PageViewTiming load timing capture

### DIFF
--- a/src/common/vitals/load-time.js
+++ b/src/common/vitals/load-time.js
@@ -12,12 +12,15 @@ export const loadTime = new VitalMetric(VITAL_NAMES.LOAD_TIME)
 if (isBrowserScope) {
   const perf = globalScope.performance
   const handler = () => {
-    if (!loadTime.isValid && perf) {
+    // setTimeout defers the read until after the load event handler returns,
+    // ensuring loadEventEnd is populated (non-zero) — matching the web-vitals onTTFB pattern
+    setTimeout(() => {
+      if (loadTime.isValid || !perf) return
       const navEntry = getNavigationEntry()
       loadTime.update({
         value: navEntry ? navEntry.loadEventEnd : (perf.timing?.loadEventEnd - originTime)
       })
-    }
+    }, 0)
   }
 
   onWindowLoad(handler, true)

--- a/tests/components/soft_navigations/instrument.test.js
+++ b/tests/components/soft_navigations/instrument.test.js
@@ -5,6 +5,7 @@ import { resetAgent, setupAgent } from '../setup-agent'
 import { faker } from '@faker-js/faker'
 
 let mainAgent
+let softNavInstrument
 
 beforeAll(() => {
   mainAgent = setupAgent({
@@ -16,15 +17,28 @@ beforeAll(() => {
 
 beforeEach(async () => {
   jest.spyOn(handleModule, 'handle')
-  new SoftNav(mainAgent)
+  softNavInstrument = new SoftNav(mainAgent)
 })
 
 afterEach(() => {
+  softNavInstrument?.abortHandler?.()
+  softNavInstrument = undefined
+
+  // SoftNav subscribes to history scoped emitter events; clear those listeners per test
+  const historyEE = mainAgent.ee.get('history')
+  ;['pushState-end', 'replaceState-end'].forEach((eventName) => {
+    historyEE.listeners(eventName).forEach((listener) => {
+      historyEE.removeEventListener(eventName, listener)
+    })
+  })
+
   resetAgent(mainAgent)
   jest.clearAllMocks()
 })
 
 test('instrument detects heuristic steps', async () => {
+  handleModule.handle.mockClear()
+
   history.pushState({}, '/foo')
   expect(handleModule.handle).toHaveBeenLastCalledWith('newURL', [expect.any(Number), window.location.href], undefined, FEATURE_NAME, expect.any(Object))
   history.replaceState({}, '')

--- a/tests/specs/pvt/timings.e2e.js
+++ b/tests/specs/pvt/timings.e2e.js
@@ -37,15 +37,18 @@ describe('pvt timings tests', () => {
 
         const load = timingsHarvests.find(harvest => harvest.request.body.find(t => t.name === 'load'))
           ?.request.body.find(timing => timing.name === 'load')
-        expect(load?.value).toBeBetween(0, duration)
+        expect(load?.value).toBeGreaterThan(0)
+        expect(load?.value).toBeLessThanOrEqual(duration)
 
         const unload = timingsHarvests.find(harvest => harvest.request.body.find(t => t.name === 'unload'))
           ?.request.body.find(timing => timing.name === 'unload')
-        expect(unload?.value).toBeBetween(0, duration)
+        expect(unload?.value).toBeGreaterThan(0)
+        expect(unload?.value).toBeLessThanOrEqual(duration)
 
         const pageHide = timingsHarvests.find(harvest => harvest.request.body.find(t => t.name === 'pageHide'))
           ?.request.body.find(timing => timing.name === 'pageHide')
-        expect(pageHide?.value).toBeBetween(0, duration)
+        expect(pageHide?.value).toBeGreaterThan(0)
+        expect(pageHide?.value).toBeLessThanOrEqual(duration)
 
         if (browserMatch(supportsCumulativeLayoutShift)) {
           const emptyCls = pageHide.attributes.find(a => a.key === 'cls')

--- a/tests/unit/common/vitals/load-time.test.js
+++ b/tests/unit/common/vitals/load-time.test.js
@@ -208,8 +208,11 @@ describe('load-time', () => {
       })
       windowLoadCallback()
       windowLoadCallback() // Should not trigger again due to isValid check
-      expect(triggered).toEqual(1)
-      done()
+      // Defer assertions past the setTimeout(0) used to ensure loadEventEnd is valid
+      setTimeout(() => {
+        expect(triggered).toEqual(1)
+        done()
+      }, 100)
     })
   })
 


### PR DESCRIPTION
The load timing is now more reliably captured for pages, inheriting the idea from web-vital's `onTTFB`. Before, it occasionally missed `loadEventEnd` from nav entry from a browser race condition, particularly for larger/longer-loaded pages, which caused load to be `0`.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-558319

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
