### PR TITLE
feat: Add websocket init config

### DIFF
--- a/.github/actions/build-ab/templates/latest.js
+++ b/.github/actions/build-ab/templates/latest.js
@@ -4,9 +4,10 @@ window.NREUM.loader_config.licenseKey = '{{{args.abLicenseKey}}}'
 window.NREUM.info.applicationID = '{{{args.abAppId}}}'
 window.NREUM.info.licenseKey = '{{{args.abLicenseKey}}}'
 window.NREUM.init.proxy.assets = 'https://staging-js-agent.newrelic.com/dev'
-window.NREUM.init.feature_flags = ['ajax_metrics_deny_list', 'register', 'websockets']
+window.NREUM.init.feature_flags = ['ajax_metrics_deny_list', 'register']
 window.NREUM.init.session_replay.enabled = true // feature is enabled, but the app settings will have sampling at 0.  We can proactively enable SR for certain test cases through app settings
 window.NREUM.init.session_trace.enabled = true // feature is enabled, but the app settings will have sampling at 0.  We can proactively enable SR for certain test cases through app settings
+window.NREUM.init.web_sockets.enabled = true
 window.NREUM.init.user_actions = {elementAttributes: ['id', 'className', 'tagName', 'type', 'ariaLabel', 'alt', 'title']}
 window.NREUM.init.ajax.capture_payloads = 'failures'
 

--- a/.github/actions/build-agent2query/templates/latest-staging-config.js
+++ b/.github/actions/build-agent2query/templates/latest-staging-config.js
@@ -31,7 +31,10 @@ NREUM.init = {
   },
   ajax: {
     deny_list: ['staging-bam-cell.nr-data.net']
+  },
+  web_sockets: {
+    enabled: true
   }
 }
-NREUM.feature_flags = ['soft_nav', 'websockets']
+NREUM.feature_flags = ['soft_nav']
 NREUM.info = { beacon: 'staging-bam-cell.nr-data.net', errorBeacon: 'staging-bam-cell.nr-data.net', licenseKey: '{{{latestStagingLicenseKey}}}', applicationID: '77606036', sa: 1 }

--- a/.github/actions/build-agent2query/templates/latest-us-prod-config.js
+++ b/.github/actions/build-agent2query/templates/latest-us-prod-config.js
@@ -31,7 +31,10 @@ NREUM.init = {
   },
   ajax: {
     deny_list: ['bam.nr-data.net']
+  },
+  web_sockets: {
+    enabled: true
   }
 }
-NREUM.feature_flags = ['soft_nav', 'websockets']
+NREUM.feature_flags = ['soft_nav']
 NREUM.info = { beacon: 'bam.nr-data.net', errorBeacon: 'bam.nr-data.net', licenseKey: '{{{latestUsProdLicenseKey}}}', applicationID: '1431915022', sa: 1 }

--- a/.github/actions/build-agent2query/templates/released-staging-config.js
+++ b/.github/actions/build-agent2query/templates/released-staging-config.js
@@ -31,7 +31,10 @@ NREUM.init = {
   },
   ajax: {
     deny_list: ['staging-bam-cell.nr-data.net']
+  },
+  web_sockets: {
+    enabled: true
   }
 }
-NREUM.feature_flags = ['soft_nav', 'websockets']
+NREUM.feature_flags = ['soft_nav']
 NREUM.info = { beacon: 'staging-bam-cell.nr-data.net', errorBeacon: 'staging-bam-cell.nr-data.net', licenseKey: '{{{releasedStagingLicenseKey}}}', applicationID: '78536307', sa: 1 }

--- a/.github/actions/build-agent2query/templates/released-us-prod-config.js
+++ b/.github/actions/build-agent2query/templates/released-us-prod-config.js
@@ -31,7 +31,10 @@ NREUM.init = {
   },
   ajax: {
     deny_list: ['bam.nr-data.net']
+  },
+  web_sockets: {
+    enabled: true
   }
 }
