### PR TITLE
feat: MFE vitals improvements

### DIFF
--- a/src/common/v2/mfe-vitals.js
+++ b/src/common/v2/mfe-vitals.js
@@ -7,7 +7,9 @@ import { globalScope, isBrowserScope } from '../constants/runtime'
 import { now } from '../timing/now'
 
 /**
- * @typedef {import('./register-api-types').RegisterAPITimings} RegisterAPITimings
+ * @typedef {import('../../loaders/api/register-api-types').RegisterAPITimings} RegisterAPITimings
+ * @typedef {import('../../loaders/api/register-api-types').RegisterAPITarget} RegisterAPITarget
+ * @typedef {import('../../loaders/api/register-api-types').RegisterAPIVitals} RegisterAPIVitals
  */
 
 const isObservable = (node) => {
@@ -18,18 +20,25 @@ const isObservable = (node) => {
   }
 }
 
+const isMatch = (dataset, target) => dataset?.nrMfeId === target.id && (!dataset?.nrMfeObserved || dataset?.nrMfeObserved === target.instance)
+
 /**
  * Check if node is within a specific MFE
  * @param {Node} node - DOM node to check
  * @param {string} id - MFE ID to match
  * @returns {boolean}
  */
-const isInMFE = (node, id) => {
-  if (!node || !id) return false
+const isInMFE = (node, target = {}) => {
+  const id = target.id
+  const instance = target.instance
+  if (!node || !id || !instance) return false
   try {
     let curr = node.nodeType === 1 ? node : node.parentElement
     while (curr?.tagName) {
-      if (curr.dataset?.nrMfeId === id) return true
+      if (isMatch(curr.dataset, target)) {
+        curr.dataset.nrMfeObserved = instance // mark that this MFE has been observed for vitals
+        return true
+      }
       curr = curr.parentNode
     }
   } catch (e) {}
@@ -42,25 +51,28 @@ const isInMFE = (node, id) => {
  * @param {Function} onMatch - Callback when matching node is *added*
  * @returns {MutationObserver}
  */
-const observeMutations = (id, onMatch) => {
+const observeMutations = (target, onMatch) => {
   // Try to find existing MFE root
-  const mfeRoot = globalScope.document?.querySelector(`[data-nr-mfe-id="${id}"]`)
+  const potentialMatches = globalScope.document?.querySelectorAll(`[data-nr-mfe-id="${target.id}"]`)
+  const mfeRoot = (Array.from(potentialMatches)).find(x => isMatch(x.dataset, target))
   let observingRoot = !!mfeRoot
+  if (observingRoot) mfeRoot.dataset.nrMfeObserved ??= target.instance // mark that this MFE has been observed for vitals
 
   const obs = new globalScope.MutationObserver(mutations => {
     mutations.forEach(m => {
       m.addedNodes.forEach(node => {
         // Check if this is the MFE root being added
         const elem = node.nodeType === 1 ? node : null
-        if (elem?.dataset?.nrMfeId === id) {
+        if (!observingRoot && isMatch(elem?.dataset, target)) {
           // Found the root! Lets switch to observing just this subtree for performance reasons
           obs.disconnect()
           obs.observe(elem, { childList: true, subtree: true })
           observingRoot = true
+          elem.dataset.nrMfeObserved = target.instance // mark that this MFE has been observed for vitals
         }
 
         // Only check isInMFE if we're observing the whole document; skip expensive ancestor walk when observing root
-        if (isObservable(node) && (observingRoot || isInMFE(node, id))) {
+        if (isObservable(node) && (observingRoot || isInMFE(node, target))) {
           onMatch(node, obs)
         }
       })
@@ -95,15 +107,16 @@ const observePerformance = (observers, config, onEntry) => {
 
 /**
  * Tracks all Core Web Vitals for a specific MFE.
- * @param {string} id - The MFE ID to track
- * @returns {{fcp: object|null, lcp: object|null, cls: object|null, inp: object|null, disconnect: Function}}
+ * @param {RegisterAPITarget} target - The MFE target to track vitals for
+ * @param {RegisterAPITimings} timings - The timings object to use for relative time calculations
+ * @returns {RegisterAPIVitals} An object containing the vitals values and a disconnect method to stop tracking
  */
-export function trackMFEVitals (id, timings) {
-  let fcpObservedAt = null
-  let lcpObservedAt = null
+export function trackMFEVitals (target, timings) {
+  let fcpObservedAt
+  let lcpObservedAt
 
   const getTimeRelativeToScriptStart = (capturedAt) => {
-    if (capturedAt === null) return null
+    if (capturedAt == null) return capturedAt
     return capturedAt - (timings?.scriptStart || timings?.registeredAt || 0)
   }
 
@@ -115,17 +128,23 @@ export function trackMFEVitals (id, timings) {
       get value () { return getTimeRelativeToScriptStart(lcpObservedAt) }
     },
     cls: {
-      value: null
+      value: undefined
     },
     inp: {
-      value: null
+      value: undefined
     },
     disconnect: () => {}
   }
 
-  if (!id || !isBrowserScope || !globalScope.MutationObserver || !globalScope.PerformanceObserver) return vitals
+  if (!target || !isBrowserScope || !globalScope.MutationObserver || !globalScope.PerformanceObserver) return vitals
 
   const observers = []
+
+  // If FCP hasn't been observed within 10 seconds, give up and shut down all observers.
+  // Once FCP is observed, the other vitals are left to record until their natural lifespan ends.
+  setTimeout(() => {
+    if (!fcpObservedAt) vitals.disconnect()
+  }, 10000)
 
   const populateVitalMinimums = () => {
     fcpObservedAt ??= now()
@@ -134,14 +153,15 @@ export function trackMFEVitals (id, timings) {
   }
 
   // if the MFE has already rendered something on the page before we could set up listeners, just populate vital minimums immediately
-  if (globalScope.document?.querySelector(`[data-nr-mfe-id="${id}"]`)) populateVitalMinimums()
+  if (globalScope.document?.querySelector(`[data-nr-mfe-id="${target.id}"]`)) populateVitalMinimums()
 
   // Track FCP - first contentful paint
-  observeMutations(id, (_, obs) => {
+  const fcpObs = observeMutations(target, (_, obs) => {
     // An observed "FCP" means _something_ rendered, so at minimum we can populate all the baseline values for the vitals
     populateVitalMinimums()
     obs.disconnect()
   })
+  observers.push(fcpObs)
 
   // Track LCP - largest contentful paint
   let largestSize = 0
@@ -167,7 +187,7 @@ export function trackMFEVitals (id, timings) {
     // ResizeObserver not supported
   }
 
-  const lcpObs = observeMutations(id, (node) => {
+  const lcpObs = observeMutations(target, (node) => {
     // an observed "LCP" means _something_ rendered, so at minimum we can make sure all the baseline values are populated for the vitals
     populateVitalMinimums()
 
@@ -214,7 +234,7 @@ export function trackMFEVitals (id, timings) {
   observePerformance(observers, { type: 'layout-shift', buffered: true }, (entry) => {
     if (entry.hadRecentInput) return
     ;(entry.sources || []).some(source => {
-      if (isInMFE(source.node, id)) {
+      if (isInMFE(source.node, target)) {
         // an observed "CLS" means _something_ rendered for the MFE, so at minimum we can make sure all the baseline values are populated for the vitals
         populateVitalMinimums()
         vitals.cls.value += entry.value
@@ -226,8 +246,8 @@ export function trackMFEVitals (id, timings) {
 
   // Track INP - interaction to next paint
   observePerformance(observers, { type: 'event', buffered: true, durationThreshold: 40 }, (entry) => {
-    if (!entry.interactionId || !isInMFE(entry.target, id)) return
-    if (vitals.inp.value === null || entry.duration > vitals.inp.value) {
+    if (!entry.interactionId || !isInMFE(entry.target, target)) return
+    if (vitals.inp.value === undefined || entry.duration > vitals.inp.value) {
       // an observed "INP" means _something_ rendered for the MFE, so at minimum we can make sure all the baseline values are populated for the vitals
       populateVitalMinimums()
       vitals.inp.value = entry.duration
@@ -252,6 +272,9 @@ export function trackMFEVitals (id, timings) {
       }
     })
     disconnectInteractionListeners()
+    ;['visibilitychange', 'pagehide'].forEach(type => {
+      globalScope.removeEventListener(type, vitals.disconnect, { once: true, passive: true })
+    })
   }
 
   // Auto-disconnect LCP observer on user interaction (per Web Vitals spec)
@@ -266,7 +289,7 @@ export function trackMFEVitals (id, timings) {
   }
 
   const handleInteraction = (event) => {
-    if (!isInMFE(event?.target, id)) return
+    if (!isInMFE(event?.target, target)) return
 
     disconnectLCP()
     disconnectInteractionListeners()

--- a/src/common/v2/mfe-vitals.js
+++ b/src/common/v2/mfe-vitals.js
@@ -22,6 +22,15 @@ const isObservable = (node) => {
 
 const isMatch = (dataset, target) => dataset?.nrMfeId === target.id && (!dataset?.nrMfeObserved || dataset?.nrMfeObserved === target.instance)
 
+const escapeSelectorValue = (value) => {
+  try {
+    return globalScope.CSS.escape(value)
+  } catch (e) {
+    // give up
+    return value
+  }
+}
+
 /**
  * Check if node is within a specific MFE
  * @param {Node} node - DOM node to check
@@ -53,8 +62,8 @@ const isInMFE = (node, target = {}) => {
  */
 const observeMutations = (target, onMatch) => {
   // Try to find existing MFE root
-  const potentialMatches = globalScope.document?.querySelectorAll(`[data-nr-mfe-id="${target.id}"]`)
-  const mfeRoot = (Array.from(potentialMatches)).find(x => isMatch(x.dataset, target))
+  const potentialMatches = globalScope.document?.querySelectorAll(`[data-nr-mfe-id="${escapeSelectorValue(target.id)}"]`)
+  const mfeRoot = (Array.from(potentialMatches) || []).find(x => isMatch(x.dataset, target))
   let observingRoot = !!mfeRoot
   if (observingRoot) mfeRoot.dataset.nrMfeObserved ??= target.instance // mark that this MFE has been observed for vitals
 
@@ -153,7 +162,8 @@ export function trackMFEVitals (target, timings) {
   }
 
   // if the MFE has already rendered something on the page before we could set up listeners, just populate vital minimums immediately
-  if (globalScope.document?.querySelector(`[data-nr-mfe-id="${target.id}"]`)) populateVitalMinimums()
+  const existingRoots = globalScope.document?.querySelectorAll(`[data-nr-mfe-id="${escapeSelectorValue(target.id)}"]`)
+  if (Array.from(existingRoots || []).some(x => isMatch(x.dataset, target))) populateVitalMinimums()
 
   // Track FCP - first contentful paint
   const fcpObs = observeMutations(target, (_, obs) => {

--- a/src/loaders/api/register-api-types.js
+++ b/src/loaders/api/register-api-types.js
@@ -53,4 +53,12 @@
  * @property {string} type - The type of timing associated with the registered entity, 'script' or 'link' if found with the performance resource API, 'fetch' for dynamic imports, 'inline' if found to be associated with the root document URL, or 'unknown' if no associated resource could be found.
  */
 
+/**
+ * @typedef {Object} RegisterAPIVitals
+ * @property {number} [fcp] - The first contentful paint timing for the registered entity.
+ * @property {number} [lcp] - The largest contentful paint timing for the registered entity.
+ * @property {number} [cls] - The cumulative layout shift score for the registered entity.
+ * @property {number} [inp] - The interaction to next paint timing for the registered entity.
+ */
+
 export default {}

--- a/src/loaders/api/register.js
+++ b/src/loaders/api/register.js
@@ -85,7 +85,7 @@ function register (agentRef, target) {
   const timings = findScriptTimings()
 
   // Track MFE vitals for this entity
-  const vitals = trackMFEVitals(target.id, timings)
+  const vitals = trackMFEVitals(target, timings)
 
   const attrs = {}
 
@@ -203,10 +203,10 @@ function register (agentRef, target) {
       timeToLoad: timeToFetch + timeToExecute, // fetch time and script time together
       timeToRegister: timings.registeredAt, // timestamp when register() was called
       // leave room to extend these with more data keys as needed
-      'nr.vitals.fcp.value': vitals.fcp?.value ?? null, // FCP vital object with value and metadata
-      'nr.vitals.lcp.value': vitals.lcp?.value ?? null, // LCP vital object with value and metadata
-      'nr.vitals.cls.value': vitals.cls?.value ?? null, // CLS vital object with value and metadata
-      'nr.vitals.inp.value': vitals.inp?.value ?? null // INP vital object with value and metadata
+      ...(vitals.fcp?.value >= 0 && { 'nr.vitals.fcp.value': vitals.fcp.value }), // FCP vital object with value and metadata
+      ...(vitals.lcp?.value >= 0 && { 'nr.vitals.lcp.value': vitals.lcp.value }), // LCP vital object with value and metadata
+      ...(vitals.cls?.value >= 0 && { 'nr.vitals.cls.value': vitals.cls.value }), // CLS vital object with value and metadata
+      ...(vitals.inp?.value >= 0 && { 'nr.vitals.inp.value': vitals.inp.value }) // INP vital object with value and metadata
     }
 
     api.recordCustomEvent('MicroFrontEndTiming', eventData)

--- a/src/loaders/api/register.js
+++ b/src/loaders/api/register.js
@@ -203,10 +203,10 @@ function register (agentRef, target) {
       timeToLoad: timeToFetch + timeToExecute, // fetch time and script time together
       timeToRegister: timings.registeredAt, // timestamp when register() was called
       // leave room to extend these with more data keys as needed
-      ...(vitals.fcp?.value >= 0 && { 'nr.vitals.fcp.value': vitals.fcp.value }), // FCP vital object with value and metadata
-      ...(vitals.lcp?.value >= 0 && { 'nr.vitals.lcp.value': vitals.lcp.value }), // LCP vital object with value and metadata
-      ...(vitals.cls?.value >= 0 && { 'nr.vitals.cls.value': vitals.cls.value }), // CLS vital object with value and metadata
-      ...(vitals.inp?.value >= 0 && { 'nr.vitals.inp.value': vitals.inp.value }) // INP vital object with value and metadata
+      ...(vitals.fcp.value >= 0 && { 'nr.vitals.fcp.value': vitals.fcp.value }), // FCP vital object with value and metadata
+      ...(vitals.lcp.value >= 0 && { 'nr.vitals.lcp.value': vitals.lcp.value }), // LCP vital object with value and metadata
+      ...(vitals.cls.value >= 0 && { 'nr.vitals.cls.value': vitals.cls.value }), // CLS vital object with value and metadata
+      ...(vitals.inp.value >= 0 && { 'nr.vitals.inp.value': vitals.inp.value }) // INP vital object with value and metadata
     }
 
     api.recordCustomEvent('MicroFrontEndTiming', eventData)

--- a/tests/specs/api/register/mfe-vitals.e2e.js
+++ b/tests/specs/api/register/mfe-vitals.e2e.js
@@ -38,43 +38,43 @@ function validateVitals (timingEvent, options = {}) {
 
   if (expectFCP) {
     expect(fcp).toBeDefined()
-    expect(fcp).not.toBeNull()
+    expect(fcp).not.toBeUndefined()
     expect(fcp).toBeGreaterThan(0)
     expect(fcp).toBeLessThan(10000) // Less than 10 seconds
-  } else if (fcp !== null && fcp !== undefined) {
+  } else if (fcp !== undefined) {
     // If FCP is present (but not required), validate it's reasonable
     expect(fcp).toBeGreaterThanOrEqual(0)
   }
 
   if (expectLCP) {
     expect(lcp).toBeDefined()
-    expect(lcp).not.toBeNull()
+    expect(lcp).not.toBeUndefined()
     expect(lcp).toBeGreaterThan(0)
     expect(lcp).toBeLessThan(10000)
     // LCP should be >= FCP if both are present
-    if (fcp !== null && fcp !== undefined) {
+    if (fcp !== undefined) {
       expect(lcp).toBeGreaterThanOrEqual(fcp)
     }
-  } else if (lcp !== null && lcp !== undefined) {
+  } else if (lcp !== undefined) {
     expect(lcp).toBeGreaterThanOrEqual(0)
   }
 
   if (expectCLS) {
     expect(cls).toBeDefined()
-    expect(cls).not.toBeNull()
+    expect(cls).not.toBeUndefined()
     // CLS is a score, typically between 0 and some small number
     expect(cls).toBeGreaterThanOrEqual(0)
     expect(cls).toBeLessThan(10) // CLS scores are typically very small
-  } else if (cls !== null && cls !== undefined) {
+  } else if (cls !== undefined) {
     expect(cls).toBeGreaterThanOrEqual(0)
   }
 
   if (expectINP) {
     expect(inp).toBeDefined()
-    expect(inp).not.toBeNull()
+    expect(inp).not.toBeUndefined()
     expect(inp).toBeGreaterThan(0)
     expect(inp).toBeLessThan(10000)
-  } else if (inp !== null && inp !== undefined) {
+  } else if (inp !== undefined) {
     expect(inp).toBeGreaterThanOrEqual(0)
   }
 }
@@ -302,14 +302,63 @@ describe('Register API - MFE Vitals Tracking', () => {
 
     // Vitals should be null or 0 for MFE with no matching content
     // FCP should be null since no content was added within the MFE scope
-    expect(timing['nr.vitals.fcp.value']).toBeNull()
-    expect(timing['nr.vitals.lcp.value']).toBeNull()
+    expect(timing['nr.vitals.fcp.value']).toBeUndefined()
+    expect(timing['nr.vitals.lcp.value']).toBeUndefined()
     // CLS might be null (unsupported) or have value 0 (supported but no shifts)
-    if (timing['nr.vitals.cls.value'] !== null) {
+    if (timing['nr.vitals.cls.value'] !== undefined) {
       const cls = timing['nr.vitals.cls.value']
       expect(cls).toBe(0)
     }
-    expect(timing['nr.vitals.inp.value']).toBeNull()
+    expect(timing['nr.vitals.inp.value']).toBeUndefined()
+  })
+
+  it('should give up tracking vitals if FCP is not observed within 10 seconds, reporting no timings', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      init: { feature_flags: ['register'] }
+    }))
+      .then(() => browser.waitForAgentLoad())
+
+    // Register an MFE and never render any content tagged with its data-nr-mfe-id,
+    // so FCP is never observed and the 10s internal timeout should kick in.
+    await browser.execute(function () {
+      window.timeoutMfe = newrelic.register({
+        id: 'fcp-timeout-mfe',
+        name: 'FCP Timeout MFE'
+      })
+    })
+
+    // Wait past the 10 second FCP timeout so the tracker gives up and disconnects its observers
+    await browser.pause(11000)
+
+    // Render content AFTER the timeout should have fired - since observers should already be
+    // disconnected at this point, this should NOT be picked up as FCP/LCP/CLS/INP
+    await browser.execute(function () {
+      const div = document.createElement('div')
+      div.textContent = 'Late content after FCP timeout'
+      div.dataset.nrMfeId = 'fcp-timeout-mfe'
+      div.style.width = '400px'
+      div.style.height = '400px'
+      document.body.appendChild(div)
+    })
+
+    await browser.pause(500)
+
+    await browser.execute(function () {
+      window.timeoutMfe.deregister()
+    })
+
+    const insightsHarvests = await mfeInsightsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+    const timingEvents = getMFETimingEvents(insightsHarvests, 'fcp-timeout-mfe')
+
+    expect(timingEvents.length).toBeGreaterThanOrEqual(1)
+    const timing = timingEvents[0]
+
+    // No vitals should have been captured - the 10s FCP timeout should have disconnected
+    // all observers before the late content was ever rendered
+    expect(timing['nr.vitals.fcp.value']).toBeUndefined()
+    expect(timing['nr.vitals.lcp.value']).toBeUndefined()
+    expect(timing['nr.vitals.cls.value']).toBeUndefined()
+    expect(timing['nr.vitals.inp.value']).toBeUndefined()
   })
 
   it('should stop tracking vitals after deregistration', async () => {
@@ -402,15 +451,128 @@ describe('Register API - MFE Vitals Tracking', () => {
     expect(timing.timeToLoad).toBeGreaterThanOrEqual(0)
     expect(timing.timeToRegister).toBeGreaterThanOrEqual(0)
 
-    // Vitals properties should exist (even if null)
-    expect(timing).toHaveProperty(['nr.vitals.fcp.value'])
-    expect(timing).toHaveProperty(['nr.vitals.lcp.value'])
-    expect(timing).toHaveProperty(['nr.vitals.cls.value'])
-    expect(timing).toHaveProperty(['nr.vitals.inp.value'])
-
     // At least FCP and LCP should have values for this test case
-    expect(timing['nr.vitals.fcp.value']).not.toBeNull()
-    expect(timing['nr.vitals.lcp.value']).not.toBeNull()
+    expect(timing['nr.vitals.fcp.value']).not.toBeUndefined()
+    expect(timing['nr.vitals.lcp.value']).not.toBeUndefined()
+  })
+
+  it('should independently detect FCP for two MFE instances sharing the same id in separate DOM trees', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      init: { feature_flags: ['register'] }
+    }))
+      .then(() => browser.waitForAgentLoad())
+
+    // Register two separate instances that share the same MFE id, before either DOM tree
+    // exists, so both trackers start out watching the whole document for their shared id.
+    await browser.execute(function () {
+      window.mfeTreeA = newrelic.register({ id: 'dual-tree-mfe', name: 'Tree A' })
+      window.mfeTreeB = newrelic.register({ id: 'dual-tree-mfe', name: 'Tree B' })
+    })
+
+    // Render the first DOM tree for this shared id
+    await browser.execute(function () {
+      const treeA = document.createElement('div')
+      treeA.dataset.nrMfeId = 'dual-tree-mfe'
+      treeA.textContent = 'Tree A content'
+      treeA.style.width = '100px'
+      treeA.style.height = '100px'
+      document.body.appendChild(treeA)
+    })
+
+    await browser.pause(300)
+
+    // Render a second, unrelated DOM tree elsewhere on the page for the SAME shared id.
+    // If a tracker had latched onto Tree A's subtree exclusively, it would never see this.
+    await browser.execute(function () {
+      const treeB = document.createElement('div')
+      treeB.dataset.nrMfeId = 'dual-tree-mfe'
+      treeB.textContent = 'Tree B content'
+      treeB.style.width = '200px'
+      treeB.style.height = '200px'
+      document.body.appendChild(treeB)
+    })
+
+    await browser.pause(300)
+
+    await browser.execute(function () {
+      window.mfeTreeA.deregister()
+      window.mfeTreeB.deregister()
+    })
+
+    const insightsHarvests = await mfeInsightsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+    const timingEvents = getMFETimingEvents(insightsHarvests, 'dual-tree-mfe')
+
+    // Both instances should have reported their own timing event
+    expect(timingEvents.length).toBe(2)
+
+    const eventA = timingEvents.find(e => e['source.name'] === 'Tree A')
+    const eventB = timingEvents.find(e => e['source.name'] === 'Tree B')
+
+    expect(eventA).toBeDefined()
+    expect(eventB).toBeDefined()
+
+    // Each instance should have detected FCP from its OWN DOM tree, independently of the other
+    validateVitals(eventA, { expectFCP: true })
+    validateVitals(eventB, { expectFCP: true })
+
+    // Tree B was rendered ~300ms after Tree A, so its FCP timestamp should reflect that later render
+    expect(eventB['nr.vitals.fcp.value'] - eventA['nr.vitals.fcp.value']).toBeGreaterThanOrEqual(300)
+  })
+
+  it.withBrowsersMatching(supportsLargestContentfulPaint)('should independently measure LCP size for two MFE instances sharing the same id', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      init: { feature_flags: ['register'] }
+    }))
+      .then(() => browser.waitForAgentLoad())
+
+    await browser.execute(function () {
+      window.mfeTreeA = newrelic.register({ id: 'dual-tree-lcp-mfe', name: 'LCP Tree A' })
+      window.mfeTreeB = newrelic.register({ id: 'dual-tree-lcp-mfe', name: 'LCP Tree B' })
+    })
+
+    // Small tree A, rendered first
+    await browser.execute(function () {
+      const treeA = document.createElement('div')
+      treeA.dataset.nrMfeId = 'dual-tree-lcp-mfe'
+      treeA.textContent = 'Small tree A'
+      treeA.style.width = '50px'
+      treeA.style.height = '50px'
+      document.body.appendChild(treeA)
+    })
+
+    await browser.pause(300)
+
+    // Larger tree B, in a completely separate part of the page, rendered second
+    await browser.execute(function () {
+      const treeB = document.createElement('div')
+      treeB.dataset.nrMfeId = 'dual-tree-lcp-mfe'
+      treeB.textContent = 'Large tree B'
+      treeB.style.width = '400px'
+      treeB.style.height = '400px'
+      document.body.appendChild(treeB)
+    })
+
+    await browser.pause(500)
+
+    await browser.execute(function () {
+      window.mfeTreeA.deregister()
+      window.mfeTreeB.deregister()
+    })
+
+    const insightsHarvests = await mfeInsightsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+    const timingEvents = getMFETimingEvents(insightsHarvests, 'dual-tree-lcp-mfe')
+
+    expect(timingEvents.length).toBe(2)
+
+    const eventA = timingEvents.find(e => e['source.name'] === 'LCP Tree A')
+    const eventB = timingEvents.find(e => e['source.name'] === 'LCP Tree B')
+
+    expect(eventA).toBeDefined()
+    expect(eventB).toBeDefined()
+
+    // Both trees should have measured LCP from their own content, not each other's
+    validateVitals(eventA, { expectLCP: true })
+    validateVitals(eventB, { expectLCP: true })
   })
 
   // it('should capture comprehensive metadata for all vitals', async () => {

--- a/tests/specs/api/register/mfe-vitals.e2e.js
+++ b/tests/specs/api/register/mfe-vitals.e2e.js
@@ -575,6 +575,104 @@ describe('Register API - MFE Vitals Tracking', () => {
     validateVitals(eventB, { expectLCP: true })
   })
 
+  it('only one of two instances sharing an id should claim a single shared DOM tree', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      init: { feature_flags: ['register'] }
+    }))
+      .then(() => browser.waitForAgentLoad())
+
+    // Two instances registered for the same id, before any matching DOM tree exists
+    await browser.execute(function () {
+      window.mfeInstanceA = newrelic.register({ id: 'shared-single-tree-mfe', name: 'Instance A' })
+      window.mfeInstanceB = newrelic.register({ id: 'shared-single-tree-mfe', name: 'Instance B' })
+    })
+
+    // Only ONE DOM tree is ever rendered for this shared id
+    await browser.execute(function () {
+      const tree = document.createElement('div')
+      tree.dataset.nrMfeId = 'shared-single-tree-mfe'
+      tree.textContent = 'Shared tree content'
+      tree.style.width = '100px'
+      tree.style.height = '100px'
+      document.body.appendChild(tree)
+    })
+
+    await browser.pause(300)
+
+    await browser.execute(function () {
+      window.mfeInstanceA.deregister()
+      window.mfeInstanceB.deregister()
+    })
+
+    const insightsHarvests = await mfeInsightsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+    const timingEvents = getMFETimingEvents(insightsHarvests, 'shared-single-tree-mfe')
+
+    // Both instances still report their own timing event...
+    expect(timingEvents.length).toBe(2)
+
+    const eventA = timingEvents.find(e => e['source.name'] === 'Instance A')
+    const eventB = timingEvents.find(e => e['source.name'] === 'Instance B')
+
+    expect(eventA).toBeDefined()
+    expect(eventB).toBeDefined()
+
+    // ...but since there's only one DOM tree to claim, exactly one of them should have
+    // observed FCP from it, and the other should have never observed anything at all.
+    const claimedCount = [eventA, eventB].filter(e => e['nr.vitals.fcp.value'] !== undefined).length
+    expect(claimedCount).toBe(1)
+  })
+
+  it.withBrowsersMatching(supportsLargestContentfulPaint)('should track a single MFE instance rendered across two separate DOM trees sharing the same id', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      init: { feature_flags: ['register'] }
+    }))
+      .then(() => browser.waitForAgentLoad())
+
+    // A single instance registered once, before either matching DOM tree exists
+    await browser.execute(function () {
+      window.singleMfe = newrelic.register({ id: 'single-instance-dual-tree-mfe', name: 'Single Instance' })
+    })
+
+    // First DOM tree for this id
+    await browser.execute(function () {
+      const treeA = document.createElement('div')
+      treeA.dataset.nrMfeId = 'single-instance-dual-tree-mfe'
+      treeA.textContent = 'Tree A content'
+      treeA.style.width = '100px'
+      treeA.style.height = '100px'
+      document.body.appendChild(treeA)
+    })
+
+    await browser.pause(300)
+
+    // A second, unrelated DOM tree elsewhere on the page, sharing the same id
+    await browser.execute(function () {
+      const treeB = document.createElement('div')
+      treeB.dataset.nrMfeId = 'single-instance-dual-tree-mfe'
+      treeB.textContent = 'Tree B content'
+      treeB.style.width = '200px'
+      treeB.style.height = '200px'
+      document.body.appendChild(treeB)
+    })
+
+    await browser.pause(300)
+
+    await browser.execute(function () {
+      window.singleMfe.deregister()
+    })
+
+    const insightsHarvests = await mfeInsightsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+    const timingEvents = getMFETimingEvents(insightsHarvests, 'single-instance-dual-tree-mfe')
+
+    // A single instance registered once should only ever report a single timing event,
+    // regardless of how many DOM trees on the page share its id.
+    expect(timingEvents.length).toBe(1)
+    const timing = timingEvents[0]
+
+    // The instance should have detected FCP and LCP from whichever tree it claimed first
+    validateVitals(timing, { expectFCP: true, expectLCP: true })
+  })
+
   // it('should capture comprehensive metadata for all vitals', async () => {
   //   await browser.url(await browser.testHandle.assetURL('instrumented.html', {
   //     init: { feature_flags: ['register'] }

--- a/tests/unit/common/v2/mfe-vitals.test.js
+++ b/tests/unit/common/v2/mfe-vitals.test.js
@@ -13,6 +13,22 @@ describe('trackMFEVitals', () => {
   let mutationCallbacks
   let performanceCallbacks
   let timings
+  let mfeTarget
+
+  const createMockElem = (opts = {}) => {
+    return {
+      // defaults
+      textContent: '',
+      nodeType: 1,
+      tagName: 'DIV',
+      nodeName: 'DIV',
+      parentElement: null,
+      parentNode: null,
+      dataset: {},
+      // overrides
+      ...opts
+    }
+  }
   const clockBaseline = 11
 
   beforeEach(async () => {
@@ -60,6 +76,13 @@ describe('trackMFEVitals', () => {
           return { dataset: { nrMfeId: 'test-mfe' } }
         }
         return null
+      }),
+      querySelectorAll: jest.fn((selector) => {
+        // By default, simulate that MFE container exists
+        if (selector.includes('data-nr-mfe-id')) {
+          return [{ dataset: { nrMfeId: 'test-mfe' } }]
+        }
+        return []
       })
     }
 
@@ -103,31 +126,36 @@ describe('trackMFEVitals', () => {
     // Import after mocking
     const module = await import('../../../../src/common/v2/mfe-vitals')
     trackMFEVitals = module.trackMFEVitals
+
+    mfeTarget = {
+      id: 'test-mfe',
+      name: 'Test MFE',
+      instance: 'abcdefg'
+    }
   })
 
   describe('FCP tracking', () => {
     it('should track FCP when contentful element is added to MFE', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
       // The collector seeds FCP as soon as it sees the MFE marker on the page.
       expect(vitals.fcp.value).toBe(clockBaseline - 1)
 
       // Create a mock element with text content inside MFE container
-      const mockContainer = {
+      const mockContainer = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
-        nodeName: 'DIV',
-        parentNode: null
-      }
+        nodeName: 'DIV'
+      })
 
-      const mockElement = {
+      const mockElement = createMockElem({
         textContent: 'Hello world',
         nodeType: 1,
         tagName: 'DIV',
         nodeName: 'DIV',
         parentElement: mockContainer,
         parentNode: mockContainer
-      }
+      })
 
       // Simulate mutation observer detecting new node
       mutationCallbacks.forEach(cb => cb([{
@@ -139,24 +167,24 @@ describe('trackMFEVitals', () => {
     })
 
     it('should use scriptStart as the timestamp anchor for FCP', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockContainer = {
+      const mockContainer = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentNode: null
-      }
+      })
 
-      const mockElement = {
+      const mockElement = createMockElem({
         textContent: 'Content',
         nodeType: 1,
         tagName: 'P',
         nodeName: 'P',
         parentElement: mockContainer,
         parentNode: mockContainer
-      }
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [mockElement] }]))
 
@@ -166,17 +194,17 @@ describe('trackMFEVitals', () => {
 
   describe('LCP tracking', () => {
     it('should track LCP as a relative timestamp', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockContainer = {
+      const mockContainer = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentNode: null
-      }
+      })
 
-      const mockElement = {
+      const mockElement = createMockElem({
         textContent: 'Large content',
         nodeType: 1,
         tagName: 'IMG',
@@ -186,8 +214,9 @@ describe('trackMFEVitals', () => {
         complete: true,
         parentElement: mockContainer,
         parentNode: mockContainer,
-        getBoundingClientRect: jest.fn(() => ({ width: 800, height: 600 }))
-      }
+        getBoundingClientRect: jest.fn(() => ({ width: 800, height: 600 })),
+        dataset: {}
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [mockElement] }]))
 
@@ -196,17 +225,17 @@ describe('trackMFEVitals', () => {
     })
 
     it('should update LCP when larger element is added', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockContainer = {
+      const mockContainer = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentNode: null
-      }
+      })
 
-      const smallElement = {
+      const smallElement = createMockElem({
         textContent: 'Small',
         nodeType: 1,
         tagName: 'DIV',
@@ -214,13 +243,14 @@ describe('trackMFEVitals', () => {
         id: 'small',
         parentElement: mockContainer,
         parentNode: mockContainer,
-        getBoundingClientRect: jest.fn(() => ({ width: 100, height: 100 }))
-      }
+        getBoundingClientRect: jest.fn(() => ({ width: 100, height: 100 })),
+        dataset: {}
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [smallElement] }]))
       const firstLcp = vitals.lcp.value
 
-      const largeElement = {
+      const largeElement = createMockElem({
         textContent: 'Large',
         nodeType: 1,
         tagName: 'DIV',
@@ -229,7 +259,7 @@ describe('trackMFEVitals', () => {
         parentElement: mockContainer,
         parentNode: mockContainer,
         getBoundingClientRect: jest.fn(() => ({ width: 800, height: 600 }))
-      }
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [largeElement] }]))
 
@@ -238,22 +268,22 @@ describe('trackMFEVitals', () => {
     })
 
     it('should extract URL from element background image', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
       const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
       mockGlobalScope.getComputedStyle = jest.fn(() => ({
         backgroundImage: 'url("https://example.com/bg.png?v=1")'
       }))
 
-      const mockContainer = {
+      const mockContainer = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentNode: null
-      }
+      })
 
-      const mockElement = {
+      const mockElement = createMockElem({
         textContent: 'Content',
         nodeType: 1,
         tagName: 'DIV',
@@ -262,7 +292,7 @@ describe('trackMFEVitals', () => {
         parentElement: mockContainer,
         parentNode: mockContainer,
         getBoundingClientRect: jest.fn(() => ({ width: 800, height: 600 }))
-      }
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [mockElement] }]))
 
@@ -271,25 +301,26 @@ describe('trackMFEVitals', () => {
 
     describe('ResizeObserver-based measurement', () => {
       it('should use ResizeObserver to measure element sizes without layout thrashing', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
-        const mockElement = {
+        const mockElement = createMockElem({
           textContent: 'Content',
           nodeType: 1,
           tagName: 'DIV',
           nodeName: 'DIV',
           parentElement: mockContainer,
           parentNode: mockContainer,
-          getBoundingClientRect: jest.fn(() => ({ width: 500, height: 400 }))
-        }
+          getBoundingClientRect: jest.fn(() => ({ width: 500, height: 400 })),
+          dataset: {}
+        })
 
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [mockElement] }]))
 
@@ -300,17 +331,17 @@ describe('trackMFEVitals', () => {
       })
 
       it('should ignore elements with zero dimensions', () => {
-        const vitals = trackMFEVitals('test-mfe', timings)
+        const vitals = trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
-        const zeroSizeElement = {
+        const zeroSizeElement = createMockElem({
           textContent: 'Hidden content',
           nodeType: 1,
           tagName: 'DIV',
@@ -318,7 +349,7 @@ describe('trackMFEVitals', () => {
           parentElement: mockContainer,
           parentNode: mockContainer,
           getBoundingClientRect: jest.fn(() => ({ width: 0, height: 0 }))
-        }
+        })
 
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [zeroSizeElement] }]))
 
@@ -327,25 +358,26 @@ describe('trackMFEVitals', () => {
       })
 
       it('should track same element only once', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
-        const mockElement = {
+        const mockElement = createMockElem({
           textContent: 'Content',
           nodeType: 1,
           tagName: 'DIV',
           nodeName: 'DIV',
           parentElement: mockContainer,
           parentNode: mockContainer,
-          getBoundingClientRect: jest.fn(() => ({ width: 300, height: 200 }))
-        }
+          getBoundingClientRect: jest.fn(() => ({ width: 300, height: 200 })),
+          dataset: {}
+        })
 
         // Add same element twice
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [mockElement] }]))
@@ -359,17 +391,17 @@ describe('trackMFEVitals', () => {
 
     describe('Image and video load event handling', () => {
       it('should capture LCP immediately for already-loaded images', () => {
-        const vitals = trackMFEVitals('test-mfe', timings)
+        const vitals = trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
-        const loadedImage = {
+        const loadedImage = createMockElem({
           nodeType: 1,
           tagName: 'IMG',
           nodeName: 'IMG',
@@ -378,7 +410,7 @@ describe('trackMFEVitals', () => {
           parentElement: mockContainer,
           parentNode: mockContainer,
           getBoundingClientRect: jest.fn(() => ({ width: 800, height: 600 }))
-        }
+        })
 
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [loadedImage] }]))
 
@@ -387,18 +419,18 @@ describe('trackMFEVitals', () => {
       })
 
       it('should wait for load event on unloaded images', () => {
-        const vitals = trackMFEVitals('test-mfe', timings)
+        const vitals = trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
         const loadListeners = []
-        const unloadedImage = {
+        const unloadedImage = createMockElem({
           nodeType: 1,
           tagName: 'IMG',
           nodeName: 'IMG',
@@ -410,7 +442,7 @@ describe('trackMFEVitals', () => {
           addEventListener: jest.fn((event, handler, options) => {
             if (event === 'load') loadListeners.push({ handler, options })
           })
-        }
+        })
 
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [unloadedImage] }]))
 
@@ -426,18 +458,18 @@ describe('trackMFEVitals', () => {
       })
 
       it('should wait for loadeddata event on video elements', () => {
-        const vitals = trackMFEVitals('test-mfe', timings)
+        const vitals = trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
         const loadeddataListeners = []
-        const unloadedVideo = {
+        const unloadedVideo = createMockElem({
           nodeType: 1,
           tagName: 'VIDEO',
           nodeName: 'VIDEO',
@@ -449,7 +481,7 @@ describe('trackMFEVitals', () => {
           addEventListener: jest.fn((event, handler, options) => {
             if (event === 'loadeddata') loadeddataListeners.push({ handler, options })
           })
-        }
+        })
 
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [unloadedVideo] }]))
 
@@ -463,17 +495,17 @@ describe('trackMFEVitals', () => {
       })
 
       it('should use once:true for image load listeners to prevent memory leaks', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
-        const unloadedImage = {
+        const unloadedImage = createMockElem({
           nodeType: 1,
           tagName: 'IMG',
           nodeName: 'IMG',
@@ -483,7 +515,7 @@ describe('trackMFEVitals', () => {
           parentNode: mockContainer,
           getBoundingClientRect: jest.fn(() => ({ width: 600, height: 400 })),
           addEventListener: jest.fn()
-        }
+        })
 
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [unloadedImage] }]))
 
@@ -495,17 +527,17 @@ describe('trackMFEVitals', () => {
       })
 
       it('should use once:true for video loadeddata listeners to prevent memory leaks', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
-        const unloadedVideo = {
+        const unloadedVideo = createMockElem({
           nodeType: 1,
           tagName: 'VIDEO',
           nodeName: 'VIDEO',
@@ -515,7 +547,7 @@ describe('trackMFEVitals', () => {
           parentNode: mockContainer,
           getBoundingClientRect: jest.fn(() => ({ width: 1920, height: 1080 })),
           addEventListener: jest.fn()
-        }
+        })
 
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [unloadedVideo] }]))
 
@@ -527,17 +559,17 @@ describe('trackMFEVitals', () => {
       })
 
       it('should observe already-loaded videos immediately', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
-        const mockContainer = {
+        const mockContainer = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentNode: null
-        }
+        })
 
-        const loadedVideo = {
+        const loadedVideo = createMockElem({
           nodeType: 1,
           tagName: 'VIDEO',
           nodeName: 'VIDEO',
@@ -547,7 +579,7 @@ describe('trackMFEVitals', () => {
           parentNode: mockContainer,
           getBoundingClientRect: jest.fn(() => ({ width: 1920, height: 1080 })),
           addEventListener: jest.fn()
-        }
+        })
 
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [loadedVideo] }]))
 
@@ -561,18 +593,17 @@ describe('trackMFEVitals', () => {
 
     describe('Disconnect on user interaction', () => {
       it('should disconnect LCP observer on pointerdown within MFE', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
         const pointerListeners = mockEventListeners.pointerdown || []
         expect(pointerListeners.length).toBeGreaterThan(0)
 
-        const mockTarget = {
+        const mockTarget = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'BUTTON',
           nodeName: 'BUTTON',
-          parentElement: null,
-          parentNode: null
-        }
+          parentElement: null
+        })
 
         // Trigger pointerdown event within MFE
         pointerListeners[0].handler({ target: mockTarget })
@@ -583,19 +614,19 @@ describe('trackMFEVitals', () => {
       })
 
       it('should disconnect LCP observer on keydown within MFE', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
         const keyListeners = mockEventListeners.keydown || []
         expect(keyListeners.length).toBeGreaterThan(0)
 
-        const mockTarget = {
+        const mockTarget = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'INPUT',
           nodeName: 'INPUT',
           parentElement: null,
           parentNode: null
-        }
+        })
 
         // Trigger keydown event within MFE
         keyListeners[0].handler({ target: mockTarget })
@@ -605,18 +636,18 @@ describe('trackMFEVitals', () => {
       })
 
       it('should not disconnect LCP observer for interactions outside MFE', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
         const pointerListeners = mockEventListeners.pointerdown || []
 
-        const outsideTarget = {
+        const outsideTarget = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'different-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV',
           parentElement: null,
           parentNode: null
-        }
+        })
 
         // Trigger event outside MFE
         pointerListeners[0].handler({ target: outsideTarget })
@@ -626,18 +657,18 @@ describe('trackMFEVitals', () => {
       })
 
       it('should remove interaction listeners after LCP disconnect', () => {
-        trackMFEVitals('test-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
         const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
 
-        const mockTarget = {
+        const mockTarget = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'BUTTON',
           nodeName: 'BUTTON',
           parentElement: null,
           parentNode: null
-        }
+        })
 
         // Trigger interaction
         mockEventListeners.pointerdown[0].handler({ target: mockTarget })
@@ -659,9 +690,9 @@ describe('trackMFEVitals', () => {
 
   describe('CLS tracking', () => {
     it('should accumulate CLS from matching layout shifts', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockNode = {
+      const mockNode = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
@@ -670,7 +701,7 @@ describe('trackMFEVitals', () => {
         className: 'shift-element',
         parentElement: null,
         parentNode: null
-      }
+      })
 
       // Simulate layout shift entry
       const shiftEntry = {
@@ -686,9 +717,9 @@ describe('trackMFEVitals', () => {
     })
 
     it('should update largest shift when bigger shift occurs', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockNode1 = {
+      const mockNode1 = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
@@ -696,9 +727,9 @@ describe('trackMFEVitals', () => {
         id: 'small-shift',
         parentElement: null,
         parentNode: null
-      }
+      })
 
-      const mockNode2 = {
+      const mockNode2 = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'IMG',
@@ -707,7 +738,7 @@ describe('trackMFEVitals', () => {
         className: 'hero',
         parentElement: null,
         parentNode: null
-      }
+      })
 
       performanceCallbacks['layout-shift']({
         getEntries: () => [
@@ -735,16 +766,16 @@ describe('trackMFEVitals', () => {
     })
 
     it('should ignore shifts with recent input', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockNode = {
+      const mockNode = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentElement: null,
         parentNode: null
-      }
+      })
 
       performanceCallbacks['layout-shift']({
         getEntries: () => [
@@ -766,17 +797,17 @@ describe('trackMFEVitals', () => {
       const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
       mockGlobalScope.document.querySelector = jest.fn(() => null)
 
-      const vitals = trackMFEVitals('missing-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      expect(vitals.cls.value).toBeNull()
+      expect(vitals.cls.value).toBeUndefined()
     })
   })
 
   describe('INP tracking', () => {
     it('should track the longest interaction duration', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockTarget = {
+      const mockTarget = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'BUTTON',
@@ -785,7 +816,7 @@ describe('trackMFEVitals', () => {
         className: 'btn primary',
         parentElement: null,
         parentNode: null
-      }
+      })
 
       const eventEntry = {
         interactionId: 123,
@@ -803,9 +834,9 @@ describe('trackMFEVitals', () => {
     })
 
     it('should update INP when longer interaction occurs', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockTarget1 = {
+      const mockTarget1 = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'INPUT',
@@ -813,9 +844,9 @@ describe('trackMFEVitals', () => {
         id: 'field1',
         parentElement: null,
         parentNode: null
-      }
+      })
 
-      const mockTarget2 = {
+      const mockTarget2 = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'BUTTON',
@@ -823,7 +854,7 @@ describe('trackMFEVitals', () => {
         id: 'field2',
         parentElement: null,
         parentNode: null
-      }
+      })
 
       performanceCallbacks.event({
         getEntries: () => [
@@ -857,16 +888,15 @@ describe('trackMFEVitals', () => {
     })
 
     it('should handle missing processingStart/End gracefully', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockTarget = {
+      const mockTarget = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
-        parentElement: null,
-        parentNode: null
-      }
+        parentElement: null
+      })
 
       const eventEntry = {
         interactionId: 123,
@@ -885,16 +915,16 @@ describe('trackMFEVitals', () => {
     })
 
     it('should ignore events without interactionId', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockTarget = {
+      const mockTarget = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentElement: null,
         parentNode: null
-      }
+      })
 
       performanceCallbacks.event({
         getEntries: () => [
@@ -907,7 +937,7 @@ describe('trackMFEVitals', () => {
         ]
       })
 
-      expect(vitals.inp.value).toBeNull()
+      expect(vitals.inp.value).toBeUndefined()
     })
   })
 
@@ -915,43 +945,44 @@ describe('trackMFEVitals', () => {
     it('should only track elements within the specified MFE', () => {
       const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
       mockGlobalScope.document.querySelector = jest.fn(() => null)
+      mockGlobalScope.document.querySelectorAll = jest.fn(() => [])
 
-      const vitals = trackMFEVitals('mfe-a', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mfeBContainer = {
+      const mfeBContainer = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'mfe-b' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentNode: null
-      }
+      })
 
-      const mfeBElement = {
+      const mfeBElement = createMockElem({
         textContent: 'MFE B content',
         nodeType: 1,
         tagName: 'DIV',
         nodeName: 'DIV',
         parentElement: mfeBContainer,
         parentNode: mfeBContainer
-      }
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [mfeBElement] }]))
 
-      expect(vitals.fcp.value).toBeNull()
+      expect(vitals.fcp.value).toBeUndefined()
     })
 
     it('should track nested elements within MFE', () => {
-      const vitals = trackMFEVitals('nested-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const parentElement = {
+      const parentElement = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'nested-mfe' },
         tagName: 'SECTION',
         nodeName: 'SECTION',
         parentNode: null
-      }
+      })
 
-      const childElement = {
+      const childElement = createMockElem({
         textContent: 'Child content',
         nodeType: 1,
         tagName: 'P',
@@ -959,7 +990,7 @@ describe('trackMFEVitals', () => {
         parentElement,
         parentNode: parentElement,
         getBoundingClientRect: jest.fn(() => ({ width: 400, height: 300 }))
-      }
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [childElement] }]))
 
@@ -973,20 +1004,20 @@ describe('trackMFEVitals', () => {
   describe('Performance optimizations', () => {
     describe('MFE root scoping', () => {
       it('should observe from MFE root when it already exists', () => {
-        const mockRoot = {
+        const mockRoot = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV'
-        }
-
-        const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
-        mockGlobalScope.document.querySelector = jest.fn((selector) => {
-          if (selector === '[data-nr-mfe-id="test-mfe"]') return mockRoot
-          return null
         })
 
-        trackMFEVitals('test-mfe', timings)
+        const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
+        mockGlobalScope.document.querySelectorAll = jest.fn((selector) => {
+          if (selector === '[data-nr-mfe-id="test-mfe"]') return [mockRoot]
+          return []
+        })
+
+        trackMFEVitals(mfeTarget, timings)
 
         // MutationObserver should observe the root, not document
         const mutationObserverInstance = mockMutationObserver.mock.instances[0]
@@ -998,9 +1029,9 @@ describe('trackMFEVitals', () => {
 
       it('should switch from document to root observation when root appears', () => {
         const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
-        mockGlobalScope.document.querySelector = jest.fn(() => null)
+        mockGlobalScope.document.querySelectorAll = jest.fn(() => [])
 
-        trackMFEVitals('dynamic-mfe', timings)
+        trackMFEVitals(mfeTarget, timings)
 
         // Initially observes document
         const mutationObserverInstance = mockMutationObserver.mock.instances[0]
@@ -1010,12 +1041,12 @@ describe('trackMFEVitals', () => {
         )
 
         // Now the MFE root appears
-        const mfeRoot = {
+        const mfeRoot = createMockElem({
           nodeType: 1,
-          dataset: { nrMfeId: 'dynamic-mfe' },
+          dataset: { nrMfeId: 'test-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV'
-        }
+        })
 
         // Simulate mutation observer detecting the root being added
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [mfeRoot] }]))
@@ -1029,12 +1060,12 @@ describe('trackMFEVitals', () => {
       })
 
       it('should skip isInMFE checks when observing from root', () => {
-        const mockRoot = {
+        const mockRoot = createMockElem({
           nodeType: 1,
           dataset: { nrMfeId: 'scoped-mfe' },
           tagName: 'DIV',
           nodeName: 'DIV'
-        }
+        })
 
         const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
         mockGlobalScope.document.querySelector = jest.fn((selector) => {
@@ -1042,16 +1073,17 @@ describe('trackMFEVitals', () => {
           return null
         })
 
-        const vitals = trackMFEVitals('scoped-mfe', timings)
+        const vitals = trackMFEVitals(mfeTarget, timings)
 
         // Add element directly under root (no parent hierarchy needed for test)
-        const mockElement = {
+        const mockElement = createMockElem({
           textContent: 'Content',
           nodeType: 1,
           tagName: 'DIV',
           nodeName: 'DIV',
-          getBoundingClientRect: jest.fn(() => ({ width: 300, height: 200 }))
-        }
+          getBoundingClientRect: jest.fn(() => ({ width: 300, height: 200 })),
+          dataset: {}
+        })
 
         // When observing from root, all mutations are implicitly in the MFE
         mutationCallbacks.forEach(cb => cb([{ addedNodes: [mockElement] }]))
@@ -1063,7 +1095,7 @@ describe('trackMFEVitals', () => {
 
   describe('disconnect functionality', () => {
     it('should disconnect all observers', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
       vitals.disconnect()
 
@@ -1088,7 +1120,7 @@ describe('trackMFEVitals', () => {
     })
 
     it('should handle disconnect errors gracefully', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
       // Override disconnect to throw
       mockMutationObserver.mock.instances.forEach(instance => {
@@ -1101,35 +1133,40 @@ describe('trackMFEVitals', () => {
 
   describe('edge cases', () => {
     it('should return empty vitals when id is missing', () => {
-      const vitals = trackMFEVitals('', timings)
+      const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
+      mockGlobalScope.document.querySelector = jest.fn(() => null)
+      mockGlobalScope.document.querySelectorAll = jest.fn(() => [])
+
+      const vitals = trackMFEVitals({ instance: 'abcdefg' }, timings)
 
       // The collector still returns the vitals shell, but the value getters are never populated.
       expect(Object.getOwnPropertyDescriptor(vitals.fcp, 'value')?.get).toEqual(expect.any(Function))
       expect(Object.getOwnPropertyDescriptor(vitals.lcp, 'value')?.get).toEqual(expect.any(Function))
-      expect(vitals.cls.value).toBeNull()
-      expect(vitals.inp.value).toBeNull()
+      expect(vitals.cls.value).toBeUndefined()
+      expect(vitals.inp.value).toBeUndefined()
     })
 
     it('should handle elements without id or className', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockContainer = {
+      const mockContainer = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentNode: null
-      }
+      })
 
-      const mockElement = {
+      const mockElement = createMockElem({
         textContent: 'No ID or class',
         nodeType: 1,
         tagName: 'SPAN',
         nodeName: 'SPAN',
         parentElement: mockContainer,
         parentNode: mockContainer,
-        getBoundingClientRect: jest.fn(() => ({ width: 200, height: 100 }))
-      }
+        getBoundingClientRect: jest.fn(() => ({ width: 200, height: 100 })),
+        dataset: {}
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [mockElement] }]))
 
@@ -1137,17 +1174,17 @@ describe('trackMFEVitals', () => {
     })
 
     it('should handle elements with className as object', () => {
-      const vitals = trackMFEVitals('test-mfe', timings)
+      const vitals = trackMFEVitals(mfeTarget, timings)
 
-      const mockContainer = {
+      const mockContainer = createMockElem({
         nodeType: 1,
         dataset: { nrMfeId: 'test-mfe' },
         tagName: 'DIV',
         nodeName: 'DIV',
         parentNode: null
-      }
+      })
 
-      const mockElement = {
+      const mockElement = createMockElem({
         textContent: 'SVG element',
         nodeType: 1,
         tagName: 'svg',
@@ -1155,8 +1192,9 @@ describe('trackMFEVitals', () => {
         className: { baseVal: 'icon' }, // SVG className is an object
         parentElement: mockContainer,
         parentNode: mockContainer,
-        getBoundingClientRect: jest.fn(() => ({ width: 50, height: 50 }))
-      }
+        getBoundingClientRect: jest.fn(() => ({ width: 50, height: 50 })),
+        dataset: {}
+      })
 
       mutationCallbacks.forEach(cb => cb([{ addedNodes: [mockElement] }]))
 

--- a/tests/unit/common/v2/mfe-vitals.test.js
+++ b/tests/unit/common/v2/mfe-vitals.test.js
@@ -793,9 +793,9 @@ describe('trackMFEVitals', () => {
     })
 
     it('should be null when MFE container is not found in DOM', () => {
-      // Override querySelector to return null (MFE not in DOM)
+      // Override querySelectorAll to return no matches (MFE not in DOM)
       const mockGlobalScope = require('../../../../src/common/constants/runtime').globalScope
-      mockGlobalScope.document.querySelector = jest.fn(() => null)
+      mockGlobalScope.document.querySelectorAll = jest.fn(() => [])
 
       const vitals = trackMFEVitals(mfeTarget, timings)
 


### PR DESCRIPTION
Implement quality of life improvements on the collection of MFE vital timings. 
- If no FCP value is observed within 10 seconds, shut down observers for memory saving and outlier control. 
- Decorate observed DOM trees with the MFE instance ID to facilitate debugging and prevent double-instrumentation of the same DOM tree from multiple instances pointed at the same MFE target.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-597354
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
