### PR TITLE
fix: Avoid capturing agent AJAX payloads

### DIFF
--- a/src/common/payloads/payloads.js
+++ b/src/common/payloads/payloads.js
@@ -13,6 +13,7 @@ import { CAPTURE_PAYLOAD_SETTINGS } from '../../features/ajax/constants'
  * @param {Object} event - An object representing the AJAX event
  * @param {number} event.statusCode - The HTTP status code
  * @param {boolean} event.hasGQLErrors - Whether the response contains GraphQL errors
+ * @param {string} event.payloadHost - The host of the AJAX payload (includes port)
  * @param {string} event.payloadHostname - The hostname of the AJAX payload
  * @param {string} [event.payloadPathname=''] - The pathname of the AJAX payload
  * @param {string[]} [beacons=[]] - Array of beacon hostnames to avoid capturing
@@ -21,13 +22,15 @@ import { CAPTURE_PAYLOAD_SETTINGS } from '../../features/ajax/constants'
 export function canCapturePayload (captureMode, {
   statusCode,
   hasGQLErrors,
+  payloadHost,
   payloadHostname,
   payloadPathname = ''
 }, beacons = []) {
   if (payloadHostname) {
     const payloadUrl = payloadHostname + payloadPathname
+    const payloadUrlWithPort = payloadHost + payloadPathname
     if (beacons.some((b) => {
-      return b === payloadUrl || payloadUrl.startsWith(b + '/')
+      return b === payloadUrl || payloadUrl.startsWith(b + '/') || b === payloadUrlWithPort || payloadUrlWithPort.startsWith(b + '/')
     })) return false
   }
   if (captureMode === CAPTURE_PAYLOAD_SETTINGS.ALL) return true

--- a/src/common/payloads/payloads.js
+++ b/src/common/payloads/payloads.js
@@ -8,13 +8,28 @@ import { CAPTURE_PAYLOAD_SETTINGS } from '../../features/ajax/constants'
 
 /**
  * Determines whether payload data should be captured based on the capture mode setting,
- * HTTP status code, and GraphQL error status.
+ * HTTP status code, and GraphQL error status.  Will never capture agent's own payloads.
  * @param {string} captureMode - The capture mode setting ('none', 'all', or 'failures')
- * @param {number} statusCode - The HTTP status code
- * @param {boolean} hasGQLErrors - Whether the response contains GraphQL errors
+ * @param {Object} event - An object representing the AJAX event
+ * @param {number} event.statusCode - The HTTP status code
+ * @param {boolean} event.hasGQLErrors - Whether the response contains GraphQL errors
+ * @param {string} event.payloadHostname - The hostname of the AJAX payload
+ * @param {string} [event.payloadPathname=''] - The pathname of the AJAX payload
+ * @param {string[]} [beacons=[]] - Array of beacon hostnames to avoid capturing
  * @returns {boolean} True if payload should be captured
  */
-export function canCapturePayload (captureMode, statusCode, hasGQLErrors) {
+export function canCapturePayload (captureMode, {
+  statusCode,
+  hasGQLErrors,
+  payloadHostname,
+  payloadPathname = ''
+}, beacons = []) {
+  if (payloadHostname) {
+    const payloadUrl = payloadHostname + payloadPathname
+    if (beacons.some((b) => {
+      return b === payloadUrl || payloadUrl.startsWith(b + '/')
+    })) return false
+  }
   if (captureMode === CAPTURE_PAYLOAD_SETTINGS.ALL) return true
   if (!captureMode || captureMode === CAPTURE_PAYLOAD_SETTINGS.NONE) return false
 

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -109,7 +109,12 @@ export class Aggregate extends AggregateBase {
     if (event.gql) event.gql.operationHasErrors = hasGQLErrors(ctx.responseBody)
 
     const capturePayloadSetting = this.agentRef.init.ajax.capture_payloads
-    const shouldCapturePayload = canCapturePayload(capturePayloadSetting, params.status, event.gql?.operationHasErrors)
+    const shouldCapturePayload = canCapturePayload(capturePayloadSetting, {
+      statusCode: event.status,
+      hasGQLErrors: event.gql?.operationHasErrors,
+      payloadHostname: params.hostname,
+      payloadPathname: params.pathname
+    }, this.agentRef.beacons)
 
     if (shouldCapturePayload) {
       // Store raw data; obfuscation and truncation will happen in the serializer

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -113,6 +113,7 @@ export class Aggregate extends AggregateBase {
       statusCode: event.status,
       hasGQLErrors: event.gql?.operationHasErrors,
       payloadHostname: params.hostname,
+      payloadHost: params.host,
       payloadPathname: params.pathname
     }, this.agentRef.beacons)
 

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -11,7 +11,7 @@ const ajaxArguments = [
   { // params
     method: 'PUT',
     status: 200,
-    host: 'https://example.com',
+    host: 'example.com:443',
     hostname: 'example.com',
     pathname: '/pathname'
   },
@@ -118,8 +118,7 @@ describe('storeXhr', () => {
 
       const expectedParams = ['method', 'status', 'host', 'hostname', 'pathname']
       const actualParams = Object.keys(fakeAgent.sharedAggregator.get(['xhr']).xhr[0].params)
-      expect(actualParams).toEqual(expect.arrayContaining(expectedParams))
-      expect(actualParams).toHaveLength(expectedParams.length)
+      expect(actualParams.sort()).toEqual(expectedParams.sort())
     })
 
     test('ajax event has expected keys', () => {
@@ -133,9 +132,8 @@ describe('storeXhr', () => {
       ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
 
       const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql', 'requestQuery', 'requestHeaders', 'responseHeaders', 'requestBody', 'responseBody']
-      const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
-      expect(actualEvent).toEqual(expect.arrayContaining(expectedEventKeys))
-      expect(actualEvent).toHaveLength(expectedEventKeys.length)
+      const actualEventKeys = Object.keys(ajaxAggregate.events.get()[0])
+      expect(actualEventKeys.sort()).toEqual(expectedEventKeys.sort())
     })
 
     test('session trace bstXhrAgg params has expected keys', () => {
@@ -152,9 +150,95 @@ describe('storeXhr', () => {
       expect(bstXhrCalls).toHaveLength(1)
       const expectedParams = ['method', 'status', 'host', 'hostname', 'pathname']
       const actualParams = Object.keys(bstXhrCalls[0][1][2])
-      expect(actualParams).toEqual(expect.arrayContaining(expectedParams))
-      expect(actualParams).toHaveLength(expectedParams.length)
+      expect(actualParams.sort()).toEqual(expectedParams.sort())
     })
+  })
+
+  test('captures payload when proxy beacon hostname and pathname does not match', async () => {
+    fakeAgent = setupAgent({
+      init: {
+        ajax: { block_internal: false, capture_payloads: CAPTURE_PAYLOAD_SETTINGS.ALL },
+        proxy: { beacon: 'example.com/foobar' }
+      }
+    })
+
+    const ajaxInstrument = new Ajax(fakeAgent)
+    await new Promise(process.nextTick)
+    ajaxAggregate = ajaxInstrument.featAggregate
+    ajaxAggregate.ee.emit('rumresp', [])
+    ajaxAggregate.drain()
+
+    context = new EventContext()
+    fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+
+    context.requestHeaders = { 'content-type': 'application/json' }
+    context.requestBody = 'fooBody'
+    context.responseHeaders = { 'content-type': 'application/json' }
+    context.responseBody = 'barBody'
+    ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+    const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql', 'requestQuery', 'requestHeaders', 'responseHeaders', 'requestBody', 'responseBody']
+    const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
+    expect(actualEvent.sort()).toEqual(expectedEventKeys.sort())
+  })
+
+  test('excludes internal payloads matches beacon hostname', async () => {
+    fakeAgent = setupAgent({
+      init: { ajax: { block_internal: false, capture_payloads: CAPTURE_PAYLOAD_SETTINGS.ALL } },
+      info: { beacon: 'example.com' }
+    })
+
+    const ajaxInstrument = new Ajax(fakeAgent)
+    await new Promise(process.nextTick)
+    ajaxAggregate = ajaxInstrument.featAggregate
+    ajaxAggregate.ee.emit('rumresp', [])
+    ajaxAggregate.drain()
+
+    context = new EventContext()
+    fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+
+    context.requestHeaders = { 'content-type': 'application/json' }
+    context.requestBody = 'fooBody'
+    context.responseHeaders = { 'content-type': 'application/json' }
+    context.responseBody = 'barBody'
+    ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+    const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql']
+    const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
+    expect(actualEvent.sort()).toEqual(expectedEventKeys.sort())
+  })
+
+  test('excludes internal payloads matches proxy beacon hostname and pathname', async () => {
+    fakeAgent = setupAgent({
+      init: {
+        ajax: { block_internal: false, capture_payloads: CAPTURE_PAYLOAD_SETTINGS.ALL },
+        proxy: { beacon: 'example.com/foobar' }
+      }
+    })
+
+    const ajaxInstrument = new Ajax(fakeAgent)
+    await new Promise(process.nextTick)
+    ajaxAggregate = ajaxInstrument.featAggregate
+    ajaxAggregate.ee.emit('rumresp', [])
+    ajaxAggregate.drain()
+
+    context = new EventContext()
+    fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+
+    context.requestHeaders = { 'content-type': 'application/json' }
+    context.requestBody = 'fooBody'
+    context.responseHeaders = { 'content-type': 'application/json' }
+    context.responseBody = 'barBody'
+
+    const origPathname = ajaxArguments[0].pathname
+    ajaxArguments[0].pathname = '/foobar/baz' // Starts with the proxy beacon pathname
+    ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+    const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql']
+    const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
+    expect(actualEvent.sort()).toEqual(expectedEventKeys.sort())
+
+    ajaxArguments[0].pathname = origPathname
   })
 })
 
@@ -169,7 +253,7 @@ describe('prepareHarvest', () => {
       end: 30,
       callbackEnd: 30,
       callbackDuration: 0,
-      domain: 'https://example.com',
+      domain: 'example.com:443',
       path: '/pathname',
       method: 'PUT',
       status: 200,

--- a/tests/specs/ajax/payload_capture.e2e.js
+++ b/tests/specs/ajax/payload_capture.e2e.js
@@ -230,3 +230,52 @@ describe('capture_payloads', () => {
     })
   })
 })
+
+describe('capture_payloads - beacon exclusion', () => {
+  let ajaxEventsCapture
+
+  beforeEach(async () => {
+    ajaxEventsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testAjaxEventsRequest })
+  })
+
+  it('does not capture agent payloads even when mode is "all"', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      init: { ajax: { capture_payloads: 'all', block_internal: false } },
+      loader: 'full'
+    }))
+    await browser.waitForAgentLoad()
+
+    await browser.execute(function (beaconHost, beaconPort) {
+      fetch('/echo-body', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'regular request' })
+      })
+      fetch('http://' + beaconHost + ':' + beaconPort + '/debug', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ secret: 'beacon payload' })
+      })
+    }, browser.testHandle.bamServerConfig.host, browser.testHandle.bamServerConfig.port)
+
+    const eventsHarvests = await ajaxEventsCapture.waitForResult({ totalCount: 2, timeout: 15000 })
+    const ajaxEvents = eventsHarvests.flatMap(h => h.request.body)
+
+    const regularEvents = ajaxEvents.filter(e => e.path === '/echo-body')
+    const beaconEvents = ajaxEvents.filter(e => e.path !== '/echo-body')
+
+    expect(regularEvents.length).toBeGreaterThan(0)
+    expect(beaconEvents.length).toBeGreaterThan(0)
+
+    regularEvents.forEach(event => {
+      const keys = event.children.map(x => x.key)
+      expect(keys).toEqual(expect.arrayContaining(['ajaxRequest.id', 'requestHeaders', 'requestBody', 'responseHeaders', 'responseBody']))
+    })
+
+    beaconEvents.forEach(event => {
+      const keys = event.children.map(x => x.key)
+      expect(keys).toEqual(expect.arrayContaining(['ajaxRequest.id']))
+      expect(keys).not.toEqual(expect.arrayContaining(['requestHeaders', 'requestBody', 'responseHeaders', 'responseBody']))
+    })
+  })
+})