-NREUM.feature_flags = ['soft_nav', 'websockets']
+NREUM.feature_flags = ['soft_nav']
 NREUM.info = { beacon: 'bam.nr-data.net', errorBeacon: 'bam.nr-data.net', licenseKey: '{{{releasedUsProdLicenseKey}}}', applicationID: '1431909786', sa: 1 }

--- a/.github/actions/internal-promotion/templates/released.js
+++ b/.github/actions/internal-promotion/templates/released.js
@@ -85,7 +85,10 @@
         }
       },
       proxy: {},
-      user_actions: {elementAttributes: ['id', 'className', 'tagName', 'type', 'ariaLabel', 'alt', 'title']}
+      user_actions: {elementAttributes: ['id', 'className', 'tagName', 'type', 'ariaLabel', 'alt', 'title']},
+      web_sockets: {
+        enabled: true
+      }
     },
     loader_config: {
       accountID: '1',

--- a/.github/workflows/publish-experiment.yml
+++ b/.github/workflows/publish-experiment.yml
@@ -112,7 +112,10 @@ jobs:
               }
             },
             proxy: {},
-            user_actions: {elementAttributes: ['id', 'className', 'tagName', 'type', 'ariaLabel', 'alt', 'title']}
+            user_actions: {elementAttributes: ['id', 'className', 'tagName', 'type', 'ariaLabel', 'alt', 'title']},
+            web_sockets: {
+              enabled: true
+            }
           };
           window.NREUM.loader_config = {
             accountID: '1',

--- a/src/common/config/init-types.js
+++ b/src/common/config/init-types.js
@@ -88,6 +88,8 @@
  * @property {Object} [user_actions]
  * @property {boolean} [user_actions.enabled] - Must be true to allow UserAction events to be captured.
  * @property {Array<string>} [user_actions.elementAttributes] - List of HTML Element properties to be captured with UserAction events' target elements. This may help to identify the source element being interacted with in the UI.
+ * @property {Object} [web_sockets]
+ * @property {boolean} [web_sockets.enabled] - Turn on/off the web sockets feature (off by default).
  */
 
 export default {}

--- a/src/common/config/init.js
+++ b/src/common/config/init.js
@@ -138,7 +138,8 @@ const InitModelFn = () => {
     session_trace: { enabled: true, autoStart: true },
     soft_navigations: { enabled: true, autoStart: true },
     ssl: undefined,
-    user_actions: { enabled: true, elementAttributes: ['id', 'className', 'tagName', 'type'] }
+    user_actions: { enabled: true, elementAttributes: ['id', 'className', 'tagName', 'type'] },
+    web_sockets: { enabled: false }
   }
 }
 

--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -251,7 +251,7 @@ export class Aggregate extends AggregateBase {
         this.addEvent(event, target)
       }, this.featureName, this.ee)
 
