### PR TITLE
fix: Avoid obfuscating keys and reserved system vals

### DIFF
--- a/src/common/payloads/payloads.js
+++ b/src/common/payloads/payloads.js
@@ -126,11 +126,11 @@ export function truncateAsString (data) {
 }
 
 /**
- * Creates string adder functions for BEL serialization with obfuscation and optional truncation.
+ * Creates string adder functions for BEL serialization with obfuscation and optional truncation, as well as raw string.
  * This ensures a single string table is used while providing separate handling for regular vs payload attributes.
  * @param {Function} getAddStringContext - Function that creates a new string table context
  * @param {Object} obfuscator - Optional obfuscator instance for string obfuscation
- * @returns {{addString: Function, addStringWithTruncation: Function}} Object containing both string adder functions
+ * @returns {{addString: Function, addStringRaw: Function, addStringWithTruncation: Function}} Object containing various string adder functions
  */
 export function createStringAdders (getAddStringContext, obfuscator) {
   const addStringRaw = getAddStringContext()
@@ -145,6 +145,7 @@ export function createStringAdders (getAddStringContext, obfuscator) {
 
   return {
     addString: (str) => processString(str, false),
+    addStringRaw: (str) => addStringRaw(str),
     addStringWithTruncation: (str) => processString(str, true)
   }
 }

--- a/src/common/payloads/payloads.js
+++ b/src/common/payloads/payloads.js
@@ -13,6 +13,7 @@ import { CAPTURE_PAYLOAD_SETTINGS } from '../../features/ajax/constants'
  * @param {Object} event - An object representing the AJAX event
  * @param {number} event.statusCode - The HTTP status code
  * @param {boolean} event.hasGQLErrors - Whether the response contains GraphQL errors
+ * @param {string} event.payloadHost - The host of the AJAX payload (includes port)
  * @param {string} event.payloadHostname - The hostname of the AJAX payload
  * @param {string} [event.payloadPathname=''] - The pathname of the AJAX payload
  * @param {string[]} [beacons=[]] - Array of beacon hostnames to avoid capturing
@@ -21,13 +22,15 @@ import { CAPTURE_PAYLOAD_SETTINGS } from '../../features/ajax/constants'
 export function canCapturePayload (captureMode, {
   statusCode,
   hasGQLErrors,
+  payloadHost,
   payloadHostname,
   payloadPathname = ''
 }, beacons = []) {
   if (payloadHostname) {
     const payloadUrl = payloadHostname + payloadPathname
+    const payloadUrlWithPort = payloadHost + payloadPathname
     if (beacons.some((b) => {
-      return b === payloadUrl || payloadUrl.startsWith(b + '/')
+      return b === payloadUrl || payloadUrl.startsWith(b + '/') || b === payloadUrlWithPort || payloadUrlWithPort.startsWith(b + '/')
     })) return false
   }
   if (captureMode === CAPTURE_PAYLOAD_SETTINGS.ALL) return true

--- a/src/common/payloads/payloads.js
+++ b/src/common/payloads/payloads.js
@@ -8,13 +8,28 @@ import { CAPTURE_PAYLOAD_SETTINGS } from '../../features/ajax/constants'
 
 /**
  * Determines whether payload data should be captured based on the capture mode setting,
- * HTTP status code, and GraphQL error status.
+ * HTTP status code, and GraphQL error status.  Will never capture agent's own payloads.
  * @param {string} captureMode - The capture mode setting ('none', 'all', or 'failures')
- * @param {number} statusCode - The HTTP status code
- * @param {boolean} hasGQLErrors - Whether the response contains GraphQL errors
+ * @param {Object} event - An object representing the AJAX event
+ * @param {number} event.statusCode - The HTTP status code
+ * @param {boolean} event.hasGQLErrors - Whether the response contains GraphQL errors
+ * @param {string} event.payloadHostname - The hostname of the AJAX payload
+ * @param {string} [event.payloadPathname=''] - The pathname of the AJAX payload
+ * @param {string[]} [beacons=[]] - Array of beacon hostnames to avoid capturing
  * @returns {boolean} True if payload should be captured
  */
-export function canCapturePayload (captureMode, statusCode, hasGQLErrors) {
+export function canCapturePayload (captureMode, {
+  statusCode,
+  hasGQLErrors,
+  payloadHostname,
+  payloadPathname = ''
+}, beacons = []) {
+  if (payloadHostname) {
+    const payloadUrl = payloadHostname + payloadPathname
+    if (beacons.some((b) => {
+      return b === payloadUrl || payloadUrl.startsWith(b + '/')
+    })) return false
+  }
   if (captureMode === CAPTURE_PAYLOAD_SETTINGS.ALL) return true
   if (!captureMode || captureMode === CAPTURE_PAYLOAD_SETTINGS.NONE) return false
 

--- a/src/common/serialize/bel-serializer.js
+++ b/src/common/serialize/bel-serializer.js
@@ -40,7 +40,16 @@ export function getAddStringContext (obfuscator, truncator) {
   }
 }
 
-export function addCustomAttributes (attrs, addString) {
+/**
+ * Attributes are serialized according to their types, using the provided serializers.  Only the first 64 attributes will be added to the payload.
+ * @param attrs
+ * @param serializers
+ * @param {function} serializers.addKey -function for serializing attribute keys
+ * @param {function} serializers.addVal - function for serializing attribute values
+ * @returns {*[]}
+ */
+export function addCustomAttributes (attrs, serializers) {
+  const { addKey, addVal } = serializers
   var attrParts = []
 
   Object.entries(attrs || {}).forEach(([key, val]) => {
@@ -48,13 +57,13 @@ export function addCustomAttributes (attrs, addString) {
     var type = 5
     var serializedValue
     // add key to string table first
-    key = addString(key, false)
+    key = addKey(key)
 
     switch (typeof val) {
       case 'object':
         if (val) {
           // serialize objects to strings
-          serializedValue = addString(stringify(val))
+          serializedValue = addVal(stringify(val))
         } else {
           // null attribute type
           type = 9
@@ -73,7 +82,7 @@ export function addCustomAttributes (attrs, addString) {
         type = 9
         break
       default:
-        serializedValue = addString(val)
+        serializedValue = addVal(val)
     }
 
     attrParts.push([type, key + (serializedValue ? ',' + serializedValue : '')])

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -109,7 +109,12 @@ export class Aggregate extends AggregateBase {
     if (event.gql) event.gql.operationHasErrors = hasGQLErrors(ctx.responseBody)
 
     const capturePayloadSetting = this.agentRef.init.ajax.capture_payloads
-    const shouldCapturePayload = canCapturePayload(capturePayloadSetting, params.status, event.gql?.operationHasErrors)
+    const shouldCapturePayload = canCapturePayload(capturePayloadSetting, {
+      statusCode: event.status,
+      hasGQLErrors: event.gql?.operationHasErrors,
+      payloadHostname: params.hostname,
+      payloadPathname: params.pathname
+    }, this.agentRef.beacons)
 
     if (shouldCapturePayload) {
       // Store raw data; obfuscation and truncation will happen in the serializer

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -156,7 +156,7 @@ export class Aggregate extends AggregateBase {
   serializer (eventBuffer) {
     if (!eventBuffer.length) return
 
-    const { addString, addStringWithTruncation } = createStringAdders(getAddStringContext, this.obfuscator)
+    const { addString, addStringRaw, addStringWithTruncation } = createStringAdders(getAddStringContext, this.obfuscator)
 
     let payload = 'bel.7;'
 
@@ -173,16 +173,16 @@ export class Aggregate extends AggregateBase {
         numeric(event.endTime - event.startTime),
         numeric(0), // callbackEnd
         numeric(0), // no callbackDuration for non-SPA events
-        addString(event.method),
+        addStringRaw(event.method),
         numeric(event.status),
         addString(event.domain),
         addString(event.path),
         numeric(event.requestSize),
         numeric(event.responseSize),
         event.type === 'fetch' ? 1 : '',
-        addString(0), // nodeId
-        nullable(event.spanId, addString, true) + // guid
-        nullable(event.traceId, addString, true) + // traceId
+        addStringRaw(0), // nodeId
+        nullable(event.spanId, addStringRaw, true) + // guid
+        nullable(event.traceId, addStringRaw, true) + // traceId
         nullable(event.spanTimestamp, numeric, false) // timestamp
       ]
 
@@ -192,12 +192,15 @@ export class Aggregate extends AggregateBase {
       const jsAttributes = this.agentRef.info.jsAttributes
 
       // Regular attributes: obfuscate only
-      const regularAttrs = addCustomAttributes({
+      let regularAttrs = addCustomAttributes({
         ...(jsAttributes || {}),
-        [AJAX_ID]: event[AJAX_ID], // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
         ...(event.targetAttributes || {}), // used to supply the version 2 attributes, either MFE target or duplication attributes for the main agent app
         ...(event.gql || {})
-      }, addString)
+      }, { addKey: addStringRaw, addVal: addString })
+
+      regularAttrs.push(...addCustomAttributes({
+        [AJAX_ID]: event[AJAX_ID] // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
+      }, { addKey: addStringRaw, addVal: addStringRaw }))
 
       // Payload attributes: obfuscate then truncate
       const payloadAttrs = addCustomAttributes({
@@ -206,7 +209,7 @@ export class Aggregate extends AggregateBase {
         ...(event.requestQuery ? { requestQuery: event.requestQuery } : {}),
         ...(event.responseBody ? { responseBody: event.responseBody } : {}),
         ...(event.responseHeaders ? { responseHeaders: event.responseHeaders } : {})
-      }, addStringWithTruncation)
+      }, { addKey: addStringRaw, addVal: addStringWithTruncation })
 
       const attrParts = [...regularAttrs, ...payloadAttrs]
       fields.unshift(numeric(attrParts.length))

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -113,6 +113,7 @@ export class Aggregate extends AggregateBase {
       statusCode: event.status,
       hasGQLErrors: event.gql?.operationHasErrors,
       payloadHostname: params.hostname,
+      payloadHost: params.host,
       payloadPathname: params.pathname
     }, this.agentRef.beacons)
 

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -148,7 +148,7 @@ export class Aggregate extends AggregateBase {
   // serialize array of timing data
   serializer (eventBuffer) {
     if (!eventBuffer?.length) return ''
-    const { addStringRaw } = createStringAdders(getAddStringContext, this.obfuscator)
+    const { addString, addStringRaw } = createStringAdders(getAddStringContext, this.obfuscator)
     const obfuscateOnly = (val) => typeof val === 'string' ? (this.obfuscator?.obfuscateString(val) ?? val) : val
 
     var payload = 'bel.6;'
@@ -162,9 +162,11 @@ export class Aggregate extends AggregateBase {
 
       this.appendGlobalCustomAttributes(timing, { addVal: obfuscateOnly })
 
-      var attrParts = addCustomAttributes(timing.attrs, {
+      const { pageUrl, ...systemReservedAttrs } = timing.attrs || {}
+      var attrParts = addCustomAttributes(systemReservedAttrs, {
         addKey: addStringRaw, addVal: addStringRaw
       })
+      if (pageUrl) attrParts.push(...addCustomAttributes({ pageUrl }, { addKey: addStringRaw, addVal: addString }))
       if (attrParts && attrParts.length > 0) {
         payload += numeric(attrParts.length) + ';' + attrParts.join(';')
       }

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -23,6 +23,7 @@ import { loadTime } from '../../../common/vitals/load-time'
 import { webdriverDetected } from '../../../common/util/webdriver-detection'
 import { cleanURL } from '../../../common/url/clean-url'
 import { EVENT_TYPES } from '../../../common/constants/events'
+import { createStringAdders } from '../../../common/payloads/payloads'
 
 export class Aggregate extends AggregateBase {
   static featureName = FEATURE_NAME
@@ -125,14 +126,15 @@ export class Aggregate extends AggregateBase {
     })
   }
 
-  appendGlobalCustomAttributes (timing) {
+  appendGlobalCustomAttributes (timing, serializers) {
+    const { addVal } = serializers
     var timingAttributes = timing.attrs || {}
 
     var reservedAttributes = ['size', 'eid', 'cls', 'type', 'fid', 'elTag', 'elUrl', 'net-type',
       'net-etype', 'net-rtt', 'net-dlink']
     Object.entries(this.agentRef.info.jsAttributes || {}).forEach(([key, val]) => {
       if (reservedAttributes.indexOf(key) < 0) {
-        timingAttributes[key] = val
+        timingAttributes[key] = addVal(val)
       }
     })
     timingAttributes.webdriverDetected = webdriverDetected
@@ -146,7 +148,8 @@ export class Aggregate extends AggregateBase {
   // serialize array of timing data
   serializer (eventBuffer) {
     if (!eventBuffer?.length) return ''
-    var addString = getAddStringContext(this.obfuscator)
+    const { addStringRaw } = createStringAdders(getAddStringContext, this.obfuscator)
+    const obfuscateOnly = (val) => typeof val === 'string' ? (this.obfuscator?.obfuscateString(val) ?? val) : val
 
     var payload = 'bel.6;'
 
@@ -154,12 +157,14 @@ export class Aggregate extends AggregateBase {
       var timing = eventBuffer[i]
 
       payload += 'e,'
-      payload += addString(timing.name) + ','
+      payload += addStringRaw(timing.name) + ','
       payload += nullable(timing.value, numeric, false) + ','
 
-      this.appendGlobalCustomAttributes(timing)
+      this.appendGlobalCustomAttributes(timing, { addVal: obfuscateOnly })
 
-      var attrParts = addCustomAttributes(timing.attrs, addString)
+      var attrParts = addCustomAttributes(timing.attrs, {
+        addKey: addStringRaw, addVal: addStringRaw
+      })
       if (attrParts && attrParts.length > 0) {
         payload += numeric(attrParts.length) + ';' + attrParts.join(';')
       }

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -94,6 +94,8 @@ export class Aggregate extends AggregateBase {
       attrs.cls = cumulativeLayoutShift.current.value
     }
 
+    attrs.webdriverDetected = webdriverDetected
+
     const timing = {
       name,
       value,
@@ -126,18 +128,13 @@ export class Aggregate extends AggregateBase {
     })
   }
 
-  appendGlobalCustomAttributes (timing, serializers) {
-    const { addVal } = serializers
-    var timingAttributes = timing.attrs || {}
+  #getGlobalCustomAttributes () {
+    const reservedAttributes = ['size', 'eid', 'cls', 'type', 'fid', 'elTag', 'elUrl', 'net-type',
+      'net-etype', 'net-rtt', 'net-dlink', 'webdriverDetected']
 
-    var reservedAttributes = ['size', 'eid', 'cls', 'type', 'fid', 'elTag', 'elUrl', 'net-type',
-      'net-etype', 'net-rtt', 'net-dlink']
-    Object.entries(this.agentRef.info.jsAttributes || {}).forEach(([key, val]) => {
-      if (reservedAttributes.indexOf(key) < 0) {
-        timingAttributes[key] = addVal(val)
-      }
-    })
-    timingAttributes.webdriverDetected = webdriverDetected
+    return Object.fromEntries(
+      Object.entries(this.agentRef.info.jsAttributes || {}).filter(([key]) => !reservedAttributes.includes(key))
+    )
   }
 
   preHarvestChecks () {
@@ -149,7 +146,8 @@ export class Aggregate extends AggregateBase {
   serializer (eventBuffer) {
     if (!eventBuffer?.length) return ''
     const { addString, addStringRaw } = createStringAdders(getAddStringContext, this.obfuscator)
-    const obfuscateOnly = (val) => typeof val === 'string' ? (this.obfuscator?.obfuscateString(val) ?? val) : val
+    const keepOrigValue = { addKey: addStringRaw, addVal: addStringRaw }
+    const obfuscateValue = { addKey: addStringRaw, addVal: addString }
 
     var payload = 'bel.6;'
 
@@ -160,13 +158,13 @@ export class Aggregate extends AggregateBase {
       payload += addStringRaw(timing.name) + ','
       payload += nullable(timing.value, numeric, false) + ','
 
-      this.appendGlobalCustomAttributes(timing, { addVal: obfuscateOnly })
+      const userAttrs = this.#getGlobalCustomAttributes()
 
       const { pageUrl, ...systemReservedAttrs } = timing.attrs || {}
-      var attrParts = addCustomAttributes(systemReservedAttrs, {
-        addKey: addStringRaw, addVal: addStringRaw
-      })
-      if (pageUrl) attrParts.push(...addCustomAttributes({ pageUrl }, { addKey: addStringRaw, addVal: addString }))
+      var attrParts = addCustomAttributes(systemReservedAttrs, keepOrigValue)
+      attrParts.push(...addCustomAttributes(userAttrs, obfuscateValue))
+      if (pageUrl) attrParts.push(...addCustomAttributes({ pageUrl }, obfuscateValue))
+
       if (attrParts && attrParts.length > 0) {
         payload += numeric(attrParts.length) + ';' + attrParts.join(';')
       }

--- a/src/features/soft_navigations/aggregate/ajax-node.js
+++ b/src/features/soft_navigations/aggregate/ajax-node.js
@@ -42,7 +42,7 @@ export class AjaxNode extends BelNode {
   }
 
   serialize (parentStartTimestamp, agentRef, ajaxObfuscator) {
-    const { addString, addStringWithTruncation } = createStringAdders(getAddStringContext, ajaxObfuscator)
+    const { addString, addStringRaw, addStringWithTruncation } = createStringAdders(getAddStringContext, ajaxObfuscator)
 
     const nodeList = []
 
@@ -54,22 +54,25 @@ export class AjaxNode extends BelNode {
       numeric(this.end - this.start), // end is relative to start
       numeric(this.callbackEnd - this.end), // callbackEnd is relative to end
       numeric(this.callbackDuration), // not relative
-      addString(this.method),
+      addStringRaw(this.method),
       numeric(this.status),
       addString(this.domain),
       addString(this.path),
       numeric(this.txSize),
       numeric(this.rxSize),
       this.requestedWith,
-      addString(this.nodeId),
-      nullable(this.spanId, addString, true) + nullable(this.traceId, addString, true) + nullable(this.spanTimestamp, numeric)
+      addStringRaw(this.nodeId),
+      nullable(this.spanId, addStringRaw, true) + nullable(this.traceId, addStringRaw, true) + nullable(this.spanTimestamp, numeric)
     ]
     // Regular attributes: obfuscate only
     const regularAttrs = addCustomAttributes({
-      [AJAX_ID]: this[AJAX_ID],
       ...(this.targetAttributes || {}),
       ...(this.gql || {})
-    }, addString)
+    }, { addKey: addStringRaw, addVal: addString })
+
+    regularAttrs.push(...addCustomAttributes({
+      [AJAX_ID]: this[AJAX_ID]
+    }, { addKey: addStringRaw, addVal: addStringRaw }))
 
     // Payload attributes: obfuscate then truncate
     const payloadAttrs = addCustomAttributes({
@@ -78,7 +81,7 @@ export class AjaxNode extends BelNode {
       ...(this.requestQuery ? { requestQuery: this.requestQuery } : {}),
       ...(this.responseBody ? { responseBody: this.responseBody } : {}),
       ...(this.responseHeaders ? { responseHeaders: this.responseHeaders } : {})
-    }, addStringWithTruncation)
+    }, { addKey: addStringRaw, addVal: addStringWithTruncation })
 
     let allAttachedNodes = [...regularAttrs, ...payloadAttrs]
     this.children.forEach(node => allAttachedNodes.push(node.serialize())) // no children is expected under ajax nodes at this time

--- a/src/features/soft_navigations/aggregate/interaction.js
+++ b/src/features/soft_navigations/aggregate/interaction.js
@@ -167,7 +167,7 @@ export class Interaction extends BelNode {
       nullable(this.firstPaint, numeric, true) + nullable(this.firstContentfulPaint, numeric)
     ]
     const customAttributes = { ...agentRef.info.jsAttributes, ...this.customAttributes } // attrs specific to this interaction should have precedence over the general custom attrs
-    const allAttachedNodes = addCustomAttributes(customAttributes || {}, addString) // start with all custom attributes
+    const allAttachedNodes = addCustomAttributes(customAttributes || {}, { addKey: addString, addVal: addString }) // start with all custom attributes
     if (agentRef.info.atts) allAttachedNodes.push('a,' + addString(agentRef.info.atts)) // add apm provided attributes
     /* Querypack encoder+decoder quirkiness:
        - If first ixn node of payload is being processed, its children's start time must be offset by this node's start. (firstStartTime should be undefined.)

--- a/src/features/soft_navigations/aggregate/interaction.js
+++ b/src/features/soft_navigations/aggregate/interaction.js
@@ -140,6 +140,7 @@ export class Interaction extends BelNode {
   serialize (firstStartTimeOfPayload, agentRef, interactionObfuscator, ajaxObfuscator) {
     const isFirstIxnOfPayload = firstStartTimeOfPayload === undefined
     const addString = getAddStringContext(interactionObfuscator)
+    const addStringRaw = (str) => addString(str, false)
     const nodeList = []
     let ixnType
     if (this.trigger === IPL_TRIGGER_NAME) ixnType = INTERACTION_TYPE.INITIAL_PAGE_LOAD
@@ -154,7 +155,7 @@ export class Interaction extends BelNode {
       numeric(this.end - this.start), // end -- relative to start
       numeric(0), // callbackEnd -- relative to start; not used by BrowserInteraction events so these are always 0
       numeric(0), // not relative; always 0 for BrowserInteraction
-      addString(this.trigger),
+      addStringRaw(this.trigger),
       addString(cleanURL(this.initialPageURL, true)),
       addString(cleanURL(this.oldURL, true)),
       addString(cleanURL(this.newURL, true)),
@@ -162,12 +163,12 @@ export class Interaction extends BelNode {
       ixnType,
       nullable(this.queueTime, numeric, true) + nullable(this.appTime, numeric, true) +
       nullable(this.oldRoute, addString, true) + nullable(this.newRoute, addString, true) +
-      addString(this.id),
-      addString(this.nodeId),
+      addStringRaw(this.id),
+      addStringRaw(this.nodeId),
       nullable(this.firstPaint, numeric, true) + nullable(this.firstContentfulPaint, numeric)
     ]
     const customAttributes = { ...agentRef.info.jsAttributes, ...this.customAttributes } // attrs specific to this interaction should have precedence over the general custom attrs
-    const allAttachedNodes = addCustomAttributes(customAttributes || {}, { addKey: addString, addVal: addString }) // start with all custom attributes
+    const allAttachedNodes = addCustomAttributes(customAttributes || {}, { addKey: addStringRaw, addVal: addString }) // start with all custom attributes
     if (agentRef.info.atts) allAttachedNodes.push('a,' + addString(agentRef.info.atts)) // add apm provided attributes
     /* Querypack encoder+decoder quirkiness:
        - If first ixn node of payload is being processed, its children's start time must be offset by this node's start. (firstStartTime should be undefined.)

--- a/src/features/soft_navigations/aggregate/interaction.js
+++ b/src/features/soft_navigations/aggregate/interaction.js
@@ -9,6 +9,7 @@ import { now } from '../../../common/timing/now'
 import { cleanURL } from '../../../common/url/clean-url'
 import { NODE_TYPE, INTERACTION_STATUS, INTERACTION_TYPE, API_TRIGGER_NAME, IPL_TRIGGER_NAME, NO_LONG_TASK_WINDOW } from '../constants'
 import { BelNode } from './bel-node'
+import { createStringAdders } from '../../../common/payloads/payloads'
 
 /**
  * link https://github.com/newrelic/nr-querypack/blob/main/schemas/bel/7.qpschema
@@ -139,8 +140,7 @@ export class Interaction extends BelNode {
    */
   serialize (firstStartTimeOfPayload, agentRef, interactionObfuscator, ajaxObfuscator) {
     const isFirstIxnOfPayload = firstStartTimeOfPayload === undefined
-    const addString = getAddStringContext(interactionObfuscator)
-    const addStringRaw = (str) => addString(str, false)
+    const { addString, addStringRaw } = createStringAdders(getAddStringContext, interactionObfuscator)
     const nodeList = []
     let ixnType
     if (this.trigger === IPL_TRIGGER_NAME) ixnType = INTERACTION_TYPE.INITIAL_PAGE_LOAD

--- a/tests/assets/obfuscate-pii.html
+++ b/tests/assets/obfuscate-pii.html
@@ -20,7 +20,7 @@
       }, {
         regex: /fakeid/g
       }, {
-        regex: /pii/g,
+        regex: /pii/ig,
         replacement: 'OBFUSCATED'
       },
       {

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -11,7 +11,7 @@ const ajaxArguments = [
   { // params
     method: 'PUT',
     status: 200,
-    host: 'https://example.com',
+    host: 'example.com:443',
     hostname: 'example.com',
     pathname: '/pathname'
   },
@@ -118,8 +118,7 @@ describe('storeXhr', () => {
 
       const expectedParams = ['method', 'status', 'host', 'hostname', 'pathname']
       const actualParams = Object.keys(fakeAgent.sharedAggregator.get(['xhr']).xhr[0].params)
-      expect(actualParams).toEqual(expect.arrayContaining(expectedParams))
-      expect(actualParams).toHaveLength(expectedParams.length)
+      expect(actualParams.sort()).toEqual(expectedParams.sort())
     })
 
     test('ajax event has expected keys', () => {
@@ -133,9 +132,8 @@ describe('storeXhr', () => {
       ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
 
       const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql', 'requestQuery', 'requestHeaders', 'responseHeaders', 'requestBody', 'responseBody']
-      const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
-      expect(actualEvent).toEqual(expect.arrayContaining(expectedEventKeys))
-      expect(actualEvent).toHaveLength(expectedEventKeys.length)
+      const actualEventKeys = Object.keys(ajaxAggregate.events.get()[0])
+      expect(actualEventKeys.sort()).toEqual(expectedEventKeys.sort())
     })
 
     test('session trace bstXhrAgg params has expected keys', () => {
@@ -152,9 +150,95 @@ describe('storeXhr', () => {
       expect(bstXhrCalls).toHaveLength(1)
       const expectedParams = ['method', 'status', 'host', 'hostname', 'pathname']
       const actualParams = Object.keys(bstXhrCalls[0][1][2])
-      expect(actualParams).toEqual(expect.arrayContaining(expectedParams))
-      expect(actualParams).toHaveLength(expectedParams.length)
+      expect(actualParams.sort()).toEqual(expectedParams.sort())
     })
+  })
+
+  test('captures payload when proxy beacon hostname and pathname does not match', async () => {
+    fakeAgent = setupAgent({
+      init: {
+        ajax: { block_internal: false, capture_payloads: CAPTURE_PAYLOAD_SETTINGS.ALL },
+        proxy: { beacon: 'example.com/foobar' }
+      }
+    })
+
+    const ajaxInstrument = new Ajax(fakeAgent)
+    await new Promise(process.nextTick)
+    ajaxAggregate = ajaxInstrument.featAggregate
+    ajaxAggregate.ee.emit('rumresp', [])
+    ajaxAggregate.drain()
+
+    context = new EventContext()
+    fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+
+    context.requestHeaders = { 'content-type': 'application/json' }
+    context.requestBody = 'fooBody'
+    context.responseHeaders = { 'content-type': 'application/json' }
+    context.responseBody = 'barBody'
+    ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+    const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql', 'requestQuery', 'requestHeaders', 'responseHeaders', 'requestBody', 'responseBody']
+    const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
+    expect(actualEvent.sort()).toEqual(expectedEventKeys.sort())
+  })
+
+  test('excludes internal payloads matches beacon hostname', async () => {
+    fakeAgent = setupAgent({
+      init: { ajax: { block_internal: false, capture_payloads: CAPTURE_PAYLOAD_SETTINGS.ALL } },
+      info: { beacon: 'example.com' }
+    })
+
+    const ajaxInstrument = new Ajax(fakeAgent)
+    await new Promise(process.nextTick)
+    ajaxAggregate = ajaxInstrument.featAggregate
+    ajaxAggregate.ee.emit('rumresp', [])
+    ajaxAggregate.drain()
+
+    context = new EventContext()
+    fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+
+    context.requestHeaders = { 'content-type': 'application/json' }
+    context.requestBody = 'fooBody'
+    context.responseHeaders = { 'content-type': 'application/json' }
+    context.responseBody = 'barBody'
+    ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+    const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql']
+    const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
+    expect(actualEvent.sort()).toEqual(expectedEventKeys.sort())
+  })
+
+  test('excludes internal payloads matches proxy beacon hostname and pathname', async () => {
+    fakeAgent = setupAgent({
+      init: {
+        ajax: { block_internal: false, capture_payloads: CAPTURE_PAYLOAD_SETTINGS.ALL },
+        proxy: { beacon: 'example.com/foobar' }
+      }
+    })
+
+    const ajaxInstrument = new Ajax(fakeAgent)
+    await new Promise(process.nextTick)
+    ajaxAggregate = ajaxInstrument.featAggregate
+    ajaxAggregate.ee.emit('rumresp', [])
+    ajaxAggregate.drain()
+
+    context = new EventContext()
+    fakeAgent.features[FEATURE_NAMES.jserrors] = {} // Set to truthy object to simulate jserrors being present
+
+    context.requestHeaders = { 'content-type': 'application/json' }
+    context.requestBody = 'fooBody'
+    context.responseHeaders = { 'content-type': 'application/json' }
+    context.responseBody = 'barBody'
+
+    const origPathname = ajaxArguments[0].pathname
+    ajaxArguments[0].pathname = '/foobar/baz' // Starts with the proxy beacon pathname
+    ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+    const expectedEventKeys = ['method', 'status', 'domain', 'path', 'requestSize', 'responseSize', 'type', 'startTime', 'endTime', 'callbackDuration', 'ajaxRequest.id', 'gql']
+    const actualEvent = Object.keys(ajaxAggregate.events.get()[0])
+    expect(actualEvent.sort()).toEqual(expectedEventKeys.sort())
+
+    ajaxArguments[0].pathname = origPathname
   })
 })
 
@@ -169,7 +253,7 @@ describe('prepareHarvest', () => {
       end: 30,
       callbackEnd: 30,
       callbackDuration: 0,
-      domain: 'https://example.com',
+      domain: 'example.com:443',
       path: '/pathname',
       method: 'PUT',
       status: 200,

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -327,11 +327,10 @@ describe('prepareHarvest', () => {
       { regex: /request/ig, replacement: 'REQUEST', eventFilter: ['AjaxRequest'] },
       { regex: /response/ig, replacement: 'RESPONSE', eventFilter: ['AjaxRequest'] }
     ]
-    // set regex to something recognizable?
-    // mock events.get to return a known event with reserved fields and some custom fields
-    // mock first, then setup agent/agg?
+
     const serializedPayload = ajaxAggregate.makeHarvestPayload(false)
     const actualEvent = qp.decode(serializedPayload.body)[0]
+
     expect(actualEvent).toEqual(expect.objectContaining({
       type: 'ajax',
       start: 1000,
@@ -350,8 +349,8 @@ describe('prepareHarvest', () => {
       traceId: 'sensitiveTraceId',
       timestamp: 1111
     }))
-    const checkChildren = (expectedObject) => expect(actualEvent.children).toEqual(expect.arrayContaining([expect.objectContaining(expectedObject)]))
 
+    const checkChildren = (expectedObject) => expect(actualEvent.children).toEqual(expect.arrayContaining([expect.objectContaining(expectedObject)]))
     checkChildren({ key: 'ajaxRequest.id', value: 'sensitiveAjaxRequestId' })
     checkChildren({ key: 'requestHeaders', value: '{"OBFUSCATEDREQUESTHeAAAder1":"OBFUSCATEDREQUESTHeAAAderVAAAlue1"}' })
     checkChildren({ key: 'requestQuery', value: 'OBFUSCATEDREQUESTQuery' })

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -290,6 +290,78 @@ describe('prepareHarvest', () => {
     })
   })
 
+  test('does not obfuscate reserved/system fields', async () => {
+    const mockEvent = {
+      startTime: 1000,
+      endTime: 2000,
+      method: 'GET',
+      status: 200,
+      domain: 'example.com',
+      path: '/api/data',
+      requestSize: 123,
+      responseSize: 456,
+      type: 'XMLHttpRequest',
+      callbackDuration: 50,
+      customField1: 'customValue1',
+      customField2: 'customValue2',
+      requestHeaders: {
+        sensitiveRequestHeader1: 'sensitiveRequestHeaderValue1'
+      },
+      requestQuery: 'sensitiveRequestQuery',
+      requestBody: 'sensitiveRequestData',
+      responseHeaders: {
+        sensitiveResponseHeader1: 'sensitiveResponseHeaderValue1'
+      },
+      responseBody: 'sensitiveResponseBody',
+      spanId: 'sensitiveSpanId',
+      traceId: 'sensitiveTraceId',
+      'ajaxRequest.id': 'sensitiveAjaxRequestId',
+      spanTimestamp: 1111
+    }
+    ajaxAggregate.events.add(mockEvent)
+
+    const origObfuscate = fakeAgent.init.obfuscate
+    fakeAgent.init.obfuscate = [
+      { regex: /sensitive/g, replacement: 'OBFUSCATED', eventFilter: ['AjaxRequest'] },
+      { regex: /a/g, replacement: 'AAA', eventFilter: ['AjaxRequest'] },
+      { regex: /request/ig, replacement: 'REQUEST', eventFilter: ['AjaxRequest'] },
+      { regex: /response/ig, replacement: 'RESPONSE', eventFilter: ['AjaxRequest'] }
+    ]
+    // set regex to something recognizable?
+    // mock events.get to return a known event with reserved fields and some custom fields
+    // mock first, then setup agent/agg?
+    const serializedPayload = ajaxAggregate.makeHarvestPayload(false)
+    const actualEvent = qp.decode(serializedPayload.body)[0]
+    expect(actualEvent).toEqual(expect.objectContaining({
+      type: 'ajax',
+      start: 1000,
+      end: 2000,
+      callbackEnd: 2000,
+      callbackDuration: 0,
+      method: 'GET',
+      status: 200,
+      domain: 'exAAAmple.com',
+      path: '/AAApi/dAAAtAAA',
+      requestBodySize: 123,
+      responseBodySize: 456,
+      requestedWith: 'XMLHttpRequest',
+      nodeId: '0',
+      guid: 'sensitiveSpanId',
+      traceId: 'sensitiveTraceId',
+      timestamp: 1111
+    }))
+    const checkChildren = (expectedObject) => expect(actualEvent.children).toEqual(expect.arrayContaining([expect.objectContaining(expectedObject)]))
+
+    checkChildren({ key: 'ajaxRequest.id', value: 'sensitiveAjaxRequestId' })
+    checkChildren({ key: 'requestHeaders', value: '{"OBFUSCATEDREQUESTHeAAAder1":"OBFUSCATEDREQUESTHeAAAderVAAAlue1"}' })
+    checkChildren({ key: 'requestQuery', value: 'OBFUSCATEDREQUESTQuery' })
+    checkChildren({ key: 'requestBody', value: 'OBFUSCATEDREQUESTDAAAtAAA' })
+    checkChildren({ key: 'responseHeaders', value: '{"OBFUSCATEDRESPONSEHeAAAder1":"OBFUSCATEDRESPONSEHeAAAderVAAAlue1"}' })
+    checkChildren({ key: 'responseBody', value: 'OBFUSCATEDRESPONSEBody' })
+
+    fakeAgent.init.obfuscate = origObfuscate
+  })
+
   test('correctly exits if maxPayload is too small', async () => {
     // Ensure soft nav is NOT present so events buffer in ajaxEvents
     delete getNREUMInitializedAgent(fakeAgent.agentIdentifier).features

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -272,10 +272,10 @@ describe('prepareHarvest', () => {
       customStringAttribute: 'customStringAttribute',
       customNumAttribute: 2,
       customBooleanAttribute: true,
-      nullCustomAttribute: null,
-      [AJAX_ID]: expect.any(String) // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
+      nullCustomAttribute: null
     }
-    fakeAgent.info.jsAttributes = expectedCustomAttributes
+    fakeAgent.info.jsAttributes = { ...expectedCustomAttributes }
+    expectedCustomAttributes[AJAX_ID] = expect.any(String) // all AjaxRequest events should have a unique identifier to allow for easier grouping and analysis in the UI
 
     const serializedPayload = ajaxAggregate.makeHarvestPayload(false)
     // serializedPayload from ajax comes back as an array of bodies now, so we just need to decode each one and flatten

--- a/tests/components/page_view_timing/aggregate.test.js
+++ b/tests/components/page_view_timing/aggregate.test.js
@@ -139,6 +139,7 @@ test('does not obfuscate timing names or attribute keys', async () => {
         { regex: /fcp/ig, replacement: 'CORRUPTED_FCP', eventFilter: ['PageViewTiming'] },
         { regex: /fi/ig, replacement: 'CORRUPTED_FI', eventFilter: ['PageViewTiming'] },
         { regex: /sensitive/g, replacement: 'OBFUSCATED', eventFilter: ['PageViewTiming'] },
+        { regex: /localhost/g, replacement: 'OBFUSCATED', eventFilter: ['PageViewTiming'] },
         { regex: /e/ig, replacement: 'E', eventFilter: ['PageViewTiming'] }
       ]
     },
@@ -155,6 +156,7 @@ test('does not obfuscate timing names or attribute keys', async () => {
 
   const harvestCall = getHarvestCalls(localAgent)[0]
   expect(harvestCall.results.value.payload.body).not.toContain('CORRUPTED')
+
   const decodedPayloads = qp.decode(harvestCall.results.value.payload.body)
   const findTimings = (timingName) => decodedPayloads.find(n => n.name === timingName)
 
@@ -193,7 +195,7 @@ test('does not obfuscate timing names or attribute keys', async () => {
   checkInpAttrs({ key: 'loadState', value: 'complete' })
 
   const globalAttrs = []
-  globalAttrs.push({ key: 'pageUrl' })
+  globalAttrs.push({ key: 'pageUrl', value: 'http://OBFUSCATED/' })
   globalAttrs.push({ key: 'net-type', value: 'cellular' })
   globalAttrs.push({ key: 'net-etype', value: '3g' })
   globalAttrs.push({ key: 'net-rtt' })

--- a/tests/components/page_view_timing/aggregate.test.js
+++ b/tests/components/page_view_timing/aggregate.test.js
@@ -131,6 +131,86 @@ test('sends INP node with right val', () => {
   expect(inpNode.attributes.find(attr => attr.key === 'cls').value).toEqual(0.1119)
 })
 
+test('does not obfuscate timing names or attribute keys', async () => {
+  const localAgent = setupAgent({
+    init: {
+      obfuscate: [
+        { regex: /lcp/ig, replacement: 'CORRUPTED_LCP', eventFilter: ['PageViewTiming'] },
+        { regex: /fcp/ig, replacement: 'CORRUPTED_FCP', eventFilter: ['PageViewTiming'] },
+        { regex: /fi/ig, replacement: 'CORRUPTED_FI', eventFilter: ['PageViewTiming'] },
+        { regex: /sensitive/g, replacement: 'OBFUSCATED', eventFilter: ['PageViewTiming'] },
+        { regex: /e/ig, replacement: 'E', eventFilter: ['PageViewTiming'] }
+      ]
+    },
+    info: {
+      jsAttributes: { sensitiveCustomKey: 'sensitiveCustomValue' }
+    }
+  })
+
+  const localInstrument = new Timings(localAgent)
+  await new Promise(process.nextTick)
+  const localAggregate = localInstrument.featAggregate
+  localAggregate.ee.emit('rumresp', {})
+  await new Promise(resolve => setTimeout(resolve, 100))
+
+  const harvestCall = getHarvestCalls(localAgent)[0]
+  expect(harvestCall.results.value.payload.body).not.toContain('CORRUPTED')
+  const decodedPayloads = qp.decode(harvestCall.results.value.payload.body)
+  const findTimings = (timingName) => decodedPayloads.find(n => n.name === timingName)
+
+  const lcp = findTimings(VITAL_NAMES.LARGEST_CONTENTFUL_PAINT)
+  const checkLcpAttrs = (obj) => expect(lcp.attributes).toEqual(expect.arrayContaining([expect.objectContaining(obj)]))
+  checkLcpAttrs({ key: 'timeToFirstByte' })
+  checkLcpAttrs({ key: 'resourceLoadDelay' })
+  checkLcpAttrs({ key: 'resourceLoadDuration' })
+  checkLcpAttrs({ key: 'resourceLoadTime' })
+  checkLcpAttrs({ key: 'elementRenderDelay' })
+
+  const fcp = findTimings(VITAL_NAMES.FIRST_CONTENTFUL_PAINT)
+  const checkFcpAttrs = (obj) => expect(fcp.attributes).toEqual(expect.arrayContaining([expect.objectContaining(obj)]))
+  checkFcpAttrs({ key: 'timeToFirstByte' })
+  checkFcpAttrs({ key: 'firstByteToFCP' })
+  checkFcpAttrs({ key: 'loadState' })
+
+  const fi = findTimings(VITAL_NAMES.FIRST_INTERACTION)
+  const checkFiAttrs = (obj) => expect(fi.attributes).toEqual(expect.arrayContaining([expect.objectContaining(obj)]))
+  checkFiAttrs({ key: 'type', value: 'pointer' })
+  checkFiAttrs({ key: 'eventTarget', value: 'button' })
+  checkFiAttrs({ key: 'loadState', value: 'complete' })
+
+  const inp = findTimings(VITAL_NAMES.INTERACTION_TO_NEXT_PAINT)
+  const checkInpAttrs = (obj) => expect(inp.attributes).toEqual(expect.arrayContaining([expect.objectContaining(obj)]))
+  checkInpAttrs({ key: 'metricId' })
+  checkInpAttrs({ key: 'eventTarget', value: 'button' })
+  checkInpAttrs({ key: 'eventTime' })
+  checkInpAttrs({ key: 'interactionTarget', value: 'button' })
+  checkInpAttrs({ key: 'interactionTime' })
+  checkInpAttrs({ key: 'interactionType', value: 'pointer' })
+  checkInpAttrs({ key: 'inputDelay' })
+  checkInpAttrs({ key: 'nextPaintTime' })
+  checkInpAttrs({ key: 'processingDuration' })
+  checkInpAttrs({ key: 'presentationDelay' })
+  checkInpAttrs({ key: 'loadState', value: 'complete' })
+
+  const globalAttrs = []
+  globalAttrs.push({ key: 'pageUrl' })
+  globalAttrs.push({ key: 'net-type', value: 'cellular' })
+  globalAttrs.push({ key: 'net-etype', value: '3g' })
+  globalAttrs.push({ key: 'net-rtt' })
+  globalAttrs.push({ key: 'net-dlink' })
+  globalAttrs.push({ key: 'cls' })
+  globalAttrs.push({ key: 'webdriverDetected' })
+  globalAttrs.push({ key: 'sensitiveCustomKey', value: 'OBFUSCATEDCustomValuE' })
+  globalAttrs.forEach(obj => {
+    checkLcpAttrs(obj)
+    checkFcpAttrs(obj)
+    checkFiAttrs(obj)
+    checkInpAttrs(obj)
+  })
+
+  resetAgent(localAgent)
+})
+
 function findTimingNode (name) {
   const harvestCalls = getHarvestCalls(mainAgent)
   const harvest = harvestCalls.find(call => call.featureName === FEATURE_NAMES.pageViewTiming && call.results.value.payload.body.includes(name))

--- a/tests/components/page_view_timing/aggregate.test.js
+++ b/tests/components/page_view_timing/aggregate.test.js
@@ -144,7 +144,10 @@ test('does not obfuscate timing names or attribute keys', async () => {
       ]
     },
     info: {
-      jsAttributes: { sensitiveCustomKey: 'sensitiveCustomValue' }
+      jsAttributes: {
+        sensitiveCustomKey: 'sensitiveCustomValue',
+        nested: { sensitiveCustomKey: 'sensitiveCustomValue' }
+      }
     }
   })
 
@@ -203,6 +206,7 @@ test('does not obfuscate timing names or attribute keys', async () => {
   globalAttrs.push({ key: 'cls' })
   globalAttrs.push({ key: 'webdriverDetected' })
   globalAttrs.push({ key: 'sensitiveCustomKey', value: 'OBFUSCATEDCustomValuE' })
+  globalAttrs.push({ key: 'nested', value: '{"OBFUSCATEDCustomKEy":"OBFUSCATEDCustomValuE"}' })
   globalAttrs.forEach(obj => {
     checkLcpAttrs(obj)
     checkFcpAttrs(obj)

--- a/tests/components/soft_navigations/aggregate.test.js
+++ b/tests/components/soft_navigations/aggregate.test.js
@@ -403,83 +403,109 @@ describe('back up buffer is cleared when', () => { // prevent mem leak
   })
 })
 
-test('does not obfuscate reserved/system field keys for ajax nodes', async () => {
-  const localAgent = setupAgent({
-    init: {
-      soft_navigations: { enabled: true },
-      obfuscate: [
-        { regex: /sensitive/g, replacement: 'OBFUSCATED', eventFilter: ['AjaxRequest'] },
-        { regex: /ajax/ig, replacement: 'AJAX', eventFilter: ['AjaxRequest'] },
-        { regex: /request/ig, replacement: 'REQUEST', eventFilter: ['AjaxRequest'] },
-        { regex: /response/ig, replacement: 'RESPONSE', eventFilter: ['AjaxRequest'] }
-      ]
-    }
+describe('obfuscation checks should preserve keys and system values', () => {
+  let localAgent, localAggregate
+
+  beforeEach(async () => {
+    localAgent = setupAgent({
+      init: {
+        soft_navigations: { enabled: true },
+        obfuscate: [
+          { regex: /sensitive/g, replacement: 'OBFUSCATED', eventFilter: ['AjaxRequest', 'BrowserInteraction'] },
+          { regex: /ajax/ig, replacement: 'AJAX', eventFilter: ['AjaxRequest'] },
+          { regex: /request/ig, replacement: 'REQUEST', eventFilter: ['AjaxRequest'] },
+          { regex: /response/ig, replacement: 'RESPONSE', eventFilter: ['AjaxRequest'] }
+        ]
+      }
+    })
+    const localInstrument = new SoftNav(localAgent)
+    await localInstrument.onAggregateImported
+    localAggregate = localInstrument.featAggregate
+
+    localAggregate.ee.emit('rumresp', [{ spa: 1 }])
+    await new Promise(process.nextTick)
   })
-  const localInstrument = new SoftNav(localAgent)
-  await localInstrument.onAggregateImported
-  const localAggregate = localInstrument.featAggregate
 
-  localAggregate.ee.emit('rumresp', [{ spa: 1 }])
-  await new Promise(process.nextTick)
+  afterEach(() => {
+    resetAgent(localAgent)
+  })
 
-  const ajaxEvent = {
-    startTime: 1000,
-    endTime: 2000,
-    method: 'GET',
-    status: 200,
-    domain: 'example.com',
-    path: '/api/data',
-    requestSize: 123,
-    responseSize: 456,
-    type: 'XMLHttpRequest',
-    callbackDuration: 0,
-    spanId: 'sensitiveSpanId',
-    traceId: 'sensitiveTraceId',
-    spanTimestamp: 3000,
-    [AJAX_ID]: 'sensitiveAjaxRequestId',
-    requestHeaders: { sensitiveRequestHeader1: 'sensitiveRequestHeaderValue1' },
-    requestQuery: 'sensitiveRequestQuery',
-    requestBody: 'sensitiveRequestData',
-    responseHeaders: { sensitiveResponseHeader1: 'sensitiveResponseHeaderValue1' },
-    responseBody: 'sensitiveResponseBody'
-  }
+  test('for ajax nodes', async () => {
+    const ajaxEvent = {
+      startTime: 1000,
+      endTime: 2000,
+      method: 'GET',
+      status: 200,
+      domain: 'example.com',
+      path: '/api/data',
+      requestSize: 123,
+      responseSize: 456,
+      type: 'XMLHttpRequest',
+      callbackDuration: 0,
+      spanId: 'sensitiveSpanId',
+      traceId: 'sensitiveTraceId',
+      spanTimestamp: 3000,
+      [AJAX_ID]: 'sensitiveAjaxRequestId',
+      requestHeaders: { sensitiveRequestHeader1: 'sensitiveRequestHeaderValue1' },
+      requestQuery: 'sensitiveRequestQuery',
+      requestBody: 'sensitiveRequestData',
+      responseHeaders: { sensitiveResponseHeader1: 'sensitiveResponseHeaderValue1' },
+      responseBody: 'sensitiveResponseBody'
+    }
 
-  localAggregate.ee.emit('ajax', [ajaxEvent, {}])
-  localAggregate.initialPageLoadInteraction.done(performance.now() + 200)
-  await new Promise(process.nextTick)
+    localAggregate.ee.emit('ajax', [ajaxEvent, {}])
+    localAggregate.initialPageLoadInteraction.done(performance.now() + 200)
+    await new Promise(process.nextTick)
 
-  const serializedPayload = localAggregate.makeHarvestPayload(false)
-  const decoded = qp.decode(serializedPayload.body)
-  const iplInteraction = decoded[0]
-  const ajaxNode = iplInteraction.children.find(c => c.type === 'ajax')
+    const serializedPayload = localAggregate.makeHarvestPayload(false)
+    const decoded = qp.decode(serializedPayload.body)
+    const iplInteraction = decoded[0]
+    const ajaxNode = iplInteraction.children.find(c => c.type === 'ajax')
 
-  expect(ajaxNode).toEqual(expect.objectContaining({
-    start: 1000,
-    end: 2000,
-    callbackEnd: 2000,
-    callbackDuration: 0,
-    method: 'GET',
-    status: 200,
-    domain: 'example.com',
-    path: '/api/data',
-    requestBodySize: 123,
-    responseBodySize: 456,
-    requestedWith: 'XMLHttpRequest',
-    nodeId: expect.any(String), // the actual value doesn't matter for this test; bel-node nodeSeen is a singleton the value may change
-    guid: 'sensitiveSpanId',
-    traceId: 'sensitiveTraceId',
-    timestamp: 3000,
-    type: 'ajax'
-  }))
+    expect(ajaxNode).toEqual(expect.objectContaining({
+      start: 1000,
+      end: 2000,
+      callbackEnd: 2000,
+      callbackDuration: 0,
+      method: 'GET',
+      status: 200,
+      domain: 'example.com',
+      path: '/api/data',
+      requestBodySize: 123,
+      responseBodySize: 456,
+      requestedWith: 'XMLHttpRequest',
+      nodeId: expect.any(String), // the actual value doesn't matter for this test; bel-node nodeSeen is a singleton the value may change
+      guid: 'sensitiveSpanId',
+      traceId: 'sensitiveTraceId',
+      timestamp: 3000,
+      type: 'ajax'
+    }))
 
-  const checkChildren = (expectedObject) => expect(ajaxNode.children).toEqual(expect.arrayContaining([expect.objectContaining(expectedObject)]))
-  checkChildren({ key: 'ajaxRequest.id', value: 'sensitiveAjaxRequestId' })
-  checkChildren({ key: 'requestHeaders', value: '{"OBFUSCATEDREQUESTHeader1":"OBFUSCATEDREQUESTHeaderValue1"}' })
-  checkChildren({ key: 'requestQuery', value: 'OBFUSCATEDREQUESTQuery' })
-  checkChildren({ key: 'requestBody', value: 'OBFUSCATEDREQUESTData' })
-  checkChildren({ key: 'responseHeaders', value: '{"OBFUSCATEDRESPONSEHeader1":"OBFUSCATEDRESPONSEHeaderValue1"}' })
-  checkChildren({ key: 'responseBody', value: 'OBFUSCATEDRESPONSEBody' })
-  resetAgent(localAgent)
+    const checkChildren = (expectedObject) => expect(ajaxNode.children).toEqual(expect.arrayContaining([expect.objectContaining(expectedObject)]))
+    checkChildren({ key: 'ajaxRequest.id', value: 'sensitiveAjaxRequestId' }) // reserved/system field keys
+
+    // keys should not be obfuscated
+    checkChildren({ key: 'requestHeaders', value: '{"OBFUSCATEDREQUESTHeader1":"OBFUSCATEDREQUESTHeaderValue1"}' })
+    checkChildren({ key: 'requestQuery', value: 'OBFUSCATEDREQUESTQuery' })
+    checkChildren({ key: 'requestBody', value: 'OBFUSCATEDREQUESTData' })
+    checkChildren({ key: 'responseHeaders', value: '{"OBFUSCATEDRESPONSEHeader1":"OBFUSCATEDRESPONSEHeaderValue1"}' })
+    checkChildren({ key: 'responseBody', value: 'OBFUSCATEDRESPONSEBody' })
+  })
+
+  test('for browser interaction nodes', async () => {
+    localAggregate.ee.emit('newUIEvent', [{ type: 'keydown', timeStamp: 100 }])
+    localAggregate.interactionInProgress.customAttributes.sensitiveFoo = 'sensitiveFooValue'
+    localAggregate.interactionInProgress.forceSave = true
+    localAggregate.interactionInProgress.done(performance.now())
+    await new Promise(process.nextTick)
+
+    const serializedPayload = localAggregate.makeHarvestPayload(false)
+    const decoded = qp.decode(serializedPayload.body)
+    const browserInteraction = decoded[0]
+    expect(browserInteraction.type).toBe('interaction')
+    const checkChildren = (expectedObject) => expect(browserInteraction.children).toEqual(expect.arrayContaining([expect.objectContaining(expectedObject)]))
+    checkChildren({ key: 'sensitiveFoo', value: 'OBFUSCATEDFooValue' })
+  })
 })
 
 function wait (ms) {

--- a/tests/components/soft_navigations/aggregate.test.js
+++ b/tests/components/soft_navigations/aggregate.test.js
@@ -1,7 +1,9 @@
+import qp from '@newrelic/nr-querypack'
 import { resetAgent, setupAgent } from '../setup-agent'
 import { Instrument as SoftNav } from '../../../src/features/soft_navigations/instrument'
 import * as loadTimeModule from '../../../src/common/vitals/load-time'
 import { INTERACTION_STATUS, NO_LONG_TASK_WINDOW, POPSTATE_MERGE_WINDOW, POPSTATE_TRIGGER } from '../../../src/features/soft_navigations/constants'
+import { AJAX_ID } from '../../../src/features/ajax/constants'
 
 let mainAgent
 
@@ -399,6 +401,85 @@ describe('back up buffer is cleared when', () => { // prevent mem leak
     softNavAggregate.interactionsToHarvest.reloadSave() // backup buffer does not duplicate retrying data
     expect(softNavAggregate.interactionsToHarvest.get().length).toEqual(1)
   })
+})
+
+test('does not obfuscate reserved/system field keys for ajax nodes', async () => {
+  const localAgent = setupAgent({
+    init: {
+      soft_navigations: { enabled: true },
+      obfuscate: [
+        { regex: /sensitive/g, replacement: 'OBFUSCATED', eventFilter: ['AjaxRequest'] },
+        { regex: /ajax/ig, replacement: 'AJAX', eventFilter: ['AjaxRequest'] },
+        { regex: /request/ig, replacement: 'REQUEST', eventFilter: ['AjaxRequest'] },
+        { regex: /response/ig, replacement: 'RESPONSE', eventFilter: ['AjaxRequest'] }
+      ]
+    }
+  })
+  const localInstrument = new SoftNav(localAgent)
+  await localInstrument.onAggregateImported
+  const localAggregate = localInstrument.featAggregate
+
+  localAggregate.ee.emit('rumresp', [{ spa: 1 }])
+  await new Promise(process.nextTick)
+
+  const ajaxEvent = {
+    startTime: 1000,
+    endTime: 2000,
+    method: 'GET',
+    status: 200,
+    domain: 'example.com',
+    path: '/api/data',
+    requestSize: 123,
+    responseSize: 456,
+    type: 'XMLHttpRequest',
+    callbackDuration: 0,
+    spanId: 'sensitiveSpanId',
+    traceId: 'sensitiveTraceId',
+    spanTimestamp: 3000,
+    [AJAX_ID]: 'sensitiveAjaxRequestId',
+    requestHeaders: { sensitiveRequestHeader1: 'sensitiveRequestHeaderValue1' },
+    requestQuery: 'sensitiveRequestQuery',
+    requestBody: 'sensitiveRequestData',
+    responseHeaders: { sensitiveResponseHeader1: 'sensitiveResponseHeaderValue1' },
+    responseBody: 'sensitiveResponseBody'
+  }
+
+  localAggregate.ee.emit('ajax', [ajaxEvent, {}])
+  localAggregate.initialPageLoadInteraction.done(performance.now() + 200)
+  await new Promise(process.nextTick)
+
+  const serializedPayload = localAggregate.makeHarvestPayload(false)
+  const decoded = qp.decode(serializedPayload.body)
+  const iplInteraction = decoded[0]
+  const ajaxNode = iplInteraction.children.find(c => c.type === 'ajax')
+
+  expect(ajaxNode).toEqual(expect.objectContaining({
+    start: 1000,
+    end: 2000,
+    callbackEnd: 2000,
+    callbackDuration: 0,
+    method: 'GET',
+    status: 200,
+    domain: 'example.com',
+    path: '/api/data',
+    requestBodySize: 123,
+    responseBodySize: 456,
+    requestedWith: 'XMLHttpRequest',
+    nodeId: expect.any(String), // the actual value doesn't matter for this test; bel-node nodeSeen is a singleton the value may change
+    guid: 'sensitiveSpanId',
+    traceId: 'sensitiveTraceId',
+    timestamp: 3000,
+    type: 'ajax'
+  }))
+
+  const checkChildren = (expectedObject) => expect(ajaxNode.children).toEqual(expect.arrayContaining([expect.objectContaining(expectedObject)]))
+  checkChildren({ key: 'ajaxRequest.id', value: 'sensitiveAjaxRequestId' })
+  checkChildren({ key: 'requestHeaders', value: '{"OBFUSCATEDREQUESTHeader1":"OBFUSCATEDREQUESTHeaderValue1"}' })
+  checkChildren({ key: 'requestQuery', value: 'OBFUSCATEDREQUESTQuery' })
+  checkChildren({ key: 'requestBody', value: 'OBFUSCATEDREQUESTData' })
+  checkChildren({ key: 'responseHeaders', value: '{"OBFUSCATEDRESPONSEHeader1":"OBFUSCATEDRESPONSEHeaderValue1"}' })
+  checkChildren({ key: 'responseBody', value: 'OBFUSCATEDRESPONSEBody' })
+  resetAgent(localAgent)
 })
 
 function wait (ms) {

--- a/tests/specs/ajax/payload_capture.e2e.js
+++ b/tests/specs/ajax/payload_capture.e2e.js
@@ -230,3 +230,52 @@ describe('capture_payloads', () => {
     })
   })
 })
+
+describe('capture_payloads - beacon exclusion', () => {
+  let ajaxEventsCapture
+
+  beforeEach(async () => {
+    ajaxEventsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testAjaxEventsRequest })
+  })
+
+  it('does not capture agent payloads even when mode is "all"', async () => {
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      init: { ajax: { capture_payloads: 'all', block_internal: false } },
+      loader: 'full'
+    }))
+    await browser.waitForAgentLoad()
+
+    await browser.execute(function (beaconHost, beaconPort) {
+      fetch('/echo-body', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'regular request' })
+      })
+      fetch('http://' + beaconHost + ':' + beaconPort + '/debug', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ secret: 'beacon payload' })
+      })
+    }, browser.testHandle.bamServerConfig.host, browser.testHandle.bamServerConfig.port)
+
+    const eventsHarvests = await ajaxEventsCapture.waitForResult({ totalCount: 2, timeout: 15000 })
+    const ajaxEvents = eventsHarvests.flatMap(h => h.request.body)
+
+    const regularEvents = ajaxEvents.filter(e => e.path === '/echo-body')
+    const beaconEvents = ajaxEvents.filter(e => e.path !== '/echo-body')
+
+    expect(regularEvents.length).toBeGreaterThan(0)
+    expect(beaconEvents.length).toBeGreaterThan(0)
+
+    regularEvents.forEach(event => {
+      const keys = event.children.map(x => x.key)
+      expect(keys).toEqual(expect.arrayContaining(['ajaxRequest.id', 'requestHeaders', 'requestBody', 'responseHeaders', 'responseBody']))
+    })
+
+    beaconEvents.forEach(event => {
+      const keys = event.children.map(x => x.key)
+      expect(keys).toEqual(expect.arrayContaining(['ajaxRequest.id']))
+      expect(keys).not.toEqual(expect.arrayContaining(['requestHeaders', 'requestBody', 'responseHeaders', 'responseBody']))
+    })
+  })
+})

--- a/tests/specs/obfuscate/obfuscate.e2e.js
+++ b/tests/specs/obfuscate/obfuscate.e2e.js
@@ -10,7 +10,7 @@ const config = {
     }, {
       regex: /fakeid/g
     }, {
-      regex: /pii/g,
+      regex: /pii/ig,
       replacement: 'OBFUSCATED'
     }, {
       regex: /comma/g,
@@ -77,18 +77,24 @@ describe('obfuscate rules', () => {
     expect(timingEventsHarvests.length).toBeGreaterThan(0)
     timingEventsHarvests.forEach(harvest => {
       checkPayload(harvest.request.body)
+      expect(harvest.request.body[0].attributes.some(attr => attr.key === 'customPiiAttribute' && attr.value === 'customOBFUSCATEDAttribute OBFUSCATED')).toBe(true)
       checkPayload(harvest.request.query)
     })
     expect(ajaxEventsHarvests.length).toBeGreaterThan(0)
-    ajaxEventsHarvests.forEach(harvest => checkPayload(harvest.request.body))
+    ajaxEventsHarvests.forEach(harvest => {
+      expect(harvest.request.body[0].children.some(x => x.key === 'customPiiAttribute' && x.value === 'customOBFUSCATEDAttribute OBFUSCATED')).toBe(true)
+      checkPayload(harvest.request.body)
+    })
     expect(errorsHarvests.length).toBeGreaterThan(0)
     errorsHarvests.forEach(harvest => {
       checkPayload(harvest.request.body)
+      expect(harvest.request.body.err[0].custom.customPiiAttribute).toBe('customOBFUSCATEDAttribute OBFUSCATED')
       checkPayload(harvest.request.query)
     })
     expect(insightsHarvests.length).toBeGreaterThan(0)
     insightsHarvests.forEach(harvest => {
       checkPayload(harvest.request.body)
+      expect(harvest.request.body.ins.some(x => x.customPiiAttribute === 'customOBFUSCATEDAttribute OBFUSCATED')).toBe(true)
       checkPayload(harvest.request.query)
     })
     expect(tracesHarvests.length).toBeGreaterThan(0)
@@ -99,11 +105,13 @@ describe('obfuscate rules', () => {
     expect(interactionEventsHarvests.length).toBeGreaterThan(0)
     interactionEventsHarvests.forEach(harvest => {
       checkPayload(harvest.request.body)
+      expect(harvest.request.body[0].children.some(x => x.key === 'customPiiAttribute' && x.value === 'customOBFUSCATEDAttribute OBFUSCATED')).toBe(true)
       checkPayload(harvest.request.query)
     })
     expect(logsHarvests.length).toBe(2)
     logsHarvests.forEach(harvest => {
       checkPayload(harvest.request.body)
+      expect(JSON.parse(harvest.request.body)[0].common.attributes.customPiiAttribute).toBe('customOBFUSCATEDAttribute OBFUSCATED')
       checkPayload(harvest.request.query)
     })
   })
@@ -142,7 +150,6 @@ describe('obfuscate rules', () => {
 
 function checkPayload (payload, customStringCheck) {
   expect(payload).toBeDefined() // payload exists
-
   var strPayload = JSON.stringify(payload)
 
   expect(strPayload.includes('pii')).toBeFalsy() // pii was obfuscated

--- a/tests/unit/common/serialize/bel-serializer.test.js
+++ b/tests/unit/common/serialize/bel-serializer.test.js
@@ -19,7 +19,7 @@ describe('addCustomAttributes in bel-serializer', () => {
 
   test('should obfuscate attribute values but not attribute keys', () => {
     const attrs = { hello: 'world' }
-    const attrParts = addCustomAttributes(attrs, addString)
+    const attrParts = addCustomAttributes(attrs, { addKey: (str) => addString(str, false), addVal: addString })
 
     expect(attrParts).toEqual([[5, "'hello,'foobar"]])
   })

--- a/tests/unit/features/ajax/instrument/capture-payloads.test.js
+++ b/tests/unit/features/ajax/instrument/capture-payloads.test.js
@@ -7,79 +7,145 @@ import { canCapturePayload } from '../../../../../src/common/payloads/payloads'
 import { hasGQLErrors } from '../../../../../src/features/ajax/aggregate/gql'
 
 describe('canCapturePayload logic', () => {
+  const genEvent = () => {
+    const event = { payloadHostname: 'example.com', statusCode: 200, hasGQLErrors: false }
+    event.status = (statusCode) => { event.statusCode = statusCode; return event }
+    event.gqlErrors = (hasGQLErrors) => { event.hasGQLErrors = hasGQLErrors; return event }
+    return event
+  }
+
   describe('none mode', () => {
     test('never captures payloads', () => {
-      expect(canCapturePayload('none', 200, false)).toBe(false)
-      expect(canCapturePayload('none', 404, false)).toBe(false)
-      expect(canCapturePayload('none', 500, false)).toBe(false)
-      expect(canCapturePayload('none', 0, false)).toBe(false)
-      expect(canCapturePayload('none', 200, true)).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(200).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(404).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(500).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(0).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('none', genEvent().status(200).gqlErrors(true))).toBe(false)
     })
 
     test('treats null/undefined as none', () => {
-      expect(canCapturePayload(null, 200, false)).toBe(false)
-      expect(canCapturePayload(undefined, 200, false)).toBe(false)
+      expect(canCapturePayload(null, genEvent().status(200).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload(undefined, genEvent().status(200).gqlErrors(false))).toBe(false)
     })
   })
 
   describe('all mode', () => {
     test('captures all payloads regardless of status', () => {
-      expect(canCapturePayload('all', 200, false)).toBe(true)
-      expect(canCapturePayload('all', 201, false)).toBe(true)
-      expect(canCapturePayload('all', 204, false)).toBe(true)
-      expect(canCapturePayload('all', 301, false)).toBe(true)
-      expect(canCapturePayload('all', 400, false)).toBe(true)
-      expect(canCapturePayload('all', 404, false)).toBe(true)
-      expect(canCapturePayload('all', 500, false)).toBe(true)
-      expect(canCapturePayload('all', 0, false)).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(200))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(201))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(204))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(301))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(400))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(404))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(500))).toBe(true)
+      expect(canCapturePayload('all', genEvent().status(0))).toBe(true)
     })
 
     test('captures all payloads regardless of GraphQL errors', () => {
-      expect(canCapturePayload('all', 200, false)).toBe(true)
-      expect(canCapturePayload('all', 200, true)).toBe(true)
+      expect(canCapturePayload('all', genEvent().gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('all', genEvent().gqlErrors(true))).toBe(true)
+    })
+
+    test('canCapturePayload returns false for hostname matching a beacon', () => {
+      const beacons = ['example.com']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com',
+        payloadPathname: '/path'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(false)
+    })
+
+    test('canCapturePayload returns false for hostname + pathname matching a beacon', () => {
+      const beacons = ['example.com/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com',
+        payloadPathname: '/path'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(false)
+    })
+
+    test('canCapturePayload returns true for hostname (no pathname) partially matching a beacon', () => {
+      const beacons = ['example.com/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(true)
+    })
+
+    test('canCapturePayload returns false for hostname + pathname partially matching a beacon', () => {
+      const beacons = ['example.com/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com',
+        payloadPathname: '/path/to/foobar'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(false)
+    })
+
+    test('canCapturePayload returns true for unrelated hostname + pathname partially matching a beacon', () => {
+      const beacons = ['example.com/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHostname: 'example.com',
+        payloadPathname: '/pathFoo'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(true)
     })
   })
 
   describe('failures mode (default)', () => {
     test('captures status code 0 (network errors)', () => {
-      expect(canCapturePayload('failures', 0, false)).toBe(true)
-      expect(canCapturePayload('failures', 0, null)).toBe(true)
-      expect(canCapturePayload('failures', 0, undefined)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(0).gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(0).gqlErrors(null))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(0).gqlErrors(undefined))).toBe(true)
     })
 
     test('does not capture 1xx status codes', () => {
-      expect(canCapturePayload('failures', 100, false)).toBe(false)
-      expect(canCapturePayload('failures', 101, false)).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(100))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(101))).toBe(false)
     })
 
     test('does not capture 2xx success status codes', () => {
-      expect(canCapturePayload('failures', 200, false)).toBe(false)
-      expect(canCapturePayload('failures', 201, false)).toBe(false)
-      expect(canCapturePayload('failures', 204, false)).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(201))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(204))).toBe(false)
     })
 
     test('does not capture 3xx redirect status codes', () => {
-      expect(canCapturePayload('failures', 301, false)).toBe(false)
-      expect(canCapturePayload('failures', 302, false)).toBe(false)
-      expect(canCapturePayload('failures', 304, false)).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(301))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(302))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(304))).toBe(false)
     })
 
     test('captures 400 status code', () => {
-      expect(canCapturePayload('failures', 400, false)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(400))).toBe(true)
     })
 
     test('captures 4xx client errors > 400', () => {
-      expect(canCapturePayload('failures', 401, false)).toBe(true)
-      expect(canCapturePayload('failures', 403, false)).toBe(true)
-      expect(canCapturePayload('failures', 404, false)).toBe(true)
-      expect(canCapturePayload('failures', 429, false)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(401))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(403))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(404))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(429))).toBe(true)
     })
 
     test('captures 5xx server errors', () => {
-      expect(canCapturePayload('failures', 500, false)).toBe(true)
-      expect(canCapturePayload('failures', 502, false)).toBe(true)
-      expect(canCapturePayload('failures', 503, false)).toBe(true)
-      expect(canCapturePayload('failures', 504, false)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(500))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(502))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(503))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(504))).toBe(true)
     })
 
     test('captures GraphQL errors with 2xx status codes', () => {
@@ -88,8 +154,8 @@ describe('canCapturePayload logic', () => {
         data: null
       })
 
-      expect(canCapturePayload('failures', 200, hasGQLErrors(gqlError))).toBe(true)
-      expect(canCapturePayload('failures', 201, hasGQLErrors(gqlError))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(gqlError)))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(201).gqlErrors(hasGQLErrors(gqlError)))).toBe(true)
     })
 
     test('captures GraphQL errors with partial data', () => {
@@ -98,7 +164,7 @@ describe('canCapturePayload logic', () => {
         data: { user: { name: 'John', email: null } }
       })
 
-      expect(canCapturePayload('failures', 200, hasGQLErrors(gqlPartialError))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(gqlPartialError)))).toBe(true)
     })
 
     test('does not capture successful GraphQL responses', () => {
@@ -106,7 +172,7 @@ describe('canCapturePayload logic', () => {
         data: { user: { name: 'John', email: 'john@example.com' } }
       })
 
-      expect(canCapturePayload('failures', 200, hasGQLErrors(gqlSuccess))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(gqlSuccess)))).toBe(false)
     })
 
     test('captures GraphQL errors even with error status codes', () => {
@@ -116,36 +182,36 @@ describe('canCapturePayload logic', () => {
       })
 
       // Should capture due to status code (isHttpError is true)
-      expect(canCapturePayload('failures', 500, hasGQLErrors(gqlError))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(500).gqlErrors(hasGQLErrors(gqlError)))).toBe(true)
     })
 
     test('handles non-JSON response bodies', () => {
-      expect(canCapturePayload('failures', 200, hasGQLErrors('plain text response'))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors('<html>content</html>'))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors(null))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors(undefined))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors('plain text response')))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors('<html>content</html>')))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(null)))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(undefined)))).toBe(false)
     })
   })
 
   describe('edge cases', () => {
     test('handles empty response bodies', () => {
-      expect(canCapturePayload('failures', 200, hasGQLErrors(''))).toBe(false)
-      expect(canCapturePayload('failures', 404, hasGQLErrors(''))).toBe(true)
-      expect(canCapturePayload('failures', 0, hasGQLErrors(''))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors('')))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(404).gqlErrors(hasGQLErrors('')))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(0).gqlErrors(hasGQLErrors('')))).toBe(true)
     })
 
     test('handles malformed GraphQL responses', () => {
-      expect(canCapturePayload('failures', 200, hasGQLErrors('{ invalid json'))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors(JSON.stringify({ errors: [] })))).toBe(false)
-      expect(canCapturePayload('failures', 200, hasGQLErrors(JSON.stringify({ errors: [{ noMessage: true }] })))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors('{ invalid json')))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(JSON.stringify({ errors: [] }))))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(200).gqlErrors(hasGQLErrors(JSON.stringify({ errors: [{ noMessage: true }] }))))).toBe(false)
     })
 
     test('handles various status code boundaries', () => {
-      expect(canCapturePayload('failures', 399, false)).toBe(false)
-      expect(canCapturePayload('failures', 400, false)).toBe(true)
-      expect(canCapturePayload('failures', 401, false)).toBe(true)
-      expect(canCapturePayload('failures', 599, false)).toBe(true)
-      expect(canCapturePayload('failures', 600, false)).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(399).gqlErrors(false))).toBe(false)
+      expect(canCapturePayload('failures', genEvent().status(400).gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(401).gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(599).gqlErrors(false))).toBe(true)
+      expect(canCapturePayload('failures', genEvent().status(600).gqlErrors(false))).toBe(true)
     })
   })
 })

