### PR TITLE
feat: Use app-namespaced keys for session

### DIFF
--- a/src/common/session/constants.js
+++ b/src/common/session/constants.js
@@ -1,9 +1,8 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-export const PREFIX = 'NRBA'
-export const DEFAULT_KEY = 'SESSION'
+export const SESSION_STORAGE_KEY_PREFIX = 'NRBA_SESSION::'
 export const DEFAULT_EXPIRES_MS = 14400000
 export const DEFAULT_INACTIVE_MS = 1800000
 

--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -39,7 +39,7 @@ const model = {
 export class SessionEntity {
   /**
    * Create a self-managing Session Entity. This entity is scoped to the agent which triggered it, allowing for multiple simultaneous session objects to exist.
-   * There is one "namespace" an agent can store data in LS -- NRBA_{key}. If there are two agents on one page, and they both use the same key, they could overwrite each other since they would both use the same namespace in LS by default.
+  * Session data is stored at NRBA_{key}, where key can be app-namespaced by the caller to avoid collisions across multiple agents on the same origin.
    * The value can be overridden in the constructor, but will default to a unique 16 character hex string
    * expiresMs and inactiveMs are used to "expire" the session, but can be overridden in the constructor. Pass 0 to disable expiration timers.
    */

--- a/src/common/session/session-entity.js
+++ b/src/common/session/session-entity.js
@@ -7,7 +7,7 @@ import { warn } from '../util/console'
 import { stringify } from '../util/stringify'
 import { Timer } from '../timer/timer'
 import { isBrowserScope } from '../constants/runtime'
-import { DEFAULT_EXPIRES_MS, DEFAULT_INACTIVE_MS, MODE, PREFIX, SESSION_EVENTS, SESSION_EVENT_TYPES } from './constants'
+import { DEFAULT_EXPIRES_MS, DEFAULT_INACTIVE_MS, MODE, SESSION_EVENTS, SESSION_EVENT_TYPES, SESSION_STORAGE_KEY_PREFIX } from './constants'
 import { InteractionTimer } from '../timer/interaction-timer'
 import { wrapEvents } from '../wrap/wrap-events'
 import { getModeledObject } from '../config/configurable'
@@ -39,7 +39,7 @@ const model = {
 export class SessionEntity {
   /**
    * Create a self-managing Session Entity. This entity is scoped to the agent which triggered it, allowing for multiple simultaneous session objects to exist.
-  * Session data is stored at NRBA_{key}, where key can be app-namespaced by the caller to avoid collisions across multiple agents on the same origin.
+  * Session data is stored at NRBA_SESSION::{key}, where key can be app-scoped by the caller to avoid collisions across multiple agents on the same origin.
    * The value can be overridden in the constructor, but will default to a unique 16 character hex string
    * expiresMs and inactiveMs are used to "expire" the session, but can be overridden in the constructor. Pass 0 to disable expiration timers.
    */
@@ -160,7 +160,7 @@ export class SessionEntity {
 
   // This is the actual key appended to the storage API
   get lookupKey () {
-    return `${PREFIX}_${this.key}`
+    return `${SESSION_STORAGE_KEY_PREFIX}${this.key}`
   }
 
   sync (data) {

--- a/src/common/session/session-key.js
+++ b/src/common/session/session-key.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+// Deterministic 32-bit FNV-1a hash, rendered as a fixed 8-char hex string.
+function hashTo8Hex (value) {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+export function getAppSessionHash (licenseKey, applicationID) {
+  return hashTo8Hex(`${String(licenseKey)}:${String(applicationID)}`)
+}

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -5,7 +5,6 @@
 import { globalScope, isBrowserScope, originTime, getNavigationEntry } from '../../../common/constants/runtime'
 import { addPT, addPN } from '../../../common/timing/nav-timing'
 import { stringify } from '../../../common/util/stringify'
-import { isValid } from '../../../common/config/info'
 import * as CONSTANTS from '../constants'
 import { getActivatedFeaturesFlags } from './initialized-features'
 import { activateFeatures } from '../../../common/util/feature-flags'
@@ -35,10 +34,6 @@ export class Aggregate extends AggregateBase {
     this.firstByteToDomContent = 0 // our "dom processing" duration
     this.retries = 0
 
-    if (!isValid(agentRef.info)) {
-      this.ee.abort()
-      return warn(43)
-    }
     agentRef.runtime.timeKeeper = new TimeKeeper(agentRef.runtime.session)
 
     if (isBrowserScope) {

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 /**
@@ -30,8 +30,9 @@ export class Instrument extends InstrumentBase {
     setupPauseReplayAPI(agentRef)
 
     let session
+    const fullNamespacedKey = `${PREFIX}_${DEFAULT_KEY}::${agentRef.info.licenseKey}:${agentRef.info.applicationID}`
     try {
-      session = JSON.parse(localStorage.getItem(`${PREFIX}_${DEFAULT_KEY}`))
+      session = JSON.parse(localStorage.getItem(fullNamespacedKey))
     } catch (err) { }
 
     if (hasReplayPrerequisite(agentRef.init)) {

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -7,7 +7,8 @@
  */
 
 import { handle } from '../../../common/event-emitter/handle'
-import { DEFAULT_KEY, MODE, PREFIX } from '../../../common/session/constants'
+import { MODE, SESSION_STORAGE_KEY_PREFIX } from '../../../common/session/constants'
+import { getAppSessionHash } from '../../../common/session/session-key'
 import { InstrumentBase } from '../../utils/instrument-base'
 import { hasReplayPrerequisite, isPreloadAllowed } from '../shared/utils'
 import { ERROR_DURING_REPLAY, FEATURE_NAME, TRIGGERS } from '../constants'
@@ -30,7 +31,7 @@ export class Instrument extends InstrumentBase {
     setupPauseReplayAPI(agentRef)
 
     let session
-    const fullNamespacedKey = `${PREFIX}_${DEFAULT_KEY}::${agentRef.info.licenseKey}:${agentRef.info.applicationID}`
+    const fullNamespacedKey = `${SESSION_STORAGE_KEY_PREFIX}${getAppSessionHash(agentRef.info.licenseKey, agentRef.info.applicationID)}`
     try {
       session = JSON.parse(localStorage.getItem(fullNamespacedKey))
     } catch (err) { }

--- a/src/features/utils/agent-session.js
+++ b/src/features/utils/agent-session.js
@@ -6,7 +6,7 @@ import { drain } from '../../common/drain/drain'
 import { registerHandler } from '../../common/event-emitter/register-handler'
 import { SessionEntity } from '../../common/session/session-entity'
 import { LocalStorage } from '../../common/storage/local-storage.js'
-import { DEFAULT_KEY } from '../../common/session/constants'
+import { getAppSessionHash } from '../../common/session/session-key'
 import { mergeInfo } from '../../common/config/info'
 import { trackObjectAttributeSize } from '../../common/util/attribute-size'
 import { handle } from '../../common/event-emitter/handle'
@@ -19,7 +19,7 @@ export function setupAgentSession (agentRef) {
   if (agentRef.runtime.session) return agentRef.runtime.session // already setup
 
   const sessionInit = agentRef.init.session
-  const namespacedKey = `${DEFAULT_KEY}::${agentRef.info.licenseKey}:${agentRef.info.applicationID}`
+  const namespacedKey = getAppSessionHash(agentRef.info.licenseKey, agentRef.info.applicationID)
 
   agentRef.runtime.session = new SessionEntity({
     agentRef,

--- a/src/features/utils/agent-session.js
+++ b/src/features/utils/agent-session.js
@@ -19,10 +19,11 @@ export function setupAgentSession (agentRef) {
   if (agentRef.runtime.session) return agentRef.runtime.session // already setup
 
   const sessionInit = agentRef.init.session
+  const namespacedKey = `${DEFAULT_KEY}::${agentRef.info.licenseKey}:${agentRef.info.applicationID}`
 
   agentRef.runtime.session = new SessionEntity({
     agentRef,
-    key: DEFAULT_KEY,
+    key: namespacedKey,
     storage: new LocalStorage(),
     expiresMs: sessionInit?.expiresMs,
     inactiveMs: sessionInit?.inactiveMs

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { FeatureBase } from './feature-base'
-import { isValid } from '../../common/config/info'
-import { configure } from '../../loaders/configure/configure'
-import { gosCDN } from '../../common/window/nreum'
 import { drain } from '../../common/drain/drain'
 import { Obfuscator } from '../../common/util/obfuscate'
 import { FEATURE_NAMES } from '../../loaders/features/features'
@@ -24,7 +21,6 @@ export class AggregateBase extends FeatureBase {
    */
   constructor (agentRef, featureName) {
     super(agentRef, featureName)
-    this.checkConfiguration(agentRef)
     this.doOnceForAllAggregate(agentRef)
 
     /** @type {Boolean} indicates if custom attributes are combined in each event payload for size estimation purposes. this is set to true in derived classes that need to evaluate custom attributes separately from the event payload */
@@ -179,34 +175,6 @@ export class AggregateBase extends FeatureBase {
     this.isRetrying = result.sent && result.retry
     if (this.isRetrying) this.events.reloadSave(this.harvestOpts)
     this.events.clearSave(this.harvestOpts)
-  }
-
-  /**
-   * Checks for additional `jsAttributes` items to support backward compatibility with implementations of the agent where
-   * loader configurations may appear after the loader code is executed.
-   */
-  checkConfiguration (existingAgent) {
-    // NOTE: This check has to happen at aggregator load time
-    if (!isValid(existingAgent.info)) {
-      const cdn = gosCDN()
-      let jsAttributes = { ...cdn.info?.jsAttributes }
-      try {
-        jsAttributes = {
-          ...jsAttributes,
-          ...existingAgent.info?.jsAttributes
-        }
-      } catch (err) {
-        // do nothing
-      }
-      configure(existingAgent, {
-        ...cdn,
-        info: {
-          ...cdn.info,
-          jsAttributes
-        },
-        runtime: existingAgent.runtime
-      }, existingAgent.runtime.loaderType)
-    }
   }
 
   /**

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -5,8 +5,8 @@
 
 /**
  * @file Defines `InstrumentBase` to be used as the super of the Instrument classes implemented by each feature.
- * Inherits and executes the `checkConfiguration` method from [FeatureBase]{@link ./feature-base}, which also
- * exposes the `blocked` property.
+ * Validates and loads feature aggregates, including a one-time late configuration check before import.
+ * Inherits `blocked` behavior from [FeatureBase]{@link ./feature-base}.
  */
 
 import { drain, registerDrain } from '../../common/drain/drain'
@@ -14,12 +14,17 @@ import { FeatureBase } from './feature-base'
 import { onWindowLoad } from '../../common/window/load'
 import { isBrowserScope } from '../../common/constants/runtime'
 import { warn } from '../../common/util/console'
+import { isValid } from '../../common/config/info'
+import { configure } from '../../loaders/configure/configure'
+import { gosCDN } from '../../common/window/nreum'
 import { FEATURE_NAMES } from '../../loaders/features/features'
 import { hasReplayPrerequisite } from '../session_replay/shared/utils'
 import { canEnableSessionTracking } from './feature-gates'
 import { single } from '../../common/util/invoke'
 import { SESSION_ERROR } from '../../common/constants/agent-constants'
 import { handle } from '../../common/event-emitter/handle'
+
+const checkedAgents = new WeakSet()
 
 /**
  * Base class for instrumenting a feature.
@@ -90,6 +95,14 @@ export class InstrumentBase extends FeatureBase {
       // or otherwise when the manual-start-all event is emitted by the start API
       await this.deferred
 
+      this.#checkConfiguration(agentRef) // check for late-appearing 'info' config on the page
+      if (!isValid(agentRef.info)) { // if there still isn't valid info, then we can't proceed with session setup or importing the aggregates
+        warn(43)
+        agentRef.ee.abort()
+        this.loadedSuccessfully(false)
+        return
+      }
+
       let session
       try {
         if (canEnableSessionTracking(agentRef.init)) { // would require some setup before certain features start
@@ -148,6 +161,36 @@ export class InstrumentBase extends FeatureBase {
         return !!session
       default:
         return true
+    }
+  }
+
+  /**
+   * Checks for additional `jsAttributes` items to support backward compatibility with implementations of the agent where
+   * loader configurations may appear after the loader code is executed.
+   */
+  #checkConfiguration (existingAgent) {
+    if (checkedAgents.has(existingAgent)) return
+    checkedAgents.add(existingAgent)
+    // NOTE: This check has to happen at load time
+    if (!isValid(existingAgent.info)) {
+      const cdn = gosCDN()
+      let jsAttributes = { ...cdn.info?.jsAttributes }
+      try {
+        jsAttributes = {
+          ...jsAttributes,
+          ...existingAgent.info?.jsAttributes
+        }
+      } catch (err) {
+        // do nothing
+      }
+      configure(existingAgent, {
+        ...cdn,
+        info: {
+          ...cdn.info,
+          jsAttributes
+        },
+        runtime: existingAgent.runtime
+      }, existingAgent.runtime.loaderType)
     }
   }
 }

--- a/src/loaders/api-base.js
+++ b/src/loaders/api-base.js
@@ -230,7 +230,7 @@ export class ApiBase {
 
   /**
    * Accepts or rejects consent when the agent is configured to require consent before harvesting.
-   * The consent state is stored in session storage inside the NRBA_SESSION object.
+    * The consent state is stored in the agent session object in browser storage.
    * {@link https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/consent/}
    * @param {boolean?} accept Whether to accept or reject consent. Defaults to true (accept) if left undefined.
    */

--- a/tests/components/interaction-timer.test.js
+++ b/tests/components/interaction-timer.test.js
@@ -1,6 +1,6 @@
 import { InteractionTimer } from '../../src/common/timer/interaction-timer'
 import { LocalMemory, model } from './session-helpers'
-import { PREFIX } from '../../src/common/session/constants'
+import { SESSION_STORAGE_KEY_PREFIX } from '../../src/common/session/constants'
 
 jest.useFakeTimers()
 
@@ -137,8 +137,8 @@ describe('pause()', () => {
 
 describe('resume()', () => {
   test('resume allows the callback continue firing', () => {
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { ...model, value, expiresAt: now + 5000, inactiveAt: Infinity, updatedAt: now } })
-    const timer = new InteractionTimer({ onEnd: jest.fn(), readStorage: () => storage.get(`${PREFIX}_${key}`) }, 100)
+    const storage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { ...model, value, expiresAt: now + 5000, inactiveAt: Infinity, updatedAt: now } })
+    const timer = new InteractionTimer({ onEnd: jest.fn(), readStorage: () => storage.get(`${SESSION_STORAGE_KEY_PREFIX}${key}`) }, 100)
     expect(timer.onEnd).toHaveBeenCalledTimes(0)
     timer.pause()
     jest.advanceTimersByTime(150)
@@ -149,8 +149,8 @@ describe('resume()', () => {
   })
 
   test('resume fires the refresh callback if session is valid', () => {
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { ...model, value, expiresAt: now + 5000, inactiveAt: Infinity, updatedAt: now } })
-    const timer = new InteractionTimer({ onEnd: jest.fn(), onRefresh: jest.fn(), readStorage: () => storage.get(`${PREFIX}_${key}`) }, 100)
+    const storage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { ...model, value, expiresAt: now + 5000, inactiveAt: Infinity, updatedAt: now } })
+    const timer = new InteractionTimer({ onEnd: jest.fn(), onRefresh: jest.fn(), readStorage: () => storage.get(`${SESSION_STORAGE_KEY_PREFIX}${key}`) }, 100)
     timer.pause()
     timer.resume()
     expect(timer.onRefresh).toHaveBeenCalledTimes(1)
@@ -158,8 +158,8 @@ describe('resume()', () => {
   })
 
   test('resume calls onEnd if storage is already invalid on resume -- expired', () => {
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { ...model, value, expiresAt: now - 5000, inactiveAt: Infinity, updatedAt: now } })
-    const timer = new InteractionTimer({ onEnd: jest.fn(), onRefresh: jest.fn(), readStorage: () => storage.get(`${PREFIX}_${key}`) }, 100)
+    const storage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { ...model, value, expiresAt: now - 5000, inactiveAt: Infinity, updatedAt: now } })
+    const timer = new InteractionTimer({ onEnd: jest.fn(), onRefresh: jest.fn(), readStorage: () => storage.get(`${SESSION_STORAGE_KEY_PREFIX}${key}`) }, 100)
     timer.pause()
     timer.resume()
     expect(timer.onRefresh).toHaveBeenCalledTimes(0)
@@ -167,8 +167,8 @@ describe('resume()', () => {
   })
 
   test('resume calls onEnd if storage is already invalid on resume -- inactive', () => {
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { ...model, value, expiresAt: now + 5000, inactiveAt: now - 5000, updatedAt: now } })
-    const timer = new InteractionTimer({ onEnd: jest.fn(), onRefresh: jest.fn(), readStorage: () => storage.get(`${PREFIX}_${key}`) }, 100)
+    const storage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { ...model, value, expiresAt: now + 5000, inactiveAt: now - 5000, updatedAt: now } })
+    const timer = new InteractionTimer({ onEnd: jest.fn(), onRefresh: jest.fn(), readStorage: () => storage.get(`${SESSION_STORAGE_KEY_PREFIX}${key}`) }, 100)
     timer.pause()
     timer.resume()
     expect(timer.onRefresh).toHaveBeenCalledTimes(0)

--- a/tests/components/session-entity.test.js
+++ b/tests/components/session-entity.test.js
@@ -1,4 +1,4 @@
-import { PREFIX } from '../../src/common/session/constants'
+import { SESSION_STORAGE_KEY_PREFIX } from '../../src/common/session/constants'
 import { SessionEntity } from '../../src/common/session/session-entity'
 import { LocalMemory, model } from './session-helpers'
 import * as runtimeModule from '../../src/common/constants/runtime'
@@ -59,7 +59,7 @@ describe('constructor', () => {
   test('expiresAt is the correct future timestamp - existing session', () => {
     const now = Date.now()
     jest.setSystemTime(now)
-    const existingData = new LocalMemory({ [`${PREFIX}_${key}`]: { ...model, value, expiresAt: now + 5000, inactiveAt: Infinity, updatedAt: now } })
+    const existingData = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { ...model, value, expiresAt: now + 5000, inactiveAt: Infinity, updatedAt: now } })
     const session = new SessionEntity({ agentRef, key, expiresMs: 100, storage: existingData })
     expect(session.state.expiresAt).toEqual(now + 5000)
   })
@@ -79,7 +79,7 @@ describe('constructor', () => {
   test('inactiveAt is the correct future timestamp - existing session', () => {
     const now = Date.now()
     jest.setSystemTime(now)
-    const existingData = new LocalMemory({ [`${PREFIX}_${key}`]: { ...model, value, inactiveAt: now + 5000, expiresAt: Infinity, updatedAt: now } })
+    const existingData = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { ...model, value, inactiveAt: now + 5000, expiresAt: Infinity, updatedAt: now } })
     const session = new SessionEntity({ agentRef, key, inactiveMs: 100, storage: existingData })
     expect(session.state.inactiveAt).toEqual(now + 5000)
   })
@@ -93,14 +93,14 @@ describe('constructor', () => {
     const newSession = new SessionEntity({ agentRef, key, storage, expiresMs: 10 })
     expect(newSession.isNew).toBeTruthy()
 
-    const newStorage = new LocalMemory({ [`${PREFIX}_${key}`]: { ...model, value, expiresAt: Infinity, inactiveAt: Infinity, updatedAt: Date.now() } })
+    const newStorage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { ...model, value, expiresAt: Infinity, inactiveAt: Infinity, updatedAt: Date.now() } })
     const existingSession = new SessionEntity({ agentRef, key, expiresMs: 10, storage: newStorage })
     expect(existingSession.isNew).toBeFalsy()
   })
 
   test('invalid stored values sets new defaults', () => {
     // missing required fields
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { invalid_fields: true } })
+    const storage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { invalid_fields: true } })
     const session = new SessionEntity({ agentRef, key, storage })
     expect(session.state).toEqual(expect.objectContaining(buildExpectedSessionState()))
   })
@@ -108,7 +108,7 @@ describe('constructor', () => {
   test('expired expiresAt value in storage sets new defaults', () => {
     const now = Date.now()
     jest.setSystemTime(now)
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { value, expiresAt: now - 100, inactiveAt: Infinity } })
+    const storage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { value, expiresAt: now - 100, inactiveAt: Infinity } })
     const session = new SessionEntity({ agentRef, key, storage })
     expect(session.state).toEqual(expect.objectContaining(buildExpectedSessionState()))
   })
@@ -116,7 +116,7 @@ describe('constructor', () => {
   test('expired inactiveAt value in storage sets new defaults', () => {
     const now = Date.now()
     jest.setSystemTime(now)
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { value, inactiveAt: now - 100, expiresAt: Infinity } })
+    const storage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { value, inactiveAt: now - 100, expiresAt: Infinity } })
     const session = new SessionEntity({ agentRef, key, storage })
     expect(session.state).toEqual(expect.objectContaining(buildExpectedSessionState()))
   })
@@ -176,19 +176,19 @@ describe('isNew', () => {
     expect(sessionInstance.isNew).toEqual(true)
   })
   test('is true after the session resets by timers | false -> true', () => {
-    storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
+    storage.set(`${SESSION_STORAGE_KEY_PREFIX}${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
     const sessionInstance = new SessionEntity({ agentRef, key, storage })
     expect(sessionInstance.isNew).toEqual(false)
     sessionInstance.reset()
     expect(sessionInstance.isNew).toEqual(true)
   })
   test('is true if reset happens on initialization after time outs off-view | expiresAt', () => {
-    storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() - 1, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
+    storage.set(`${SESSION_STORAGE_KEY_PREFIX}${key}`, { ...model, value, expiresAt: Date.now() - 1, inactiveAt: Date.now() + 100000, updatedAt: Date.now() })
     const sessionInstance = new SessionEntity({ agentRef, key, storage })
     expect(sessionInstance.isNew).toEqual(true)
   })
   test('is true if reset happens on initialization after time outs off-view | inactiveAt', () => {
-    storage.set(`${PREFIX}_${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() - 1, updatedAt: Date.now() })
+    storage.set(`${SESSION_STORAGE_KEY_PREFIX}${key}`, { ...model, value, expiresAt: Date.now() + 100000, inactiveAt: Date.now() - 1, updatedAt: Date.now() })
     const sessionInstance = new SessionEntity({ agentRef, key, storage })
     expect(sessionInstance.isNew).toEqual(true)
   })
@@ -203,7 +203,7 @@ describe('read()', () => {
   })
 
   test('"pre-existing" sessions get data from read()', () => {
-    const storage = new LocalMemory({ [`${PREFIX}_${key}`]: { ...model, value, expiresAt: Infinity, inactiveAt: Infinity } })
+    const storage = new LocalMemory({ [`${SESSION_STORAGE_KEY_PREFIX}${key}`]: { ...model, value, expiresAt: Infinity, inactiveAt: Infinity } })
     const session = new SessionEntity({ agentRef, key, storage })
     expect(session.isNew).toBeFalsy()
     expect(session.read()).toEqual(expect.objectContaining({

--- a/tests/components/session_replay/instrument.test.js
+++ b/tests/components/session_replay/instrument.test.js
@@ -1,7 +1,7 @@
 import { resetAgent, setupAgent } from '../setup-agent'
 import { Instrument as SessionReplay } from '../../../src/features/session_replay/instrument'
 import * as nreumModule from '../../../src/common/window/nreum'
-import { DEFAULT_KEY, PREFIX } from '../../../src/common/session/constants'
+import { getAppSessionStorageKey } from '../../../src/common/session/session-key'
 import { MODE } from '../../specs/util/helpers'
 
 let mainAgent, savedInitialSession
@@ -118,7 +118,7 @@ describe('Preload early records', () => {
   })
 
   test('when replay already on in namespaced localStorage session, even if preload flag disabled', async () => {
-    const namespacedKey = `${PREFIX}_${DEFAULT_KEY}::${mainAgent.info.licenseKey}:${mainAgent.info.applicationID}`
+    const namespacedKey = getAppSessionStorageKey(mainAgent.info.licenseKey, mainAgent.info.applicationID)
     localStorage.setItem(namespacedKey, JSON.stringify({ sessionReplayMode: MODE.FULL }))
     mainAgent.runtime.session = undefined
     Object.assign(mainAgent.init.session_replay, { preload: false, enabled: true })

--- a/tests/components/session_replay/instrument.test.js
+++ b/tests/components/session_replay/instrument.test.js
@@ -1,6 +1,7 @@
 import { resetAgent, setupAgent } from '../setup-agent'
 import { Instrument as SessionReplay } from '../../../src/features/session_replay/instrument'
 import * as nreumModule from '../../../src/common/window/nreum'
+import { DEFAULT_KEY, PREFIX } from '../../../src/common/session/constants'
 import { MODE } from '../../specs/util/helpers'
 
 let mainAgent, savedInitialSession
@@ -108,6 +109,19 @@ describe('Preload early records', () => {
   test('when replay already on in existing session, even if preload flag disabled', async () => {
     Object.assign(mainAgent.init.session_replay, { preload: false, enabled: true })
     mainAgent.runtime.session.write({ sessionReplayMode: MODE.FULL })
+
+    const sessionReplayInstrument = new SessionReplay(mainAgent)
+    await new Promise(process.nextTick)
+
+    expect(sessionReplayInstrument.recorder).toBeDefined()
+    expect(mainAgent.runtime.isRecording).toEqual(true)
+  })
+
+  test('when replay already on in namespaced localStorage session, even if preload flag disabled', async () => {
+    const namespacedKey = `${PREFIX}_${DEFAULT_KEY}::${mainAgent.info.licenseKey}:${mainAgent.info.applicationID}`
+    localStorage.setItem(namespacedKey, JSON.stringify({ sessionReplayMode: MODE.FULL }))
+    mainAgent.runtime.session = undefined
+    Object.assign(mainAgent.init.session_replay, { preload: false, enabled: true })
 
     const sessionReplayInstrument = new SessionReplay(mainAgent)
     await new Promise(process.nextTick)

--- a/tests/components/session_replay/instrument.test.js
+++ b/tests/components/session_replay/instrument.test.js
@@ -1,7 +1,8 @@
 import { resetAgent, setupAgent } from '../setup-agent'
 import { Instrument as SessionReplay } from '../../../src/features/session_replay/instrument'
 import * as nreumModule from '../../../src/common/window/nreum'
-import { getAppSessionStorageKey } from '../../../src/common/session/session-key'
+import { getAppSessionHash } from '../../../src/common/session/session-key'
+import { SESSION_STORAGE_KEY_PREFIX } from '../../../src/common/session/constants'
 import { MODE } from '../../specs/util/helpers'
 
 let mainAgent, savedInitialSession
@@ -118,7 +119,7 @@ describe('Preload early records', () => {
   })
 
   test('when replay already on in namespaced localStorage session, even if preload flag disabled', async () => {
-    const namespacedKey = getAppSessionStorageKey(mainAgent.info.licenseKey, mainAgent.info.applicationID)
+    const namespacedKey = `${SESSION_STORAGE_KEY_PREFIX}${getAppSessionHash(mainAgent.info.licenseKey, mainAgent.info.applicationID)}`
     localStorage.setItem(namespacedKey, JSON.stringify({ sessionReplayMode: MODE.FULL }))
     mainAgent.runtime.session = undefined
     Object.assign(mainAgent.init.session_replay, { preload: false, enabled: true })

--- a/tests/specs/api/setCustomAttribute.e2e.js
+++ b/tests/specs/api/setCustomAttribute.e2e.js
@@ -97,7 +97,7 @@ describe('newrelic api', () => {
 
       const session = await browser.execute(function () {
         const agent = Object.values(newrelic.initializedAgents)[0]
-        return localStorage.getItem(`NRBA_${agent.runtime.session.key}`)
+        return localStorage.getItem(agent.runtime.session.lookupKey)
       })
       expect(JSON.parse(session).custom.testing).toEqual(randomValue) // initial page load has custom attribute in memory
       expect(JSON.parse(session).custom['testing-load']).toEqual(randomValue) // initial page load has custom attribute in memory
@@ -128,7 +128,7 @@ describe('newrelic api', () => {
 
       const sessionAfterNavigate = await browser.execute(function () {
         const agent = Object.values(newrelic.initializedAgents)[0]
-        return localStorage.getItem(`NRBA_${agent.runtime.session.key}`)
+        return localStorage.getItem(agent.runtime.session.lookupKey)
       })
       expect(JSON.parse(sessionAfterNavigate).custom.testing).toEqual(randomValueAfterNavigate) // initial page load has custom attribute in memory
       expect(JSON.parse(sessionAfterNavigate).custom['testing-load']).toEqual(randomValueAfterNavigate) // initial page load has custom attribute in memory

--- a/tests/specs/api/setCustomAttribute.e2e.js
+++ b/tests/specs/api/setCustomAttribute.e2e.js
@@ -96,7 +96,8 @@ describe('newrelic api', () => {
       expect(rumResult[0].request.body.ja).toEqual({ testing: randomValue, 'testing-load': randomValue, webdriverDetected: expectedWebdriverDetected }) // initial page load has custom attribute
 
       const session = await browser.execute(function () {
-        return localStorage.getItem('NRBA_SESSION')
+        const agent = Object.values(newrelic.initializedAgents)[0]
+        return localStorage.getItem(`NRBA_${agent.runtime.session.key}`)
       })
       expect(JSON.parse(session).custom.testing).toEqual(randomValue) // initial page load has custom attribute in memory
       expect(JSON.parse(session).custom['testing-load']).toEqual(randomValue) // initial page load has custom attribute in memory
@@ -126,7 +127,8 @@ describe('newrelic api', () => {
       expect(rumResultAfterNavigate[1].request.body.ja).not.toEqual({ testing: randomValue, 'testing-load': randomValueAfterNavigate, webdriverDetected: expectedWebdriverDetected }) // 2nd page load value is not first load value
 
       const sessionAfterNavigate = await browser.execute(function () {
-        return localStorage.getItem('NRBA_SESSION')
+        const agent = Object.values(newrelic.initializedAgents)[0]
+        return localStorage.getItem(`NRBA_${agent.runtime.session.key}`)
       })
       expect(JSON.parse(sessionAfterNavigate).custom.testing).toEqual(randomValueAfterNavigate) // initial page load has custom attribute in memory
       expect(JSON.parse(sessionAfterNavigate).custom['testing-load']).toEqual(randomValueAfterNavigate) // initial page load has custom attribute in memory

--- a/tests/specs/npm/micro-agent.e2e.js
+++ b/tests/specs/npm/micro-agent.e2e.js
@@ -79,11 +79,11 @@ describe('micro-agent', () => {
       expect(payloadMatchesAppId(query.a, data.val, data.actionName, data.customAttr)).toEqual(true)
     })
 
-    expect(logsHarvest.length).toEqual(0)
+    expect(logsHarvest.length).toEqual(1)
 
-    // check to ensure both agents have the same logging mode (shared session)
+    // check to ensure both agents have the appropriate logging mode (separate session)
     expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.OFF, api: LOGGING_MODE.OFF })
-    expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
+    expect(result.agent2.loggingMode).toEqual({ auto: LOGGING_MODE.DEBUG, api: LOGGING_MODE.DEBUG })
     expect(tests[1]).toEqual({ rum: true, err: true, pa: true, log: false })
     expect(tests[2]).toEqual({ rum: true, err: true, pa: true, log: false })
   })
@@ -163,9 +163,9 @@ describe('micro-agent', () => {
       expect(payloadMatchesAppId(query.a, data.val, data.actionName, data.customAttr)).toEqual(true)
     })
 
-    // check to ensure both agents have the same logging mode (shared session)
+    // check to ensure both agents have the appropriate logging mode (separate session)
     expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.INFO, api: LOGGING_MODE.INFO })
-    expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
+    expect(result.agent2.loggingMode).toEqual({ auto: LOGGING_MODE.DEBUG, api: LOGGING_MODE.DEBUG })
     expect(logsHarvest.length).toEqual(2)
 
     logsHarvest.forEach(({ request: { query, body } }) => {
@@ -254,9 +254,9 @@ describe('micro-agent', () => {
       expect(payloadMatchesAppId(query.a, data.val, data.actionName, data.customAttr)).toEqual(true)
     })
 
-    // check to ensure both agents have the same logging mode (shared session)
+    // check to ensure both agents have the appropriate logging mode (separate session)
     expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.INFO, api: LOGGING_MODE.INFO })
-    expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
+    expect(result.agent2.loggingMode).toEqual({ auto: LOGGING_MODE.DEBUG, api: LOGGING_MODE.DEBUG })
 
     expect(logsHarvest.length).toEqual(2)
     logsHarvest.forEach(({ request: { query, body } }) => {

--- a/tests/specs/npm/micro-agent.e2e.js
+++ b/tests/specs/npm/micro-agent.e2e.js
@@ -4,11 +4,34 @@ import { testErrorsRequest, testInsRequest, testLogsRequest, testRumRequest } fr
 import { LOGGING_MODE } from '../../../src/features/logging/constants'
 
 describe('micro-agent', () => {
-  it('all agents correctly shuts down logging if first agent receives LOGGING_MODE.OFF', async () => {
-    await browser.enableLogging({
-      logMode: LOGGING_MODE.OFF,
-      secondLogMode: LOGGING_MODE.DEBUG
-    })
+  beforeEach(async () => {
+    await browser.destroyAgentSession()
+  })
+
+  async function waitForBothMicroAgentsLoggingInitialized () {
+    await browser.waitUntil(
+      () => browser.execute(function () {
+        const log1 = window.agent1?.features?.logging
+        const log2 = window.agent2?.features?.logging
+        if (!log1 || !log2) return false
+
+        const mode1 = log1.loggingMode
+        const mode2 = log2.loggingMode
+        const modeReady = mode1 && mode2 &&
+          typeof mode1.auto === 'number' && typeof mode1.api === 'number' &&
+          typeof mode2.auto === 'number' && typeof mode2.api === 'number'
+
+        return modeReady && log1.drained === true && log2.drained === true
+      }),
+      {
+        timeout: 10000,
+        timeoutMsg: 'Both micro-agent logging aggregates never fully initialized'
+      }
+    )
+  }
+
+  it('shuts down logging for both micro-agents when logging mode is OFF', async () => {
+    await browser.enableLogging({ logMode: LOGGING_MODE.OFF })
 
     const [rumCapture, errorsCapture, insightsCapture, logsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
       { test: testRumRequest },
@@ -19,6 +42,7 @@ describe('micro-agent', () => {
     // Note: this tests when micro-agents are created around the same time
     await browser.url(await browser.testHandle.assetURL('test-builds/browser-agent-wrapper/micro-agent.html'))
       .then(() => browser.waitForAgentLoad())
+      .then(() => waitForBothMicroAgentsLoggingInitialized())
 
     const result = await browser.execute(function () {
       // each payload in this test is decorated with data that matches its appId for ease of testing
@@ -81,14 +105,14 @@ describe('micro-agent', () => {
 
     expect(logsHarvest.length).toEqual(0)
 
-    // check to ensure both agents have the same logging mode (shared session)
+    // both agents should be fully disabled for logging in this scenario
     expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.OFF, api: LOGGING_MODE.OFF })
     expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
     expect(tests[1]).toEqual({ rum: true, err: true, pa: true, log: false })
     expect(tests[2]).toEqual({ rum: true, err: true, pa: true, log: false })
   })
 
-  it('Smoke Test - Can send distinct payloads of all relevant data types to 2 distinct app IDs', async () => {
+  it('Smoke Test - sends distinct payloads for all relevant data types to two app IDs', async () => {
     await browser.enableLogging({
       logMode: LOGGING_MODE.INFO,
       secondLogMode: LOGGING_MODE.DEBUG
@@ -103,6 +127,7 @@ describe('micro-agent', () => {
     // Note: this tests when micro-agents are created around the same time
     await browser.url(await browser.testHandle.assetURL('test-builds/browser-agent-wrapper/micro-agent.html'))
       .then(() => browser.waitForAgentLoad())
+      .then(() => waitForBothMicroAgentsLoggingInitialized())
 
     const result = await browser.execute(function () {
       // each payload in this test is decorated with data that matches its appId for ease of testing
@@ -163,9 +188,11 @@ describe('micro-agent', () => {
       expect(payloadMatchesAppId(query.a, data.val, data.actionName, data.customAttr)).toEqual(true)
     })
 
-    // check to ensure both agents have the same logging mode (shared session)
-    expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.INFO, api: LOGGING_MODE.INFO })
-    expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
+    // with secondLogMode enabled, each agent can land on INFO or DEBUG depending on startup timing.
+    expect([LOGGING_MODE.INFO, LOGGING_MODE.DEBUG]).toContain(result.agent1.loggingMode.auto)
+    expect(result.agent1.loggingMode.api).toEqual(result.agent1.loggingMode.auto)
+    expect([LOGGING_MODE.INFO, LOGGING_MODE.DEBUG]).toContain(result.agent2.loggingMode.auto)
+    expect(result.agent2.loggingMode.api).toEqual(result.agent2.loggingMode.auto)
     expect(logsHarvest.length).toEqual(2)
 
     logsHarvest.forEach(({ request: { query, body } }) => {
@@ -177,7 +204,7 @@ describe('micro-agent', () => {
   })
 
   // https://new-relic.atlassian.net/browse/NR-453240 <-- issue with rollup seen here around dynamic imports
-  it('Smoke Test - Can send distinct payloads of all relevant data types to 2 distinct app IDs - ROLL UP BUNDLE', async () => {
+  it('Smoke Test - sends distinct payloads for all relevant data types to two app IDs - ROLL UP BUNDLE', async () => {
     await browser.enableLogging({
       logMode: LOGGING_MODE.INFO,
       secondLogMode: LOGGING_MODE.DEBUG
@@ -193,6 +220,7 @@ describe('micro-agent', () => {
     // Note: this tests when micro-agent creation is staggered
     await browser.url(await browser.testHandle.assetURL('test-builds/rollup-micro-agent/index.html'))
       .then(() => browser.waitForAgentLoad())
+      .then(() => waitForBothMicroAgentsLoggingInitialized())
 
     const result = await browser.execute(function () {
       // each payload in this test is decorated with data that matches its appId for ease of testing
@@ -254,9 +282,11 @@ describe('micro-agent', () => {
       expect(payloadMatchesAppId(query.a, data.val, data.actionName, data.customAttr)).toEqual(true)
     })
 
-    // check to ensure both agents have the same logging mode (shared session)
-    expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.INFO, api: LOGGING_MODE.INFO })
-    expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
+    // with secondLogMode enabled, each agent can land on INFO or DEBUG depending on startup timing.
+    expect([LOGGING_MODE.INFO, LOGGING_MODE.DEBUG]).toContain(result.agent1.loggingMode.auto)
+    expect(result.agent1.loggingMode.api).toEqual(result.agent1.loggingMode.auto)
+    expect([LOGGING_MODE.INFO, LOGGING_MODE.DEBUG]).toContain(result.agent2.loggingMode.auto)
+    expect(result.agent2.loggingMode.api).toEqual(result.agent2.loggingMode.auto)
 
     expect(logsHarvest.length).toEqual(2)
     logsHarvest.forEach(({ request: { query, body } }) => {

--- a/tests/specs/npm/micro-agent.e2e.js
+++ b/tests/specs/npm/micro-agent.e2e.js
@@ -4,34 +4,11 @@ import { testErrorsRequest, testInsRequest, testLogsRequest, testRumRequest } fr
 import { LOGGING_MODE } from '../../../src/features/logging/constants'
 
 describe('micro-agent', () => {
-  beforeEach(async () => {
-    await browser.destroyAgentSession()
-  })
-
-  async function waitForBothMicroAgentsLoggingInitialized () {
-    await browser.waitUntil(
-      () => browser.execute(function () {
-        const log1 = window.agent1?.features?.logging
-        const log2 = window.agent2?.features?.logging
-        if (!log1 || !log2) return false
-
-        const mode1 = log1.loggingMode
-        const mode2 = log2.loggingMode
-        const modeReady = mode1 && mode2 &&
-          typeof mode1.auto === 'number' && typeof mode1.api === 'number' &&
-          typeof mode2.auto === 'number' && typeof mode2.api === 'number'
-
-        return modeReady && log1.drained === true && log2.drained === true
-      }),
-      {
-        timeout: 10000,
-        timeoutMsg: 'Both micro-agent logging aggregates never fully initialized'
-      }
-    )
-  }
-
-  it('shuts down logging for both micro-agents when logging mode is OFF', async () => {
-    await browser.enableLogging({ logMode: LOGGING_MODE.OFF })
+  it('all agents correctly shuts down logging if first agent receives LOGGING_MODE.OFF', async () => {
+    await browser.enableLogging({
+      logMode: LOGGING_MODE.OFF,
+      secondLogMode: LOGGING_MODE.DEBUG
+    })
 
     const [rumCapture, errorsCapture, insightsCapture, logsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
       { test: testRumRequest },
@@ -42,7 +19,6 @@ describe('micro-agent', () => {
     // Note: this tests when micro-agents are created around the same time
     await browser.url(await browser.testHandle.assetURL('test-builds/browser-agent-wrapper/micro-agent.html'))
       .then(() => browser.waitForAgentLoad())
-      .then(() => waitForBothMicroAgentsLoggingInitialized())
 
     const result = await browser.execute(function () {
       // each payload in this test is decorated with data that matches its appId for ease of testing
@@ -105,14 +81,14 @@ describe('micro-agent', () => {
 
     expect(logsHarvest.length).toEqual(0)
 
-    // both agents should be fully disabled for logging in this scenario
+    // check to ensure both agents have the same logging mode (shared session)
     expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.OFF, api: LOGGING_MODE.OFF })
     expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
     expect(tests[1]).toEqual({ rum: true, err: true, pa: true, log: false })
     expect(tests[2]).toEqual({ rum: true, err: true, pa: true, log: false })
   })
 
-  it('Smoke Test - sends distinct payloads for all relevant data types to two app IDs', async () => {
+  it('Smoke Test - Can send distinct payloads of all relevant data types to 2 distinct app IDs', async () => {
     await browser.enableLogging({
       logMode: LOGGING_MODE.INFO,
       secondLogMode: LOGGING_MODE.DEBUG
@@ -127,7 +103,6 @@ describe('micro-agent', () => {
     // Note: this tests when micro-agents are created around the same time
     await browser.url(await browser.testHandle.assetURL('test-builds/browser-agent-wrapper/micro-agent.html'))
       .then(() => browser.waitForAgentLoad())
-      .then(() => waitForBothMicroAgentsLoggingInitialized())
 
     const result = await browser.execute(function () {
       // each payload in this test is decorated with data that matches its appId for ease of testing
@@ -188,11 +163,9 @@ describe('micro-agent', () => {
       expect(payloadMatchesAppId(query.a, data.val, data.actionName, data.customAttr)).toEqual(true)
     })
 
-    // with secondLogMode enabled, each agent can land on INFO or DEBUG depending on startup timing.
-    expect([LOGGING_MODE.INFO, LOGGING_MODE.DEBUG]).toContain(result.agent1.loggingMode.auto)
-    expect(result.agent1.loggingMode.api).toEqual(result.agent1.loggingMode.auto)
-    expect([LOGGING_MODE.INFO, LOGGING_MODE.DEBUG]).toContain(result.agent2.loggingMode.auto)
-    expect(result.agent2.loggingMode.api).toEqual(result.agent2.loggingMode.auto)
+    // check to ensure both agents have the same logging mode (shared session)
+    expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.INFO, api: LOGGING_MODE.INFO })
+    expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
     expect(logsHarvest.length).toEqual(2)
 
     logsHarvest.forEach(({ request: { query, body } }) => {
@@ -204,7 +177,7 @@ describe('micro-agent', () => {
   })
 
   // https://new-relic.atlassian.net/browse/NR-453240 <-- issue with rollup seen here around dynamic imports
-  it('Smoke Test - sends distinct payloads for all relevant data types to two app IDs - ROLL UP BUNDLE', async () => {
+  it('Smoke Test - Can send distinct payloads of all relevant data types to 2 distinct app IDs - ROLL UP BUNDLE', async () => {
     await browser.enableLogging({
       logMode: LOGGING_MODE.INFO,
       secondLogMode: LOGGING_MODE.DEBUG
@@ -220,7 +193,6 @@ describe('micro-agent', () => {
     // Note: this tests when micro-agent creation is staggered
     await browser.url(await browser.testHandle.assetURL('test-builds/rollup-micro-agent/index.html'))
       .then(() => browser.waitForAgentLoad())
-      .then(() => waitForBothMicroAgentsLoggingInitialized())
 
     const result = await browser.execute(function () {
       // each payload in this test is decorated with data that matches its appId for ease of testing
@@ -282,11 +254,9 @@ describe('micro-agent', () => {
       expect(payloadMatchesAppId(query.a, data.val, data.actionName, data.customAttr)).toEqual(true)
     })
 
-    // with secondLogMode enabled, each agent can land on INFO or DEBUG depending on startup timing.
-    expect([LOGGING_MODE.INFO, LOGGING_MODE.DEBUG]).toContain(result.agent1.loggingMode.auto)
-    expect(result.agent1.loggingMode.api).toEqual(result.agent1.loggingMode.auto)
-    expect([LOGGING_MODE.INFO, LOGGING_MODE.DEBUG]).toContain(result.agent2.loggingMode.auto)
-    expect(result.agent2.loggingMode.api).toEqual(result.agent2.loggingMode.auto)
+    // check to ensure both agents have the same logging mode (shared session)
+    expect(result.agent1.loggingMode).toEqual({ auto: LOGGING_MODE.INFO, api: LOGGING_MODE.INFO })
+    expect(result.agent2.loggingMode).toEqual(result.agent1.loggingMode)
 
     expect(logsHarvest.length).toEqual(2)
     logsHarvest.forEach(({ request: { query, body } }) => {

--- a/tests/specs/session-manager.e2e.js
+++ b/tests/specs/session-manager.e2e.js
@@ -1,6 +1,7 @@
 import { supportsMultiTabSessions } from '../../tools/browser-matcher/common-matchers.mjs'
 import { testErrorsRequest } from '../../tools/testing-server/utils/expect-tests'
 import { buildExpectedSessionState } from './util/helpers'
+import { PREFIX } from '../../src/common/session/constants'
 
 const config = {
   init: {
@@ -27,6 +28,23 @@ describe('newrelic session ID', () => {
       const { localStorage } = await browser.getAgentSessionInfo()
 
       expect(localStorage).toEqual(anySession())
+    })
+
+    it('should store session data under app namespaced key', async () => {
+      await browser.url(await browser.testHandle.assetURL('session-entity.html', config))
+        .then(() => browser.waitForAgentLoad())
+
+      const namespacedStorage = await browser.execute(function (prefix) {
+        const agent = Object.values(newrelic.initializedAgents)[0]
+        const key = `${prefix}_${agent.runtime.session.key}`
+        return {
+          key,
+          value: JSON.parse(localStorage.getItem(key) || '{}')
+        }
+      }, PREFIX)
+
+      expect(namespacedStorage.key).toEqual(expect.stringMatching(/^NRBA_SESSION::.+:.+$/))
+      expect(namespacedStorage.value).toEqual(anySession())
     })
   })
 

--- a/tests/specs/session-manager.e2e.js
+++ b/tests/specs/session-manager.e2e.js
@@ -43,7 +43,7 @@ describe('newrelic session ID', () => {
         }
       }, PREFIX)
 
-      expect(namespacedStorage.key).toEqual(expect.stringMatching(/^NRBA_SESSION::.+:.+$/))
+      expect(namespacedStorage.key).toEqual(expect.stringMatching(/^NRBA_SESSION::[a-f0-9]{8}$/))
       expect(namespacedStorage.value).toEqual(anySession())
     })
   })

--- a/tests/specs/session-manager.e2e.js
+++ b/tests/specs/session-manager.e2e.js
@@ -1,7 +1,6 @@
 import { supportsMultiTabSessions } from '../../tools/browser-matcher/common-matchers.mjs'
 import { testErrorsRequest } from '../../tools/testing-server/utils/expect-tests'
 import { buildExpectedSessionState } from './util/helpers'
-import { PREFIX } from '../../src/common/session/constants'
 
 const config = {
   init: {
@@ -34,14 +33,14 @@ describe('newrelic session ID', () => {
       await browser.url(await browser.testHandle.assetURL('session-entity.html', config))
         .then(() => browser.waitForAgentLoad())
 
-      const namespacedStorage = await browser.execute(function (prefix) {
+      const namespacedStorage = await browser.execute(function () {
         const agent = Object.values(newrelic.initializedAgents)[0]
-        const key = `${prefix}_${agent.runtime.session.key}`
+        const key = agent.runtime.session.lookupKey
         return {
           key,
           value: JSON.parse(localStorage.getItem(key) || '{}')
         }
-      }, PREFIX)
+      })
 
       expect(namespacedStorage.key).toEqual(expect.stringMatching(/^NRBA_SESSION::[a-f0-9]{8}$/))
       expect(namespacedStorage.value).toEqual(anySession())

--- a/tests/specs/soft_navigations/payloads.e2e.js
+++ b/tests/specs/soft_navigations/payloads.e2e.js
@@ -1,4 +1,4 @@
-import { notIOS, notSafari, supportsFirstPaint } from '../../../tools/browser-matcher/common-matchers.mjs'
+import { lambdaTestWebdriverFalse, notIOS, notSafari, supportsFirstPaint } from '../../../tools/browser-matcher/common-matchers.mjs'
 import { testInteractionEventsRequest, testErrorsRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('attribution tests', () => {
@@ -53,11 +53,12 @@ describe('attribution tests', () => {
         ).then(() => browser.waitForAgentLoad())
       ])
       const ipl = interactionHarvests[0].request.body[0]
+      const expectedAttributeType = browserMatch(lambdaTestWebdriverFalse) ? 'falseAttribute' : 'trueAttribute'
 
       expect(ipl.trigger).toEqual('initialPageLoad')
       expect(ipl.children).toEqual([
         { key: 'isFirstOfSession', type: 'trueAttribute' },
-        { key: 'webdriverDetected', type: 'falseAttribute' }
+        { key: 'webdriverDetected', type: expectedAttributeType }
       ])
       expect(ipl.isRouteChange).not.toBeTruthy()
       if (browserMatch(notIOS)) expect(ipl.oldURL).toEqual('') // ios on lambdatest appears to return the wrong value for referrer when using browser.execute, which breaks this test condition. Confirmed referrer behavior works in real env
@@ -84,11 +85,12 @@ describe('attribution tests', () => {
         ).then(() => browser.waitForAgentLoad())
       ])
       const ipl = interactionHarvests[0].request.body[0]
+      const expectedAttributeType = browserMatch(lambdaTestWebdriverFalse) ? 'falseAttribute' : 'trueAttribute'
 
       expect(ipl.trigger).toEqual('initialPageLoad')
       expect(ipl.children).toEqual([
         { key: 'isFirstOfSession', type: 'trueAttribute' },
-        { key: 'webdriverDetected', type: 'falseAttribute' }
+        { key: 'webdriverDetected', type: expectedAttributeType }
       ])
       expect(ipl.isRouteChange).not.toBeTruthy()
       if (browserMatch(notIOS)) expect(ipl.oldURL).toEqual('') // ios on lambdatest appears to return the wrong value for referrer when using browser.execute, which breaks this test condition. Confirmed referrer behavior works in real env
@@ -115,11 +117,12 @@ describe('attribution tests', () => {
         ).then(() => browser.waitForAgentLoad())
       ])
       const ipl = interactionHarvests[0].request.body[0]
+      const expectedAttributeType = browserMatch(lambdaTestWebdriverFalse) ? 'falseAttribute' : 'trueAttribute'
 
       expect(ipl.trigger).toEqual('initialPageLoad')
       expect(ipl.children).toEqual([
         { key: 'isFirstOfSession', type: 'trueAttribute' },
-        { key: 'webdriverDetected', type: 'falseAttribute' }
+        { key: 'webdriverDetected', type: expectedAttributeType }
       ])
       expect(ipl.isRouteChange).not.toBeTruthy()
       if (browserMatch(notIOS)) expect(ipl.oldURL).toEqual('') // ios on lambdatest appears to return the wrong value for referrer when using browser.execute, which breaks this test condition. Confirmed referrer behavior works in real env

--- a/tests/specs/soft_navigations/payloads.e2e.js
+++ b/tests/specs/soft_navigations/payloads.e2e.js
@@ -55,7 +55,10 @@ describe('attribution tests', () => {
       const ipl = interactionHarvests[0].request.body[0]
 
       expect(ipl.trigger).toEqual('initialPageLoad')
-      expect(ipl.children.length).toEqual(1)
+      expect(ipl.children).toEqual([
+        { key: 'isFirstOfSession', type: 'trueAttribute' },
+        { key: 'webdriverDetected', type: 'falseAttribute' }
+      ])
       expect(ipl.isRouteChange).not.toBeTruthy()
       if (browserMatch(notIOS)) expect(ipl.oldURL).toEqual('') // ios on lambdatest appears to return the wrong value for referrer when using browser.execute, which breaks this test condition. Confirmed referrer behavior works in real env
 
@@ -83,7 +86,10 @@ describe('attribution tests', () => {
       const ipl = interactionHarvests[0].request.body[0]
 
       expect(ipl.trigger).toEqual('initialPageLoad')
-      expect(ipl.children.length).toEqual(1)
+      expect(ipl.children).toEqual([
+        { key: 'isFirstOfSession', type: 'trueAttribute' },
+        { key: 'webdriverDetected', type: 'falseAttribute' }
+      ])
       expect(ipl.isRouteChange).not.toBeTruthy()
       if (browserMatch(notIOS)) expect(ipl.oldURL).toEqual('') // ios on lambdatest appears to return the wrong value for referrer when using browser.execute, which breaks this test condition. Confirmed referrer behavior works in real env
 
@@ -111,7 +117,10 @@ describe('attribution tests', () => {
       const ipl = interactionHarvests[0].request.body[0]
 
       expect(ipl.trigger).toEqual('initialPageLoad')
-      expect(ipl.children.length).toEqual(1)
+      expect(ipl.children).toEqual([
+        { key: 'isFirstOfSession', type: 'trueAttribute' },
+        { key: 'webdriverDetected', type: 'falseAttribute' }
+      ])
       expect(ipl.isRouteChange).not.toBeTruthy()
       if (browserMatch(notIOS)) expect(ipl.oldURL).toEqual('') // ios on lambdatest appears to return the wrong value for referrer when using browser.execute, which breaks this test condition. Confirmed referrer behavior works in real env
 

--- a/tests/specs/soft_navigations/xhr.e2e.js
+++ b/tests/specs/soft_navigations/xhr.e2e.js
@@ -1,5 +1,6 @@
 import { checkAjaxEvents, checkSpa } from '../../util/basic-checks'
 import { testInteractionEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { lambdaTestWebdriverFalse } from '../../../tools/browser-matcher/common-matchers.mjs'
 
 describe('XHR SPA Interaction Tracking', () => {
   let interactionsCapture
@@ -117,9 +118,10 @@ describe('XHR SPA Interaction Tracking', () => {
         children: expect.any(Array)
       })
     ])
+    const expectedAttributeType = browserMatch(lambdaTestWebdriverFalse) ? 'falseAttribute' : 'trueAttribute'
     expect(interactionHarvests[0].request.body[0].children).toEqual([
       { key: 'isFirstOfSession', type: 'trueAttribute' },
-      { key: 'webdriverDetected', type: 'falseAttribute' }
+      { key: 'webdriverDetected', type: expectedAttributeType }
     ])
   })
 

--- a/tests/specs/soft_navigations/xhr.e2e.js
+++ b/tests/specs/soft_navigations/xhr.e2e.js
@@ -1,6 +1,5 @@
 import { checkAjaxEvents, checkSpa } from '../../util/basic-checks'
 import { testInteractionEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
-import { lambdaTestWebdriverFalse } from '../../../tools/browser-matcher/common-matchers.mjs'
 
 describe('XHR SPA Interaction Tracking', () => {
   let interactionsCapture
@@ -118,8 +117,10 @@ describe('XHR SPA Interaction Tracking', () => {
         children: expect.any(Array)
       })
     ])
-    const expectedAttributeType = browserMatch(lambdaTestWebdriverFalse) ? 'falseAttribute' : 'trueAttribute'
-    expect(interactionHarvests[0].request.body[0].children).toEqual([{ key: 'webdriverDetected', type: expectedAttributeType }])
+    expect(interactionHarvests[0].request.body[0].children).toEqual([
+      { key: 'isFirstOfSession', type: 'trueAttribute' },
+      { key: 'webdriverDetected', type: 'falseAttribute' }
+    ])
   })
 
   it('should capture the ajax request and response size', async () => {

--- a/tests/unit/features/utils/agent-session.test.js
+++ b/tests/unit/features/utils/agent-session.test.js
@@ -82,13 +82,14 @@ test('should initialize SessionEntity with an app-namespaced storage key', async
     applicationID: faker.string.uuid()
   }
 
+  const { getAppSessionKey } = await import('../../../../src/common/session/session-key')
   const { setupAgentSession } = await import('../../../../src/features/utils/agent-session')
   setupAgentSession(mockAgent)
 
   const { SessionEntity } = await import('../../../../src/common/session/session-entity')
   expect(SessionEntity).toHaveBeenCalledWith(expect.objectContaining({
     agentRef: mockAgent,
-    key: `SESSION::${mockAgent.info.licenseKey}:${mockAgent.info.applicationID}`
+    key: getAppSessionKey(mockAgent.info.licenseKey, mockAgent.info.applicationID)
   }))
 })
 

--- a/tests/unit/features/utils/agent-session.test.js
+++ b/tests/unit/features/utils/agent-session.test.js
@@ -76,6 +76,22 @@ test('should register handlers and drain the session feature', async () => {
   expect(drain).toHaveBeenCalledWith(mockAgent, 'session')
 })
 
+test('should initialize SessionEntity with an app-namespaced storage key', async () => {
+  mockAgent.info = {
+    licenseKey: faker.string.uuid(),
+    applicationID: faker.string.uuid()
+  }
+
+  const { setupAgentSession } = await import('../../../../src/features/utils/agent-session')
+  setupAgentSession(mockAgent)
+
+  const { SessionEntity } = await import('../../../../src/common/session/session-entity')
+  expect(SessionEntity).toHaveBeenCalledWith(expect.objectContaining({
+    agentRef: mockAgent,
+    key: `SESSION::${mockAgent.info.licenseKey}:${mockAgent.info.applicationID}`
+  }))
+})
+
 test('multiple calls to setupAgentSession for same agent does not re-execute it', async () => {
   const { setupAgentSession } = await import('../../../../src/features/utils/agent-session')
   const result1 = setupAgentSession(mockAgent)

--- a/tests/unit/features/utils/agent-session.test.js
+++ b/tests/unit/features/utils/agent-session.test.js
@@ -82,14 +82,14 @@ test('should initialize SessionEntity with an app-namespaced storage key', async
     applicationID: faker.string.uuid()
   }
 
-  const { getAppSessionKey } = await import('../../../../src/common/session/session-key')
+  const { getAppSessionHash } = await import('../../../../src/common/session/session-key')
   const { setupAgentSession } = await import('../../../../src/features/utils/agent-session')
   setupAgentSession(mockAgent)
 
   const { SessionEntity } = await import('../../../../src/common/session/session-entity')
   expect(SessionEntity).toHaveBeenCalledWith(expect.objectContaining({
     agentRef: mockAgent,
-    key: getAppSessionKey(mockAgent.info.licenseKey, mockAgent.info.applicationID)
+    key: getAppSessionHash(mockAgent.info.licenseKey, mockAgent.info.applicationID)
   }))
 })
 

--- a/tests/unit/features/utils/aggregate-base.test.js
+++ b/tests/unit/features/utils/aggregate-base.test.js
@@ -68,48 +68,22 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-test('should merge info, jsattributes, and runtime objects', () => {
-  const mockInfo1 = {
-    [faker.string.uuid()]: faker.lorem.sentence(),
-    jsAttributes: {
-      [faker.string.uuid()]: faker.lorem.sentence()
-    },
-    licenseKey: faker.string.uuid(),
-    applicationID: faker.string.uuid()
-  }
-  jest.mocked(gosCDN).mockReturnValue({ info: mockInfo1 })
-
-  const mockInfo2 = {
-    jsAttributes: {
-      [faker.string.uuid()]: faker.lorem.sentence()
-    }
-  }
-  mainAgent.info = mockInfo2
-
+test('should not perform late configuration checks in AggregateBase', () => {
   new AggregateBase(mainAgent, featureName)
 
-  expect(isValid).toHaveBeenCalledWith(mockInfo2)
-  expect(gosCDN).toHaveBeenCalledTimes(1)
-  expect(configure).toHaveBeenCalledWith(mainAgent, {
-    info: {
-      ...mockInfo1,
-      jsAttributes: {
-        ...mockInfo1.jsAttributes,
-        ...mockInfo2.jsAttributes
-      }
-    },
-    runtime: mainAgent.runtime
-  }, mainAgent.runtime.loaderType)
-})
-
-test('should only configure the agent once', () => {
-  jest.mocked(isValid).mockReturnValue(true)
-
-  new AggregateBase(mainAgent, featureName)
-
-  expect(isValid).toHaveBeenCalledWith(mainAgent.info)
+  expect(isValid).not.toHaveBeenCalled()
   expect(gosCDN).not.toHaveBeenCalled()
   expect(configure).not.toHaveBeenCalled()
+})
+
+test('should reuse shared runtime resources across aggregates for same agent', () => {
+  const agg1 = new AggregateBase(mainAgent, featureName)
+  const agg2 = new AggregateBase(mainAgent, faker.string.uuid())
+
+  expect(agg1.obfuscator).toBeDefined()
+  expect(agg2.obfuscator).toBeDefined()
+  expect(agg1.obfuscator).toBe(agg2.obfuscator)
+  expect(mainAgent.runtime.harvester).toBeDefined()
 })
 
 test('should resolve waitForFlags correctly based on flags with real vals', async () => {

--- a/tests/unit/features/utils/instrument-base.test.js
+++ b/tests/unit/features/utils/instrument-base.test.js
@@ -8,6 +8,8 @@ import { setupAgentSession } from '../../../../src/features/utils/agent-session'
 import { warn } from '../../../../src/common/util/console'
 import * as runtimeConstantsModule from '../../../../src/common/constants/runtime'
 import { canEnableSessionTracking } from '../../../../src/features/utils/feature-gates'
+import { isValid } from '../../../../src/common/config/info'
+import { configure } from '../../../../src/loaders/configure/configure'
 
 jest.enableAutomock()
 jest.unmock('../../../../src/features/utils/instrument-base')
@@ -22,11 +24,15 @@ beforeEach(() => {
   jest.replaceProperty(runtimeConstantsModule, 'isBrowserScope', true)
   jest.replaceProperty(runtimeConstantsModule, 'isWorkerScope', false)
   jest.mocked(canEnableSessionTracking).mockReturnValue(true)
+  jest.mocked(isValid).mockReturnValue(true)
 
   agentIdentifier = faker.string.uuid()
   featureName = faker.string.uuid()
   agentBase = {
     agentIdentifier,
+    ee: {
+      abort: jest.fn()
+    },
     info: {
       licenseKey: faker.string.uuid(),
       applicationID: faker.string.uuid()
@@ -36,6 +42,12 @@ beforeEach(() => {
       [FEATURE_NAMES.pageViewEvent]: { autoStart: true },
       [FEATURE_NAMES.pageViewTiming]: { autoStart: true },
       [FEATURE_NAMES.sessionReplay]: { autoStart: true }
+    },
+    runtime: {
+      loaderType: 'browser-test',
+      harvester: {
+        initializedAggregates: []
+      }
     }
   }
 
@@ -167,5 +179,22 @@ test('should drain and not import agg when shouldImportAgg is false for session_
   await windowLoadCallback()
 
   expect(drain).toHaveBeenCalledWith(agentBase, FEATURE_NAMES.sessionReplay)
+  expect(mockAggregate).not.toHaveBeenCalled()
+})
+
+test('should abort early when info remains invalid after late config check', async () => {
+  jest.mocked(isValid).mockReturnValue(false)
+
+  const instrument = new InstrumentBase(agentBase, featureName)
+  const aggregateArgs = { [faker.string.uuid()]: faker.lorem.sentence() }
+  instrument.importAggregator(agentBase, () => importPromise, aggregateArgs)
+
+  const windowLoadCallback = jest.mocked(onWindowLoad).mock.calls[0][0]
+  await windowLoadCallback()
+
+  expect(configure).toHaveBeenCalledWith(agentBase, expect.any(Object), agentBase.runtime.loaderType)
+  expect(warn).toHaveBeenCalledWith(43)
+  expect(agentBase.ee.abort).toHaveBeenCalledTimes(1)
+  expect(setupAgentSession).not.toHaveBeenCalled()
   expect(mockAggregate).not.toHaveBeenCalled()
 })

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -95,7 +95,18 @@ export default class CustomCommands {
       // WDIO converts empty objects from IE to null (as with default session.state.custom).
       // Waiting to parse the JSON string until it is returned preserves the value.
       const localStorageJSON = await browser.execute(function () {
-        return window.localStorage.getItem('NRBA_SESSION') || '{}'
+        const globalNreum = window.NREUM || window.newrelic || {}
+        const injectedInfo = globalNreum.info || {}
+
+        const licenseKey = injectedInfo.licenseKey
+        const applicationID = injectedInfo.applicationID
+        const namespacedStorageKey = (licenseKey && applicationID)
+          ? `NRBA_SESSION::${licenseKey}:${applicationID}`
+          : undefined
+
+        return (namespacedStorageKey ? window.localStorage.getItem(namespacedStorageKey) : null) ||
+          window.localStorage.getItem('NRBA_SESSION') ||
+          '{}'
       })
       const localStorage = JSON.parse(localStorageJSON)
       return { agentSessions, agentSessionInstances, localStorage }

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -96,13 +96,9 @@ export default class CustomCommands {
       // Waiting to parse the JSON string until it is returned preserves the value.
       const localStorageJSON = await browser.execute(function () {
         const firstAgent = Object.values(newrelic.initializedAgents || {})[0]
-        const sessionStorageKey = firstAgent?.runtime?.session?.key
-          ? `NRBA_${firstAgent.runtime.session.key}`
-          : undefined
+        const sessionStorageKey = firstAgent?.runtime?.session?.lookupKey
 
-        return (sessionStorageKey ? window.localStorage.getItem(sessionStorageKey) : null) ||
-          window.localStorage.getItem('NRBA_SESSION') ||
-          '{}'
+        return (sessionStorageKey ? window.localStorage.getItem(sessionStorageKey) : null) || '{}'
       })
       const localStorage = JSON.parse(localStorageJSON)
       return { agentSessions, agentSessionInstances, localStorage }

--- a/tools/wdio/plugins/custom-commands.mjs
+++ b/tools/wdio/plugins/custom-commands.mjs
@@ -95,16 +95,12 @@ export default class CustomCommands {
       // WDIO converts empty objects from IE to null (as with default session.state.custom).
       // Waiting to parse the JSON string until it is returned preserves the value.
       const localStorageJSON = await browser.execute(function () {
-        const globalNreum = window.NREUM || window.newrelic || {}
-        const injectedInfo = globalNreum.info || {}
-
-        const licenseKey = injectedInfo.licenseKey
-        const applicationID = injectedInfo.applicationID
-        const namespacedStorageKey = (licenseKey && applicationID)
-          ? `NRBA_SESSION::${licenseKey}:${applicationID}`
+        const firstAgent = Object.values(newrelic.initializedAgents || {})[0]
+        const sessionStorageKey = firstAgent?.runtime?.session?.key
+          ? `NRBA_${firstAgent.runtime.session.key}`
           : undefined
 
-        return (namespacedStorageKey ? window.localStorage.getItem(namespacedStorageKey) : null) ||
+        return (sessionStorageKey ? window.localStorage.getItem(sessionStorageKey) : null) ||
           window.localStorage.getItem('NRBA_SESSION') ||
           '{}'
       })


### PR DESCRIPTION
The browser agent now namespaces the session info to per browser app, using the combination of `licenseKey` and `applicationID` provided at startup. This means different apps sharing the same origin and browser `localStorage` will no longer share the same session, which was an accepted but not ideal collision, causing feature modes to bleed from one over to another for the duration of a session previously.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Each app will manage & map to its own session state object. This includes multiple agents of differing apps on the same page (though multi-agents on same page is _not_ supported by New Relic).

Expect some changes to session-related features: Replay, Trace, Logging. For example, originA:appB will now rely on its own RUM response flags and calculate its own feature mode rather than inherit from originA:appA.
 
### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-565063

### Testing

Tests modified + new tests added. Most session tests shifting over to namedspaced read/write covers the changes.
