### PR TITLE
chore: change off to none

### DIFF
--- a/src/common/config/init-types.js
+++ b/src/common/config/init-types.js
@@ -11,6 +11,7 @@
  * @property {boolean} [ajax.block_internal] - If true, agent requests going to harvest endpoint are treated as on deny list. In other words, agent will not self-report AJAX.
  * @property {boolean} [ajax.enabled] - Turn on/off the ajax feature (on by default).
  * @property {boolean} [ajax.autoStart] - If true, the agent will automatically start the ajax feature. Otherwise, it will be in a deferred state until the `start` API method is called.
+ * @property {('none'|'failures'|'all')} [ajax.capture_payloads] - Controls when AJAX request/response payloads are captured. 'none' = never capture, 'failures' = capture only on errors (4xx, 5xx, network errors, GraphQL errors), 'all' = always capture.
  * @property {Object} [api]
  * @property {Object} [api.register]
  * @property {boolean} [api.register.enabled] - If true, the agent will allow registered children to be sent to the server.

--- a/src/common/config/init.js
+++ b/src/common/config/init.js
@@ -48,7 +48,7 @@ const InitModelFn = () => {
     }
   }
   return {
-    ajax: { deny_list: undefined, block_internal: true, enabled: true, autoStart: true, capture_payloads: CAPTURE_PAYLOAD_SETTINGS.OFF },
+    ajax: { deny_list: undefined, block_internal: true, enabled: true, autoStart: true, capture_payloads: CAPTURE_PAYLOAD_SETTINGS.NONE },
     api: {
       register: {
         get enabled () { return hiddenState.feature_flags.includes(FEATURE_FLAGS.REGISTER) || hiddenState.experimental.register },

--- a/src/common/payloads/payloads.js
+++ b/src/common/payloads/payloads.js
@@ -9,14 +9,14 @@ import { CAPTURE_PAYLOAD_SETTINGS } from '../../features/ajax/constants'
 /**
  * Determines whether payload data should be captured based on the capture mode setting,
  * HTTP status code, and GraphQL error status.
- * @param {string} captureMode - The capture mode setting ('off', 'all', or 'failures')
+ * @param {string} captureMode - The capture mode setting ('none', 'all', or 'failures')
  * @param {number} statusCode - The HTTP status code
  * @param {boolean} hasGQLErrors - Whether the response contains GraphQL errors
  * @returns {boolean} True if payload should be captured
  */
 export function canCapturePayload (captureMode, statusCode, hasGQLErrors) {
   if (captureMode === CAPTURE_PAYLOAD_SETTINGS.ALL) return true
-  if (!captureMode || captureMode === CAPTURE_PAYLOAD_SETTINGS.OFF) return false
+  if (!captureMode || captureMode === CAPTURE_PAYLOAD_SETTINGS.NONE) return false
 
   // Default "failures" mode
   return statusCode === 0 || statusCode >= 400 || hasGQLErrors === true

--- a/src/features/ajax/constants.js
+++ b/src/features/ajax/constants.js
@@ -6,7 +6,7 @@ import { FEATURE_NAMES } from '../../loaders/features/features'
 
 export const FEATURE_NAME = FEATURE_NAMES.ajax
 export const CAPTURE_PAYLOAD_SETTINGS = {
-  OFF: 'off',
+  NONE: 'none',
   FAILURES: 'failures',
   ALL: 'all'
 }

--- a/tests/components/ajax/instrument.test.js
+++ b/tests/components/ajax/instrument.test.js
@@ -222,7 +222,7 @@ describe('payload capture configuration', () => {
   // These tests just verify that the configuration constants are properly defined
 
   test('CAPTURE_PAYLOAD_SETTINGS constants are defined', () => {
-    expect(CAPTURE_PAYLOAD_SETTINGS.OFF).toEqual('off')
+    expect(CAPTURE_PAYLOAD_SETTINGS.NONE).toEqual('none')
     expect(CAPTURE_PAYLOAD_SETTINGS.ALL).toEqual('all')
     expect(CAPTURE_PAYLOAD_SETTINGS.FAILURES).toEqual('failures')
   })

--- a/tests/specs/ajax/payload_capture.e2e.js
+++ b/tests/specs/ajax/payload_capture.e2e.js
@@ -11,7 +11,7 @@ describe('capture_payloads', () => {
   })
 
   const modes = [
-    'off',
+    'none',
     'failures',
     'all'
   ]

--- a/tests/unit/common/config/init.test.js
+++ b/tests/unit/common/config/init.test.js
@@ -10,7 +10,7 @@ test('init props exist and return expected defaults', () => {
     block_internal: true,
     deny_list: undefined,
     enabled: true,
-    capture_payloads: 'off'
+    capture_payloads: 'none'
   })
   expect(config.api).toEqual({
     register: {

--- a/tests/unit/features/ajax/instrument/capture-payloads.test.js
+++ b/tests/unit/features/ajax/instrument/capture-payloads.test.js
@@ -7,16 +7,16 @@ import { canCapturePayload } from '../../../../../src/common/payloads/payloads'
 import { hasGQLErrors } from '../../../../../src/features/ajax/aggregate/gql'
 
 describe('canCapturePayload logic', () => {
-  describe('off mode', () => {
+  describe('none mode', () => {
     test('never captures payloads', () => {
-      expect(canCapturePayload('off', 200, false)).toBe(false)
-      expect(canCapturePayload('off', 404, false)).toBe(false)
-      expect(canCapturePayload('off', 500, false)).toBe(false)
-      expect(canCapturePayload('off', 0, false)).toBe(false)
-      expect(canCapturePayload('off', 200, true)).toBe(false)
+      expect(canCapturePayload('none', 200, false)).toBe(false)
+      expect(canCapturePayload('none', 404, false)).toBe(false)
+      expect(canCapturePayload('none', 500, false)).toBe(false)
+      expect(canCapturePayload('none', 0, false)).toBe(false)
+      expect(canCapturePayload('none', 200, true)).toBe(false)
     })
 
-    test('treats null/undefined as off', () => {
+    test('treats null/undefined as none', () => {
       expect(canCapturePayload(null, 200, false)).toBe(false)
       expect(canCapturePayload(undefined, 200, false)).toBe(false)
     })

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -88,7 +88,7 @@ module.exports.defaultInitBlock = {
   ajax: {
     deny_list: [],
     block_internal: false,
-    capture_payloads: 'off', // off by default to not break existing ajax/spa tests. payload tests are conducted separately and explicitly.
+    capture_payloads: 'none', // none by default to not break existing ajax/spa tests. payload tests are conducted separately and explicitly.
     ...enabledFeature
   },
   api: {


### PR DESCRIPTION
This PR changes "off" to "none" for AJAX payloads, [a recent discovery of divergence between API and Agent](https://new-relic.atlassian.net/browse/NR-529882)
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
**https://new-relic.atlassian.net/browse/NR-577170?atlOrigin=eyJpIjoiOWI1Yjg3OWRjZTIyNDU4Nzg3YWY5YjhlMDJlNjU1YTAiLCJwIjoiaiJ9**
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