--- a/tests/unit/features/ajax/instrument/capture-payloads.test.js
+++ b/tests/unit/features/ajax/instrument/capture-payloads.test.js
@@ -104,6 +104,32 @@ describe('canCapturePayload logic', () => {
       const actual = canCapturePayload('all', event, beacons)
       expect(actual).toBe(true)
     })
+
+    test('canCapturePayload returns false for host + pathname matching a beacon with port', () => {
+      const beacons = ['example.com:8080/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHost: 'example.com:8080',
+        payloadHostname: 'example.com',
+        payloadPathname: '/path'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(false)
+    })
+
+    test('canCapturePayload returns true for host + pathname NOT matching a beacon with port', () => {
+      const beacons = ['example.com:58467/path']
+      const event = {
+        statusCode: 200,
+        hasGQLErrors: false,
+        payloadHost: 'example.com:58466',
+        payloadHostname: 'example.com',
+        payloadPathname: '/path'
+      }
+      const actual = canCapturePayload('all', event, beacons)
+      expect(actual).toBe(true)
+    })
   })
 
   describe('failures mode (default)', () => {

--- a/tests/unit/features/page_view_timing/aggregate/index.test.js
+++ b/tests/unit/features/page_view_timing/aggregate/index.test.js
@@ -392,7 +392,9 @@ function getAgentInternalFormat (inputInQueryPackDecodedFormat) {
   agentFormat.forEach(timingNode => {
     timingNode.attrs = {}
     timingNode.attributes.forEach(attr => {
-      timingNode.attrs[attr.key] = attr.value
+      if (attr.type === 'trueAttribute') timingNode.attrs[attr.key] = true
+      else if (attr.type === 'falseAttribute') timingNode.attrs[attr.key] = false
+      else timingNode.attrs[attr.key] = attr.value
     })
     delete timingNode.attributes
   })

--- a/tests/unit/features/soft_navigations/aggregate/ajax-node.test.js
+++ b/tests/unit/features/soft_navigations/aggregate/ajax-node.test.js
@@ -82,9 +82,9 @@ test('Ajax serialize output is correct', () => {
   const ajn = new AjaxNode(someAjaxEvent)
 
   expect(ajn.nodeId).toEqual(1)
-  expect(ajn.serialize(0, someAgent)).toEqual("2,4,sg,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'ajaxRequest.id,'1234;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL")
+  expect(ajn.serialize(0, someAgent)).toEqual("2,4,sg,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;5,'ajaxRequest.id,'1234")
   // The start (and end) timestamp should translate based on "parent" timestamp passed in:
-  expect(ajn.serialize(512, someAgent)).toEqual("2,4,e8,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'ajaxRequest.id,'1234;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL")
+  expect(ajn.serialize(512, someAgent)).toEqual("2,4,e8,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;5,'ajaxRequest.id,'1234")
 })
 
 test('obfuscation happens before truncation and result stays under 4KB in browser interactions', () => {


### PR DESCRIPTION
Preserves all keys as well as reserved system values for AjaxRequest and Page View Timing events.

---

### Overview

System fields from events that use the BEL serializer were previously passed through the user-configured obfuscator. This is now avoided by
- introducing a separate `addStringRaw` serializer that bypasses obfuscation for all keys, and 
- refactoring the `addCustomAttributes` function to accept `{ addKey, addVal }` serializers.  This creates more flexibility for callers to control which attributes can be preserved as system fields.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-584189

### Testing

Extended component tests to ensure all affected event fields are tested.
