### PR TITLE
chore: LLM PR review via Nerd Completion (test)

### DIFF
--- a/.github/actions/llm-code-review/action.yml
+++ b/.github/actions/llm-code-review/action.yml
@@ -1,0 +1,43 @@
+# This composite action fetches a pull request's diff and sends it to
+# New Relic's internal Nerd Completion LLM gateway for an automated review.
+
+name: 'LLM Code Review'
+
+inputs:
+  token:
+    description: "The github token to use for fetching the pull request diff."
+    required: true
+  pr_number:
+    description: "Pull request number to review."
+    required: true
+  nc_base_url:
+    description: "Base URL of the Nerd Completion gateway."
+    required: true
+  nc_api_token:
+    description: "Bearer token used to authenticate with Nerd Completion."
+    required: true
+  nc_model:
+    description: "Model alias to request from Nerd Completion."
+    required: true
+
+outputs:
+  review:
+    description: "The review text returned by Nerd Completion, or empty if the review could not be generated."
+    value: ${{ steps.action-script.outputs.review }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install dependencies
+      run: npm install --silent --no-progress --prefix $GITHUB_ACTION_PATH/..
+      shell: bash
+    - name: Run action script
+      id: action-script
+      run: |
+        node $GITHUB_ACTION_PATH/index.js \
+          --github-token ${{ inputs.token }} \
+          --pr-number ${{ inputs.pr_number }} \
+          --nc-base-url ${{ inputs.nc_base_url }} \
+          --nc-api-token ${{ inputs.nc_api_token }} \
+          --nc-model ${{ inputs.nc_model }}
+      shell: bash

--- a/.github/actions/llm-code-review/args.js
+++ b/.github/actions/llm-code-review/args.js
@@ -1,0 +1,24 @@
+import process from 'process'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+export const args = yargs(hideBin(process.argv))
+  .usage('$0 [options]')
+
+  .string('github-token')
+  .describe('github-token', 'GitHub token used to fetch the pull request diff')
+
+  .string('pr-number')
+  .describe('pr-number', 'Pull request number to review')
+
+  .string('nc-base-url')
+  .describe('nc-base-url', 'Base URL of the Nerd Completion gateway')
+
+  .string('nc-api-token')
+  .describe('nc-api-token', 'Bearer token used to authenticate with Nerd Completion')
+
+  .string('nc-model')
+  .describe('nc-model', 'Model alias to request from Nerd Completion')
+
+  .demandOption(['github-token', 'pr-number', 'nc-base-url', 'nc-api-token', 'nc-model'])
+  .argv

--- a/.github/actions/llm-code-review/index.js
+++ b/.github/actions/llm-code-review/index.js
@@ -1,0 +1,92 @@
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import { Octokit } from '@octokit/rest'
+import { args } from './args.js'
+import { fetchRetry } from '../shared-utils/fetch-retry.js'
+
+const MAX_DIFF_LENGTH = 60000
+const EXCLUDED_FILE_PATTERNS = [/package-lock\.json$/, /\.min\.js$/, /^build\//]
+
+const REVIEW_SYSTEM_PROMPT = `You are an experienced JavaScript/browser-agent reviewer. Review the following pull request diff for the New Relic Browser Agent. Call out correctness bugs, security issues, and missed edge cases. Be concise and reference file paths and line numbers where possible. If nothing of substance stands out, say so briefly.`
+
+const octokit = new Octokit({ auth: args.githubToken })
+const { owner, repo } = github.context.repo
+
+function filterDiff (diff) {
+  const lines = diff.split('\n')
+  const kept = []
+  let skippingFile = false
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git')) {
+      const filePath = line.split(' b/')[1] ?? ''
+      skippingFile = EXCLUDED_FILE_PATTERNS.some(pattern => pattern.test(filePath))
+    }
+    if (!skippingFile) kept.push(line)
+  }
+
+  let filtered = kept.join('\n')
+  let truncated = false
+  if (filtered.length > MAX_DIFF_LENGTH) {
+    filtered = filtered.slice(0, MAX_DIFF_LENGTH)
+    truncated = true
+  }
+
+  return { filtered, truncated }
+}
+
+async function main () {
+  const { data: prDiff } = await octokit.pulls.get({
+    owner,
+    repo,
+    pull_number: args.prNumber,
+    mediaType: { format: 'diff' }
+  })
+
+  const { filtered, truncated } = filterDiff(prDiff)
+
+  if (!filtered.trim()) {
+    console.log('No reviewable changes found in diff after filtering.')
+    core.setOutput('review', '')
+    return
+  }
+
+  const response = await fetchRetry(`${args.ncBaseUrl}/v1/chat/completions`, {
+    retry: 3,
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${args.ncApiToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: args.ncModel,
+      messages: [
+        { role: 'system', content: REVIEW_SYSTEM_PROMPT },
+        { role: 'user', content: filtered }
+      ]
+    })
+  })
+
+  if (!response?.ok) {
+    console.error(`Nerd Completion request failed with status ${response?.status}. ${response?.statusText}`)
+    core.setOutput('review', '')
+    return
+  }
+
+  const body = await response.json()
+  const review = body?.choices?.[0]?.message?.content
+
+  if (!review) {
+    console.error('Nerd Completion response did not contain review content.')
+    core.setOutput('review', '')
+    return
+  }
+
+  const suffix = truncated ? '\n\n_Note: this diff was truncated before review due to size._' : ''
+  core.setOutput('review', `${review}${suffix}`)
+}
+
+main().catch(err => {
+  console.error(`LLM code review failed: ${err.message}`)
+  core.setOutput('review', '')
+})

