### PR TITLE
feat: Do not obfuscate attribute keys

### DIFF
--- a/src/common/serialize/bel-serializer.js
+++ b/src/common/serialize/bel-serializer.js
@@ -27,9 +27,9 @@ export function getAddStringContext (obfuscator, truncator) {
 
   return addString
 
-  function addString (str) {
+  function addString (str, obfuscate = true) {
     if (typeof str === 'undefined' || str === '') return ''
-    str = obfuscator?.obfuscateString(String(str)) ?? String(str)
+    str = obfuscate ? (obfuscator?.obfuscateString(String(str)) ?? String(str)) : String(str)
     str = truncator?.(str) ?? str
     if (hasOwnProp.call(stringTable, str)) {
       return numeric(stringTable[str], true)
@@ -48,7 +48,7 @@ export function addCustomAttributes (attrs, addString) {
     var type = 5
     var serializedValue
     // add key to string table first
-    key = addString(key)
+    key = addString(key, false)
 
     switch (typeof val) {
       case 'object':

--- a/tests/unit/common/serialize/bel-serializer.test.js
+++ b/tests/unit/common/serialize/bel-serializer.test.js
@@ -1,0 +1,26 @@
+import { addCustomAttributes, getAddStringContext } from '../../../../src/common/serialize/bel-serializer.js'
+import { Obfuscator } from '../../../../src/common/util/obfuscate.js'
+
+describe('addCustomAttributes in bel-serializer', () => {
+  let addString
+
+  beforeEach(() => {
+    const rules = [{
+      regex: /hello/g,
+      replacement: 'foobar'
+    },
+    {
+      regex: /world/g,
+      replacement: 'foobar'
+    }]
+    const obfuscator = new Obfuscator({ init: { obfuscate: rules } })
+    addString = getAddStringContext(obfuscator, undefined)
+  })
+
+  test('should obfuscate attribute values but not attribute keys', () => {
+    const attrs = { hello: 'world' }
+    const attrParts = addCustomAttributes(attrs, addString)
+
+    expect(attrParts).toEqual([[5, "'hello,'foobar"]])
+  })
+})


### PR DESCRIPTION
Do not obfuscate attribute keys in our addCustomAttributes method for the BEL serializer. This change affects attributes in AjaxRequest, PageViewTiming, and BrowserInteraction (soft nav only) events.

---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

We decided to not obfuscate attribute keys in our BEL serializer; we still obfuscate the attribute values. It was too easy and destructive with our obfuscation rules to corrupt the event attribute keys for AjaxRequest, PageViewTiming, and BrowserInteraction events. This PR adds a safeguard against that, assuming that users won't put sensitive data in their attribute keys.

### Related Issue(s)

JIRA: https://new-relic.atlassian.net/browse/NR-582722

### Testing

Make sure all tests pass. It's possible that a few e2e tests might be indirectly impacted.