--- a/tests/unit/features/ajax/instrument/capture-payloads.test.js
+++ b/tests/unit/features/ajax/instrument/capture-payloads.test.js
@@ -7,79 +7,145 @@ import { canCapturePayload } from '../../../../../src/common/payloads/payloads'
 import { hasGQLErrors } from '../../../../../src/features/ajax/aggregate/gql'
 
 describe('canCapturePayload logic', () => {
+  const genEvent = () => {
+    const event = { payloadHostname: 'example.com', statusCode: 200, hasGQLErrors: false }
+    event.status = (statusCode) => { event.statusCode = statusCode; return event }
+    event.gqlErrors = (hasGQLErrors) => { event.hasGQLErrors = hasGQLErrors; return event }
+    return event
+  }
+
   describe('none mode', () => {
     test('never captures payloads', () => {
-      expect(canCapturePayload('none', 200, false)).toBe(false)
-      expect(canCapturePayload('none', 404, false)).toBe(false)
-      expect(canCapturePayload('none', 500, false)).toBe(false)
-      expect(canCapturePayload('none', 0, false)).toBe(false)
-      expect(canCapturePayload('none', 200, true)).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(200).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(404).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(500).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(0).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(200).gqlErrors(true))).toBe(false)
     })
 
     test('treats null/undefined as none', () => {
-      expect(canCapturePayload(null, 200, false)).toBe(false)
-      expect(canCapturePayload(undefined, 200, false)).toBe(false)
+      expect(canCapturePayload(null, genEvent().status(200).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload(undefined, genEvent().status(200).gqlErrors(false))).toBe(false)
     })
   })
 
   describe('all mode', () => {
     test('captures all payloads regardless of status', () => {
-      expect(canCapturePayload('all', 200, false)).toBe(true)
-      expect(canCapturePayload('all', 201, false)).toBe(true)
-      expect(canCapturePayload('all', 204, false)).toBe(true)
-      expect(canCapturePayload('all', 301, false)).toBe(true)
-      expect(canCapturePayload('all', 400, false)).toBe(true)
-      expect(canCapturePayload('all', 404, false)).toBe(true)
-      expect(canCapturePayload('all', 500, false)).toBe(true)
-      expect(canCapturePayload('all', 0, false)).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(200))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(201))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(204))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(301))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(400))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(404))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(500))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(0))).toBe(true)
     })
 
     test('captures all payloads regardless of GraphQL errors', () => {
-      expect(canCapturePayload('all', 200, false)).toBe(true)
-      expect(canCapturePayload('all', 200, true)).toBe(true)
+      expect(canCapturePayload('all', genEvent().gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('all', genEvent().gqlErrors(true))).toBe(true)
+    })
+
+    test('canCapturePayload returns false for hostname matching a beacon', () => {
+      const beacons = ['example.com']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com',
+        payloadPathname: '/path'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(false)
+    })
+
+    test('canCapturePayload returns false for hostname + pathname matching a beacon', () => {
+      const beacons = ['example.com/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com',
+        payloadPathname: '/path'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(false)
+    })
+
+    test('canCapturePayload returns true for hostname (no pathname) partially matching a beacon', () => {
+      const beacons = ['example.com/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(true)
+    })
+
+    test('canCapturePayload returns false for hostname + pathname partially matching a beacon', () => {
+      const beacons = ['example.com/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com',
+        payloadPathname: '/path/to/foobar'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(false)
+    })
+
+    test('canCapturePayload returns true for unrelated hostname + pathname partially matching a beacon', () => {
+      const beacons = ['example.com/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com',
+        payloadPathname: '/pathFoo'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(true)
     })
   })
 
   describe('failures mode (default)', () => {
     test('captures status code 0 (network errors)', () => {
-      expect(canCapturePayload('failures', 0, false)).toBe(true)
-      expect(canCapturePayload('failures', 0, null)).toBe(true)
-      expect(canCapturePayload('failures', 0, undefined)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(0).gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(0).gqlErrors(null))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(0).gqlErrors(undefined))).toBe(true)
     })
 
     test('does not capture 1xx status codes', () => {
-      expect(canCapturePayload('failures', 100, false)).toBe(false)
-      expect(canCapturePayload('failures', 101, false)).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(100))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(101))).toBe(false)
     })
 
     test('does not capture 2xx success status codes', () => {
-      expect(canCapturePayload('failures', 200, false)).toBe(false)
-      expect(canCapturePayload('failures', 201, false)).toBe(false)
-      expect(canCapturePayload('failures', 204, false)).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(201))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(204))).toBe(false)
     })
 
     test('does not capture 3xx redirect status codes', () => {
-      expect(canCapturePayload('failures', 301, false)).toBe(false)
-      expect(canCapturePayload('failures', 302, false)).toBe(false)
-      expect(canCapturePayload('failures', 304, false)).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(301))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(302))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(304))).toBe(false)
     })
 
     test('captures 400 status code', () => {
-      expect(canCapturePayload('failures', 400, false)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(400))).toBe(true)
     })
 
     test('captures 4xx client errors > 400', () => {
-      expect(canCapturePayload('failures', 401, false)).toBe(true)
-      expect(canCapturePayload('failures', 403, false)).toBe(true)
-      expect(canCapturePayload('failures', 404, false)).toBe(true)
-      expect(canCapturePayload('failures', 429, false)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(401))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(403))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(404))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(429))).toBe(true)
     })
 
     test('captures 5xx server errors', () => {
-      expect(canCapturePayload('failures', 500, false)).toBe(true)
-      expect(canCapturePayload('failures', 502, false)).toBe(true)
-      expect(canCapturePayload('failures', 503, false)).toBe(true)
-      expect(canCapturePayload('failures', 504, false)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(500))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(502))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(503))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(504))).toBe(true)
     })
 
     test('captures GraphQL errors with 2xx status codes', () => {
@@ -88,8 +154,8 @@ describe('canCapturePayload logic', () => {
         data: null
       })
 
-      expect(canCapturePayload('failures', 200, hasGQLErrors(gqlError))).toBe(true)
-      expect(canCapturePayload('failures', 201, hasGQLErrors(gqlError))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(gqlError)))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(201).gqlErrors(hasGQLErrors(gqlError)))).toBe(true)
     })
 
     test('captures GraphQL errors with partial data', () => {
@@ -98,7 +164,7 @@ describe('canCapturePayload logic', () => {
         data: { user: { name: 'John', email: null } }
       })
 
-      expect(canCapturePayload('failures', 200, hasGQLErrors(gqlPartialError))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(gqlPartialError)))).toBe(true)
     })
 
     test('does not capture successful GraphQL responses', () => {
@@ -106,7 +172,7 @@ describe('canCapturePayload logic', () => {
         data: { user: { name: 'John', email: 'john@example.com' } }
       })
 
-      expect(canCapturePayload('failures', 200, hasGQLErrors(gqlSuccess))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(gqlSuccess)))).toBe(false)
     })
 
     test('captures GraphQL errors even with error status codes', () => {
@@ -116,36 +182,36 @@ describe('canCapturePayload logic', () => {
       })
 
       // Should capture due to status code (isHttpError is true)
-      expect(canCapturePayload('failures', 500, hasGQLErrors(gqlError))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(500).gqlErrors(hasGQLErrors(gqlError)))).toBe(true)
     })
 
     test('handles non-JSON response bodies', () => {
-      expect(canCapturePayload('failures', 200, hasGQLErrors('plain text response'))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors('<html>content</html>'))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors(null))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors(undefined))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors('plain text response')))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors('<html>content</html>')))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(null)))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(undefined)))).toBe(false)
     })
   })
 
   describe('edge cases', () => {
     test('handles empty response bodies', () => {
-      expect(canCapturePayload('failures', 200, hasGQLErrors(''))).toBe(false)
-      expect(canCapturePayload('failures', 404, hasGQLErrors(''))).toBe(true)
-      expect(canCapturePayload('failures', 0, hasGQLErrors(''))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors('')))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(404).gqlErrors(hasGQLErrors('')))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(0).gqlErrors(hasGQLErrors('')))).toBe(true)
     })
 
     test('handles malformed GraphQL responses', () => {
-      expect(canCapturePayload('failures', 200, hasGQLErrors('{ invalid json'))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors(JSON.stringify({ errors: [] })))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors(JSON.stringify({ errors: [{ noMessage: true }] })))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors('{ invalid json')))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(JSON.stringify({ errors: [] }))))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(JSON.stringify({ errors: [{ noMessage: true }] }))))).toBe(false)
     })
 
     test('handles various status code boundaries', () => {
-      expect(canCapturePayload('failures', 399, false)).toBe(false)
-      expect(canCapturePayload('failures', 400, false)).toBe(true)
-      expect(canCapturePayload('failures', 401, false)).toBe(true)
-      expect(canCapturePayload('failures', 599, false)).toBe(true)
-      expect(canCapturePayload('failures', 600, false)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(399).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(400).gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(401).gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(599).gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(600).gqlErrors(false))).toBe(true)
     })
   })
 })

--- a/tests/unit/features/ajax/instrument/capture-payloads.test.js
+++ b/tests/unit/features/ajax/instrument/capture-payloads.test.js
@@ -104,6 +104,32 @@ describe('canCapturePayload logic', () => {
       const actual = canCapturePayload('all', event, beacons)
       expect(actual).toBe(true)
     })
+
+    test('canCapturePayload returns false for host + pathname matching a beacon with port', () => {
+      const beacons = ['example.com:8080/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHost: 'example.com:8080',
+        payloadHostname: 'example.com',
+        payloadPathname: '/path'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(false)
+    })
+
+    test('canCapturePayload returns true for host + pathname NOT matching a beacon with port', () => {
+      const beacons = ['example.com:58467/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHost: 'example.com:58466',
+        payloadHostname: 'example.com',
+        payloadPathname: '/path'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(true)
+    })
   })
 
   describe('failures mode (default)', () => {


### PR DESCRIPTION
Prevent the AJAX `capture_payloads` feature from capturing the agent's own telemetry requests (harvests to NR beacon endpoints). 
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

In this PR, `canCapturePayload` was refactored to accept an object and a `beacons` array to help detect and avoid capturing the agent's own AJAX payloads. 

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-582726

### Testing

Updated related unit + component tests.
