### PR TITLE
fix: Deduplicate auto-instrumented MFE events

### DIFF
--- a/src/common/v2/utils.js
+++ b/src/common/v2/utils.js
@@ -30,6 +30,13 @@ export function getRegisteredTargetsFromId (id, agentRef) {
 
 /**
  * Returns the registered target(s) associated with a given filename if found in the resource timing API during registration. Returns an empty array if no target is found.
+ * Multiple registrations that resolve to the same underlying script asset AND represent the same logical MFE (i.e.
+ * share the same customer-supplied `target.id`) are collapsed to a single target via
+ * {@link dedupeRegisteredEntitiesByAsset}, since auto-instrumented events (AJAX, JS errors, logs, WebSockets) should
+ * only be reported once per real occurrence when the same MFE was registered many times over -- not once per
+ * duplicate registration. Distinct MFEs (different `target.id`) that happen to share a script (e.g. two different
+ * MFEs both registered from the same inline `<script>` block) are intentionally NOT collapsed, since each is a
+ * genuinely different entity that should still receive its own copy of the matched event.
  * @param {string} filename
  * @param {*} agentRef
  * @returns {import("../../interfaces/registered-entity").RegisterAPIMetadataTarget[]}
@@ -37,7 +44,52 @@ export function getRegisteredTargetsFromId (id, agentRef) {
 export function getRegisteredTargetsFromFilename (filename, agentRef) {
   if (!filename || !agentRef?.init.api.register.enabled) return []
   const registeredEntities = agentRef.runtime.registeredEntities
-  return registeredEntities?.filter(entity => entity.metadata.timings?.asset?.endsWith(filename)).map(entity => entity.metadata.target) || []
+  const matches = registeredEntities?.filter(entity => entity.metadata.timings?.asset?.endsWith(filename))
+  return dedupeRegisteredEntitiesByAsset(matches).map(entity => entity.metadata.target)
+}
+
+/**
+ * Collapses a list of registered entities down to one canonical entity per unique, defined `metadata.timings.asset` +
+ * `target.id` combination. Entities whose asset could not be resolved (undefined -- e.g. inline scripts or scripts
+ * not found in the resource timing buffer) are never deduped against each other or against resolved entities, since
+ * there is no signal that they represent the same underlying script. Entities that share an asset but have different
+ * `target.id`s are never deduped against each other either, since a differing id means the customer registered
+ * genuinely distinct MFEs (not duplicate registrations of the same one).
+ *
+ * Canonical selection per asset+id: prefer an entity whose target has not been deregistered (`target.blocked ===
+ * false`) over one that has; otherwise the first-encountered entity wins, for determinism.
+ * @param {Array} entities registered entities (each with `metadata.timings.asset` and `metadata.target`)
+ * @returns {Array} deduped list of entities, preserving relative order of first occurrence
+ */
+export function dedupeRegisteredEntitiesByAsset (entities) {
+  if (!entities?.length) return entities || []
+
+  const byKey = new Map() // `${asset}::${id}` -> canonical entity
+  const result = []
+
+  for (const entity of entities) {
+    const asset = entity.metadata?.timings?.asset
+    if (!asset) {
+      // can't safely dedupe unresolved-asset entities -- always keep as-is
+      result.push(entity)
+      continue
+    }
+
+    const key = `${asset}::${entity.metadata?.target?.id}`
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, entity)
+      result.push(entity)
+    } else if (existing.metadata.target?.blocked && !entity.metadata.target?.blocked) {
+      // swap in a non-deregistered target as the canonical one for this asset+id
+      const idx = result.indexOf(existing)
+      if (idx !== -1) result[idx] = entity
+      byKey.set(key, entity)
+    }
+    // else: existing canonical entity wins (already non-blocked, or both blocked -- first wins); drop this duplicate
+  }
+
+  return result
 }
 
 /**
@@ -104,8 +156,30 @@ export function findTargetsFromStackTrace (agentRef) {
   } catch (err) {
     // Silent catch to prevent errors from propagating
   }
-  if (!targets.length) targets.push(undefined) // if we can't find any targets from the stack trace, return an array with undefined to signify the container agent is the target
-  return targets
+
+  const deduped = dedupeTargetsByInstance(targets)
+  if (!deduped.length) deduped.push(undefined) // if we can't find any targets from the stack trace, return an array with undefined to signify the container agent is the target
+  return deduped
+}
+
+/**
+ * Removes duplicate targets from an array, keyed by `target.instance`. This guards against the same canonical
+ * target re-entering the array via multiple matched stack-frame URLs (e.g. a recursive call whose stack contains the
+ * same file at multiple depths). Entries with no `instance` (i.e. `undefined`, meaning "the container agent")
+ * naturally collapse to a single entry too, which is the desired behavior.
+ * @param {Array} targets
+ * @returns {Array} deduped list of targets, preserving relative order of first occurrence
+ */
+export function dedupeTargetsByInstance (targets) {
+  const seen = new Set()
+  const result = []
+  for (const target of targets) {
+    const key = target?.instance
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(target)
+  }
+  return result
 }
 
 /**

--- a/tests/assets/js/mfe/mfe-dedup.js
+++ b/tests/assets/js/mfe/mfe-dedup.js
@@ -1,0 +1,31 @@
+/**
+ * Simulates the customer-reported bug (NR-586577): a single MFE bundle calling `newrelic.register()`
+ * many times (e.g. once per rendered component instance) instead of once per bundle. Auto-instrumented
+ * events (AJAX, console logs, JS errors) triggered from this script should be reported once, regardless
+ * of how many times it registered -- while explicit register-API calls and MicroFrontEndTiming should
+ * remain per-registration.
+ */
+const REGISTRATION_COUNT = 30
+
+// all 30 registrations use the SAME id/name -- this is the reported bug: one logical MFE
+// registered repeatedly (e.g. once per rendered component instance) instead of once per bundle
+window.__dedupApis = []
+for (let i = 0; i < REGISTRATION_COUNT; i++) {
+  window.__dedupApis.push(newrelic.register({ id: 'dedup-mfe', name: 'DedupMFE' }))
+}
+
+// explicit API-driven calls are tied to a specific instance and must remain per-instance (not deduped)
+window.__dedupApis.forEach((api, i) => api.log(`explicit log ${i}`))
+
+// auto-instrumented AJAX call -- should be reported once, not once per duplicate registration
+fetch('/dedup-marker-test').catch(() => {})
+
+// auto-captured console log -- should be reported once
+console.log('auto captured log from mfe-dedup.js')
+
+// auto-captured uncaught error -- should be reported once
+setTimeout(() => {
+  throw new Error('auto captured error from mfe-dedup.js')
+}, 0)
+
+window.__deregisterDedupApis = () => window.__dedupApis.forEach(api => api.deregister())

