### PR TITLE
fix: Keep Ajax payload out of unrelated events

### DIFF
--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -102,22 +102,22 @@ export class Aggregate extends AggregateBase {
       [AJAX_ID]: generateUuid() // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
     }
 
-    event.gql = params.gql = parseGQL({
+    event.gql = parseGQL({
       body: ctx.requestBody,
       query: ctx.parsedOrigin?.search
     })
-    if (event.gql) event.gql.operationHasErrors = params.gql.operationHasErrors = hasGQLErrors(ctx.responseBody)
+    if (event.gql) event.gql.operationHasErrors = hasGQLErrors(ctx.responseBody)
 
     const capturePayloadSetting = this.agentRef.init.ajax.capture_payloads
     const shouldCapturePayload = canCapturePayload(capturePayloadSetting, params.status, event.gql?.operationHasErrors)
 
     if (shouldCapturePayload) {
       // Store raw data; obfuscation and truncation will happen in the serializer
-      params.requestQuery = event.requestQuery = parseQueryString(ctx.parsedOrigin?.search)
-      params.requestHeaders = event.requestHeaders = ctx.requestHeaders
-      params.responseHeaders = event.responseHeaders = ctx.responseHeaders
-      if (isLikelyHumanReadable(ctx.requestHeaders, ctx.requestBody)) params.requestBody = event.requestBody = ctx.requestBody
-      if (isLikelyHumanReadable(ctx.responseHeaders, ctx.responseBody)) params.responseBody = event.responseBody = ctx.responseBody
+      event.requestQuery = parseQueryString(ctx.parsedOrigin?.search)
+      event.requestHeaders = ctx.requestHeaders
+      event.responseHeaders = ctx.responseHeaders
+      if (isLikelyHumanReadable(ctx.requestHeaders, ctx.requestBody)) event.requestBody = ctx.requestBody
+      if (isLikelyHumanReadable(ctx.responseHeaders, ctx.responseBody)) event.responseBody = ctx.responseBody
     }
 
     if (ctx.dt) {

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -5,7 +5,7 @@ import * as handleModule from '../../../src/common/event-emitter/handle'
 import { Instrument as Ajax } from '../../../src/features/ajax/instrument'
 import { resetAgent, setupAgent } from '../setup-agent'
 import { EventContext } from '../../../src/common/event-emitter/event-context'
-import { AJAX_ID } from '../../../src/features/ajax/constants'
+import { AJAX_ID, CAPTURE_PAYLOAD_SETTINGS } from '../../../src/features/ajax/constants'
 
 const ajaxArguments = [
   { // params
@@ -99,6 +99,62 @@ describe('storeXhr', () => {
       FEATURE_NAMES.softNav,
       expect.any(Object)
     )
+  })
+
+  describe('data shapes', () => {
+    beforeEach(() => {
+      fakeAgent.features = {}
+    })
+
+    test('timeslice metric params should have expected keys', () => {
+      fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+      fakeAgent.init.ajax.capture_payloads = CAPTURE_PAYLOAD_SETTINGS.ALL
+
+      context.requestHeaders = { 'content-type': 'application/json' }
+      context.requestBody = 'fooBody'
+      context.responseHeaders = { 'content-type': 'application/json' }
+      context.responseBody = 'barBody'
+      ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+      const expectedParams = ['method', 'status', 'host', 'hostname', 'pathname']
+      const actualParams = Object.keys(fakeAgent.sharedAggregator.get(['xhr']).xhr[0].params)
+      expect(actualParams).toEqual(expect.arrayContaining(expectedParams))
+      expect(actualParams).toHaveLength(expectedParams.length)
+    })
+
+    test('ajax event has expected keys', () => {
+      fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+      fakeAgent.init.ajax.capture_payloads = CAPTURE_PAYLOAD_SETTINGS.ALL
+
+      context.requestHeaders = { 'content-type': 'application/json' }
+      context.requestBody = 'fooBody'
+      context.responseHeaders = { 'content-type': 'application/json' }
+      context.responseBody = 'barBody'
+      ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+      const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql', 'requestQuery', 'requestHeaders', 'responseHeaders', 'requestBody', 'responseBody']
+      const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
+      expect(actualEvent).toEqual(expect.arrayContaining(expectedEventKeys))
+      expect(actualEvent).toHaveLength(expectedEventKeys.length)
+    })
+
+    test('session trace bstXhrAgg params has expected keys', () => {
+      fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+      fakeAgent.init.ajax.capture_payloads = CAPTURE_PAYLOAD_SETTINGS.ALL
+
+      context.requestHeaders = { 'content-type': 'application/json' }
+      context.requestBody = 'fooBody'
+      context.responseHeaders = { 'content-type': 'application/json' }
+      context.responseBody = 'barBody'
+      ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+      const bstXhrCalls = jest.mocked(handleModule.handle).mock.calls.filter(call => call[0] === 'bstXhrAgg')
+      expect(bstXhrCalls).toHaveLength(1)
+      const expectedParams = ['method', 'status', 'host', 'hostname', 'pathname']
+      const actualParams = Object.keys(bstXhrCalls[0][1][2])
+      expect(actualParams).toEqual(expect.arrayContaining(expectedParams))
+      expect(actualParams).toHaveLength(expectedParams.length)
+    })
   })
 })
 


### PR DESCRIPTION
Drops captured AJAX request + payload info from unrelated events (AJAX timeslice metrics, session trace) via a shared `params` object.

---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

In this PR, we remove assignments to the `params` object inside `storeXHR`.  It was possibly a legacy mechanism for passing info to the old SPA implementation. Verified these fields are not pulled from `params` in the consumer.  The consumer should be pulling these fields from the AjaxNode/events directly.

### Related Issue(s)

[NR-582727](https://new-relic.atlassian.net/browse/NR-582727)

### Testing

Added component tests for the shape of params in timeslice metrics + session trace, as well as the Ajax event.

Params:
```
['method', 'status', 'host', 'hostname', 'pathname']
```

Ajax:
```
['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 
'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql', 'requestQuery', 'requestHeaders', 
'responseHeaders', 'requestBody', 'responseBody']
```


[NR-582727]: https://new-relic.atlassian.net/browse/NR-582727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