--- a/.github/actions/llm-code-review/index.js
+++ b/.github/actions/llm-code-review/index.js
@@ -15,6 +15,7 @@ const { owner, repo } = github.context.repo
 function filterDiff (diff) {
   const lines = diff.split('\n')
   const kept = []
+  
 
   let skippingFile = false
 

--- a/.github/actions/llm-code-review/index.js
+++ b/.github/actions/llm-code-review/index.js
@@ -87,6 +87,8 @@ async function main () {
 }
 
 main().catch(err => {
-  console.error(`LLM code review failed: ${err.message}`)
+  const detail = err.code ?? err.cause?.code ?? err.cause?.message ?? 'unknown'
+  console.error(`LLM code review failed: ${err.message} (detail: ${detail})`)
+  if (err.stack) console.error(err.stack)
   core.setOutput('review', '')
 })

--- a/.github/actions/llm-code-review/index.js
+++ b/.github/actions/llm-code-review/index.js
@@ -15,6 +15,8 @@ const { owner, repo } = github.context.repo
 function filterDiff (diff) {
   const lines = diff.split('\n')
   const kept = []
+
+  
   let skippingFile = false
 
   for (const line of lines) {

--- a/.github/actions/llm-code-review/index.js
+++ b/.github/actions/llm-code-review/index.js
@@ -51,29 +51,48 @@ async function main () {
     return
   }
 
-  const response = await fetchRetry(`${args.ncBaseUrl}/v1/chat/completions`, {
+  const requestUrl = `${args.ncBaseUrl}/v1/chat/completions`
+  const requestBody = JSON.stringify({
+    model: args.ncModel,
+    messages: [
+      { role: 'system', content: REVIEW_SYSTEM_PROMPT },
+      { role: 'user', content: filtered }
+    ]
+  })
+
+  // DEBUG: prints a copy-pasteable curl command for manually reproducing this request.
+  // The token is masked by GitHub Actions log redaction since it comes from a secret,
+  // but the placeholder here also guards against redaction failing.
+  console.log('DEBUG curl for Nerd Completion request:')
+  console.log(`curl -s -o - -w '\\nHTTP_STATUS:%{http_code}\\n' -X POST '${requestUrl}' \\
+  -H 'Authorization: Bearer ***REDACTED***' \\
+  -H 'Content-Type: application/json' \\
+  -d '${requestBody.replace(/'/g, "'\\''")}'`)
+
+  const response = await fetchRetry(requestUrl, {
     retry: 3,
     method: 'POST',
     headers: {
       Authorization: `Bearer ${args.ncApiToken}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({
-      model: args.ncModel,
-      messages: [
-        { role: 'system', content: REVIEW_SYSTEM_PROMPT },
-        { role: 'user', content: filtered }
-      ]
-    })
+    body: requestBody
   })
 
+  console.log(`DEBUG Nerd Completion response status: ${response?.status} ${response?.statusText}`)
+
   if (!response?.ok) {
+    const errorBody = await response?.text().catch(() => '<unreadable body>')
     console.error(`Nerd Completion request failed with status ${response?.status}. ${response?.statusText}`)
+    console.log(`DEBUG Nerd Completion error response body:\n${errorBody}`)
     core.setOutput('review', '')
     return
   }
 
-  const body = await response.json()
+  const rawBody = await response.text()
+  console.log(`DEBUG Nerd Completion response body:\n${rawBody}`)
+
+  const body = JSON.parse(rawBody)
   const review = body?.choices?.[0]?.message?.content
 
   if (!review) {

--- a/.github/actions/llm-code-review/index.js
+++ b/.github/actions/llm-code-review/index.js
@@ -53,11 +53,12 @@ async function main () {
     return
   }
 
-  const requestUrl = `${args.ncBaseUrl}/v1/chat/completions`
+  const requestUrl = `${args.ncBaseUrl}/v1/messages`
   const requestBody = JSON.stringify({
     model: args.ncModel,
+    max_tokens: 4096,
+    system: REVIEW_SYSTEM_PROMPT,
     messages: [
-      { role: 'system', content: REVIEW_SYSTEM_PROMPT },
       { role: 'user', content: filtered }
     ]
   })
@@ -95,7 +96,7 @@ async function main () {
   console.log(`DEBUG Nerd Completion response body:\n${rawBody}`)
 
   const body = JSON.parse(rawBody)
-  const review = body?.choices?.[0]?.message?.content
+  const review = body?.content?.[0]?.text
 
   if (!review) {
     console.error('Nerd Completion response did not contain review content.')

--- a/.github/actions/llm-code-review/index.js
+++ b/.github/actions/llm-code-review/index.js
@@ -16,7 +16,6 @@ function filterDiff (diff) {
   const lines = diff.split('\n')
   const kept = []
 
-  
   let skippingFile = false
 
   for (const line of lines) {

--- a/.github/actions/shared-utils/fetch-retry.js
+++ b/.github/actions/shared-utils/fetch-retry.js
@@ -29,6 +29,8 @@ export async function fetchRetry (url, options) {
         retryLimit--
       }
     } catch (error) {
+      console.error(`fetchRetry: attempt failed for ${url} (code=${error.code ?? 'n/a'}): ${error.message}`)
+
       if (retryLimit <= 1) {
         throw error
       }

--- a/.github/workflows/llm-code-review.yml
+++ b/.github/workflows/llm-code-review.yml
@@ -1,0 +1,44 @@
+# This workflow sends the pull request diff to New Relic's internal
+# Nerd Completion LLM gateway and posts the resulting review as a PR
+# comment. It runs on the self-hosted runner because Nerd Completion
+# is only reachable from inside New Relic's network.
+
+name: 'LLM Code Review'
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  llm-review:
+    runs-on: Browser-Agent-Assigned-IP-Linux
+    timeout-minutes: 10
+    continue-on-error: true
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.11.0 # See package.json for the stable node version that works with our testing.  Do not change this unless you know what you are doing as some node versions do not play nicely with our testing server.
+      - name: Run LLM code review
+        id: llm-review
+        uses: ./.github/actions/llm-code-review
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_number: ${{ github.event.number }}
+          nc_base_url: ${{ vars.NERD_COMPLETION_BASE_URL }}
+          nc_api_token: ${{ secrets.NERD_COMPLETION_API_TOKEN }}
+          nc_model: ${{ vars.NERD_COMPLETION_MODEL }}
+      - name: Comment pull request
+        if: steps.llm-review.outputs.review != ''
+        uses: ./.github/actions/comment-pull-request
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr_number: ${{ github.event.number }}
+          comment: ${{ steps.llm-review.outputs.review }}
+          comment_tag: <!-- nerd_completion_code_review -->

--- a/.github/workflows/llm-code-review.yml
+++ b/.github/workflows/llm-code-review.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pr_number: ${{ github.event.number }}
-          nc_base_url: ${{ vars.NERD_COMPLETION_BASE_URL }}
+          nc_base_url: ${{ secrets.NERD_COMPLETION_BASE_URL }}
           nc_api_token: ${{ secrets.NERD_COMPLETION_API_TOKEN }}
-          nc_model: ${{ vars.NERD_COMPLETION_MODEL }}
+          nc_model: ${{ secrets.NERD_COMPLETION_MODEL }}
       - name: Comment pull request
         if: steps.llm-review.outputs.review != ''
         uses: ./.github/actions/comment-pull-request


### PR DESCRIPTION
## Summary
- Adds a composite action + workflow that fetches a PR diff and requests an automated review from New Relic's internal Nerd Completion gateway.
- Draft PR opened purely to trigger the new `llm-code-review.yml` workflow for testing; NC budget for the API token has not been provisioned yet (pending #air-nerd-completion), so calls may fail on budget validation.

## Test plan
- [ ] Confirm the `LLM Code Review` workflow run appears in Actions for this PR
- [ ] Check auth against Nerd Completion staging succeeds (no 401)
- [ ] Check `/v1/chat/completions` route resolves (no 404)
- [ ] Note any budget-related failure (expected until budget-tool is run)