--- a/tests/specs/api/register/general.e2e.js
+++ b/tests/specs/api/register/general.e2e.js
@@ -1,7 +1,8 @@
 import {
-  // testLogsRequest,
-  testMFEErrorsRequest
-  // testMFEInsRequest
+  testLogsRequest,
+  testMFEErrorsRequest,
+  testMFEAjaxEventsRequest,
+  testMFEInsRequest
 } from '../../../../tools/testing-server/utils/expect-tests'
 
 describe('Register API - General Behaviors', () => {
@@ -452,5 +453,72 @@ describe('Register API - General Behaviors', () => {
       expect(sourceKeys).toEqual(expect.arrayContaining(['source.name', 'source.id', 'source.type']))
       expect(sourceKeys.length).toBe(3)
     })
+  })
+
+  it('collapses auto-instrumented events across duplicate registrations of the same MFE script, while keeping API-driven calls and MicroFrontEndTiming per-instance', async () => {
+    const [mfeErrorsCapture, mfeAjaxCapture, logsCapture, mfeInsightsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testMFEErrorsRequest },
+      { test: testMFEAjaxEventsRequest },
+      { test: testLogsRequest },
+      { test: testMFEInsRequest }
+    ])
+
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', {
+      init: { feature_flags: ['register'] }
+    })).then(() => browser.waitForAgentLoad())
+
+    // mfe-dedup.js registers the same MFE 30 times, then triggers one auto AJAX call, one
+    // auto-captured console.log, one uncaught error, and 30 explicit `.log()` calls (one per registration)
+    await browser.execute(function () {
+      const script = document.createElement('script')
+      script.src = './js/mfe/mfe-dedup.js'
+      document.head.appendChild(script)
+    })
+
+    await browser.pause(500)
+
+    // deregister all 30 instances to flush their MicroFrontEndTiming events
+    await browser.execute(function () {
+      window.__deregisterDedupApis()
+    })
+
+    const [errorsHarvests, ajaxHarvests, logsHarvests, insightsHarvests] = await Promise.all([
+      mfeErrorsCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      mfeAjaxCapture.waitForResult({ totalCount: 1, timeout: 10000 }),
+      logsCapture.waitForResult({ timeout: 15000 }),
+      // 30 near-simultaneous deregister() calls can legitimately produce more than one insights harvest
+      // request -- wait out the full window rather than stopping after the first one arrives, or events
+      // in a later harvest get silently dropped from this capture.
+      mfeInsightsCapture.waitForResult({ timeout: 15000 })
+    ])
+
+    // exactly 1 auto-captured JS error, not 30
+    const autoErrors = errorsHarvests
+      .flatMap(({ request: { body } }) => body.err || [])
+      .filter(err => err.params.message.includes('auto captured error from mfe-dedup.js'))
+    expect(autoErrors.length).toBe(1)
+
+    // exactly 1 auto-instrumented AJAX event, not 30
+    const autoAjaxEvents = ajaxHarvests
+      .flatMap(({ request: { body } }) => body || [])
+      .filter(event => event.path === '/dedup-marker-test')
+    expect(autoAjaxEvents.length).toBe(1)
+
+    // logs: 1 auto-captured console.log + 30 explicit `.log()` calls (one per registration, never deduped).
+    // Explicit calls are asserted with a generous lower bound rather than an exact count, since harvesting
+    // 30 near-simultaneous log calls can legitimately split across harvest boundaries -- the important
+    // invariant here is that they are clearly NOT collapsed down to 1 like the auto-captured log is.
+    const allLogs = logsHarvests.flatMap(({ request: { body } }) => JSON.parse(body)[0].logs)
+    const autoLogs = allLogs.filter(log => log.message === 'auto captured log from mfe-dedup.js')
+    const explicitLogs = allLogs.filter(log => /^explicit log \d+$/.test(log.message))
+    expect(autoLogs.length).toBe(1)
+    expect(explicitLogs.length).toBeGreaterThanOrEqual(20)
+    expect(new Set(explicitLogs.map(log => log.message)).size).toBe(explicitLogs.length) // each is distinct, none deduped
+
+    // MicroFrontEndTiming stays per-instance: 30 registrations of the same id => still 30 distinct timing events
+    const timingEvents = insightsHarvests
+      .flatMap(({ request: { body } }) => body.ins)
+      .filter(event => event.eventType === 'MicroFrontEndTiming' && event['source.name'] === 'DedupMFE')
+    expect(timingEvents.length).toBe(30)
   })
 })