-      if (agentRef.init.feature_flags.includes('websockets')) {
+      if (agentRef.init.feature_flags.includes('websockets') || agentRef.init.web_sockets?.enabled) {
         registerHandler('ws-complete', (nrData) => {
           const event = {
             ...nrData,

--- a/src/features/generic_events/instrument/index.js
+++ b/src/features/generic_events/instrument/index.js
@@ -26,7 +26,7 @@ export class Instrument extends InstrumentBase {
   static featureName = FEATURE_NAME
   constructor (agentRef) {
     super(agentRef, FEATURE_NAME)
-    const websocketsEnabled = agentRef.init.feature_flags.includes('websockets')
+    const websocketsEnabled = agentRef.init.feature_flags.includes('websockets') || agentRef.init.web_sockets?.enabled
     const securityPolicyViolationEnabled = !agentRef.init.feature_flags.includes('no_spv')
 
     /** config values that gate whether the generic events aggregator should be imported at all */

--- a/tests/assets/websocket-error.html
+++ b/tests/assets/websocket-error.html
@@ -8,7 +8,7 @@
     <title>WebSocket Error Linkage Test</title>
     {init} {config}
     <script>
-      NREUM.init.feature_flags = ['websockets']
+      NREUM.init.web_sockets = { enabled: true }
     </script>
     {loader}
     <script>

--- a/tests/assets/websocket-multi-send-msg.html
+++ b/tests/assets/websocket-multi-send-msg.html
@@ -8,7 +8,7 @@
     <title>WebSocket Multi-Type Send/Receive Test</title>
     {init} {config}
     <script>
-      NREUM.init.feature_flags = ['websockets']
+      NREUM.init.web_sockets = { enabled: true }
     </script>
     {loader}
     <script>

--- a/tests/assets/websockets.html
+++ b/tests/assets/websockets.html
@@ -8,7 +8,7 @@
     <title>RUM Unit Test</title>
     {init} {config}
     <script>
-      NREUM.init.feature_flags = ['websockets']
+      NREUM.init.web_sockets = { enabled: true }
     </script>
     {loader}
     <script>

--- a/tests/components/generic_events/instrument/index.test.js
+++ b/tests/components/generic_events/instrument/index.test.js
@@ -90,7 +90,8 @@ describe('generic events sub-features', () => {
     mainAgent.init.page_action.enabled = false
     mainAgent.init.user_actions.enabled = false
     mainAgent.init.performance = { capture_marks: false, capture_measures: false, resources: { enabled: false } }
-    mainAgent.init.feature_flags = ['websockets', 'no_spv']
+    mainAgent.init.web_sockets = { enabled: true }
+    mainAgent.init.feature_flags = ['no_spv']
 
     const genericEventsInstrument = new GenericEvents(mainAgent)
     await new Promise(process.nextTick)

--- a/tests/specs/ins/websockets.e2e.js
+++ b/tests/specs/ins/websockets.e2e.js
@@ -229,7 +229,7 @@ describe.withBrowsersMatching(supportsWebSocketsTesting)('WebSocket wrapper', ()
     // Load a simple instrumented page with websockets feature enabled
     const url = await browser.testHandle.assetURL('instrumented.html', {
       loader: 'spa',
-      init: { feature_flags: ['websockets'] }
+      init: { web_sockets: { enabled: true } }
     })
     await browser.url(url).then(() => browser.waitForAgentLoad())
 

--- a/tests/unit/common/config/init.test.js
+++ b/tests/unit/common/config/init.test.js
@@ -4,7 +4,7 @@ jest.mock('../../../../src/common/util/console.js')
 
 test('init props exist and return expected defaults', () => {
   const config = mergeInit({})
-  expect(Object.keys(config).length).toEqual(23)
+  expect(Object.keys(config).length).toEqual(24)
   expect(config.ajax).toEqual({
     autoStart: true,
     block_internal: true,
@@ -130,7 +130,12 @@ test('init props exist and return expected defaults', () => {
     enabled: true,
     elementAttributes: ['id', 'className', 'tagName', 'type']
   })
-  expect(config.browser_consent_mode.enabled).toEqual(false)
+  expect(config.browser_consent_mode).toEqual({
+    enabled: false
+  })
+  expect(config.web_sockets).toEqual({
+    enabled: false
+  })
 })
 
 describe('property getters/setters used for validation', () => {

--- a/tools/test-builds/library-wrapper/src/reconnecting-websocket.js
+++ b/tools/test-builds/library-wrapper/src/reconnecting-websocket.js
@@ -6,7 +6,7 @@ const opts = {
   info: NREUM.info,
   init: {
     ...NREUM.init,
-    feature_flags: ['websockets']
+    web_sockets: { enabled: true }
   }
 }
 

--- a/tools/test-builds/library-wrapper/src/robust-websocket.js
+++ b/tools/test-builds/library-wrapper/src/robust-websocket.js
@@ -6,7 +6,7 @@ const opts = {
   info: NREUM.info,
   init: {
     ...NREUM.init,
-    feature_flags: ['websockets']
+    web_sockets: { enabled: true }
   }
 }
 


### PR DESCRIPTION
Adds `web_sockets` block to NREUM init configuration. Setting `web_sockets.enabled` to `true` turns on the web sockets feature. The web sockets feature is disabled by default.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Adds `web_sockets` configuration in the init block to turn on the web sockets feature. It can also be turned on through the `websockets` feature flag.

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-553178

### Testing

Make sure tests pass, especially the library tests.