--- a/tests/unit/common/util/v2.test.js
+++ b/tests/unit/common/util/v2.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getVersion2Attributes, getRegisteredTargetsFromFilename, findTargetsFromStackTrace, getRegisteredTargetsFromId } from '../../../../src/common/v2/utils'
+import { getVersion2Attributes, getRegisteredTargetsFromFilename, findTargetsFromStackTrace, getRegisteredTargetsFromId, dedupeRegisteredEntitiesByAsset, dedupeTargetsByInstance } from '../../../../src/common/v2/utils'
 
 describe('v2 utilities', () => {
   describe('getRegisteredTargetsFromFilename', () => {
@@ -179,6 +179,147 @@ describe('v2 utilities', () => {
       const result = getRegisteredTargetsFromFilename('app.js', agentRef)
       expect(result).toEqual([])
     })
+
+    test('collapses multiple registrations of the same asset to a single target', () => {
+      const registeredEntities = Array.from({ length: 30 }, (_, i) => ({
+        metadata: {
+          timings: {
+            asset: 'https://example.com/mfe.js'
+          },
+          target: {
+            id: 'viz-dev',
+            name: 'Viz (dev)',
+            type: 'MFE',
+            instance: `instance-${i}`,
+            blocked: false
+          }
+        }
+      }))
+
+      const agentRef = {
+        runtime: { registeredEntities },
+        init: {
+          api: {
+            register: {
+              enabled: true,
+              duplicate_data_to_container: false
+            }
+          }
+        }
+      }
+
+      const result = getRegisteredTargetsFromFilename('mfe.js', agentRef)
+      expect(result).toHaveLength(1)
+    })
+
+    test('does not collapse two distinct MFEs (different ids) registered from the same inline script', () => {
+      // mirrors register-api.html: two different MFEs (agent1/agent2) both registered from the same
+      // inline <script> block, so both resolve the same `timings.asset` (the page's own URL) -- these
+      // must each keep receiving their own copy of matched auto-detected events, since they are
+      // genuinely different registered entities, not duplicate registrations of the same one.
+      const registeredEntities = [
+        {
+          metadata: {
+            timings: { asset: 'https://example.com/page.html' },
+            target: { id: '1', name: 'agent1', type: 'MFE', instance: 'instance-1', blocked: false }
+          }
+        },
+        {
+          metadata: {
+            timings: { asset: 'https://example.com/page.html' },
+            target: { id: '2', name: 'agent2', type: 'MFE', instance: 'instance-2', blocked: false }
+          }
+        }
+      ]
+
+      const agentRef = {
+        runtime: { registeredEntities },
+        init: {
+          api: {
+            register: {
+              enabled: true,
+              duplicate_data_to_container: false
+            }
+          }
+        }
+      }
+
+      const result = getRegisteredTargetsFromFilename('page.html', agentRef)
+      expect(result).toHaveLength(2)
+      expect(result.map(t => t.id).sort()).toEqual(['1', '2'])
+    })
+  })
+
+  describe('dedupeRegisteredEntitiesByAsset', () => {
+    test('returns empty array for empty/undefined input', () => {
+      expect(dedupeRegisteredEntitiesByAsset([])).toEqual([])
+      expect(dedupeRegisteredEntitiesByAsset(undefined)).toEqual([])
+    })
+
+    test('returns single entity with defined asset unchanged', () => {
+      const entity = { metadata: { timings: { asset: 'a.js' }, target: { blocked: false } } }
+      expect(dedupeRegisteredEntitiesByAsset([entity])).toEqual([entity])
+    })
+
+    test('collapses multiple entities sharing the same defined asset', () => {
+      const entities = Array.from({ length: 5 }, () => ({
+        metadata: { timings: { asset: 'shared.js' }, target: { blocked: false } }
+      }))
+      const result = dedupeRegisteredEntitiesByAsset(entities)
+      expect(result).toHaveLength(1)
+      expect(entities).toContain(result[0])
+    })
+
+    test('prefers a non-blocked target as the canonical entity for a shared asset+id', () => {
+      const blockedA = { metadata: { timings: { asset: 'shared.js' }, target: { id: 'viz-dev', blocked: true } } }
+      const blockedB = { metadata: { timings: { asset: 'shared.js' }, target: { id: 'viz-dev', blocked: true } } }
+      const active = { metadata: { timings: { asset: 'shared.js' }, target: { id: 'viz-dev', blocked: false } } }
+
+      const result = dedupeRegisteredEntitiesByAsset([blockedA, blockedB, active])
+      expect(result).toHaveLength(1)
+      expect(result[0]).toBe(active)
+    })
+
+    test('falls back to first-match-wins when all sharing an asset+id are blocked', () => {
+      const first = { metadata: { timings: { asset: 'shared.js' }, target: { id: 'viz-dev', blocked: true } } }
+      const second = { metadata: { timings: { asset: 'shared.js' }, target: { id: 'viz-dev', blocked: true } } }
+
+      const result = dedupeRegisteredEntitiesByAsset([first, second])
+      expect(result).toHaveLength(1)
+      expect(result[0]).toBe(first)
+    })
+
+    test('does not collapse entities that share an asset but have different ids (distinct MFEs registered from the same script)', () => {
+      const mfe1 = { metadata: { timings: { asset: 'shared.js' }, target: { id: '1', blocked: false } } }
+      const mfe2 = { metadata: { timings: { asset: 'shared.js' }, target: { id: '2', blocked: false } } }
+
+      const result = dedupeRegisteredEntitiesByAsset([mfe1, mfe2])
+      expect(result).toHaveLength(2)
+      expect(result).toEqual([mfe1, mfe2])
+    })
+
+    test('never collapses entities with an undefined asset', () => {
+      const entities = Array.from({ length: 5 }, () => ({
+        metadata: { timings: { asset: undefined }, target: { blocked: false } }
+      }))
+      const result = dedupeRegisteredEntitiesByAsset(entities)
+      expect(result).toHaveLength(5)
+    })
+
+    test('dedupes shared assets while leaving unresolved-asset entities untouched', () => {
+      const assetA = Array.from({ length: 3 }, () => ({ metadata: { timings: { asset: 'a.js' }, target: { blocked: false } } }))
+      const assetB = Array.from({ length: 2 }, () => ({ metadata: { timings: { asset: 'b.js' }, target: { blocked: false } } }))
+      const unresolved = Array.from({ length: 2 }, () => ({ metadata: { timings: { asset: undefined }, target: { blocked: false } } }))
+
+      const result = dedupeRegisteredEntitiesByAsset([...assetA, ...assetB, ...unresolved])
+      expect(result).toHaveLength(4) // 1 for asset A, 1 for asset B, 2 untouched unresolved
+    })
+
+    test('handles entities missing metadata.timings entirely without crashing', () => {
+      const entities = Array.from({ length: 5 }, () => ({ metadata: { target: { blocked: false } } }))
+      const result = dedupeRegisteredEntitiesByAsset(entities)
+      expect(result).toHaveLength(5)
+    })
   })
 
   describe('getRegisteredTargetsFromId', () => {
@@ -345,6 +486,34 @@ describe('v2 utilities', () => {
       // Should not throw, should return empty array
       const result = findTargetsFromStackTrace(agentRef)
       expect(result).toEqual([])
+    })
+  })
+
+  describe('dedupeTargetsByInstance', () => {
+    test('returns empty array for empty input', () => {
+      expect(dedupeTargetsByInstance([])).toEqual([])
+    })
+
+    test('collapses duplicate instances, preserving first occurrence', () => {
+      const first = { instance: 'a', name: 'first' }
+      const dup = { instance: 'a', name: 'duplicate' }
+      const second = { instance: 'b', name: 'second' }
+
+      const result = dedupeTargetsByInstance([first, dup, second])
+      expect(result).toEqual([first, second])
+    })
+
+    test('collapses multiple undefined targets to a single entry', () => {
+      const result = dedupeTargetsByInstance([undefined, undefined, undefined])
+      expect(result).toEqual([undefined])
+    })
+
+    test('preserves distinct real targets alongside a single undefined entry', () => {
+      const a = { instance: 'a' }
+      const b = { instance: 'b' }
+
+      const result = dedupeTargetsByInstance([a, undefined, b, undefined])
+      expect(result).toEqual([a, undefined, b])
     })
   })
 


### PR DESCRIPTION
Fixes duplicate reporting of auto-instrumented events (AJAX requests, JS errors, console logs, WebSocket activity etc.) when a micro-frontend is registered with the `register()` API multiple times. Previously, a single auto-instrumented event originating from a repeatedly-registered MFE script would be reported once per registration — Auto-detected events are now collapsed to a single report per real occurrence when they resolve to the same underlying script and the same registered MFE `id`. Explicit API-driven calls (`.addPageAction()`, `.log()`, `.noticeError()`, etc.) and `MicroFrontEndTiming` events remain per-registration, as intended, and distinct MFEs that happen to share a script (e.g. two different MFEs registered from the same inline `<script>` block) continue to be reported independently.

---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Customer teams building on top of the `register()` API (micro-frontend support) were calling `newrelic.register()` once per rendered component instance instead of once per MFE bundle (e.g. one nerdpack rendering 30 visualizations registered 30 times). Because auto-instrumentation attributes browser events to MFEs by matching JS call-stack URLs against each registered entity's resolved script asset (`getRegisteredTargetsFromFilename` / `findTargetsFromStackTrace` in `src/common/v2/utils.js`), every one of those 30 duplicate registrations independently matched the same real AJAX call, error, console log, or WebSocket event — producing 30 duplicate events instead of 1. This showed up as `ERR_INSUFFICIENT_RESOURCES` network flooding for at least one customer.

This PR adds a dedup step at the point auto-detection resolves matching registered targets:
- `dedupeRegisteredEntitiesByAsset` (new, in `src/common/v2/utils.js`) collapses registered entities down to one canonical entity per unique `(resolved script asset, target.id)` pair, preferring a non-deregistered target as canonical. Entities with an unresolved asset (e.g. inline scripts that couldn't be correlated) are never collapsed, since there's no signal they represent the same script. Entities that share a script but have *different* `id`s are also never collapsed, since that means the customer registered genuinely distinct MFEs (e.g. two different MFEs both registered from the same inline `<script>` block) — each should still receive its own copy of matched events.
- `dedupeTargetsByInstance` (new, same file) is a defensive second pass in `findTargetsFromStackTrace` that collapses duplicate targets that could re-enter the array via multiple matched stack frames.

Because both fan-out paths (`findTargetsFromStackTrace` for AJAX/WebSockets/logs, and jserrors' `#deriveTargets`) bottom out in `getRegisteredTargetsFromFilename`, this is a single choke-point fix — no changes were needed to any `wrap-*`, feature aggregate, or `register.js` code. Explicit register-API calls (`.addPageAction()`, `.log()`, `.noticeError()`, `.measure()`, `.recordCustomEvent()`) and `MicroFrontEndTiming` events bypass this matching entirely (they always carry their own explicit target) and are unaffected — they remain per-registration, as required.

### Related Issue(s)

- https://new-relic.atlassian.net/browse/NR-586577
- https://new-relic.atlassian.net/browse/NR-586579

### Testing

**Unit tests** (`tests/unit/common/util/v2.test.js`):
- `npm run test:unit -- v2.test.js`
- New coverage for `dedupeRegisteredEntitiesByAsset` and `dedupeTargetsByInstance`: same-asset+id collapse, blocked/non-blocked canonical selection, unresolved-asset entities never collapsed, and — critically — entities that share an asset but have *different* ids are never collapsed (regression guard for the "two distinct MFEs registered from the same inline script" scenario).
- New case on `getRegisteredTargetsFromFilename` simulating 30 duplicate registrations of the same MFE collapsing to 1 target, and a companion case mirroring `register-api.html` (two different MFE ids sharing an inline script) confirming both remain distinct.

**E2E test** (`tests/specs/api/register/general.e2e.js`, new fixture `tests/assets/js/mfe/mfe-dedup.js`):
- `npm run wdio -- --spec tests/specs/api/register/general.e2e.js`
- The fixture registers the same MFE `id` 30 times from one script, then triggers one auto-instrumented AJAX call, one auto-captured console log, one uncaught error, and 30 explicit `.log()` calls (one per registration).
- Test asserts each auto-detected event type is reported exactly once, while the 30 explicit log calls and 30 `MicroFrontEndTiming` events remain per-registration.

**Regression coverage:**
- Full unit + component suite: `npm run test:unit && npm run test:component` (1414 tests passing).
- Existing `tests/specs/api/register/flags.e2e.js` (`Base.with register`) continues to pass — this test specifically encodes the "two different MFEs sharing a script both get their own copy of matched events" behavior, which this fix preserves via the `id`-aware dedup key.
- Existing `tests/specs/api/register/auto-detection-*.e2e.js` suite (AJAX, errors, logs, WebSockets, user actions) continues to pass, confirming multi-script MFE attribution is unaffected.
