### PR TITLE
feat: Introduce v2 PageView & decouple connect service call

### DIFF
--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -143,3 +143,5 @@
 `A session replay payload failed to send and is being retried. Recording is paused during the retry period, and will resume when a successful harvest is made. Some replay activity may be missed during retry phases.`
 ### 71
 `An invalid feature mode was detected and set to "off".`
+### 72
+`Unable to initialized Connector and/or Harvester.`

--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -106,7 +106,7 @@
 ### 52
 `Unexpected problem encountered. There should be at least one app for harvest!`
 ### 53
-`Did not receive a valid entityGuid from connection response`
+`Failed to parse connect response.`
 ### 54
 `An experimental feature is being used. Support can not be offered for issues`
 ### 55

--- a/docs/warning-codes.md
+++ b/docs/warning-codes.md
@@ -144,4 +144,4 @@
 ### 71
 `An invalid feature mode was detected and set to "off".`
 ### 72
-`Unable to initialized Connector and/or Harvester.`
+`Unable to initialize Connector and/or Harvester.`

--- a/src/common/config/runtime.js
+++ b/src/common/config/runtime.js
@@ -41,6 +41,7 @@ const RuntimeModel = {
   disabled: false,
   /** @type {Map<string, {staged: boolean, priority: number}>} */
   drainRegistry: new Map(),
+  connector: undefined,
   harvester: undefined,
   isolatedBacklog: false,
   isRecording: false, // true when actively recording, false when paused or stopped

--- a/src/common/event-listener/event-listener-opts.js
+++ b/src/common/event-listener/event-listener-opts.js
@@ -15,6 +15,6 @@ export function windowAddEventListener (event, listener, capture = false, abortS
   window.addEventListener(event, listener, eventListenerOpts(capture, abortSignal))
 }
 /** Do not use this within the worker context. */
-export function documentAddEventListener (event, listener, abortSignal, capture = false) {
+export function documentAddEventListener (event, listener, capture = false, abortSignal) {
   document.addEventListener(event, listener, eventListenerOpts(capture, abortSignal))
 }

--- a/src/common/event-listener/event-listener-opts.js
+++ b/src/common/event-listener/event-listener-opts.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 export function eventListenerOpts (useCapture, abortSignal) {
@@ -15,6 +15,6 @@ export function windowAddEventListener (event, listener, capture = false, abortS
   window.addEventListener(event, listener, eventListenerOpts(capture, abortSignal))
 }
 /** Do not use this within the worker context. */
-export function documentAddEventListener (event, listener, capture = false, abortSignal) {
+export function documentAddEventListener (event, listener, abortSignal, capture = false) {
   document.addEventListener(event, listener, eventListenerOpts(capture, abortSignal))
 }

--- a/src/common/harvest/connector.js
+++ b/src/common/harvest/connector.js
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isBrowserScope } from '../constants/runtime'
+import { send } from './send'
+import { TimeKeeper } from '../timing/time-keeper'
+import { activateFeatures } from '../util/feature-flags'
+import { now } from '../timing/now'
+import { warn } from '../util/console'
+import { VERSION } from '../constants/env'
+import { FEATURE_NAMES, FEATURE_TO_ENDPOINT } from '../../loaders/features/features'
+import { handle } from '../event-emitter/handle'
+import { SUPPORTABILITY_METRIC_CHANNEL } from '../../features/metrics/constants'
+
+const MAX_CONNECT_ATTEMPTS = 3
+const CONNECT_RETRY_BASE_MS = 3000 // affects each retry window proportionally (attempt 2: 0-3s, 3: 0-6s, 4: 0-12s, etc)
+
+export class Connector {
+  #agentRef
+  #connectStartTime
+  #numOfAttempts = 0
+
+  constructor (agentRef) {
+    if (!agentRef.init.feature_flags.includes('rum_v2')) return // the Connector does not run in v1; legacy PVE has its own BCS handling
+    this.#agentRef = agentRef
+    agentRef.runtime.timeKeeper = new TimeKeeper(agentRef.runtime.session)
+
+    if (isBrowserScope) {
+      const cached = agentRef.runtime.session && agentRef.runtime.session.state.cachedRumResponse
+      if (cached) {
+        if (cached.config) { // the old v1 RUM response does not have a config field, so this guards against breaking change on existing sessions at release time
+          this.#applyConnectResponse(cached)
+          return
+        } else this.#agentRef.runtime.session.reset() // this can be removed on the next version after rls, once the old format and sessions have expired or reset
+      }
+    }
+    this.makeConnectRequest()
+  }
+
+  makeConnectRequest () {
+    this.#connectStartTime = now()
+    return send(this.#agentRef, {
+      endpoint: `connect/2/${this.#agentRef.info.licenseKey}`,
+      payload: {
+        body: {},
+        qs: {
+          a: this.#agentRef.info.applicationID,
+          v: VERSION
+        }
+      },
+      localOpts: { sendEmptyBody: true },
+      raw: true,
+      featureName: 'connect',
+      cbFinished: this.#processConnectResponse.bind(this)
+    })
+  }
+
+  #applyConnectResponse (response) {
+    if (!Object.keys(this.#agentRef.runtime.appMetadata).length) this.#agentRef.runtime.appMetadata = response.app
+    activateFeatures(response.config, this.#agentRef)
+  }
+
+  #processConnectResponse ({ sent, status, retry, xhr, responseText }) {
+    const connectEndTime = now()
+    const session = this.#agentRef.runtime.session
+
+    if (session) {
+      // Double check that there isn't a response saved (e.g. from another agent/browser tab) btwn the async time of the request and now in a race-condition.
+      const cachedResp = session.state.cachedRumResponse
+      if (cachedResp) {
+        this.#applyConnectResponse(cachedResp)
+      }
+    }
+
+    const shouldRetry = sent && retry // important to note: no retry if HTTP status is 0
+    if (shouldRetry && ++this.#numOfAttempts < MAX_CONNECT_ATTEMPTS) {
+      // We use an exponential backoff calculation for the retry to avoid thundering herd, skipping any further processing.
+      const delay = Math.floor(Math.random() * CONNECT_RETRY_BASE_MS * (2 ** (this.#numOfAttempts - 1)))
+      setTimeout(this.makeConnectRequest.bind(this), delay)
+      return
+    }
+
+    if (status >= 400 || status === 0) {
+      warn(18, status)
+
+      // Get estimated payload size of our backlog.
+      const textEncoder = new TextEncoder()
+      const payloadSize = Object.values(newrelic.ee.backlog).reduce((acc, value) => {
+        if (!value) return acc
+        const encoded = textEncoder.encode(value)
+        return acc + encoded.byteLength
+      }, 0)
+
+      // Send SMs about the (last) failed connect request, then abort agent.
+      const BCSError = 'BCS/Error/'
+      const sm = [{
+        params: {
+          name: BCSError + status
+        },
+        stats: {
+          c: 1
+        }
+      }, {
+        params: {
+          name: BCSError + 'Duration/Ms'
+        },
+        stats: {
+          c: 1,
+          t: connectEndTime - this.#connectStartTime
+        }
+      }, {
+        params: {
+          name: BCSError + 'Dropped/Bytes'
+        },
+        stats: {
+          c: 1,
+          t: payloadSize
+        }
+      }]
+      send(this.#agentRef, { // note we have to send it this way because the Metrics feature will never be harvested under this branch of code (BCS failure)
+        endpoint: FEATURE_TO_ENDPOINT[FEATURE_NAMES.metrics],
+        payload: { body: { sm } },
+        featureName: FEATURE_NAMES.metrics
+      })
+
+      this.#agentRef.ee.abort()
+      return
+    }
+
+    let resp
+    try {
+      resp = JSON.parse(responseText)
+    } catch (error) {
+      warn(53, error)
+      this.#agentRef.ee.abort()
+      return
+    }
+    if (session) session.write({ cachedRumResponse: resp }) // store the response for other pages later in same session or in parallel tabs
+    try {
+      const wasReady = this.#agentRef.runtime.timeKeeper.ready
+      this.#agentRef.runtime.timeKeeper.processRumRequest(xhr, this.#connectStartTime, connectEndTime, resp.app.nrServerTime)
+      if (!this.#agentRef.runtime.timeKeeper.ready) throw new Error('TimeKeeper not ready')
+
+      // If timeKeeper's origin time is ahead of nrServerTime, then the timestamp is invalid. Report a supportability metric.
+      const timeDiff = this.#agentRef.runtime.timeKeeper.correctedOriginTime - resp.app.nrServerTime
+      if (wasReady && timeDiff > 0) {
+        handle(SUPPORTABILITY_METRIC_CHANNEL, ['Generic/TimeKeeper/InvalidTimestamp/Seen', timeDiff], undefined, FEATURE_NAMES.metrics, this.#agentRef.ee)
+      }
+    } catch (error) {
+      warn(17, error)
+      this.#agentRef.ee.abort()
+      return
+    }
+
+    this.#applyConnectResponse(resp)
+  }
+}

--- a/src/common/harvest/connector.js
+++ b/src/common/harvest/connector.js
@@ -72,6 +72,7 @@ export class Connector {
       const cachedResp = session.state.cachedRumResponse
       if (cachedResp) {
         this.#applyConnectResponse(cachedResp)
+        return
       }
     }
 

--- a/src/common/harvest/connector.js
+++ b/src/common/harvest/connector.js
@@ -30,10 +30,10 @@ export class Connector {
     if (isBrowserScope) {
       const cached = agentRef.runtime.session && agentRef.runtime.session.state.cachedRumResponse
       if (cached) {
-        if (cached.config) { // the old v1 RUM response does not have a config field, so this guards against breaking change on existing sessions at release time
-          this.#applyConnectResponse(cached)
-          return
-        } else this.#agentRef.runtime.session.reset() // this can be removed on the next version after rls, once the old format and sessions have expired or reset
+        // `cachedRumResponse` is stored flat (`{ app, ...flags }`, matching the old v1 RUM response), so re-nest it before applying.
+        const { app, ...config } = cached
+        this.#applyConnectResponse({ app, config })
+        return
       }
     }
     this.makeConnectRequest()
@@ -58,9 +58,9 @@ export class Connector {
     })
   }
 
-  #applyConnectResponse (response) {
-    if (!Object.keys(this.#agentRef.runtime.appMetadata).length) this.#agentRef.runtime.appMetadata = response.app
-    activateFeatures(response.config, this.#agentRef)
+  #applyConnectResponse ({ app, config }) {
+    if (!Object.keys(this.#agentRef.runtime.appMetadata).length) this.#agentRef.runtime.appMetadata = app
+    activateFeatures(config, this.#agentRef)
   }
 
   #processConnectResponse ({ sent, status, retry, xhr, responseText }) {
@@ -71,7 +71,9 @@ export class Connector {
       // Double check that there isn't a response saved (e.g. from another agent/browser tab) btwn the async time of the request and now in a race-condition.
       const cachedResp = session.state.cachedRumResponse
       if (cachedResp) {
-        this.#applyConnectResponse(cachedResp)
+        // `cachedRumResponse` is stored flat (`{ app, ...flags }`, matching the old v1 RUM response), so re-nest it before applying.
+        const { app, ...config } = cachedResp
+        this.#applyConnectResponse({ app, config })
         return
       }
     }
@@ -143,7 +145,8 @@ export class Connector {
       this.#agentRef.ee.abort()
       return
     }
-    if (session) session.write({ cachedRumResponse: resp }) // store the response for other pages later in same session or in parallel tabs
+    // store the response for other pages later in same session or in parallel tabs; flatten `.config` into the old v1 RUM response shape
+    if (session) session.write({ cachedRumResponse: { app: resp.app, ...resp.config } })
     try {
       const wasReady = this.#agentRef.runtime.timeKeeper.ready
       this.#agentRef.runtime.timeKeeper.processRumRequest(xhr, this.#connectStartTime, connectEndTime, resp.app.nrServerTime)

--- a/src/common/harvest/connector.js
+++ b/src/common/harvest/connector.js
@@ -42,7 +42,7 @@ export class Connector {
   makeConnectRequest (retryHeaders) {
     this.#connectStartTime = now()
     return send(this.#agentRef, {
-      endpoint: `connect/2/${this.#agentRef.info.licenseKey}`,
+      endpoint: `browser/connect/2/${this.#agentRef.info.licenseKey}`,
       payload: {
         body: {},
         qs: {

--- a/src/common/harvest/connector.js
+++ b/src/common/harvest/connector.js
@@ -10,7 +10,7 @@ import { activateFeatures } from '../util/feature-flags'
 import { now } from '../timing/now'
 import { warn } from '../util/console'
 import { VERSION } from '../constants/env'
-import { FEATURE_NAMES, FEATURE_TO_ENDPOINT } from '../../loaders/features/features'
+import { CONNECT, FEATURE_NAMES, FEATURE_TO_ENDPOINT } from '../../loaders/features/features'
 import { handle } from '../event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../../features/metrics/constants'
 
@@ -53,7 +53,7 @@ export class Connector {
       },
       localOpts: { sendEmptyBody: true, headers: retryHeaders },
       raw: true,
-      featureName: 'connect',
+      featureName: CONNECT,
       cbFinished: this.#processConnectResponse.bind(this)
     })
   }

--- a/src/common/harvest/connector.js
+++ b/src/common/harvest/connector.js
@@ -39,7 +39,7 @@ export class Connector {
     this.makeConnectRequest()
   }
 
-  makeConnectRequest () {
+  makeConnectRequest (retryHeaders) {
     this.#connectStartTime = now()
     return send(this.#agentRef, {
       endpoint: `connect/2/${this.#agentRef.info.licenseKey}`,
@@ -47,10 +47,11 @@ export class Connector {
         body: {},
         qs: {
           a: this.#agentRef.info.applicationID,
-          v: VERSION
+          v: VERSION,
+          s: this.#agentRef.runtime.session?.state.value || '0'
         }
       },
-      localOpts: { sendEmptyBody: true },
+      localOpts: { sendEmptyBody: true, headers: retryHeaders },
       raw: true,
       featureName: 'connect',
       cbFinished: this.#processConnectResponse.bind(this)
@@ -78,7 +79,11 @@ export class Connector {
     if (shouldRetry && ++this.#numOfAttempts < MAX_CONNECT_ATTEMPTS) {
       // We use an exponential backoff calculation for the retry to avoid thundering herd, skipping any further processing.
       const delay = Math.floor(Math.random() * CONNECT_RETRY_BASE_MS * (2 ** (this.#numOfAttempts - 1)))
-      setTimeout(this.makeConnectRequest.bind(this), delay)
+      const retryHeaders = [
+        { key: 'X-Retry-Count', value: this.#numOfAttempts },
+        { key: 'X-Previous-Status', value: status }
+      ]
+      setTimeout(() => this.makeConnectRequest(retryHeaders), delay)
       return
     }
 

--- a/src/common/harvest/harvester.js
+++ b/src/common/harvest/harvester.js
@@ -31,21 +31,10 @@ export class Harvester {
     this.#started = true
 
     subscribeToEOL(() => {
-      /* Deferred to a microtask so this runs after the ENTIRE synchronous 'visibilitychange' dispatch completes --
-      including any other same-event listeners (e.g. web-vitals' CWV APIs like onINP, which only report their final
-      value from within their own 'visibilitychange' listener). Whichever listener registered first still runs
-      first, but our actual harvest work no longer happens inline within that race -- it always happens after the
-      whole dispatch settles, so a listener that runs later in the same dispatch (regardless of registration order)
-      still gets to add its data before we snapshot the buffer.
-      This alone was sufficient to stop losing INP, which only ever reports via its own 'visibilitychange' listener.
-      It was NOT, on its own, sufficient for CLS -- see the `capture=true` note on page_view_timing's own CLS
-      listener for the other half of that fix. */
-      queueMicrotask(() => {
-        this.initializedAggregates.forEach(aggregateInst => { // let all features wrap up things needed to do before ANY harvest in case there's last minute cross-feature data dependencies
-          if (typeof aggregateInst.harvestOpts.beforeUnload === 'function') aggregateInst.harvestOpts.beforeUnload()
-        })
-        this.initializedAggregates.forEach(aggregateInst => this.triggerHarvestFor(aggregateInst, { isFinalHarvest: true }))
+      this.initializedAggregates.forEach(aggregateInst => { // let all features wrap up things needed to do before ANY harvest in case there's last minute cross-feature data dependencies
+        if (typeof aggregateInst.harvestOpts.beforeUnload === 'function') aggregateInst.harvestOpts.beforeUnload()
       })
+      this.initializedAggregates.forEach(aggregateInst => this.triggerHarvestFor(aggregateInst, { isFinalHarvest: true }))
     })
 
     const onHarvestInterval = () => {

--- a/src/common/harvest/harvester.js
+++ b/src/common/harvest/harvester.js
@@ -22,22 +22,31 @@ export class Harvester {
   constructor (agentRef) {
     this.agentRef = agentRef
 
-    // Create obfuscator for harvest metadata (referrer URL, etc.)
     // No event type specified - applies to all harvests regardless of feature
     this.obfuscator = new Obfuscator(agentRef)
-
-    subscribeToEOL(() => { // do one last harvest round or check
-      this.initializedAggregates.forEach(aggregateInst => { // let all features wrap up things needed to do before ANY harvest in case there's last minute cross-feature data dependencies
-        if (typeof aggregateInst.harvestOpts.beforeUnload === 'function') aggregateInst.harvestOpts.beforeUnload()
-      })
-      this.initializedAggregates.forEach(aggregateInst => this.triggerHarvestFor(aggregateInst, { isFinalHarvest: true }))
-      /* This callback should run in bubble phase, so that CWV api, like "onLCP", is called before the final harvest so that emitted timings are part of last outgoing. */
-    }, false)
   }
 
   startTimer (harvestInterval = this.agentRef.init.harvest.interval) {
     if (this.#started) return
     this.#started = true
+
+    subscribeToEOL(() => {
+      /* Deferred to a microtask so this runs after the ENTIRE synchronous 'visibilitychange' dispatch completes --
+      including any other same-event listeners (e.g. web-vitals' CWV APIs like onINP, which only report their final
+      value from within their own 'visibilitychange' listener). Whichever listener registered first still runs
+      first, but our actual harvest work no longer happens inline within that race -- it always happens after the
+      whole dispatch settles, so a listener that runs later in the same dispatch (regardless of registration order)
+      still gets to add its data before we snapshot the buffer.
+      This alone was sufficient to stop losing INP, which only ever reports via its own 'visibilitychange' listener.
+      It was NOT, on its own, sufficient for CLS -- see the `capture=true` note on page_view_timing's own CLS
+      listener for the other half of that fix. */
+      queueMicrotask(() => {
+        this.initializedAggregates.forEach(aggregateInst => { // let all features wrap up things needed to do before ANY harvest in case there's last minute cross-feature data dependencies
+          if (typeof aggregateInst.harvestOpts.beforeUnload === 'function') aggregateInst.harvestOpts.beforeUnload()
+        })
+        this.initializedAggregates.forEach(aggregateInst => this.triggerHarvestFor(aggregateInst, { isFinalHarvest: true }))
+      })
+    })
 
     const onHarvestInterval = () => {
       this.initializedAggregates.forEach(aggregateInst => this.triggerHarvestFor(aggregateInst))

--- a/src/common/harvest/send.js
+++ b/src/common/harvest/send.js
@@ -2,7 +2,7 @@
  * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-import { JSERRORS, RUM, EVENTS, FEATURE_NAMES, BLOBS, LOGS } from '../../loaders/features/features'
+import { JSERRORS, RUM, EVENTS, FEATURE_NAMES, BLOBS, LOGS, CONNECT } from '../../loaders/features/features'
 import { VERSION } from '../constants/env'
 import { globalScope, isWorkerScope } from '../constants/runtime'
 import { handle } from '../event-emitter/handle'
@@ -94,6 +94,7 @@ export function send (agentRef, { endpoint, payload, localOpts = {}, submitMetho
 
     function trackHarvestMetadata () {
       try {
+        if (featureName === CONNECT) return
         if (featureName === FEATURE_NAMES.jserrors && !body?.err) return
 
         const hasReplay = baseParams.includes('hr=1')

--- a/src/common/harvest/send.js
+++ b/src/common/harvest/send.js
@@ -12,7 +12,7 @@ import { cleanURL } from '../url/clean-url'
 import { obj, param } from '../url/encode'
 import { warn } from '../util/console'
 import { stringify } from '../util/stringify'
-import { xhr as xhrMethod, xhrFetch as fetchMethod } from '../util/submit-data'
+import { xhr as xhrMethod, xhrFetch as fetchMethod, getSubmitMethod } from '../util/submit-data'
 import { dispatchGlobalEvent } from '../dispatch/global-event'
 
 /**
@@ -27,7 +27,7 @@ const warnings = {}
  * @param {NetworkSendSpec} spec Specification for sending data
  * @returns {boolean} True if a network call was made. Note that this does not mean or guarantee that it was successful.
  */
-export function send (agentRef, { endpoint, payload, localOpts = {}, submitMethod, cbFinished, raw, featureName, endpointVersion = 1, harvesterObfuscator }) {
+export function send (agentRef, { endpoint, payload, localOpts = {}, submitMethod = getSubmitMethod(), cbFinished, raw, featureName, endpointVersion = 1, harvesterObfuscator }) {
   if (!agentRef.info.errorBeacon) return false
 
   let { body, qs } = cleanPayload(payload)
@@ -39,16 +39,18 @@ export function send (agentRef, { endpoint, payload, localOpts = {}, submitMetho
 
   const protocol = agentRef.init.ssl === false ? 'http' : 'https'
   const perceivedBeacon = agentRef.init.proxy.beacon || agentRef.info.errorBeacon
+  const includeEndpointName = endpoint !== RUM || endpointVersion !== 1
   const url = raw
     ? `${protocol}://${perceivedBeacon}/${endpoint}`
-    : `${protocol}://${perceivedBeacon}${endpoint !== RUM ? '/' + endpoint : ''}/${endpointVersion}/${agentRef.info.licenseKey}`
+    : `${protocol}://${perceivedBeacon}${includeEndpointName ? '/' + endpoint : ''}/${endpointVersion}/${agentRef.info.licenseKey}`
   const baseParams = !raw ? baseQueryString(agentRef, qs, endpoint, harvesterObfuscator) : ''
   let payloadParams = obj(qs, agentRef.runtime.maxBytes)
   if (baseParams === '' && payloadParams.startsWith('&')) {
     payloadParams = payloadParams.substring(1)
   }
 
-  const fullUrl = `${url}?${baseParams}${payloadParams}`
+  const queryString = `${baseParams}${payloadParams}`
+  const fullUrl = queryString ? `${url}?${queryString}` : url // omit the '?' if there are no query params
   const gzip = !!qs?.attributes?.includes('gzip')
 
   // all gzipped data is already in the correct format and needs no transformation

--- a/src/common/harvest/send.js
+++ b/src/common/harvest/send.js
@@ -63,7 +63,7 @@ export function send (agentRef, { endpoint, payload, localOpts = {}, submitMetho
   // Warn--once per endpoint--if the agent tries to send large payloads
   if (endpoint !== BLOBS && stringBody.length > 750000 && (warnings[endpoint] = (warnings[endpoint] || 0) + 1) === 1) warn(28, endpoint)
 
-  const headers = [{ key: 'content-type', value: 'text/plain' }]
+  const headers = [{ key: 'content-type', value: 'text/plain' }, ...(localOpts.headers || [])]
 
   /* Since workers don't support sendBeacon right now, they can only use XHR method.
       Because they still do permit synch XHR, the idea is that at final harvest time (worker is closing),
@@ -191,7 +191,6 @@ function baseQueryString (agentRef, qs, endpoint, harvesterObfuscator) {
     transactionNameParam(),
     param('ct', agentRef.runtime.customTransaction),
     '&rst=' + now(),
-    '&ck=0', // ck param DEPRECATED - still expected by backend
     '&s=' + (session?.state.value || '0'), // the 0 id encaps all untrackable and default traffic
     param('ref', ref),
     param('ptid', (agentRef.runtime.ptid ? '' + agentRef.runtime.ptid : ''))

--- a/src/common/timer/interaction-timer.js
+++ b/src/common/timer/interaction-timer.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { Timer } from './timer'
@@ -53,7 +53,7 @@ export class InteractionTimer extends Timer {
         if (state === 'hidden') this.pause()
         // vis change --> visible is treated like a new interaction with the page
         else this.resume()
-      }, false, false, this.abortController?.signal)
+      }, false, this.abortController?.signal)
     }
   }
 

--- a/src/common/unload/eol.js
+++ b/src/common/unload/eol.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { globalScope, isWorkerScope, isBrowserScope } from '../constants/runtime'
@@ -22,9 +22,9 @@ if (isWorkerScope) {
  * This is used, for example, to submit a final harvest and send all remaining data on best-effort.
  * @param {function} cb - func to run before or during the last reliable event or time of an env's life span
  */
-export function subscribeToEOL (cb, capturePhase) {
+export function subscribeToEOL (cb) {
   if (isBrowserScope) {
-    subscribeToVisibilityChange(cb, true, capturePhase) // when user switches tab or hides window, esp. mobile scenario
+    subscribeToVisibilityChange(cb, true) // when user switches tab or hides window, esp. mobile scenario
   } else if (isWorkerScope) {
     globalScope.cleanupTasks.push(cb) // close() should run these tasks before quitting thread
   }

--- a/src/common/util/console.js
+++ b/src/common/util/console.js
@@ -68,7 +68,7 @@ import { dispatchGlobalEvent } from '../dispatch/global-event'
  * | 50 | Failed to connect. Cannot allow registered API. |
  * | 51 | Container agent is not available to register with. Can not connect |
  * | 52 | Unexpected problem encountered. There should be at least one app for harvest! |
- * | 53 | Did not receive a valid entityGuid from connection response |
+ * | 53 | Failed to parse connect response. |
  * | 54 | An experimental feature is being used. Support can not be offered for issues |
  * | 55 | Register API has been disabled on the container agent |
  * | 56 | Could not find a matching entity to store data |
@@ -87,7 +87,7 @@ import { dispatchGlobalEvent } from '../dispatch/global-event'
  * | 69 | More than one Browser agent is running on the page |
  * | 70 | A session replay payload failed to send and is being retried. Recording is paused during the retry period, and will resume when a successful harvest is made. Some replay activity may be missed during retry phases. |
  * | 71 | An invalid feature mode was detected and set to "off". |
- * | 72 | Unable to initialized Connector and/or Harvester. |
+ * | 72 | Unable to initialize Connector and/or Harvester. |
  *
  * @param {number} code The warning code to emit, which will be used to link to the warning code documentation
  * @param {*} [secondary] Secondary data to include, usually an extra message, error or object

--- a/src/common/util/console.js
+++ b/src/common/util/console.js
@@ -87,6 +87,7 @@ import { dispatchGlobalEvent } from '../dispatch/global-event'
  * | 69 | More than one Browser agent is running on the page |
  * | 70 | A session replay payload failed to send and is being retried. Recording is paused during the retry period, and will resume when a successful harvest is made. Some replay activity may be missed during retry phases. |
  * | 71 | An invalid feature mode was detected and set to "off". |
+ * | 72 | Unable to initialized Connector and/or Harvester. |
  *
  * @param {number} code The warning code to emit, which will be used to link to the warning code documentation
  * @param {*} [secondary] Secondary data to include, usually an extra message, error or object

--- a/src/common/util/feature-flags.js
+++ b/src/common/util/feature-flags.js
@@ -19,7 +19,7 @@ export function activateFeatures (flags, agentRef) {
   // let any window level subscribers know that the agent is running, per install docs
   dispatchGlobalEvent({
     loaded: true,
-    drained: true,
+    drained: !agentRef.init.feature_flags.includes('rum_v2'), // v2 RUM always call activateFeatures before any group is drained (in waitForFlags)
     type: 'lifecycle',
     name: 'load',
     feature: undefined,

--- a/src/common/window/page-visibility.js
+++ b/src/common/window/page-visibility.js
@@ -11,7 +11,7 @@ import { documentAddEventListener, windowAddEventListener } from '../event-liste
  * @returns void
  */
 export function subscribeToVisibilityChange (cb, toHiddenOnly = false, capture, abortSignal) {
-  documentAddEventListener('visibilitychange', handleVisibilityChange, abortSignal, capture)
+  documentAddEventListener('visibilitychange', handleVisibilityChange, capture, abortSignal)
 
   function handleVisibilityChange () {
     if (toHiddenOnly) { // trigger cb on change to hidden state only

--- a/src/common/window/page-visibility.js
+++ b/src/common/window/page-visibility.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -11,7 +11,7 @@ import { documentAddEventListener, windowAddEventListener } from '../event-liste
  * @returns void
  */
 export function subscribeToVisibilityChange (cb, toHiddenOnly = false, capture, abortSignal) {
-  documentAddEventListener('visibilitychange', handleVisibilityChange, capture, abortSignal)
+  documentAddEventListener('visibilitychange', handleVisibilityChange, abortSignal, capture)
 
   function handleVisibilityChange () {
     if (toHiddenOnly) { // trigger cb on change to hidden state only

--- a/src/features/page_view_event/aggregate/index.js
+++ b/src/features/page_view_event/aggregate/index.js
@@ -132,9 +132,7 @@ export class Aggregate extends AggregateBase {
     }
     this.events.add(body)
 
-    if (this.agentRef.runtime.harvester.triggerHarvestFor(this, {
-      sendEmptyBody: true
-    }).ranSend) this.sentRum = true
+    if (this.agentRef.runtime.harvester.triggerHarvestFor(this).ranSend) this.sentRum = true
   }
 
   serializer (eventBuffer) { // this is necessary because PVE sends a single item rather than an array; in the case of undefined, this prevents sending [null] as body
@@ -162,9 +160,7 @@ export class Aggregate extends AggregateBase {
     super.postHarvestCleanup({ sent, retry: retry && !hasCachedRumResponse }) // this will set isRetrying & re-buffer the body if request is to be retried
 
     if (this.isRetrying && this.retries++ < 1) { // Only retry once
-      setTimeout(() => this.agentRef.runtime.harvester.triggerHarvestFor(this, {
-        sendEmptyBody: true
-      }), 5000) // Retry sending the RUM event after 5 seconds
+      setTimeout(() => this.agentRef.runtime.harvester.triggerHarvestFor(this), 5000) // Retry sending the RUM event after 5 seconds
       return
     }
 

--- a/src/features/page_view_event/aggregate_v2/index.js
+++ b/src/features/page_view_event/aggregate_v2/index.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { globalScope, isBrowserScope, originTime, getNavigationEntry } from '../../../common/constants/runtime'
+import { addPT, addPN } from '../../../common/timing/nav-timing'
+import { stringify } from '../../../common/util/stringify'
+import * as CONSTANTS from '../constants'
+import { getActivatedFeaturesFlags } from '../aggregate/initialized-features'
+import { AggregateBase } from '../../utils/aggregate-base'
+import { firstContentfulPaint } from '../../../common/vitals/first-contentful-paint'
+import { firstPaint } from '../../../common/vitals/first-paint'
+import { timeToFirstByte } from '../../../common/vitals/time-to-first-byte'
+import { Obfuscator } from '../../../common/util/obfuscate'
+import { webdriverDetected } from '../../../common/util/webdriver-detection'
+import { EVENT_TYPES } from '../../../common/constants/events'
+
+export class Aggregate extends AggregateBase {
+  static featureName = CONSTANTS.FEATURE_NAME
+
+  #timeToFirstByte = 0
+  #firstByteToWindowLoad = 0 // our "frontend" duration
+  #firstByteToDomContent = 0 // our "dom processing" duration
+  #obfuscator
+
+  constructor (agentRef) {
+    super(agentRef, CONSTANTS.FEATURE_NAME)
+    this.#obfuscator = new Obfuscator(agentRef, EVENT_TYPES.PVE)
+
+    if (isBrowserScope) {
+      timeToFirstByte.subscribe(({ value, attrs }) => {
+        const navEntry = attrs.navigationEntry
+        this.#timeToFirstByte = Math.max(value, this.#timeToFirstByte)
+        this.#firstByteToWindowLoad = Math.max(Math.round(navEntry.loadEventEnd - this.#timeToFirstByte), this.#firstByteToWindowLoad) // our "frontend" duration
+        this.#firstByteToDomContent = Math.max(Math.round(navEntry.domContentLoadedEventEnd - this.#timeToFirstByte), this.#firstByteToDomContent) // our "dom processing" duration
+      })
+    }
+
+    this.waitForFlags(([])).then(() => {
+      const body = this.#obfuscator.traverseAndObfuscateEvents({ ja: { ...agentRef.info.jsAttributes, webdriverDetected } })
+      this.events.add(body)
+      this.drain()
+    })
+  }
+
+  queryStringsBuilder () {
+    const info = this.agentRef.info
+    const measures = {}
+
+    if (info.queueTime) measures.qt = info.queueTime
+    if (info.applicationTime) measures.ap = info.applicationTime
+
+    // These 3 values should've been recorded after load and before this func runs. They are part of the minimum required for PageView events to be created.
+    // Following PR #428, which demands that the BA must drive entity indexing, these need to be sent even outside of the main window context where PerformanceTiming
+    // or PerformanceNavigationTiming do not exists. Hence, they'll be filled in by 0s instead in, for example, worker threads that still init the PVE module.
+    measures.be = this.#timeToFirstByte
+    measures.fe = this.#firstByteToWindowLoad
+    measures.dc = this.#firstByteToDomContent
+
+    const queryParameters = {
+      at: info.atts,
+      af: getActivatedFeaturesFlags(this.agentRef).join(','),
+      ...measures,
+      fp: firstPaint.current.value,
+      fcp: firstContentfulPaint.current.value
+    }
+    if (globalScope.performance) {
+      const navTimingEntry = getNavigationEntry()
+      if (navTimingEntry) { // Navigation Timing level 2 API that replaced PerformanceTiming & PerformanceNavigation
+        const perf = ({
+          timing: addPT(originTime, navTimingEntry, {}),
+          navigation: addPN(navTimingEntry, {})
+        })
+        queryParameters.perf = stringify(perf)
+      } else if (typeof PerformanceTiming !== 'undefined') { // Modern Safari iFrames and Safari pre-15 do not support level 2 timing.
+        const perf = ({
+          timing: addPT(originTime, globalScope.performance.timing, {}, true),
+          navigation: addPN(globalScope.performance.navigation, {})
+        })
+        queryParameters.perf = stringify(perf)
+      }
+    }
+    const { correctedOriginTime } = this.agentRef.runtime.timeKeeper
+    if (correctedOriginTime) queryParameters.timestamp = correctedOriginTime // a "PageView" is set to represent the page's (server adjusted) origin time rather than when event is recorded/harvested
+
+    return queryParameters
+  }
+
+  get harvestEndpointVersion () {
+    return 2
+  }
+
+  serializer (eventBuffer) { // this is necessary because PVE sends a single item rather than an array; in the case of undefined, this prevents sending [null] as body
+    return eventBuffer[0]
+  }
+}

--- a/src/features/page_view_event/aggregate_v2/index.js
+++ b/src/features/page_view_event/aggregate_v2/index.js
@@ -60,6 +60,7 @@ export class Aggregate extends AggregateBase {
     const queryParameters = {
       at: info.atts,
       af: getActivatedFeaturesFlags(this.agentRef).join(','),
+      igp: this.agentRef.runtime.appMetadata.igp,
       ...measures,
       fp: firstPaint.current.value,
       fcp: firstContentfulPaint.current.value

--- a/src/features/page_view_event/instrument/index.js
+++ b/src/features/page_view_event/instrument/index.js
@@ -20,7 +20,12 @@ export class Instrument extends InstrumentBase {
     /** feature specific APIs */
     setupSetPageViewNameAPI(agentRef)
 
-    this.importAggregator(agentRef, () => import(/* webpackChunkName: "page_view_event-aggregate" */ '../aggregate'))
+    this.importAggregator(agentRef, () => {
+      if (agentRef.init.feature_flags.includes('rum_v2')) {
+        return import(/* webpackChunkName: "page_view_event-aggregate" */ '../aggregate_v2')
+      }
+      return import(/* webpackChunkName: "page_view_event-aggregate" */ '../aggregate')
+    })
   }
 
   setupInspectionEvents () {

--- a/src/features/page_view_timing/aggregate/index.js
+++ b/src/features/page_view_timing/aggregate/index.js
@@ -58,7 +58,11 @@ export class Aggregate extends AggregateBase {
         const { name, value, attrs } = cumulativeLayoutShift.current
         if (value === undefined) return
         this.addTiming(name, value * 1000, attrs)
-      }, true, true) // CLS node should only reports on vis change rather than on every change
+      }, true, true) // CLS node should only report on vis change rather than on every change.
+      /* NOTE: the capture=true is required -- empirically verified against a real browser (Chrome) for CLS
+      timing node to reliably be in the same final harvest as the rest, alongside Harvester#startTimer's
+      queueMicrotask deferral of the EOL harvest itself. Dropping this flag caused CLS to be split into its own,
+      separate, later harvest instead of going out together with pageHide/INP. */
 
       this.drain()
     })

--- a/src/features/session_replay/instrument/index.js
+++ b/src/features/session_replay/instrument/index.js
@@ -46,6 +46,10 @@ export class Instrument extends InstrumentBase {
       }) // could handle specific fail-state behaviors with a .catch block here
     }
 
+    // If the aggregate never successfully loads (missing session prerequisite, or the aggregate module itself
+    // fails to import/construct), any preload recording that already started needs to be stopped.
+    this.abortHandler = this.#abort
+
     this.importAggregator(this.agentRef, () => import(/* webpackChunkName: "session_replay-aggregate" */ '../aggregate'), this)
 
     /** If the recorder is running, we can pass error events on to the agg to help it switch to full mode later */
@@ -108,6 +112,11 @@ export class Instrument extends InstrumentBase {
           this.recorder.startRecording(TRIGGERS.API, MODE.FULL)
         }) // could handle specific fail-state behaviors with a .catch block here
     }
+  }
+
+  /** Stops any preload recording that already started if the aggregate never ends up successfully loading. */
+  #abort () {
+    this.recorder?.stopRecording()
   }
 }
 

--- a/src/features/session_replay/shared/recorder.js
+++ b/src/features/session_replay/shared/recorder.js
@@ -204,7 +204,8 @@ export class Recorder {
 
     // We are making an effort to try to keep payloads manageable for unloading.  If they reach the unload limit before their interval,
     // it will send immediately.  This often happens on the first snapshot, which can be significantly larger than the other payloads.
-    if (((this.events.hasSnapshot && this.events.hasMeta) || payloadSize > IDEAL_PAYLOAD_SIZE) && !this.isErrorMode) {
+    // (the aggregate may not exist yet/at all if its own bootstrap hasn't finished or failed -- nothing to harvest for in that case.)
+    if (((this.events.hasSnapshot && this.events.hasMeta) || payloadSize > IDEAL_PAYLOAD_SIZE) && !this.isErrorMode && this.srInstrument.featAggregate) {
       // if we've made it to the ideal size of ~16kb before the interval timer, we should send early.
       this.agentRef.runtime.harvester.triggerHarvestFor(this.srInstrument.featAggregate)
     }

--- a/src/features/utils/aggregate-base.js
+++ b/src/features/utils/aggregate-base.js
@@ -5,7 +5,6 @@
 import { FeatureBase } from './feature-base'
 import { drain } from '../../common/drain/drain'
 import { FEATURE_NAMES } from '../../loaders/features/features'
-import { Harvester } from '../../common/harvest/harvester'
 import { EventBuffer } from './event-buffer'
 import { handle } from '../../common/event-emitter/handle'
 import { SUPPORTABILITY_METRIC_CHANNEL } from '../metrics/constants'
@@ -21,7 +20,6 @@ export class AggregateBase extends FeatureBase {
    */
   constructor (agentRef, featureName) {
     super(agentRef, featureName)
-    this.doOnceForAllAggregate(agentRef)
 
     /** @type {Boolean} indicates if custom attributes are combined in each event payload for size estimation purposes. this is set to true in derived classes that need to evaluate custom attributes separately from the event payload */
     this.customAttributesAreSeparate = false
@@ -176,16 +174,6 @@ export class AggregateBase extends FeatureBase {
     this.isRetrying = result.sent && result.retry
     if (this.isRetrying) this.events.reloadSave(this.harvestOpts)
     this.events.clearSave(this.harvestOpts)
-  }
-
-  /**
-   * These are actions related to shared resources that should be initialized once by whichever feature Aggregate subclass loads first.
-   * This method should run after checkConfiguration, which may reset the agent's info/runtime object that is used here.
-   */
-  doOnceForAllAggregate (agentRef) {
-    // Note: obfuscator is now created per-feature for their specific event types
-
-    if (!agentRef.runtime.harvester) agentRef.runtime.harvester = new Harvester(agentRef)
   }
 
   /**

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -226,8 +226,8 @@ async function ensureRuntimeBootstrap (agentRef, ee, featureName) {
       import(/* webpackChunkName: "connector" */ '../../common/harvest/connector'),
       import(/* webpackChunkName: "harvester" */ '../../common/harvest/harvester')
     ])
-    if (!agentRef.runtime.connector) agentRef.runtime.connector = new Connector(agentRef)
-    if (!agentRef.runtime.harvester) agentRef.runtime.harvester = new Harvester(agentRef)
+    agentRef.runtime.connector = new Connector(agentRef)
+    agentRef.runtime.harvester = new Harvester(agentRef)
   })()
 
   runtimeBootstrapPromises.set(agentRef, bootstrapPromise)

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -25,6 +25,7 @@ import { SESSION_ERROR } from '../../common/constants/agent-constants'
 import { handle } from '../../common/event-emitter/handle'
 
 const checkedAgents = new WeakSet()
+const runtimeBootstrapPromises = new WeakMap()
 
 /**
  * Base class for instrumenting a feature.
@@ -103,16 +104,13 @@ export class InstrumentBase extends FeatureBase {
         return
       }
 
-      let session
-      try {
-        if (canEnableSessionTracking(agentRef.init)) { // would require some setup before certain features start
-          const { setupAgentSession } = await import(/* webpackChunkName: "session-manager" */ './agent-session')
-          session = setupAgentSession(agentRef)
-        }
+      try { // in the interest of keeping loader file size small, some modules are lazy-loaded as part of the larger async chunk
+        await ensureRuntimeBootstrap(agentRef, this.ee, this.featureName)
       } catch (e) {
-        warn(20, e)
-        this.ee.emit('internal-error', [e])
-        handle(SESSION_ERROR, [e], undefined, this.featureName, this.ee)
+        warn(72, e)
+        this.ee.abort() // failed Connector or Harvester will cause entire agent to shutdown
+        this.loadedSuccessfully(false)
+        return
       }
 
       /**
@@ -120,24 +118,27 @@ export class InstrumentBase extends FeatureBase {
        * it's only responsible for aborting its one specific feature, rather than all.
        */
       try {
-        if (!this.#shouldImportAgg(this.featureName, session, agentRef.init)) {
+        if (!this.#shouldImportAgg(this.featureName, agentRef.runtime.session, agentRef.init)) {
+          this.abortHandler?.()
           drain(this.agentRef, this.featureName)
           this.loadedSuccessfully(false) // aggregate module isn't loaded at all
           return
         }
         const { Aggregate } = await fetchAggregator()
+
         this.featAggregate = new Aggregate(agentRef, argsObjFromInstrument)
 
         agentRef.runtime.harvester.initializedAggregates.push(this.featAggregate) // "subscribe" the feature to future harvest intervals (PVE will start the timer)
         this.loadedSuccessfully(true)
       } catch (e) {
         warn(34, e)
-        this.abortHandler?.() // undo any important alterations made to the page
+        this.abortHandler?.()
         // not supported yet but nice to do: "abort" this agent's EE for this feature specifically
         drain(this.agentRef, this.featureName, true)
         this.loadedSuccessfully(false)
-        if (this.ee) this.ee.abort()
       }
+
+      agentRef.runtime.harvester.startTimer()
     }
 
     // For regular web pages, we want to wait and lazy-load the aggregator only after all page resources are loaded.
@@ -193,4 +194,42 @@ export class InstrumentBase extends FeatureBase {
       }, existingAgent.runtime.loaderType)
     }
   }
+}
+
+/**
+ * Lazily initializes the shared runtime bootstrap for a given agent exactly once. This loads session setup, Connector, and
+ * Harvester through shared async chunks and returns the same in-flight Promise to any concurrent callers.
+ *
+ * Session setup failures are reported but do not stop bootstrap. Connector or Harvester failures are allowed to bubble so the caller can abort the agent.
+ *
+ * @param {Object} agentRef - The agent reference object.
+ * @param {Object} ee - The feature event emitter used for error reporting.
+ * @param {string} featureName - The feature name used when reporting session setup errors.
+ * @returns {Promise<void>} Resolves when the shared bootstrap completes.
+ */
+async function ensureRuntimeBootstrap (agentRef, ee, featureName) {
+  if (runtimeBootstrapPromises.has(agentRef)) return runtimeBootstrapPromises.get(agentRef)
+
+  const bootstrapPromise = (async () => {
+    if (canEnableSessionTracking(agentRef.init)) {
+      try {
+        const { setupAgentSession } = await import(/* webpackChunkName: "session-manager" */ './agent-session')
+        setupAgentSession(agentRef) // sets agentRef.runtime.session, if successful
+      } catch (e) {
+        warn(20, e)
+        ee.emit('internal-error', [e])
+        handle(SESSION_ERROR, [e], undefined, featureName, ee)
+      }
+    }
+
+    const [{ Connector }, { Harvester }] = await Promise.all([
+      import(/* webpackChunkName: "connector" */ '../../common/harvest/connector'),
+      import(/* webpackChunkName: "harvester" */ '../../common/harvest/harvester')
+    ])
+    if (!agentRef.runtime.connector) agentRef.runtime.connector = new Connector(agentRef)
+    if (!agentRef.runtime.harvester) agentRef.runtime.harvester = new Harvester(agentRef)
+  })()
+
+  runtimeBootstrapPromises.set(agentRef, bootstrapPromise)
+  await bootstrapPromise
 }

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -227,12 +227,14 @@ async function ensureRuntimeBootstrap (agentRef, ee, featureName) {
     agentRef.runtime.connector = new Connector(agentRef)
     agentRef.runtime.harvester = new Harvester(agentRef)
 
-    /* Only start the harvest timer (and its EOL 'visibilitychange' listener, see Harvester#startTimer) once every feature has
-    finished attempting to load its aggregate, so Harvester's listener always registers after any aggregate-level listeners
-    that need to run first (e.g. web-vitals' CWV APIs like onINP/onLCP, subscribed when the page_view_timing aggregate loads).
-    Deliberately not awaited here: every feature awaits this same bootstrap promise before attempting its OWN aggregate load,
-    so blocking on all features' `onAggregateImported` here would cause deadlock. */
-    Promise.all(Object.values(agentRef.features).map(feature => feature.onAggregateImported))
+    /* Wait for auto-started features' aggregates to load before starting the harvest timer, so Harvester's EOL
+    listener registers after aggregate-level listeners like web-vitals' CWV APIs. Not awaited here to avoid
+    deadlock, since every feature awaits this same bootstrap promise before its own aggregate load.
+    Only auto-started features are waited on: an autoStart:false feature only registers in drainRegistry once
+    `start` is called, so filtering on that registry excludes any feature that's never started instead of
+    blocking startTimer() forever. */
+    const autoStartedFeatures = Object.values(agentRef.features).filter(feature => agentRef.runtime.drainRegistry.has(feature.featureName))
+    Promise.all(autoStartedFeatures.map(feature => feature.onAggregateImported))
       .then(() => agentRef.runtime.harvester.startTimer())
   })()
 

--- a/src/features/utils/instrument-base.js
+++ b/src/features/utils/instrument-base.js
@@ -128,7 +128,7 @@ export class InstrumentBase extends FeatureBase {
 
         this.featAggregate = new Aggregate(agentRef, argsObjFromInstrument)
 
-        agentRef.runtime.harvester.initializedAggregates.push(this.featAggregate) // "subscribe" the feature to future harvest intervals (PVE will start the timer)
+        agentRef.runtime.harvester.initializedAggregates.push(this.featAggregate) // "subscribe" the feature to future harvest intervals
         this.loadedSuccessfully(true)
       } catch (e) {
         warn(34, e)
@@ -137,8 +137,6 @@ export class InstrumentBase extends FeatureBase {
         drain(this.agentRef, this.featureName, true)
         this.loadedSuccessfully(false)
       }
-
-      agentRef.runtime.harvester.startTimer()
     }
 
     // For regular web pages, we want to wait and lazy-load the aggregator only after all page resources are loaded.
@@ -228,6 +226,14 @@ async function ensureRuntimeBootstrap (agentRef, ee, featureName) {
     ])
     agentRef.runtime.connector = new Connector(agentRef)
     agentRef.runtime.harvester = new Harvester(agentRef)
+
+    /* Only start the harvest timer (and its EOL 'visibilitychange' listener, see Harvester#startTimer) once every feature has
+    finished attempting to load its aggregate, so Harvester's listener always registers after any aggregate-level listeners
+    that need to run first (e.g. web-vitals' CWV APIs like onINP/onLCP, subscribed when the page_view_timing aggregate loads).
+    Deliberately not awaited here: every feature awaits this same bootstrap promise before attempting its OWN aggregate load,
+    so blocking on all features' `onAggregateImported` here would cause deadlock. */
+    Promise.all(Object.values(agentRef.features).map(feature => feature.onAggregateImported))
+      .then(() => agentRef.runtime.harvester.startTimer())
   })()
 
   runtimeBootstrapPromises.set(agentRef, bootstrapPromise)

--- a/src/loaders/agent.js
+++ b/src/loaders/agent.js
@@ -93,10 +93,11 @@ export class Agent extends AgentBase {
     try {
       const enabledFeatures = getEnabledFeatures(this.init)
       const featuresToStart = [...this.desiredFeatures]
+      const isRumV2Enabled = this.init.feature_flags.includes('rum_v2')
 
       featuresToStart.sort((a, b) => featurePriority[a.featureName] - featurePriority[b.featureName])
       featuresToStart.forEach(InstrumentCtor => {
-        if (!enabledFeatures[InstrumentCtor.featureName] && InstrumentCtor.featureName !== FEATURE_NAMES.pageViewEvent) return // PVE is required to run even if it's marked disabled
+        if (!enabledFeatures[InstrumentCtor.featureName] && (isRumV2Enabled || InstrumentCtor.featureName !== FEATURE_NAMES.pageViewEvent)) return // PVE is required to run even if it's marked disabled unless rum_v2 is enabled
 
         const dependencies = getFeatureDependencyNames(InstrumentCtor.featureName)
         const missingDependencies = dependencies.filter(featName => !(featName in this.features)) // any other feature(s) this depends on should've been initialized on prior iterations by priority order

--- a/src/loaders/api/consent.js
+++ b/src/loaders/api/consent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { prefix, CONSENT } from './constants'
@@ -23,7 +23,7 @@ export function setupConsentAPI (agent) {
       pveInst.onAggregateImported.then((loaded) => {
         const pveAgg = pveInst.featAggregate
         if (loaded && !pveAgg.sentRum) {
-          pveAgg.sendRum()
+          pveAgg.sendRum?.() // only the old v1 aggregate has a sendRum method that acts as a blocker for the rest of the agent; v2 aggregate will auto report when harvester becomes unblocked
         }
       })
     }

--- a/src/loaders/features/features.js
+++ b/src/loaders/features/features.js
@@ -8,6 +8,7 @@ export const EVENTS = 'events'
 export const JSERRORS = 'jserrors'
 export const BLOBS = 'browser/blobs'
 export const RUM = 'rum'
+export const CONNECT = 'connect'
 export const LOGS = 'browser/logs'
 
 export const FEATURE_NAMES = {

--- a/tests/assets/instrumented-rumv2.html
+++ b/tests/assets/instrumented-rumv2.html
@@ -6,13 +6,12 @@
 <html>
   <head>
     <title>RUM Unit Test</title>
+    {init} 
+    {config}
     <script>
-      window.NREUM||(NREUM={});
-      NREUM.init = {
-        browser_consent_mode: { enabled: true }
-      }
+      NREUM.init.feature_flags = ['rum_v2']
     </script>
-    {config} {loader}
+    {loader}
   </head>
   <body>Instrumented!</body>
 </html>

--- a/tests/components/harvester-eol-order.test.js
+++ b/tests/components/harvester-eol-order.test.js
@@ -1,0 +1,109 @@
+import { setupAgent, resetAgent } from './setup-agent'
+import { InstrumentBase } from '../../src/features/utils/instrument-base'
+import { FEATURE_NAMES } from '../../src/loaders/features/features'
+import { subscribeToVisibilityChange } from '../../src/common/window/page-visibility'
+
+/**
+ * Regression coverage for the INP-loss bug: Harvester's EOL harvest is triggered from a 'visibilitychange' listener,
+ * which races against any OTHER 'visibilitychange' listener registered by a feature's own aggregate (e.g. web-vitals'
+ * onINP, which -- unlike onCLS/onLCP -- only ever reports its value from within its own 'visibilitychange' listener,
+ * since our subscription doesn't set `reportAllChanges`). If Harvester's listener happened to run first and snapshot
+ * the buffer before that other listener added its data, the data is lost for good -- there's no second chance on a
+ * hard navigation.
+ *
+ * Harvester#startTimer fixes this by deferring the actual harvest work in its EOL callback to a microtask (see
+ * queueMicrotask there). Since 'visibilitychange' dispatch is fully synchronous -- every listener on `document` runs
+ * to completion in one call stack -- deferring only the harvest means it always runs after that whole synchronous
+ * dispatch settles, regardless of which listener happened to register first. This test proves that using a real
+ * (non-fake) 'visibilitychange' event, with a fast-resolving feature and a slow-resolving one (like page_view_timing's
+ * real aggregate chunk vs. a trivial one) so the registration order actually varies and isn't something the test
+ * controls -- the microtask deferral should keep the order correct regardless.
+ *
+ * This alone was confirmed (via real-browser testing, not this suite) to be enough to fix INP, but NOT enough to fix
+ * CLS -- page_view_timing's own CLS-flush listener additionally needed `capture: true` (see the comment at its
+ * `subscribeToVisibilityChange` call site) before its data reliably landed in the same final harvest as the rest.
+ * jsdom's simplified event dispatch does not reproduce whatever real-Chrome behavior made that flag necessary --
+ * both cases pass below regardless of capture -- so this suite validates the microtask deferral's logical guarantee
+ * (order-independence within a single dispatch), while the capture-phase requirement remains a real-browser-only
+ * finding that this automated suite can't independently verify.
+ */
+
+describe('Harvester EOL listener ordering', () => {
+  let agent
+  let addedListeners
+
+  beforeEach(() => {
+    // Neither the dummy aggregate's nor Harvester's own 'visibilitychange' listener can be unsubscribed through the
+    // public API, but jsdom's `document` persists across tests in this file -- without removing them, a prior test's
+    // listener leaks into the next dispatch. Capture every listener added during the test so it can be torn down.
+    addedListeners = []
+    jest.spyOn(document, 'addEventListener').mockImplementation((...args) => {
+      addedListeners.push(args)
+      return Document.prototype.addEventListener.apply(document, args)
+    })
+  })
+
+  afterEach(() => {
+    addedListeners.forEach(args => Document.prototype.removeEventListener.apply(document, args))
+    jest.restoreAllMocks()
+    if (agent) resetAgent(agent)
+    agent = undefined
+  })
+
+  test.each([
+    ['bubble phase (default)', false],
+    ['capture phase (matches page_view_timing\'s CLS listener)', true]
+  ])('fires after a %s visibilitychange listener registered by a slower-loading feature aggregate', async (_, capture) => {
+    const order = []
+
+    class FastAggregate {
+      constructor () {
+        this.harvestOpts = {} // Harvester's EOL callback reads this before triggering a harvest
+      }
+    }
+
+    class SlowAggregate {
+      constructor () {
+        this.harvestOpts = {}
+        // Mimics a feature aggregate that, like page_view_timing's web-vitals wiring, subscribes its own
+        // 'visibilitychange' listener as part of construction.
+        subscribeToVisibilityChange(() => order.push('aggregate'), false, capture)
+      }
+    }
+
+    agent = setupAgent({
+      init: {
+        [FEATURE_NAMES.ajax]: { autoStart: true },
+        [FEATURE_NAMES.pageViewTiming]: { autoStart: true }
+      }
+    })
+
+    const fastInstrument = new InstrumentBase(agent, FEATURE_NAMES.ajax)
+    const slowInstrument = new InstrumentBase(agent, FEATURE_NAMES.pageViewTiming)
+    agent.features[FEATURE_NAMES.ajax] = fastInstrument
+    agent.features[FEATURE_NAMES.pageViewTiming] = slowInstrument
+
+    // The fast feature's aggregate module resolves immediately; the slow one resolves only after a real async delay,
+    // mimicking a slower-loading chunk (e.g. page_view_timing's, which pulls in the web-vitals library).
+    fastInstrument.importAggregator(agent, () => Promise.resolve({ Aggregate: FastAggregate }))
+    slowInstrument.importAggregator(agent, () => new Promise(resolve => {
+      setTimeout(() => resolve({ Aggregate: SlowAggregate }), 20)
+    }))
+
+    // Let both features -- and the fire-and-forget `Promise.all(...).then(startTimer)` in ensureRuntimeBootstrap that
+    // depends on both -- fully settle before dispatching.
+    await Promise.all([fastInstrument.onAggregateImported, slowInstrument.onAggregateImported])
+    await new Promise(process.nextTick)
+    await new Promise(process.nextTick)
+
+    jest.spyOn(agent.runtime.harvester, 'triggerHarvestFor').mockImplementation(() => order.push('harvester'))
+
+    jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    document.dispatchEvent(new Event('visibilitychange'))
+    await null // Harvester's actual harvest work is deferred to a microtask -- see Harvester#startTimer
+
+    // triggerHarvestFor runs once per initialized aggregate (fast + slow); the key assertion is that 'aggregate' --
+    // the slow feature's own listener -- always precedes both.
+    expect(order).toEqual(['aggregate', 'harvester', 'harvester'])
+  })
+})

--- a/tests/components/harvester.test.js
+++ b/tests/components/harvester.test.js
@@ -2,6 +2,7 @@ import { setupAgent, resetAgent } from './setup-agent'
 import { InstrumentBase } from '../../src/features/utils/instrument-base'
 import { FEATURE_NAMES } from '../../src/loaders/features/features'
 import { subscribeToVisibilityChange } from '../../src/common/window/page-visibility'
+import { Harvester } from '../../src/common/harvest/harvester'
 
 /**
  * Regression coverage for the INP-loss bug: Harvester's EOL harvest is triggered from a 'visibilitychange' listener,
@@ -25,9 +26,9 @@ import { subscribeToVisibilityChange } from '../../src/common/window/page-visibi
  * jsdom's simplified event dispatch does not reproduce whatever real-Chrome behavior made that flag necessary --
  * both cases pass below regardless of capture -- so this suite validates the microtask deferral's logical guarantee
  * (order-independence within a single dispatch), while the capture-phase requirement remains a real-browser-only
- * finding that this automated suite can't independently verify.
+ * finding that this automated suite can't independently verify. See tests/specs/pvt/timings.e2e.js's "sends
+ * pageHide, CLS & INP together in a single EoL harvest" test for the real-browser coverage of both fixes together.
  */
-
 describe('Harvester EOL listener ordering', () => {
   let agent
   let addedListeners
@@ -105,5 +106,85 @@ describe('Harvester EOL listener ordering', () => {
     // triggerHarvestFor runs once per initialized aggregate (fast + slow); the key assertion is that 'aggregate' --
     // the slow feature's own listener -- always precedes both.
     expect(order).toEqual(['aggregate', 'harvester', 'harvester'])
+  })
+})
+
+/**
+ * Regression coverage for a deadlock risk in ensureRuntimeBootstrap (instrument-base.js): Harvester#startTimer is
+ * only called once every AUTO-STARTED feature's onAggregateImported has resolved. A feature configured
+ * autoStart: false never resolves onAggregateImported until the `start` API is called (see InstrumentBase's
+ * constructor and its `deferred` promise) -- if such a feature is simply never started, a naive
+ * `Promise.all(Object.values(agentRef.features).map(f => f.onAggregateImported))` would wait on it forever,
+ * which means startTimer() -- and therefore ALL harvesting, for every feature, not just the deferred one --
+ * would never run either.
+ *
+ * The fix filters that Promise.all down to only features present in agentRef.runtime.drainRegistry at the time
+ * ensureRuntimeBootstrap reads it. An auto-started feature registers itself there synchronously, in its
+ * InstrumentBase constructor, well before this bootstrap (deferred to window load) ever runs; a never-started
+ * autoStart: false feature does not register until `start` is actually called. So the registry already reflects
+ * exactly the auto-started set by the time it's read, and a feature that never starts is excluded rather than
+ * blocking the rest of the agent.
+ *
+ * (An earlier attempt fixed the deadlock by starting the timer unconditionally/immediately instead of gating on
+ * any features at all -- that was reverted because it broke real INP capture in
+ * tests/specs/pvt/timings.e2e.js's "FI, INP & LCP" test.)
+ */
+describe('Harvester#startTimer is not blocked by a never-started autoStart:false feature', () => {
+  let agent
+
+  afterEach(() => {
+    if (agent) resetAgent(agent)
+    agent = undefined
+  })
+
+  test('starts the timer once auto-started features finish loading, without waiting on a feature that never calls start()', async () => {
+    class TrivialAggregate {
+      constructor () {
+        this.harvestOpts = {}
+      }
+    }
+
+    // Deliberately NOT reusing FEATURE_NAMES.ajax/pageViewTiming (as the 'Harvester EOL listener ordering' describe
+    // above does): agentRef.runtime.drainRegistry is the SAME shared Map instance across every agent created in
+    // this file (mergeRuntime/RuntimeModel copies its default Map by reference, not a per-agent clone -- see
+    // src/common/config/runtime.js), and registerDrain's guard means an entry, once added, is never overwritten.
+    // The dummy aggregates above never call their own drain(), so 'ajax'/'page_view_timing' stay registered
+    // forever, which would make THIS test's own drainRegistry.has() check for either name a false positive
+    // regardless of run order. Picking two different real feature names (init only recognizes known feature
+    // keys, so these can't be made-up strings) sidesteps that entirely.
+    const autoStartFeatureName = FEATURE_NAMES.metrics
+    const neverStartedFeatureName = FEATURE_NAMES.genericEvents
+    agent = setupAgent({
+      init: {
+        [autoStartFeatureName]: { autoStart: true },
+        [neverStartedFeatureName]: { autoStart: false } // deliberately never started below
+      }
+    })
+
+    const autoStartedInstrument = new InstrumentBase(agent, autoStartFeatureName)
+    const neverStartedInstrument = new InstrumentBase(agent, neverStartedFeatureName)
+    agent.features[autoStartFeatureName] = autoStartedInstrument
+    agent.features[neverStartedFeatureName] = neverStartedInstrument
+
+    // Spy at the prototype level (mirrors setup-agent.js's approach for Connector/Harvester) since no instance
+    // exists yet -- agentRef.runtime.harvester is created asynchronously, inside ensureRuntimeBootstrap.
+    const startTimerSpy = jest.spyOn(Harvester.prototype, 'startTimer')
+
+    autoStartedInstrument.importAggregator(agent, () => Promise.resolve({ Aggregate: TrivialAggregate }))
+    neverStartedInstrument.importAggregator(agent, () => Promise.resolve({ Aggregate: TrivialAggregate }))
+
+    await autoStartedInstrument.onAggregateImported
+    // Let the fire-and-forget Promise.all(...).then(startTimer) chain in ensureRuntimeBootstrap settle.
+    await new Promise(process.nextTick)
+    await new Promise(process.nextTick)
+
+    expect(startTimerSpy).toHaveBeenCalled()
+
+    let neverStartedResolved = false
+    neverStartedInstrument.onAggregateImported.then(() => { neverStartedResolved = true })
+    await new Promise(process.nextTick)
+    expect(neverStartedResolved).toEqual(false)
+
+    startTimerSpy.mockRestore()
   })
 })

--- a/tests/components/page_view_event/aggregate.test.js
+++ b/tests/components/page_view_event/aggregate.test.js
@@ -1,5 +1,6 @@
 import { setupAgent } from '../setup-agent'
 import { Instrument as PageViewEvent } from '../../../src/features/page_view_event/instrument'
+import { setupAgentSession } from '../../../src/features/utils/agent-session'
 import * as sendModule from '../../../src/common/harvest/send'
 import { TextEncoder } from 'util'
 
@@ -208,6 +209,8 @@ describe('RUM call', () => {
     test('sets appMetadata from cached app without waiting for RUM call/response', async () => {
       const cachedApp = { agents: [{ entityGuid: 'cached-guid' }], nrServerTime: someServerTime }
       const agentWithCache = setupAgent()
+      // These tests seed a cached RUM response before the real bootstrap runs, so the session needs to exist upfront.
+      setupAgentSession(agentWithCache)
       agentWithCache.runtime.appMetadata = {}
       agentWithCache.runtime.session.state.cachedRumResponse = { app: cachedApp, ...featFlags }
 
@@ -220,6 +223,8 @@ describe('RUM call', () => {
     test('activates features immediately without waiting for RUM call/response', async () => {
       const cachedApp = { agents: [{ entityGuid: 'cached-guid' }], nrServerTime: someServerTime }
       const agentWithCache = setupAgent()
+      // These tests seed a cached RUM response before the real bootstrap runs, so the session needs to exist upfront.
+      setupAgentSession(agentWithCache)
       agentWithCache.runtime.session.state.cachedRumResponse = { app: cachedApp, ...featFlags }
 
       expect(agentWithCache.runtime.activatedFeatures).toBeUndefined()
@@ -294,6 +299,8 @@ describe('RUM call', () => {
     test('does not emit rumresp a second time when RUM call succeeds', async () => {
       const cachedApp = { agents: [{ entityGuid: 'test-guid' }], nrServerTime: someServerTime }
       const agentWithCache = setupAgent()
+      // These tests seed a cached RUM response before the real bootstrap runs, so the session needs to exist upfront.
+      setupAgentSession(agentWithCache)
       agentWithCache.info.errorBeacon = 'fake-beacon'
       agentWithCache.runtime.session.state.cachedRumResponse = { app: cachedApp, ...featFlags }
 

--- a/tests/components/page_view_event/aggregate.test.js
+++ b/tests/components/page_view_event/aggregate.test.js
@@ -24,9 +24,7 @@ test('PageViewEvent does not throw on Harvester driven processes', () => {
   expect(mainAgent.runtime.harvester.triggerHarvestFor(pveAggregate, { isFinalHarvest: true }).ranSend).toEqual(false) // mimics what the harvester does on EoL
 
   pveAggregate.events.add(undefined) // ensure request even if sendRum() puts empty body into buffer
-  expect(mainAgent.runtime.harvester.triggerHarvestFor(pveAggregate, {
-    sendEmptyBody: true
-  }).ranSend).toEqual(true) // mimics the manual trigger in PVE `sendRum`; this should return true as it actually tries to "send"
+  expect(mainAgent.runtime.harvester.triggerHarvestFor(pveAggregate).ranSend).toEqual(true) // mimics the manual trigger in PVE `sendRum`; this should return true as it actually tries to "send"
 })
 
 test('PageViewEvent reports SM on invalid timestamp', () => {

--- a/tests/components/page_view_event/aggregate_v2.test.js
+++ b/tests/components/page_view_event/aggregate_v2.test.js
@@ -1,6 +1,7 @@
 import { setupAgent } from '../setup-agent'
 import { Instrument as PageViewEvent } from '../../../src/features/page_view_event/instrument'
 import * as sendModule from '../../../src/common/harvest/send'
+import { CONNECT } from '../../../src/loaders/features/features'
 
 describe('PageViewEvent aggregate v2', () => {
   test('uses harvest endpoint version 2', async () => {
@@ -69,7 +70,7 @@ describe('PageViewEvent aggregate v2', () => {
     await new Promise(process.nextTick)
     const pveAggregate = pveInst.featAggregate
 
-    const connectCall = sendSpy.mock.calls.find(call => call[1].featureName === 'connect')
+    const connectCall = sendSpy.mock.calls.find(call => call[1].featureName === CONNECT)
     connectCall[1].cbFinished({
       sent: true,
       status: 200,
@@ -106,7 +107,7 @@ describe('PageViewEvent aggregate v2', () => {
     await new Promise(process.nextTick)
     const pveAggregate = pveInst.featAggregate
 
-    const connectCall = sendSpy.mock.calls.find(call => call[1].featureName === 'connect')
+    const connectCall = sendSpy.mock.calls.find(call => call[1].featureName === CONNECT)
     connectCall[1].cbFinished({
       sent: true,
       status: 200,

--- a/tests/components/page_view_event/aggregate_v2.test.js
+++ b/tests/components/page_view_event/aggregate_v2.test.js
@@ -1,0 +1,87 @@
+import { setupAgent } from '../setup-agent'
+import { Instrument as PageViewEvent } from '../../../src/features/page_view_event/instrument'
+import * as sendModule from '../../../src/common/harvest/send'
+
+describe('PageViewEvent aggregate v2', () => {
+  test('uses harvest endpoint version 2', async () => {
+    const agent = setupAgent({
+      init: { feature_flags: ['rum_v2'] },
+      runtime: {
+        activatedFeatures: {},
+        connector: {}
+      }
+    })
+
+    const pveInst = new PageViewEvent(agent)
+    await new Promise(process.nextTick)
+
+    expect(pveInst.featAggregate.harvestEndpointVersion).toEqual(2)
+  })
+
+  test('only sends once consent is granted and harvester runs', async () => {
+    const sendSpy = jest.spyOn(sendModule, 'send').mockImplementation(() => true)
+
+    const agent = setupAgent({
+      init: {
+        feature_flags: ['rum_v2'],
+        browser_consent_mode: { enabled: true }
+      },
+      runtime: {
+        activatedFeatures: {},
+        connector: {},
+        consented: false
+      }
+    })
+    agent.info.errorBeacon = 'fake-beacon'
+
+    const pveInst = new PageViewEvent(agent)
+    await new Promise(process.nextTick)
+    const pveAggregate = pveInst.featAggregate
+
+    // Ensure there is payload ready before we trigger harvest checks.
+    pveAggregate.events.add({ ja: {} })
+
+    expect(agent.runtime.harvester.triggerHarvestFor(pveAggregate).ranSend).toEqual(false)
+    expect(sendSpy).not.toHaveBeenCalled()
+
+    agent.runtime.consented = true
+
+    expect(agent.runtime.harvester.triggerHarvestFor(pveAggregate).ranSend).toEqual(true)
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+
+    sendSpy.mockRestore()
+  })
+
+  test('builds query timestamp from corrected origin time', async () => {
+    const agent = setupAgent({
+      init: { feature_flags: ['rum_v2'] },
+      runtime: {
+        activatedFeatures: {},
+        connector: {}
+      }
+    })
+
+    const pveInst = new PageViewEvent(agent)
+    await new Promise(process.nextTick)
+    const pveAggregate = pveInst.featAggregate
+
+    const query = pveAggregate.queryStringsBuilder()
+    expect(query.timestamp).toEqual(agent.runtime.timeKeeper.correctedOriginTime)
+  })
+
+  test('serializes only the first buffered payload entry', async () => {
+    const agent = setupAgent({
+      init: { feature_flags: ['rum_v2'] },
+      runtime: {
+        activatedFeatures: {},
+        connector: {}
+      }
+    })
+
+    const pveInst = new PageViewEvent(agent)
+    await new Promise(process.nextTick)
+    const pveAggregate = pveInst.featAggregate
+
+    expect(pveAggregate.serializer([{ ja: { a: 1 } }, { ja: { b: 2 } }])).toEqual({ ja: { a: 1 } })
+  })
+})

--- a/tests/components/page_view_event/aggregate_v2.test.js
+++ b/tests/components/page_view_event/aggregate_v2.test.js
@@ -53,6 +53,82 @@ describe('PageViewEvent aggregate v2', () => {
     sendSpy.mockRestore()
   })
 
+  test('forwards igp from the connect response as a query param on the v2 PageView harvest', async () => {
+    const sendSpy = jest.spyOn(sendModule, 'send').mockImplementation(() => true)
+
+    const agent = setupAgent({
+      init: { feature_flags: ['rum_v2'] },
+      runtime: {
+        activatedFeatures: {},
+        appMetadata: {} // clear setupAgent's default so Connector's guard actually applies the connect response below
+      }
+    })
+    agent.info.errorBeacon = 'fake-beacon'
+
+    const pveInst = new PageViewEvent(agent)
+    await new Promise(process.nextTick)
+    const pveAggregate = pveInst.featAggregate
+
+    const connectCall = sendSpy.mock.calls.find(call => call[1].featureName === 'connect')
+    connectCall[1].cbFinished({
+      sent: true,
+      status: 200,
+      retry: false,
+      xhr: { status: 200 },
+      responseText: JSON.stringify({
+        app: { agents: [{ entityGuid: 'guid' }], nrServerTime: Date.now(), igp: 'opaque-igp-token' },
+        config: {}
+      })
+    })
+
+    expect(pveAggregate.queryStringsBuilder().igp).toEqual('opaque-igp-token')
+
+    sendSpy.mockRestore()
+  })
+
+  test('outgoing v2 PageView harvest XHR URL includes the igp forwarded from connect', async () => {
+    // Let `send()` run for real so it builds the actual URL; only stub the actual network dispatch (`.send()`).
+    // `.open()` is left to run for real -- jsdom's XHR requires it to have actually run before `setRequestHeader` is called.
+    const openSpy = jest.spyOn(XMLHttpRequest.prototype, 'open')
+    jest.spyOn(XMLHttpRequest.prototype, 'send').mockImplementation(() => {})
+    const sendSpy = jest.spyOn(sendModule, 'send')
+
+    const agent = setupAgent({
+      init: { feature_flags: ['rum_v2'] },
+      runtime: {
+        activatedFeatures: {},
+        appMetadata: {} // clear setupAgent's default so Connector's guard actually applies the connect response below
+      }
+    })
+    agent.info.errorBeacon = 'fake-beacon'
+
+    const pveInst = new PageViewEvent(agent)
+    await new Promise(process.nextTick)
+    const pveAggregate = pveInst.featAggregate
+
+    const connectCall = sendSpy.mock.calls.find(call => call[1].featureName === 'connect')
+    connectCall[1].cbFinished({
+      sent: true,
+      status: 200,
+      retry: false,
+      xhr: { status: 200 },
+      responseText: JSON.stringify({
+        app: { agents: [{ entityGuid: 'guid' }], nrServerTime: Date.now(), igp: 'opaque-igp-token' },
+        config: {}
+      })
+    })
+
+    pveAggregate.events.add({ ja: {} })
+    agent.runtime.harvester.triggerHarvestFor(pveAggregate)
+
+    const harvestUrl = openSpy.mock.calls.map(call => call[1]).find(url => url.includes('/rum/2/'))
+    expect(harvestUrl).toContain('igp=opaque-igp-token')
+
+    openSpy.mockRestore()
+    XMLHttpRequest.prototype.send.mockRestore()
+    sendSpy.mockRestore()
+  })
+
   test('builds query timestamp from corrected origin time', async () => {
     const agent = setupAgent({
       init: { feature_flags: ['rum_v2'] },

--- a/tests/components/page_view_event/aggregate_v2.test.js
+++ b/tests/components/page_view_event/aggregate_v2.test.js
@@ -7,8 +7,7 @@ describe('PageViewEvent aggregate v2', () => {
     const agent = setupAgent({
       init: { feature_flags: ['rum_v2'] },
       runtime: {
-        activatedFeatures: {},
-        connector: {}
+        activatedFeatures: {}
       }
     })
 
@@ -18,7 +17,7 @@ describe('PageViewEvent aggregate v2', () => {
     expect(pveInst.featAggregate.harvestEndpointVersion).toEqual(2)
   })
 
-  test('only sends once consent is granted and harvester runs', async () => {
+  test('only sends telemetry once consent is granted and harvester runs', async () => {
     const sendSpy = jest.spyOn(sendModule, 'send').mockImplementation(() => true)
 
     const agent = setupAgent({
@@ -28,7 +27,6 @@ describe('PageViewEvent aggregate v2', () => {
       },
       runtime: {
         activatedFeatures: {},
-        connector: {},
         consented: false
       }
     })
@@ -40,6 +38,9 @@ describe('PageViewEvent aggregate v2', () => {
 
     // Ensure there is payload ready before we trigger harvest checks.
     pveAggregate.events.add({ ja: {} })
+
+    // The rum_v2 Connector fires its own connect request during bootstrap; only the harvest calls below are under test.
+    sendSpy.mockClear()
 
     expect(agent.runtime.harvester.triggerHarvestFor(pveAggregate).ranSend).toEqual(false)
     expect(sendSpy).not.toHaveBeenCalled()
@@ -56,8 +57,7 @@ describe('PageViewEvent aggregate v2', () => {
     const agent = setupAgent({
       init: { feature_flags: ['rum_v2'] },
       runtime: {
-        activatedFeatures: {},
-        connector: {}
+        activatedFeatures: {}
       }
     })
 
@@ -73,8 +73,7 @@ describe('PageViewEvent aggregate v2', () => {
     const agent = setupAgent({
       init: { feature_flags: ['rum_v2'] },
       runtime: {
-        activatedFeatures: {},
-        connector: {}
+        activatedFeatures: {}
       }
     })
 

--- a/tests/components/session_replay/instrument.test.js
+++ b/tests/components/session_replay/instrument.test.js
@@ -5,12 +5,17 @@ import { getAppSessionHash } from '../../../src/common/session/session-key'
 import { SESSION_STORAGE_KEY_PREFIX } from '../../../src/common/session/constants'
 import { MODE } from '../../specs/util/helpers'
 
-let mainAgent, savedInitialSession
-
-beforeAll(() => {
-  mainAgent = setupAgent({
+/**
+ * Creates a never-bootstrapped agent, distinct from the shared `mainAgent` below. Some tests need the
+ * SessionReplay runtime bootstrap (session setup + Connector/Harvester creation) to actually run so they can
+ * observe or interfere with it -- `mainAgent`'s bootstrap is cached after the first real Instrument in this
+ * file uses it, so reusing it can't simulate "session doesn't exist/fails to init yet".
+ * @param {object} sessionReplayInit - value for `init.session_replay`
+ */
+function setupFreshAgent (sessionReplayInit) {
+  return setupAgent({
     init: {
-      session_replay: { preload: false, enabled: true }
+      session_replay: sessionReplayInit
     },
     runtime: {
       timeKeeper: {
@@ -18,14 +23,15 @@ beforeAll(() => {
       }
     }
   })
-  jest.spyOn(mainAgent.runtime.harvester, 'triggerHarvestFor').mockImplementation(() => Promise.resolve())
-  savedInitialSession = mainAgent.runtime.session
+}
+
+let mainAgent
+
+beforeAll(() => {
+  mainAgent = setupFreshAgent({ preload: false, enabled: true })
 })
 
 afterEach(() => {
-  if (!mainAgent.runtime.session) {
-    mainAgent.runtime.session = savedInitialSession
-  }
   if (jest.mocked(nreumModule.gosNREUMOriginals).mock) {
     jest.mocked(nreumModule.gosNREUMOriginals).mockRestore()
   }
@@ -90,21 +96,28 @@ describe('Replay', () => { // this is moreso a test of the SR-specific logic wit
 })
 
 describe('Preload early records', () => {
+  let localAgent
+
   beforeEach(() => {
     localStorage.clear()
     mainAgent.init.privacy.cookies_enabled = true
     mainAgent.init.session_trace.enabled = true
   })
 
-  test('with flag enabled and if session dne yet', async () => {
-    mainAgent.runtime.session = undefined
-    Object.assign(mainAgent.init.session_replay, { preload: true, enabled: true })
+  afterEach(() => {
+    if (localAgent) resetAgent(localAgent)
+    localAgent = undefined
+  })
 
-    const sessionReplayInstrument = new SessionReplay(mainAgent)
+  test('with flag enabled and if session dne yet', async () => {
+    localAgent = setupFreshAgent({ preload: true, enabled: true })
+    localAgent.runtime.session = undefined
+
+    const sessionReplayInstrument = new SessionReplay(localAgent)
     await new Promise(process.nextTick)
 
     expect(sessionReplayInstrument.recorder).toBeDefined()
-    expect(mainAgent.runtime.isRecording).toEqual(true)
+    expect(localAgent.runtime.isRecording).toEqual(true)
   })
 
   test('when replay already on in existing session, even if preload flag disabled', async () => {
@@ -119,19 +132,19 @@ describe('Preload early records', () => {
   })
 
   test('when replay already on in namespaced localStorage session, even if preload flag disabled', async () => {
-    const namespacedKey = `${SESSION_STORAGE_KEY_PREFIX}${getAppSessionHash(mainAgent.info.licenseKey, mainAgent.info.applicationID)}`
+    localAgent = setupFreshAgent({ preload: false, enabled: true })
+    const namespacedKey = `${SESSION_STORAGE_KEY_PREFIX}${getAppSessionHash(localAgent.info.licenseKey, localAgent.info.applicationID)}`
     localStorage.setItem(namespacedKey, JSON.stringify({ sessionReplayMode: MODE.FULL }))
-    mainAgent.runtime.session = undefined
-    Object.assign(mainAgent.init.session_replay, { preload: false, enabled: true })
+    localAgent.runtime.session = undefined
 
-    const sessionReplayInstrument = new SessionReplay(mainAgent)
+    const sessionReplayInstrument = new SessionReplay(localAgent)
     await new Promise(process.nextTick)
 
     expect(sessionReplayInstrument.recorder).toBeDefined()
-    expect(mainAgent.runtime.isRecording).toEqual(true)
+    expect(localAgent.runtime.isRecording).toEqual(true)
   })
 
-  test('when replay already on in existing session, even if flag enabled but a pre-req is not', async () => {
+  test('stops preload recording if replay was already on in existing session but a pre-req is not met', async () => {
     mainAgent.init.privacy.cookies_enabled = false
     Object.assign(mainAgent.init.session_replay, { preload: false, enabled: true })
     mainAgent.runtime.session.write({ sessionReplayMode: MODE.FULL })
@@ -140,7 +153,8 @@ describe('Preload early records', () => {
     await new Promise(process.nextTick)
 
     expect(sessionReplayInstrument.recorder).toBeDefined()
-    expect(mainAgent.runtime.isRecording).toEqual(true)
+    // shouldImportAgg is false here (missing prerequisite), which now always stops any preload recording.
+    expect(mainAgent.runtime.isRecording).toEqual(false)
   })
 
   test('if replay is off in existing session, but all required flags are enabled', async () => {
@@ -160,18 +174,31 @@ describe('Preload recording stops if', () => {
     Object.assign(mainAgent.init.session_replay, { preload: true, enabled: true })
   })
 
+  // The first test below needs its own fresh agent (rather than the shared `mainAgent`) because the runtime
+  // bootstrap (session setup + Connector/Harvester creation) only ever runs once per agent -- reusing
+  // `mainAgent` would skip session setup entirely since it already succeeded in the tests above, so the
+  // mocked `setupAgentSession` throw would never actually run.
+  let localAgent
+
+  afterEach(() => {
+    if (localAgent) resetAgent(localAgent)
+    localAgent = undefined
+    jest.clearAllMocks()
+  })
+
   test('session entity fails to initialize', async () => {
     jest.doMock('../../../src/features/utils/agent-session', () => ({
       __esModule: true,
       setupAgentSession: jest.fn(() => { throw new Error('RIP') })
     }))
-    mainAgent.runtime.session = undefined
+    localAgent = setupFreshAgent({ preload: true, enabled: true })
+    localAgent.runtime.session = undefined
 
-    const sessionReplayInstrument = new SessionReplay(mainAgent)
+    const sessionReplayInstrument = new SessionReplay(localAgent)
     await new Promise(process.nextTick)
 
     expect(sessionReplayInstrument.recorder).toBeDefined()
-    expect(mainAgent.runtime.isRecording).toEqual(false)
+    expect(localAgent.runtime.isRecording).toEqual(false)
   })
 
   test('replay aggregate fails to initialize', async () => {
@@ -180,6 +207,7 @@ describe('Preload recording stops if', () => {
       setupAgentSession: jest.fn(() => { throw new Error('RIP') })
     }))
 
+    // This scenario doesn't need a fresh bootstrap (session setup already succeeded), so it can reuse `mainAgent`.
     const sessionReplayInstrument = new SessionReplay(mainAgent)
     await new Promise(process.nextTick)
 

--- a/tests/components/setup-agent.js
+++ b/tests/components/setup-agent.js
@@ -3,10 +3,9 @@ import { setNREUMInitializedAgent } from '../../src/common/window/nreum'
 import { configure } from '../../src/loaders/configure/configure'
 import { ee } from '../../src/common/event-emitter/contextual-ee'
 import { TimeKeeper } from '../../src/common/timing/time-keeper'
-import { setupAgentSession } from '../../src/features/utils/agent-session'
+import { Connector } from '../../src/common/harvest/connector'
 import { Harvester } from '../../src/common/harvest/harvester'
 import { EventAggregator } from '../../src/common/aggregate/event-aggregator'
-import { canEnableSessionTracking } from '../../src/features/utils/feature-gates'
 
 const entityGuid = faker.string.uuid()
 
@@ -52,19 +51,32 @@ export function setupAgent ({ agentOverrides = {}, info = {}, init = {}, loaderC
     'browser-test',
     true
   )
-  if (canEnableSessionTracking(fakeAgent.init)) {
-    setupAgentSession(fakeAgent)
-  }
+  /* Deliberately does NOT set up `runtime.session`/`runtime.connector`/`runtime.harvester` here: the real
+  runtime bootstrap (`ensureRuntimeBootstrap` in instrument-base.js) creates all three exactly once, the
+  first time any feature's own `importAggregator` runs for this agent. Every caller of `setupAgent()`
+  constructs a real Instrument before touching those properties, so pre-creating them here would just be
+  guessing at values the real bootstrap is about to replace anyway. */
 
+  /* TimeKeeper is the one exception: it's normally created either by the rum_v2 Connector or by the v1 PVE
+  aggregate (see src/features/page_view_event/aggregate/index.js), so tests for any OTHER feature never
+  get one "for free" -- they need this fallback. */
   if (!fakeAgent.runtime.timeKeeper) {
     fakeAgent.runtime.timeKeeper = new TimeKeeper(fakeAgent.runtime.session)
     fakeAgent.runtime.timeKeeper.processRumRequest({}, 450, 600, Date.now())
   }
   fakeAgent.features = {}
-  if (!fakeAgent.runtime.harvester) fakeAgent.runtime.harvester = new Harvester(fakeAgent)
   fakeAgent.sharedAggregator = new EventAggregator()
 
-  jest.spyOn(fakeAgent.runtime.harvester, 'triggerHarvestFor')
+  // Spy at the prototype level (rather than on an instance) for both classes, since no instance may exist
+  // yet -- a prototype spy tracks calls on whichever instance `ensureRuntimeBootstrap` eventually creates.
+  // Skip a class whose module is jest.mock()'d (automock assigns mocked methods per-instance, not on the
+  // prototype), in which case every new instance already gets its own working jest.fn() for that method.
+  if (typeof Connector.prototype.makeConnectRequest === 'function') {
+    jest.spyOn(Connector.prototype, 'makeConnectRequest')
+  }
+  if (typeof Harvester.prototype.triggerHarvestFor === 'function') {
+    jest.spyOn(Harvester.prototype, 'triggerHarvestFor')
+  }
 
   return fakeAgent
 }
@@ -98,5 +110,5 @@ function resetAggregator (agentRef) {
 }
 
 function resetSession (agentRef) {
-  agentRef.runtime.session.reset()
+  agentRef.runtime.session?.reset()
 }

--- a/tests/components/soft_navigations/aggregate.test.js
+++ b/tests/components/soft_navigations/aggregate.test.js
@@ -1,5 +1,6 @@
 import { resetAgent, setupAgent } from '../setup-agent'
 import { Instrument as SoftNav } from '../../../src/features/soft_navigations/instrument'
+import { Harvester } from '../../../src/common/harvest/harvester'
 import * as loadTimeModule from '../../../src/common/vitals/load-time'
 import { INTERACTION_STATUS, NO_LONG_TASK_WINDOW, POPSTATE_MERGE_WINDOW, POPSTATE_TRIGGER } from '../../../src/features/soft_navigations/constants'
 
@@ -11,11 +12,11 @@ beforeAll(() => {
       soft_navigations: { enabled: true }
     }
   })
-  mainAgent.runtime.harvester = {
-    triggerHarvestFor: jest.fn(),
-    startTimer: jest.fn(),
-    initializedAggregates: []
-  }
+  // The agent's real bootstrap flow (ensureRuntimeBootstrap) always replaces `runtime.harvester` with a fresh
+  // Harvester once a feature imports its aggregate, so stub out its behavior at the prototype level instead of
+  // assigning a plain object here (which would just get discarded).
+  jest.spyOn(Harvester.prototype, 'triggerHarvestFor').mockImplementation(() => ({ ranSend: false }))
+  jest.spyOn(Harvester.prototype, 'startTimer').mockImplementation(() => {})
 })
 
 let softNavAggregate

--- a/tests/components/soft_navigations/aggregate.test.js
+++ b/tests/components/soft_navigations/aggregate.test.js
@@ -13,6 +13,7 @@ beforeAll(() => {
   })
   mainAgent.runtime.harvester = {
     triggerHarvestFor: jest.fn(),
+    startTimer: jest.fn(),
     initializedAggregates: []
   }
 })

--- a/tests/specs/connector/index.e2e.js
+++ b/tests/specs/connector/index.e2e.js
@@ -1,0 +1,216 @@
+import { testConnectRequest, testMetricsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
+
+const rumV2Config = { init: { feature_flags: ['rum_v2'] } }
+
+// A custom connect matcher that excludes CORS preflight (OPTIONS) requests. The retry tests below add a
+// non-simple header, which triggers a preflight to the same /connect/2/:testId path -- with the path-only
+// testConnectRequest matcher, that preflight would either be miscounted as an extra connect attempt in a
+// capture, OR (worse, for scheduleReply) get hijacked into returning the SCHEDULED FAILURE status itself,
+// which fails the preflight and silently blocks the real retry POST from ever being sent. So this matcher is
+// used for both capturing AND scheduling replies in any test here that involves a retry. Test-handle serializes
+// `test` functions across a process boundary (see expect-tests.js), so this must stay self-contained rather
+// than delegating to the imported matcher.
+function testConnectPostRequest (request) {
+  const url = new URL(request.url, 'resolve://')
+  return url.pathname === `/connect/2/${this.testId}` && request.method === 'POST'
+}
+
+describe('Connector (rum_v2 browser connect)', () => {
+  afterEach(async () => {
+    await browser.testHandle.clearScheduledReplies('bamServer')
+    await browser.destroyAgentSession()
+  })
+
+  it('sends a connect request, activates features from its response, and feeds its igp token to the v2 page view harvest', async () => {
+    const [connectCapture, rumCapture, metricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testConnectRequest },
+      { test: testRumRequest }, // under rum_v2, page_view_event's aggregate_v2 still delivers over /rum/2/ -- but via the normal harvester cycle (harvestEndpointVersion 2), not a special immediate RUM call like v1
+      { test: testMetricsRequest }
+    ])
+
+    const [[connectHarvest]] = await Promise.all([
+      connectCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', rumV2Config))
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    expect(connectHarvest.request.query.a).toBeTruthy() // applicationID
+    expect(connectHarvest.request.query.v).toBeTruthy() // agent version
+    expect(connectHarvest.request.query.s).toBeTruthy() // session ID
+    expect(connectHarvest.reply.statusCode).toEqual(200)
+    const connectReplyBody = JSON.parse(connectHarvest.reply.body)
+    expect(connectReplyBody).toEqual(expect.objectContaining({
+      config: expect.objectContaining({
+        err: expect.any(Number),
+        ins: expect.any(Number),
+        spa: expect.any(Number),
+        sr: expect.any(Number),
+        srs: expect.any(Number),
+        st: expect.any(Number),
+        sts: expect.any(Number)
+      }),
+      app: expect.objectContaining({
+        agents: expect.arrayContaining([expect.objectContaining({ entityGuid: expect.any(String) })]),
+        nrServerTime: expect.any(Number),
+        igp: expect.any(String)
+      })
+    }))
+
+    // activateFeatures having run is what let waitForAgentLoad above resolve; the harvester should also now be
+    // running as a result, so a normal feature (metrics) harvest still goes out on the final (unload) harvest.
+    const [metricsHarvests, rumHarvests] = await Promise.all([
+      metricsCapture.waitForResult({ timeout: 10000 }),
+      rumCapture.waitForResult({ timeout: 10000 }),
+      browser.url(await browser.testHandle.assetURL('/'))
+    ])
+    expect(metricsHarvests[0].request.body.sm.length).toBeGreaterThan(0)
+
+    // page_view_event's v2 aggregate reads the igp token straight off Connector's applied appMetadata -- proving
+    // the two features are actually wired together through the bootstrap, not just independently functional.
+    expect(rumHarvests[0].request.query.igp).toEqual(connectReplyBody.app.igp)
+  })
+
+  it('reuses the cached connect response on a later navigation within the same session instead of connecting again', async () => {
+    const connectCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testConnectRequest })
+
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', rumV2Config))
+      .then(() => browser.waitForAgentLoad())
+
+    const [firstConnectHarvest] = await connectCapture.waitForResult({ totalCount: 1 })
+
+    const cachedBeforeNav = await browser.execute(function () {
+      return Object.values(newrelic.initializedAgents)[0].runtime.session.state.cachedRumResponse
+    })
+    expect(cachedBeforeNav).toEqual(expect.objectContaining({ config: expect.any(Object) }))
+
+    // Reload within the SAME session (localStorage persists across a refresh by default)
+    await browser.refresh()
+      .then(() => browser.waitForAgentLoad())
+
+    // Give a would-be second connect request a chance to land, then confirm it never did.
+    const allConnectHarvests = await connectCapture.waitForResult({ timeout: 3000 })
+    expect(allConnectHarvests.length).toEqual(1)
+    expect(allConnectHarvests[0]).toEqual(firstConnectHarvest)
+
+    const activatedAfterNav = await browser.execute(function () {
+      return !!Object.values(newrelic.initializedAgents)[0].runtime.activatedFeatures
+    })
+    expect(activatedAfterNav).toEqual(true)
+  })
+
+  it('retries a retryable connect failure twice, with correctly incrementing headers, before eventually succeeding', async () => {
+    // Use a POST-only matcher: each retry attempt below adds a non-simple header, which triggers a CORS
+    // preflight OPTIONS request to the same path that would otherwise be miscounted as extra connect attempts.
+    const connectCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testConnectPostRequest })
+    // Scheduled replies are consumed in the order they were added (one per matching request, see
+    // TestHandle#processRequest), so these two queue up and fail the first two attempts; the third goes through
+    // to the real handler and succeeds. The second failure uses a DIFFERENT retryable status (502, not 500) than
+    // the first, so the X-Previous-Status assertion below is proving it reflects the immediately preceding
+    // attempt's actual status rather than happening to match because both failures used the same code.
+    await browser.testHandle.scheduleReply('bamServer', { test: testConnectPostRequest, statusCode: 500, body: '', permanent: false })
+    await browser.testHandle.scheduleReply('bamServer', { test: testConnectPostRequest, statusCode: 502, body: '', permanent: false })
+
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', rumV2Config))
+
+    // Two backoff rounds (up to ~3s then ~6s, see CONNECT_RETRY_BASE_MS in connector.js) can push this well past
+    // waitForAgentLoad's fixed 30s cap, so wait directly on the connect capture with a more generous budget instead.
+    const connectHarvests = await connectCapture.waitForResult({ totalCount: 3, timeout: 25000 })
+
+    expect(connectHarvests[0].reply.statusCode).toEqual(500)
+    expect(connectHarvests[0].request.headers['x-retry-count']).toBeUndefined() // the initial attempt carries no retry headers
+
+    expect(connectHarvests[1].reply.statusCode).toEqual(502)
+    expect(connectHarvests[1].request.headers['x-retry-count']).toEqual('1')
+    expect(connectHarvests[1].request.headers['x-previous-status']).toEqual('500')
+
+    expect(connectHarvests[2].reply.statusCode).toEqual(200)
+    expect(connectHarvests[2].request.headers['x-retry-count']).toEqual('2')
+    expect(connectHarvests[2].request.headers['x-previous-status']).toEqual('502')
+
+    // Confirm nothing beyond the 3 attempts that were actually needed ever went out.
+    const settledConnectHarvests = await connectCapture.waitForResult({ timeout: 3000 })
+    expect(settledConnectHarvests.length).toEqual(3)
+
+    const activated = await browser.waitUntil(
+      () => browser.execute(function () {
+        return !!Object.values(newrelic.initializedAgents)[0].runtime.activatedFeatures
+      }),
+      { timeout: 5000, timeoutMsg: 'features never activated after connect eventually succeeded' }
+    )
+    expect(activated).toEqual(true)
+  })
+
+  it('gives up after exhausting the max retry attempts (3) and aborts, without ever attempting a 4th connect call', async () => {
+    const connectCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testConnectPostRequest })
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testConnectPostRequest,
+      statusCode: 500,
+      body: '',
+      permanent: true // every attempt fails; there's no 4th attempt to consume this after the 3rd anyway
+    })
+
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', rumV2Config))
+      .then(() => browser.waitUntil(
+        () => browser.execute(function () {
+          return Object.values(newrelic.initializedAgents)[0]?.ee.aborted
+        }),
+        { timeout: 20000, timeoutMsg: 'agent never aborted after exhausting connect retries' }
+      ))
+
+    // MAX_CONNECT_ATTEMPTS is 3 in connector.js: the initial attempt plus retries at numOfAttempts 1 and 2. The
+    // 3rd failure increments numOfAttempts to 3, which fails the `< MAX_CONNECT_ATTEMPTS` check, so no 3rd retry
+    // (4th network call) is ever made -- it falls through to the same hard-failure/abort path as a 4xx.
+    const connectHarvests = await connectCapture.waitForResult({ timeout: 15000 })
+    expect(connectHarvests.length).toEqual(3)
+    connectHarvests.forEach(harvest => expect(harvest.reply.statusCode).toEqual(500))
+    expect(connectHarvests[1].request.headers['x-retry-count']).toEqual('1')
+    expect(connectHarvests[2].request.headers['x-retry-count']).toEqual('2')
+
+    // Give a would-be 4th attempt a chance to land, then confirm it never did.
+    const settledConnectHarvests = await connectCapture.waitForResult({ timeout: 5000 })
+    expect(settledConnectHarvests.length).toEqual(3)
+
+    const activated = await browser.execute(function () {
+      return !!Object.values(newrelic.initializedAgents)[0].runtime.activatedFeatures
+    })
+    expect(activated).toEqual(false)
+  })
+
+  it('aborts the agent and stops all further harvesting when the connect request fails with a non-retryable status (400)', async () => {
+    const [connectCapture, metricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testConnectRequest },
+      { test: testMetricsRequest }
+    ])
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testConnectRequest,
+      statusCode: 400,
+      body: '',
+      permanent: true
+    })
+
+    await browser.url(await browser.testHandle.assetURL('instrumented.html', rumV2Config))
+      .then(() => browser.waitUntil(
+        () => browser.execute(function () {
+          return Object.values(newrelic.initializedAgents)[0]?.ee.aborted
+        }),
+        { timeout: 15000, timeoutMsg: 'agent never aborted after failed connect' }
+      ))
+
+    const connectHarvests = await connectCapture.waitForResult({ timeout: 3000 })
+    expect(connectHarvests.length).toEqual(1)
+    expect(connectHarvests[0].reply.statusCode).toEqual(400)
+
+    const activated = await browser.execute(function () {
+      return !!Object.values(newrelic.initializedAgents)[0].runtime.activatedFeatures
+    })
+    expect(activated).toEqual(false)
+
+    // Only the BCS-error supportability metrics (sent directly by Connector, bypassing the harvester) should go
+    // out; the metrics feature itself was never activated, so its normal harvester-driven harvest never fires.
+    const metricsHarvests = await metricsCapture.waitForResult({ timeout: 3000 })
+    expect(metricsHarvests.length).toEqual(1)
+    expect(metricsHarvests[0].request.body.sm).toEqual(expect.arrayContaining([
+      expect.objectContaining({ params: expect.objectContaining({ name: 'BCS/Error/400' }) })
+    ]))
+  })
+})

--- a/tests/specs/connector/index.e2e.js
+++ b/tests/specs/connector/index.e2e.js
@@ -3,16 +3,16 @@ import { testConnectRequest, testMetricsRequest, testRumRequest } from '../../..
 const rumV2Config = { init: { feature_flags: ['rum_v2'] } }
 
 // A custom connect matcher that excludes CORS preflight (OPTIONS) requests. The retry tests below add a
-// non-simple header, which triggers a preflight to the same /connect/2/:testId path -- with the path-only
-// testConnectRequest matcher, that preflight would either be miscounted as an extra connect attempt in a
-// capture, OR (worse, for scheduleReply) get hijacked into returning the SCHEDULED FAILURE status itself,
+// non-simple header, which triggers a preflight to the same /browser/connect/2/:testId path -- with the
+// path-only testConnectRequest matcher, that preflight would either be miscounted as an extra connect attempt in
+// a capture, OR (worse, for scheduleReply) get hijacked into returning the SCHEDULED FAILURE status itself,
 // which fails the preflight and silently blocks the real retry POST from ever being sent. So this matcher is
 // used for both capturing AND scheduling replies in any test here that involves a retry. Test-handle serializes
 // `test` functions across a process boundary (see expect-tests.js), so this must stay self-contained rather
 // than delegating to the imported matcher.
 function testConnectPostRequest (request) {
   const url = new URL(request.url, 'resolve://')
-  return url.pathname === `/connect/2/${this.testId}` && request.method === 'POST'
+  return url.pathname === `/browser/connect/2/${this.testId}` && request.method === 'POST'
 }
 
 describe('Connector (rum_v2 browser connect)', () => {

--- a/tests/specs/pvt/timings.e2e.js
+++ b/tests/specs/pvt/timings.e2e.js
@@ -1,5 +1,5 @@
 import { supportsCumulativeLayoutShift, supportsFirstPaint, supportsInteractionToNextPaint, supportsLargestContentfulPaint } from '../../../tools/browser-matcher/common-matchers.mjs'
-import { testTimingEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { testConnectRequest, testTimingEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 const loadersToTest = ['rum', 'spa']
 
@@ -180,6 +180,66 @@ describe('pvt timings tests', () => {
           expect(timingsHarvests.find(harvest => harvest.request.body.find(t => t.name === 'cls'))).toBeTruthy()
         })
       })
+    })
+
+    ;[
+      ['v1', {}],
+      ['rum_v2', { feature_flags: ['rum_v2'] }]
+    ].forEach(([label, init]) => {
+      /**
+       * Regression coverage for an INP/CLS-loss bug: Harvester's EOL harvest is triggered from a 'visibilitychange'
+       * listener, which races against any OTHER 'visibilitychange' listener registered by a feature's own aggregate
+       * -- namely web-vitals' onINP, which (unlike onCLS) only ever reports its final value from within its own
+       * 'visibilitychange' listener. If Harvester's listener ran first and snapshotted the buffer before onINP
+       * added its data, INP was lost for good on that unload. The fix required both: (1) deferring Harvester's
+       * actual harvest work to a microtask so it always runs after the whole synchronous 'visibilitychange'
+       * dispatch settles (see Harvester#startTimer), and (2) `capture: true` on this file's own CLS-flush listener
+       * (see the subscribeToVisibilityChange call above) -- confirmed only via real-browser testing, since jsdom's
+       * simplified event dispatch doesn't reproduce whatever made that flag necessary. Neither fix is gated behind
+       * rum_v2 -- both apply unconditionally -- so this runs under v1 too, to prove the fix (which predates rum_v2)
+       * wasn't accidentally scoped to only the v2 path. rum_v2 additionally routes bootstrap through a Connector
+       * that does its own async connect/2 round trip before aggregates finish loading -- the v2 case here proves
+       * that extra async work doesn't reopen the ordering race.
+       */
+      it.withBrowsersMatching([supportsCumulativeLayoutShift, supportsInteractionToNextPaint])(
+        `sends pageHide, CLS & INP together in a single EoL harvest (${label})`,
+        async () => {
+          const connectCapture = init.feature_flags?.includes('rum_v2')
+            ? await browser.testHandle.createNetworkCaptures('bamServer', { test: testConnectRequest })
+            : undefined
+
+          await browser.url(await browser.testHandle.assetURL('cls-pagehide.html', { loader: 'spa', init }))
+            .then(() => browser.waitForAgentLoad())
+
+          // Under rum_v2, Connector's connect/2 round trip must complete (and features must activate) before any
+          // of this can happen.
+          if (connectCapture) await connectCapture.waitForResult({ totalCount: 1 })
+
+          const [timingsHarvests] = await Promise.all([
+            timingsCapture.waitForResult({ timeout: 10000 }),
+            $('#btn1').click().then(() => browser.waitUntil(
+              () => browser.execute(function () { return window.contentAdded === true }),
+              { timeout: 10000, timeoutMsg: 'contentAdded was never set' }
+            ))
+          ])
+
+          // pageHide only ever fires once, on the EoL 'visibilitychange' dispatch that cls-pagehide.html triggers
+          // itself -- so the harvest containing it IS the EoL harvest. An unrelated periodic tick could still land
+          // its own harvest in the same wait window (e.g. under load), which is fine; what regressed before was CLS/
+          // INP landing in a SEPARATE harvest from pageHide instead of this same one, so that's the actual check --
+          // not merely counting harvests (which an unrelated tick would make an unreliable proxy) or flattening
+          // across all of them (which would hide exactly this failure mode).
+          const eolHarvest = timingsHarvests.find(harvest => harvest.request.body.some(e => e.name === 'pageHide'))
+          expect(eolHarvest).toBeTruthy()
+          const names = eolHarvest.request.body.map(e => e.name)
+
+          expect(names).toEqual(expect.arrayContaining(['pageHide', 'cls', 'inp']))
+
+          const pageHide = eolHarvest.request.body.find(e => e.name === 'pageHide')
+          const cls = pageHide.attributes.find(a => a.key === 'cls')
+          expect(cls.value).toBeGreaterThan(0)
+        }
+      )
     })
   })
 

--- a/tests/specs/pvt/timings.e2e.js
+++ b/tests/specs/pvt/timings.e2e.js
@@ -198,7 +198,7 @@ describe('pvt timings tests', () => {
        * simplified event dispatch doesn't reproduce whatever made that flag necessary. Neither fix is gated behind
        * rum_v2 -- both apply unconditionally -- so this runs under v1 too, to prove the fix (which predates rum_v2)
        * wasn't accidentally scoped to only the v2 path. rum_v2 additionally routes bootstrap through a Connector
-       * that does its own async connect/2 round trip before aggregates finish loading -- the v2 case here proves
+       * that does its own async browser/connect/2 round trip before aggregates finish loading -- the v2 case here proves
        * that extra async work doesn't reopen the ordering race.
        */
       it.withBrowsersMatching([supportsCumulativeLayoutShift, supportsInteractionToNextPaint])(
@@ -211,7 +211,7 @@ describe('pvt timings tests', () => {
           await browser.url(await browser.testHandle.assetURL('cls-pagehide.html', { loader: 'spa', init }))
             .then(() => browser.waitForAgentLoad())
 
-          // Under rum_v2, Connector's connect/2 round trip must complete (and features must activate) before any
+          // Under rum_v2, Connector's browser/connect/2 round trip must complete (and features must activate) before any
           // of this can happen.
           if (connectCapture) await connectCapture.waitForResult({ totalCount: 1 })
 

--- a/tests/specs/pvt/timings.e2e.js
+++ b/tests/specs/pvt/timings.e2e.js
@@ -208,7 +208,7 @@ describe('pvt timings tests', () => {
             ? await browser.testHandle.createNetworkCaptures('bamServer', { test: testConnectRequest })
             : undefined
 
-          await browser.url(await browser.testHandle.assetURL('cls-pagehide.html', { loader: 'spa', init }))
+          await browser.url(await browser.testHandle.assetURL('cls-lcp.html', { loader: 'spa', init }))
             .then(() => browser.waitForAgentLoad())
 
           // Under rum_v2, Connector's browser/connect/2 round trip must complete (and features must activate) before any
@@ -217,18 +217,25 @@ describe('pvt timings tests', () => {
 
           const [timingsHarvests] = await Promise.all([
             timingsCapture.waitForResult({ timeout: 10000 }),
-            $('#btn1').click().then(() => browser.waitUntil(
-              () => browser.execute(function () { return window.contentAdded === true }),
-              { timeout: 10000, timeoutMsg: 'contentAdded was never set' }
-            ))
+            // cls-lcp.html triggers a real layout shift (cls) and LCP a moment after load regardless of this click;
+            // the click itself is what produces the first interaction (fi/inp).
+            $('#btn1').click()
+              .then(() => browser.waitUntil(
+                () => browser.execute(function () { return window.contentAdded === true }),
+                { timeout: 10000, timeoutMsg: 'contentAdded was never set' }
+              ))
+              // real navigation away, rather than the page faking a 'visibilitychange' dispatch itself -- this is what
+              // actually fires the browser's own EoL 'visibilitychange'/'pagehide' sequence, the same way pageHide is
+              // triggered in the "interaction related timings" describe block above.
+              .then(async () => browser.url(await browser.testHandle.assetURL('/')))
           ])
 
-          // pageHide only ever fires once, on the EoL 'visibilitychange' dispatch that cls-pagehide.html triggers
-          // itself -- so the harvest containing it IS the EoL harvest. An unrelated periodic tick could still land
-          // its own harvest in the same wait window (e.g. under load), which is fine; what regressed before was CLS/
-          // INP landing in a SEPARATE harvest from pageHide instead of this same one, so that's the actual check --
-          // not merely counting harvests (which an unrelated tick would make an unreliable proxy) or flattening
-          // across all of them (which would hide exactly this failure mode).
+          // pageHide only ever fires once, on the real EoL navigation above -- so the harvest containing it IS the
+          // EoL harvest. An unrelated periodic tick could still land its own harvest in the same wait window (e.g.
+          // under load), which is fine; what regressed before was CLS/INP landing in a SEPARATE harvest from
+          // pageHide instead of this same one, so that's the actual check -- not merely counting harvests (which an
+          // unrelated tick would make an unreliable proxy) or flattening across all of them (which would hide
+          // exactly this failure mode).
           const eolHarvest = timingsHarvests.find(harvest => harvest.request.body.some(e => e.name === 'pageHide'))
           expect(eolHarvest).toBeTruthy()
           const names = eolHarvest.request.body.map(e => e.name)

--- a/tests/specs/rum/index_v2.e2e.js
+++ b/tests/specs/rum/index_v2.e2e.js
@@ -24,7 +24,7 @@ const legacyAttributionConfig = {
  * it's really just a normal harvester-driven harvest now. Compare against tests/specs/rum/*.e2e.js, which cover the
  * v1-only behaviors this file intentionally does NOT reproduce for v2 (fsh, and RUM failure blocking every other
  * feature). Retry/backoff on a retryable status is generic Harvester behavior (already covered in the harvesting
- * e2e group) and isn't re-tested here; Connector's OWN retry/backoff for the connect/2 call -- a genuinely new
+ * e2e group) and isn't re-tested here; Connector's OWN retry/backoff for the browser/connect/2 call -- a genuinely new
  * logical unit, not shared with the harvester -- is covered separately in tests/specs/connector/index.e2e.js.
  */
 describe('page_view_event v2 (rum_v2) harvest behavior', () => {
@@ -43,7 +43,7 @@ describe('page_view_event v2 (rum_v2) harvest behavior', () => {
     // Under v1 (src/features/page_view_event/aggregate/index.js), sendRum's queryParameters includes tt/us/ac/pr/
     // xx/ua straight from loader config, plus fsh derived from whether a cached RUM response already existed when
     // PVE queried it. aggregate_v2's queryStringsBuilder (src/features/page_view_event/aggregate_v2/index.js)
-    // does not build any of these -- fsh is meaningless under v2 since Connector's connect/2 call already writes
+    // does not build any of these -- fsh is meaningless under v2 since Connector's browser/connect/2 call already writes
     // cachedRumResponse to session storage before ANY aggregate, including PVE-v2 itself, ever harvests (even on
     // a page's first-ever load); the loader-config attribution params (tt/us/ac/pr/xx/ua) aren't read at all.
     const connectCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testConnectRequest })
@@ -60,7 +60,7 @@ describe('page_view_event v2 (rum_v2) harvest behavior', () => {
     // af (activated feature flags) is still built by aggregate_v2 the same way v1 did.
     expect(rumHarvest.request.query.af).toBeTruthy()
 
-    // igp is v2-only -- sourced from Connector's connect/2 response (app.igp) rather than any loader/legacy RUM
+    // igp is v2-only -- sourced from Connector's browser/connect/2 response (app.igp) rather than any loader/legacy RUM
     // concept -- and must survive the query string's URI encode/decode round trip unchanged.
     const [connectHarvest] = await connectCapture.waitForResult({ totalCount: 1 })
     const connectReplyBody = JSON.parse(connectHarvest.reply.body)
@@ -80,7 +80,7 @@ describe('page_view_event v2 (rum_v2) harvest behavior', () => {
     const firstIgp = firstRumHarvest.request.query.igp
     expect(firstIgp).toBeTruthy()
 
-    // If session caching were broken and a second connect/2 call actually went out on reload, it would land here
+    // If session caching were broken and a second browser/connect/2 call actually went out on reload, it would land here
     // and get back a DIFFERENT igp than the first -- so this is a real regression check on the caching itself, not
     // just an assertion that happens to pass because the mock server would otherwise always reply with same igp.
     const decoyIgp = 'decoy-igp-should-never-be-used'

--- a/tests/specs/rum/index_v2.e2e.js
+++ b/tests/specs/rum/index_v2.e2e.js
@@ -1,0 +1,148 @@
+import { testConnectRequest, testErrorsRequest, testRumRequest } from '../../../tools/testing-server/utils/expect-tests'
+
+const rumV2Config = { init: { feature_flags: ['rum_v2'] } }
+
+// Loader config that, under v1 (see tests/specs/rum/index.e2e.js's "should capture detailed APM decorations"),
+// populates tt/us/ac/pr/xx/ua on the RUM query string. Reused here (merged with rum_v2) so the "removed" assertion
+// below is proving those params are actually dropped by aggregate_v2, not just naturally empty in this test config.
+const legacyAttributionConfig = {
+  config: {
+    ttGuid: '21EC2020-3AEA-1069-A2DD-08002B30309D',
+    account: 'test_account',
+    user: 'test_user',
+    product: 'test_product',
+    extra: 'test_extra',
+    userAttributes: 'test_userAttributes'
+  },
+  init: rumV2Config.init
+}
+
+/**
+ * page_view_event's v2 aggregate (src/features/page_view_event/aggregate_v2) replaces the special-cased, immediate,
+ * non-retrying v1 RUM call with a payload that goes out over the SAME Harvester#triggerHarvestFor path as any other
+ * feature -- see harvestEndpointVersion=2, which routes it to the legacy-shaped /rum/2/:testId endpoint even though
+ * it's really just a normal harvester-driven harvest now. Compare against tests/specs/rum/*.e2e.js, which cover the
+ * v1-only behaviors this file intentionally does NOT reproduce for v2 (fsh, and RUM failure blocking every other
+ * feature). Retry/backoff on a retryable status is generic Harvester behavior (already covered in the harvesting
+ * e2e group) and isn't re-tested here; Connector's OWN retry/backoff for the connect/2 call -- a genuinely new
+ * logical unit, not shared with the harvester -- is covered separately in tests/specs/connector/index.e2e.js.
+ */
+describe('page_view_event v2 (rum_v2) harvest behavior', () => {
+  let rumCapture
+
+  beforeEach(async () => {
+    rumCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testRumRequest })
+  })
+
+  afterEach(async () => {
+    await browser.testHandle.clearScheduledReplies('bamServer')
+    await browser.destroyAgentSession()
+  })
+
+  it('drops v1-only attribution/session query params, but still sends the v2-required af and igp', async () => {
+    // Under v1 (src/features/page_view_event/aggregate/index.js), sendRum's queryParameters includes tt/us/ac/pr/
+    // xx/ua straight from loader config, plus fsh derived from whether a cached RUM response already existed when
+    // PVE queried it. aggregate_v2's queryStringsBuilder (src/features/page_view_event/aggregate_v2/index.js)
+    // does not build any of these -- fsh is meaningless under v2 since Connector's connect/2 call already writes
+    // cachedRumResponse to session storage before ANY aggregate, including PVE-v2 itself, ever harvests (even on
+    // a page's first-ever load); the loader-config attribution params (tt/us/ac/pr/xx/ua) aren't read at all.
+    const connectCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testConnectRequest })
+
+    const [[rumHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', legacyAttributionConfig))
+        .then(() => browser.waitForAgentLoad())
+    ])
+
+    const removedV1Params = ['tt', 'us', 'ac', 'pr', 'xx', 'ua', 'fsh']
+    removedV1Params.forEach(key => expect(rumHarvest.request.query[key]).toBeUndefined())
+
+    // af (activated feature flags) is still built by aggregate_v2 the same way v1 did.
+    expect(rumHarvest.request.query.af).toBeTruthy()
+
+    // igp is v2-only -- sourced from Connector's connect/2 response (app.igp) rather than any loader/legacy RUM
+    // concept -- and must survive the query string's URI encode/decode round trip unchanged.
+    const [connectHarvest] = await connectCapture.waitForResult({ totalCount: 1 })
+    const connectReplyBody = JSON.parse(connectHarvest.reply.body)
+    expect(rumHarvest.request.query.igp).toBeTruthy()
+    expect(decodeURIComponent(rumHarvest.request.query.igp)).toEqual(connectReplyBody.app.igp)
+  })
+
+  it('sends the same igp on a page reload within an existing session, sourced from the cached connect response rather than a new connect call', async () => {
+    const connectCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testConnectRequest })
+
+    const [[firstRumHarvest], [firstConnectHarvest]] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 1 }),
+      connectCapture.waitForResult({ totalCount: 1 }),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', rumV2Config))
+        .then(() => browser.waitForAgentLoad())
+    ])
+    const firstIgp = firstRumHarvest.request.query.igp
+    expect(firstIgp).toBeTruthy()
+
+    // If session caching were broken and a second connect/2 call actually went out on reload, it would land here
+    // and get back a DIFFERENT igp than the first -- so this is a real regression check on the caching itself, not
+    // just an assertion that happens to pass because the mock server would otherwise always reply with same igp.
+    const decoyIgp = 'decoy-igp-should-never-be-used'
+    const decoyConnectResponse = JSON.parse(firstConnectHarvest.reply.body)
+    decoyConnectResponse.app.igp = decoyIgp
+    await browser.testHandle.scheduleReply('bamServer', {
+      test: testConnectRequest,
+      statusCode: 200,
+      body: JSON.stringify(decoyConnectResponse),
+      permanent: false
+    })
+
+    // Reload within the SAME session (localStorage persists across same-origin navigations by default) -- Connector
+    // should reuse session.state.cachedRumResponse instead of connecting again (see tests/specs/connector/index.e2e.js
+    // for that behavior in isolation), and PVE-v2 should read the exact same igp back off that cached response.
+    const [rumHarvests] = await Promise.all([
+      rumCapture.waitForResult({ totalCount: 2 }),
+      browser.url(await browser.testHandle.assetURL('instrumented.html', rumV2Config))
+        .then(() => browser.waitForAgentLoad())
+    ])
+    const secondRumHarvest = rumHarvests[1]
+
+    expect(secondRumHarvest.request.query.igp).toEqual(firstIgp)
+    expect(secondRumHarvest.request.query.igp).not.toEqual(decoyIgp)
+
+    const connectHarvests = await connectCapture.waitForResult({ timeout: 3000 })
+    expect(connectHarvests.length).toEqual(1)
+  })
+
+  ;[400, 404].forEach(statusCode => {
+    it(`drops the page view payload without retrying or aborting the agent on a non-retryable status (${statusCode}), while other features keep harvesting`, async () => {
+      const errorsCapture = await browser.testHandle.createNetworkCaptures('bamServer', { test: testErrorsRequest })
+      await browser.testHandle.scheduleReply('bamServer', {
+        test: testRumRequest,
+        permanent: true,
+        statusCode,
+        body: ''
+      })
+
+      const [rumHarvests] = await Promise.all([
+        rumCapture.waitForResult({ timeout: 10000 }),
+        browser.url(await browser.testHandle.assetURL('instrumented.html', rumV2Config))
+          .then(() => browser.waitForAgentLoad())
+          .then(() => browser.execute(function () { newrelic.noticeError(new Error('hippo hangry')) }))
+      ])
+
+      // Unlike v1 (see tests/specs/rum/retry-harvesting.e2e.js), a failed PVE-v2 harvest does not gate or abort
+      // anything else -- it's just one feature's harvest among many, so it fails on its own and nothing retries it
+      // (there's no more data queued for it to send again; see AggregateBase#postHarvestCleanup).
+      expect(rumHarvests.length).toEqual(1)
+      expect(rumHarvests[0].reply.statusCode).toEqual(statusCode)
+
+      const aborted = await browser.execute(function () {
+        return Object.values(newrelic.initializedAgents)[0].ee.aborted
+      })
+      expect(aborted).toEqual(false)
+
+      const [errorsHarvest] = await errorsCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+      expect(errorsHarvest.reply.statusCode).toEqual(200)
+      expect(errorsHarvest.request.body.err).toEqual(expect.arrayContaining([
+        expect.objectContaining({ params: expect.objectContaining({ message: 'hippo hangry' }) })
+      ]))
+    })
+  })
+})

--- a/tests/unit/common/harvest/connector.test.js
+++ b/tests/unit/common/harvest/connector.test.js
@@ -363,7 +363,7 @@ describe('Connector', () => {
     handleSpy.mockRestore()
   })
 
-  test('applies cached response found during callback before processing live response', () => {
+  test('applies cached response found during callback and skips processing the live response entirely', () => {
     send.mockReturnValue(true)
 
     const session = {
@@ -402,6 +402,12 @@ describe('Connector', () => {
     })
 
     expect(agent.runtime.appMetadata).toEqual(cached.app)
-    expect(activateFeatures).toHaveBeenNthCalledWith(1, cached.config, agent)
+    // The live response must never be applied on top of the cached one -- only a single activateFeatures call,
+    // for the cached config -- otherwise features would be activated/configured twice (once per response).
+    expect(activateFeatures).toHaveBeenCalledTimes(1)
+    expect(activateFeatures).toHaveBeenCalledWith(cached.config, agent)
+    // The live response must not clobber the session's cached one, and TimeKeeper must not process it either.
+    expect(session.write).not.toHaveBeenCalled()
+    expect(agent.runtime.timeKeeper.ready).toEqual(false)
   })
 })

--- a/tests/unit/common/harvest/connector.test.js
+++ b/tests/unit/common/harvest/connector.test.js
@@ -77,7 +77,7 @@ describe('Connector', () => {
   test('uses cached response and skips network request', () => {
     const cachedResponse = {
       app: { agents: [{ entityGuid: 'cached-guid' }], nrServerTime: Date.now() },
-      config: { err: 1 }
+      err: 1
     }
 
     const agent = {
@@ -98,7 +98,7 @@ describe('Connector', () => {
 
     expect(send).not.toHaveBeenCalled()
     expect(agent.runtime.appMetadata).toEqual(cachedResponse.app)
-    expect(activateFeatures).toHaveBeenCalledWith(cachedResponse.config, agent)
+    expect(activateFeatures).toHaveBeenCalledWith({ err: 1 }, agent)
   })
 
   test('processes successful connect response and caches it', () => {
@@ -133,7 +133,7 @@ describe('Connector', () => {
       responseText: JSON.stringify(response)
     })
 
-    expect(session.write).toHaveBeenCalledWith({ cachedRumResponse: response })
+    expect(session.write).toHaveBeenCalledWith({ cachedRumResponse: { app: response.app, ...response.config } })
     expect(agent.runtime.appMetadata).toEqual(response.app)
     expect(activateFeatures).toHaveBeenCalledWith(response.config, agent)
   })
@@ -386,7 +386,7 @@ describe('Connector', () => {
 
     const cached = {
       app: { agents: [{ entityGuid: 'cached-guid' }], nrServerTime: Date.now() + 10000 },
-      config: { err: 1 }
+      err: 1
     }
     session.state.cachedRumResponse = cached
 
@@ -405,7 +405,7 @@ describe('Connector', () => {
     // The live response must never be applied on top of the cached one -- only a single activateFeatures call,
     // for the cached config -- otherwise features would be activated/configured twice (once per response).
     expect(activateFeatures).toHaveBeenCalledTimes(1)
-    expect(activateFeatures).toHaveBeenCalledWith(cached.config, agent)
+    expect(activateFeatures).toHaveBeenCalledWith({ err: 1 }, agent)
     // The live response must not clobber the session's cached one, and TimeKeeper must not process it either.
     expect(session.write).not.toHaveBeenCalled()
     expect(agent.runtime.timeKeeper.ready).toEqual(false)

--- a/tests/unit/common/harvest/connector.test.js
+++ b/tests/unit/common/harvest/connector.test.js
@@ -63,10 +63,10 @@ describe('Connector', () => {
       endpoint: 'connect/2/license-key',
       raw: true,
       featureName: 'connect',
-      localOpts: { sendEmptyBody: true },
+      localOpts: { sendEmptyBody: true, headers: undefined },
       payload: {
         body: {},
-        qs: { a: 'app-id', v: VERSION }
+        qs: { a: 'app-id', v: VERSION, s: '0' }
       },
       cbFinished: expect.any(Function)
     }))
@@ -197,6 +197,18 @@ describe('Connector', () => {
     })
 
     expect(timeoutSpy).toHaveBeenCalledTimes(1)
+
+    jest.runAllTimers()
+
+    expect(send).toHaveBeenLastCalledWith(agent, expect.objectContaining({
+      localOpts: {
+        sendEmptyBody: true,
+        headers: [
+          { key: 'X-Retry-Count', value: 1 },
+          { key: 'X-Previous-Status', value: 429 }
+        ]
+      }
+    }))
 
     timeoutSpy.mockRestore()
     jest.useRealTimers()

--- a/tests/unit/common/harvest/connector.test.js
+++ b/tests/unit/common/harvest/connector.test.js
@@ -45,6 +45,8 @@ describe('Connector', () => {
 
     expect(send).not.toHaveBeenCalled()
     expect(agent.runtime.timeKeeper).toBeUndefined()
+    expect(activateFeatures).not.toHaveBeenCalled()
+    expect(agent.ee.abort).not.toHaveBeenCalled()
   })
 
   test('sends connect payload to connect endpoint', () => {

--- a/tests/unit/common/harvest/connector.test.js
+++ b/tests/unit/common/harvest/connector.test.js
@@ -62,7 +62,7 @@ describe('Connector', () => {
     new Connector(agent)
 
     expect(send).toHaveBeenCalledWith(agent, expect.objectContaining({
-      endpoint: 'connect/2/license-key',
+      endpoint: 'browser/connect/2/license-key',
       raw: true,
       featureName: 'connect',
       localOpts: { sendEmptyBody: true, headers: undefined },

--- a/tests/unit/common/harvest/connector.test.js
+++ b/tests/unit/common/harvest/connector.test.js
@@ -1,0 +1,393 @@
+import { Connector } from '../../../../src/common/harvest/connector'
+import { send } from '../../../../src/common/harvest/send'
+import { activateFeatures } from '../../../../src/common/util/feature-flags'
+import * as handleModule from '../../../../src/common/event-emitter/handle'
+import { VERSION } from '../../../../src/common/constants/env'
+import { TextEncoder } from 'util'
+
+jest.mock('../../../../src/common/harvest/send', () => ({
+  send: jest.fn()
+}))
+
+jest.mock('../../../../src/common/util/feature-flags', () => ({
+  activateFeatures: jest.fn()
+}))
+
+describe('Connector', () => {
+  let originalNewrelic
+
+  beforeAll(() => {
+    originalNewrelic = global.newrelic
+  })
+
+  afterAll(() => {
+    global.newrelic = originalNewrelic
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.TextEncoder = TextEncoder
+  })
+
+  afterEach(() => {
+    global.TextEncoder = undefined
+  })
+
+  test('does nothing when rum_v2 flag is disabled', () => {
+    const agent = {
+      init: { feature_flags: [] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: { appMetadata: {}, session: undefined },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+
+    expect(send).not.toHaveBeenCalled()
+    expect(agent.runtime.timeKeeper).toBeUndefined()
+  })
+
+  test('sends connect payload to connect endpoint', () => {
+    send.mockReturnValue(true)
+
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: { appMetadata: {}, session: undefined },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+
+    expect(send).toHaveBeenCalledWith(agent, expect.objectContaining({
+      endpoint: 'connect/2/license-key',
+      raw: true,
+      featureName: 'connect',
+      localOpts: { sendEmptyBody: true },
+      payload: {
+        body: {},
+        qs: { a: 'app-id', v: VERSION }
+      },
+      cbFinished: expect.any(Function)
+    }))
+  })
+
+  test('uses cached response and skips network request', () => {
+    const cachedResponse = {
+      app: { agents: [{ entityGuid: 'cached-guid' }], nrServerTime: Date.now() },
+      config: { err: 1 }
+    }
+
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session: {
+          state: { cachedRumResponse: cachedResponse },
+          read: jest.fn(),
+          write: jest.fn()
+        }
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+
+    expect(send).not.toHaveBeenCalled()
+    expect(agent.runtime.appMetadata).toEqual(cachedResponse.app)
+    expect(activateFeatures).toHaveBeenCalledWith(cachedResponse.config, agent)
+  })
+
+  test('processes successful connect response and caches it', () => {
+    send.mockReturnValue(true)
+
+    const session = {
+      state: { cachedRumResponse: undefined },
+      read: jest.fn(() => ({})),
+      write: jest.fn()
+    }
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+    const cbFinished = send.mock.calls[0][1].cbFinished
+    const response = {
+      app: { agents: [{ entityGuid: 'guid-1' }], nrServerTime: Date.now() + 10000 },
+      config: { err: 1, st: 1 }
+    }
+    cbFinished({
+      sent: true,
+      status: 200,
+      retry: false,
+      xhr: { status: 200 },
+      responseText: JSON.stringify(response)
+    })
+
+    expect(session.write).toHaveBeenCalledWith({ cachedRumResponse: response })
+    expect(agent.runtime.appMetadata).toEqual(response.app)
+    expect(activateFeatures).toHaveBeenCalledWith(response.config, agent)
+  })
+
+  test('processes successful connect response without session', () => {
+    send.mockReturnValue(true)
+
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session: undefined
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+    const cbFinished = send.mock.calls[0][1].cbFinished
+    const response = {
+      app: { agents: [{ entityGuid: 'guid-no-session' }], nrServerTime: Date.now() + 10000 },
+      config: { err: 1, st: 1 }
+    }
+    cbFinished({
+      sent: true,
+      status: 200,
+      retry: false,
+      xhr: { status: 200 },
+      responseText: JSON.stringify(response)
+    })
+
+    expect(agent.runtime.appMetadata).toEqual(response.app)
+    expect(activateFeatures).toHaveBeenCalledWith(response.config, agent)
+  })
+
+  test('schedules retry on retriable connect failure', () => {
+    jest.useFakeTimers()
+    const timeoutSpy = jest.spyOn(global, 'setTimeout')
+    send.mockReturnValue(true)
+
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session: {
+          state: { cachedRumResponse: undefined },
+          read: jest.fn(() => ({})),
+          write: jest.fn()
+        }
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+    const cbFinished = send.mock.calls[0][1].cbFinished
+    cbFinished({
+      sent: true,
+      status: 429,
+      retry: true,
+      xhr: { status: 429 },
+      responseText: ''
+    })
+
+    expect(timeoutSpy).toHaveBeenCalledTimes(1)
+
+    timeoutSpy.mockRestore()
+    jest.useRealTimers()
+  })
+
+  test('falls through to hard failure after max retry attempts and aborts', () => {
+    send.mockReturnValue(true)
+    global.newrelic = { ee: { backlog: { x: 'abc', y: null, z: 'def' } } }
+
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session: {
+          state: { cachedRumResponse: undefined },
+          read: jest.fn(() => ({})),
+          write: jest.fn()
+        }
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+    const cbFinished = send.mock.calls[0][1].cbFinished
+
+    cbFinished({ sent: true, status: 429, retry: true, xhr: { status: 429 }, responseText: '' })
+    cbFinished({ sent: true, status: 429, retry: true, xhr: { status: 429 }, responseText: '' })
+    cbFinished({ sent: true, status: 429, retry: true, xhr: { status: 429 }, responseText: '' })
+
+    expect(send).toHaveBeenCalledTimes(2) // connect request + metrics SM send
+    expect(send).toHaveBeenLastCalledWith(agent, expect.objectContaining({
+      featureName: 'metrics',
+      endpoint: expect.any(String),
+      payload: expect.objectContaining({
+        body: expect.objectContaining({
+          sm: expect.arrayContaining([
+            expect.objectContaining({ params: { name: 'BCS/Error/429' } }),
+            expect.objectContaining({ params: { name: 'BCS/Error/Duration/Ms' } }),
+            expect.objectContaining({ params: { name: 'BCS/Error/Dropped/Bytes' } })
+          ])
+        })
+      })
+    }))
+    expect(agent.ee.abort).toHaveBeenCalledTimes(1)
+  })
+
+  test('aborts on JSON parse error', () => {
+    send.mockReturnValue(true)
+
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session: {
+          state: { cachedRumResponse: undefined },
+          read: jest.fn(() => ({})),
+          write: jest.fn()
+        }
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+    const cbFinished = send.mock.calls[0][1].cbFinished
+    cbFinished({ sent: true, status: 200, retry: false, xhr: { status: 200 }, responseText: '{' })
+
+    expect(agent.ee.abort).toHaveBeenCalledTimes(1)
+  })
+
+  test('aborts when timeKeeper processing fails', () => {
+    send.mockReturnValue(true)
+
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session: {
+          state: { cachedRumResponse: undefined },
+          read: jest.fn(() => ({})),
+          write: jest.fn()
+        }
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+    agent.runtime.timeKeeper.processRumRequest = jest.fn(() => {})
+    Object.defineProperty(agent.runtime.timeKeeper, 'ready', { value: false, configurable: true })
+
+    const cbFinished = send.mock.calls[0][1].cbFinished
+    cbFinished({
+      sent: true,
+      status: 200,
+      retry: false,
+      xhr: { status: 200 },
+      responseText: JSON.stringify({
+        app: { agents: [{ entityGuid: 'guid' }], nrServerTime: Date.now() + 10000 },
+        config: { err: 1 }
+      })
+    })
+
+    expect(agent.ee.abort).toHaveBeenCalledTimes(1)
+  })
+
+  test('reports invalid timestamp SM when timekeeper was already ready', () => {
+    send.mockReturnValue(true)
+    const handleSpy = jest.spyOn(handleModule, 'handle')
+
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session: {
+          state: { cachedRumResponse: undefined },
+          read: jest.fn(() => ({})),
+          write: jest.fn()
+        }
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+    Object.defineProperty(agent.runtime.timeKeeper, 'ready', { value: true, configurable: true })
+    Object.defineProperty(agent.runtime.timeKeeper, 'correctedOriginTime', { value: 12000, configurable: true })
+    agent.runtime.timeKeeper.processRumRequest = jest.fn(() => {})
+
+    const cbFinished = send.mock.calls[0][1].cbFinished
+    cbFinished({
+      sent: true,
+      status: 200,
+      retry: false,
+      xhr: { status: 200 },
+      responseText: JSON.stringify({
+        app: { agents: [{ entityGuid: 'guid' }], nrServerTime: 10000 },
+        config: { err: 1 }
+      })
+    })
+
+    expect(handleSpy).toHaveBeenCalledWith(
+      'storeSupportabilityMetrics',
+      ['Generic/TimeKeeper/InvalidTimestamp/Seen', 2000],
+      undefined,
+      'metrics',
+      agent.ee
+    )
+    handleSpy.mockRestore()
+  })
+
+  test('applies cached response found during callback before processing live response', () => {
+    send.mockReturnValue(true)
+
+    const session = {
+      state: { cachedRumResponse: undefined },
+      read: jest.fn(() => ({})),
+      write: jest.fn()
+    }
+    const agent = {
+      init: { feature_flags: ['rum_v2'] },
+      info: { licenseKey: 'license-key', applicationID: 'app-id' },
+      runtime: {
+        appMetadata: {},
+        session
+      },
+      ee: { abort: jest.fn() }
+    }
+
+    new Connector(agent)
+    const cbFinished = send.mock.calls[0][1].cbFinished
+
+    const cached = {
+      app: { agents: [{ entityGuid: 'cached-guid' }], nrServerTime: Date.now() + 10000 },
+      config: { err: 1 }
+    }
+    session.state.cachedRumResponse = cached
+
+    cbFinished({
+      sent: true,
+      status: 200,
+      retry: false,
+      xhr: { status: 200 },
+      responseText: JSON.stringify({
+        app: { agents: [{ entityGuid: 'live-guid' }], nrServerTime: Date.now() + 10000 },
+        config: { err: 0 }
+      })
+    })
+
+    expect(agent.runtime.appMetadata).toEqual(cached.app)
+    expect(activateFeatures).toHaveBeenNthCalledWith(1, cached.config, agent)
+  })
+})

--- a/tests/unit/common/harvest/harvester.test.js
+++ b/tests/unit/common/harvest/harvester.test.js
@@ -153,7 +153,7 @@ describe('send', () => {
     const submitMethod = jest.fn()
 
     send(fakeAgent, {
-      endpoint: 'connect/2/license-key',
+      endpoint: 'browser/connect/2/license-key',
       payload: { body: { apps: [{ appId: 'app-id' }] } },
       localOpts: {},
       submitMethod,
@@ -161,7 +161,7 @@ describe('send', () => {
     })
 
     expect(submitMethod).toHaveBeenCalledWith(expect.objectContaining({
-      url: 'https://test/connect/2/license-key'
+      url: 'https://test/browser/connect/2/license-key'
     }))
   })
 })

--- a/tests/unit/common/harvest/harvester.test.js
+++ b/tests/unit/common/harvest/harvester.test.js
@@ -1,5 +1,6 @@
 import { Harvester } from '../../../../src/common/harvest/harvester'
 import { send } from '../../../../src/common/harvest/send'
+import { RUM } from '../../../../src/loaders/features/features'
 
 let mockEolCb
 jest.mock('../../../../src/common/unload/eol', () => ({
@@ -85,6 +86,7 @@ describe('On EOL harvest', () => {
 describe('send', () => {
   beforeAll(() => {
     fakeAgent.info.errorBeacon = 'test'
+    fakeAgent.info.licenseKey = 'license-key'
     fakeAgent.init.proxy = {}
     fakeAgent.runtime = { obfuscator: { obfuscateString: jest.fn() } }
   })
@@ -106,6 +108,57 @@ describe('send', () => {
   })
   test('does send if sendEmptyBody', () => {
     expect(send(fakeAgent, { endpoint: 'someEndpoint', targetApp: 'someApp', payload: { body: '' }, localOpts: { sendEmptyBody: true }, submitMethod: jest.fn() })).toEqual(true)
+  })
+
+  test('formats v1 rum URL without endpoint segment', () => {
+    const submitMethod = jest.fn()
+
+    send(fakeAgent, {
+      endpoint: RUM,
+      payload: { body: { foo: 'bar' } },
+      localOpts: {},
+      submitMethod,
+      endpointVersion: 1
+    })
+
+    expect(submitMethod).toHaveBeenCalledWith(expect.objectContaining({
+      url: expect.stringContaining('https://test/1/license-key?')
+    }))
+    expect(submitMethod).toHaveBeenCalledWith(expect.objectContaining({
+      url: expect.not.stringContaining('/rum/1/license-key')
+    }))
+  })
+
+  test('formats v2 rum URL with endpoint segment', () => {
+    const submitMethod = jest.fn()
+
+    send(fakeAgent, {
+      endpoint: RUM,
+      payload: { body: { foo: 'bar' } },
+      localOpts: {},
+      submitMethod,
+      endpointVersion: 2
+    })
+
+    expect(submitMethod).toHaveBeenCalledWith(expect.objectContaining({
+      url: expect.stringContaining('https://test/rum/2/license-key?')
+    }))
+  })
+
+  test('does not append a question mark for raw requests with no query params', () => {
+    const submitMethod = jest.fn()
+
+    send(fakeAgent, {
+      endpoint: 'connect/2/license-key',
+      payload: { body: { apps: [{ appId: 'app-id' }] } },
+      localOpts: {},
+      submitMethod,
+      raw: true
+    })
+
+    expect(submitMethod).toHaveBeenCalledWith(expect.objectContaining({
+      url: 'https://test/connect/2/license-key'
+    }))
   })
 })
 

--- a/tests/unit/common/harvest/harvester.test.js
+++ b/tests/unit/common/harvest/harvester.test.js
@@ -22,11 +22,11 @@ beforeEach(() => {
   mockEolCb = undefined
 })
 
-test('Harvester does not start timer loop on initialization', () => {
+test('Harvester does not subscribe to EOL or start timer loop on initialization', () => {
   jest.spyOn(global, 'setTimeout')
 
   const harvester = new Harvester(fakeAgent)
-  expect(mockEolCb).not.toBeUndefined()
+  expect(mockEolCb).toBeUndefined()
   expect(harvester.agentRef).toEqual(fakeAgent)
   expect(global.setTimeout).not.toHaveBeenCalled()
 })
@@ -54,24 +54,28 @@ test('On harvest interval, triggerHarvest runs for every aggregate', () => {
 })
 
 describe('On EOL harvest', () => {
-  test('triggerHarvestFor runs for every aggregate', () => {
+  test('triggerHarvestFor runs for every aggregate', async () => {
     const harvester = new Harvester(fakeAgent)
     harvester.triggerHarvestFor = jest.fn()
+    harvester.startTimer() // EOL is only subscribed once the timer starts
 
     expect(harvester.initializedAggregates.length).toEqual(0)
     harvester.initializedAggregates.push({ harvestOpts: {} }, { harvestOpts: {} })
     mockEolCb()
+    await null // the actual harvest work is deferred to a microtask -- see Harvester#startTimer
     expect(harvester.triggerHarvestFor).toHaveBeenCalledTimes(2)
     expect(harvester.triggerHarvestFor).toHaveBeenLastCalledWith(expect.any(Object), { isFinalHarvest: true })
   })
 
-  test('all aggregates beforeUnload provided are called prior to triggering harvest', () => {
+  test('all aggregates beforeUnload provided are called prior to triggering harvest', async () => {
     const harvester = new Harvester(fakeAgent)
     harvester.triggerHarvestFor = jest.fn(() => performance.now())
+    harvester.startTimer() // EOL is only subscribed once the timer starts
 
     const secondBeforeUnload = jest.fn(() => performance.now())
     harvester.initializedAggregates.push({ harvestOpts: { } }, { harvestOpts: { beforeUnload: secondBeforeUnload } })
     mockEolCb()
+    await null // the actual harvest work is deferred to a microtask -- see Harvester#startTimer
     expect(harvester.triggerHarvestFor).toHaveBeenCalledTimes(2)
     expect(secondBeforeUnload).toHaveBeenCalledTimes(1)
 

--- a/tests/unit/common/util/feature-flags.test.js
+++ b/tests/unit/common/util/feature-flags.test.js
@@ -19,6 +19,7 @@ beforeEach(() => {
   agentRef = {
     agentIdentifier,
     ee: eventEmitterModule.ee.get(agentIdentifier),
+    init: { feature_flags: [] },
     runtime: {}
   }
 })

--- a/tests/unit/features/utils/instrument-base.test.js
+++ b/tests/unit/features/utils/instrument-base.test.js
@@ -46,7 +46,8 @@ beforeEach(() => {
     runtime: {
       loaderType: 'browser-test',
       harvester: {
-        initializedAggregates: []
+        initializedAggregates: [],
+        startTimer: jest.fn()
       }
     }
   }

--- a/tests/unit/features/utils/instrument-base.test.js
+++ b/tests/unit/features/utils/instrument-base.test.js
@@ -30,6 +30,7 @@ beforeEach(() => {
   featureName = faker.string.uuid()
   agentBase = {
     agentIdentifier,
+    features: {},
     ee: {
       abort: jest.fn()
     },

--- a/tests/unit/loaders/agent.test.js
+++ b/tests/unit/loaders/agent.test.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const mockPveCtor = jest.fn()
+
+class MockPageViewEvent {
+  static featureName = 'page_view_event'
+
+  constructor () {
+    mockPveCtor()
+  }
+}
+
+beforeEach(() => {
+  jest.resetModules()
+  jest.clearAllMocks()
+
+  jest.doMock('../../../src/loaders/agent-base', () => ({
+    __esModule: true,
+    AgentBase: class {
+      constructor () {
+        this.agentIdentifier = 'agent-id'
+      }
+    }
+  }))
+
+  jest.doMock('../../../src/loaders/features/enabled-features', () => ({
+    __esModule: true,
+    getEnabledFeatures: jest.fn(() => ({ page_view_event: false }))
+  }))
+
+  jest.doMock('../../../src/loaders/configure/configure', () => ({
+    __esModule: true,
+    configure: jest.fn((agent, options) => {
+      agent.info = options.info || { licenseKey: 'license', applicationID: 'app-id' }
+      agent.init = options.init || { feature_flags: [] }
+      agent.loader_config = options.loader_config || {}
+      agent.runtime = options.runtime || {}
+    })
+  }))
+
+  jest.doMock('../../../src/loaders/features/featureDependencies', () => ({
+    __esModule: true,
+    getFeatureDependencyNames: jest.fn(() => [])
+  }))
+
+  jest.doMock('../../../src/loaders/features/features', () => ({
+    __esModule: true,
+    featurePriority: { page_view_event: 1 },
+    FEATURE_NAMES: { pageViewEvent: 'page_view_event' }
+  }))
+
+  jest.doMock('../../../src/features/page_view_event/instrument', () => ({
+    __esModule: true,
+    Instrument: MockPageViewEvent
+  }))
+
+  jest.doMock('../../../src/common/window/nreum', () => ({
+    __esModule: true,
+    gosNREUM: jest.fn(() => ({ initializedAgents: { 'agent-id': {} }, ee: { get: jest.fn(() => ({ abort: jest.fn() })) } })),
+    setNREUMInitializedAgent: jest.fn()
+  }))
+
+  jest.doMock('../../../src/common/util/console', () => ({
+    __esModule: true,
+    warn: jest.fn()
+  }))
+
+  jest.doMock('../../../src/common/constants/runtime', () => ({
+    __esModule: true,
+    globalScope: {}
+  }))
+
+  jest.doMock('../../../src/loaders/api/setCustomAttribute', () => ({ __esModule: true, setupSetCustomAttributeAPI: jest.fn() }))
+  jest.doMock('../../../src/loaders/api/setUserId', () => ({ __esModule: true, setupSetUserIdAPI: jest.fn() }))
+  jest.doMock('../../../src/loaders/api/setApplicationVersion', () => ({ __esModule: true, setupSetApplicationVersionAPI: jest.fn() }))
+  jest.doMock('../../../src/loaders/api/start', () => ({ __esModule: true, setupStartAPI: jest.fn() }))
+  jest.doMock('../../../src/loaders/api/consent', () => ({ __esModule: true, setupConsentAPI: jest.fn() }))
+})
+
+describe('Agent run behavior with rum_v2', () => {
+  test('keeps page_view_event when rum_v2 is disabled even if feature is disabled', async () => {
+    const { Agent } = await import('../../../src/loaders/agent')
+
+    new Agent({
+      info: { licenseKey: 'license', applicationID: 'app-id' },
+      init: { feature_flags: [] },
+      features: []
+    })
+
+    expect(mockPveCtor).toHaveBeenCalledTimes(1)
+  })
+
+  test('skips page_view_event when rum_v2 is enabled and feature is disabled', async () => {
+    const { Agent } = await import('../../../src/loaders/agent')
+
+    new Agent({
+      info: { licenseKey: 'license', applicationID: 'app-id' },
+      init: { feature_flags: ['rum_v2'] },
+      features: []
+    })
+
+    expect(mockPveCtor).not.toHaveBeenCalled()
+  })
+})

--- a/tests/util/basic-checks.js
+++ b/tests/util/basic-checks.js
@@ -23,7 +23,6 @@ expect.extend({
 
 export const baseQuery = expect.objectContaining({
   a: expect.any(String),
-  ck: expect.any(String),
   ref: expect.any(String),
   rst: expect.any(String),
   s: expect.any(String),
@@ -35,7 +34,6 @@ export function checkRumQuery ({ query }, { liteAgent } = {}) {
   expect(query).toMatchObject({
     a: expect.any(String),
     be: expect.any(String),
-    ck: expect.any(String),
     dc: expect.any(String),
     fe: expect.any(String),
     perf: expect.any(String),

--- a/tools/testing-server/constants.js
+++ b/tools/testing-server/constants.js
@@ -78,7 +78,8 @@ module.exports.rumFlags = (flags = {}, app = {}) => ({
     agents: app.agents || [
       { entityGuid: mockEntityGuid() }
     ],
-    nrServerTime: app.nrServerTime || Date.now()
+    nrServerTime: app.nrServerTime || Date.now(),
+    igp: app.igp || 'mock-igp-token'
   }
 })
 

--- a/tools/testing-server/plugins/bam-parser/index.js
+++ b/tools/testing-server/plugins/bam-parser/index.js
@@ -1,7 +1,7 @@
 const fp = require('fastify-plugin')
 const querypack = require('@newrelic/nr-querypack')
 
-const beaconRequestsRegex = /^((\/((events)|(jserrors)|(ins)|(resources)))?\/(1|2)\/)|(\/browser\/blobs)/i
+const beaconRequestsRegex = /^((\/((events)|(jserrors)|(ins)|(resources)|(rum)))?\/(1|2)\/)|(\/connect\/2\/)|(\/browser\/blobs)/i
 
 /**
  * Fastify plugin to add a custom text/plain content parser that uses querypack.

--- a/tools/testing-server/routes/bam-apis.js
+++ b/tools/testing-server/routes/bam-apis.js
@@ -48,7 +48,7 @@ module.exports = fp(async function (fastify) {
   })
   fastify.route({
     method: ['GET', 'POST'],
-    url: '/connect/2/:testId',
+    url: '/browser/connect/2/:testId',
     handler: async function (request, reply) {
       return reply
         .header('content-type', 'application/json')

--- a/tools/testing-server/routes/bam-apis.js
+++ b/tools/testing-server/routes/bam-apis.js
@@ -9,6 +9,24 @@ const { storeReplayData } = require('../utils/replay-buffer')
  * @param {TestServer} testServer test server instance
  */
 module.exports = fp(async function (fastify) {
+  const makeConnectResponse = () => {
+    const flags = rumFlags()
+    return {
+      config: {
+        err: flags.err,
+        ins: flags.ins,
+        spa: flags.spa,
+        sr: flags.sr,
+        srs: flags.srs,
+        st: flags.st,
+        sts: flags.sts,
+        log: flags.log,
+        logapi: flags.logapi
+      },
+      app: flags.app
+    }
+  }
+
   fastify.route({
     method: ['GET', 'POST'],
     url: '/debug',
@@ -26,6 +44,24 @@ module.exports = fp(async function (fastify) {
         .header('Timing-Allow-Origin', request.headers.origin)
         .code(200)
         .send(JSON.stringify(rumFlags()))
+    }
+  })
+  fastify.route({
+    method: ['GET', 'POST'],
+    url: '/connect/2/:testId',
+    handler: async function (request, reply) {
+      return reply
+        .header('content-type', 'application/json')
+        .header('Timing-Allow-Origin', request.headers.origin)
+        .code(200)
+        .send(JSON.stringify(makeConnectResponse()))
+    }
+  })
+  fastify.route({
+    method: ['GET', 'POST'],
+    url: '/rum/2/:testId',
+    handler: async function (request, reply) {
+      return reply.code(200).send('')
     }
   })
   fastify.route({

--- a/tools/testing-server/utils/expect-tests.js
+++ b/tools/testing-server/utils/expect-tests.js
@@ -19,7 +19,12 @@ module.exports.testAssetRequest = function testAssetRequest (request) {
 
 module.exports.testRumRequest = function testRumRequest (request) {
   const url = new URL(request.url, 'resolve://')
-  return url.pathname === `/1/${this.testId}`
+  return url.pathname === `/1/${this.testId}` || url.pathname === `/rum/2/${this.testId}`
+}
+
+module.exports.testConnectRequest = function testConnectRequest (request) {
+  const url = new URL(request.url, 'resolve://')
+  return url.pathname === `/connect/2/${this.testId}`
 }
 
 module.exports.testEventsRequest = function testEventsRequest (request) {

--- a/tools/testing-server/utils/expect-tests.js
+++ b/tools/testing-server/utils/expect-tests.js
@@ -24,7 +24,7 @@ module.exports.testRumRequest = function testRumRequest (request) {
 
 module.exports.testConnectRequest = function testConnectRequest (request) {
   const url = new URL(request.url, 'resolve://')
-  return url.pathname === `/connect/2/${this.testId}`
+  return url.pathname === `/browser/connect/2/${this.testId}`
 }
 
 module.exports.testEventsRequest = function testEventsRequest (request) {


### PR DESCRIPTION
The old RUM request responsible for both retrieving app configurations and `PageView` generation is now split (temporarily under a feature flag). This makes the agent more resilient on problematic connect cycles or unsuccessful config retrieval, and the `PageView` event would no longer be the dependency blocking other events from harvesting.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

**This new behavior is gated by the `rum_v2` feature flag in this PR. Both versions of the code exists for now in the build.**

### Bootstrap / lifecycle

- Introduced a shared, one-time-per-agent `ensureRuntimeBootstrap` in _instrument-base.js_ that sets up session, Connector, and Harvester. AggregateBase#doOnceForAllAggregate was removed.
- Harvester's EOL (visibilitychange) listener relocated from constructor to `startTimer()`, called only after every feature has finished attempting its aggregate init. (This way, it always registers after feature-level visibilitychange listeners, e.g. web-vitals.)
- A new Connector unit handles the connect call with its own retry (up to 3 attempts, exponential backoff) and abort.
- Failure to construct Connector and Harvester now aborts the whole agent. Session-setup failure alone remains non-fatal and only warns.

### PVE v2

- Under `rum_v2`, PVE instrument loads a new aggregate_v2 module instead of the old aggregate. v2 shares the same harvest & retry logic as other features rather than v1's special-cased RUM call. A failed POST will not affect other features.
- v2 drops query params tt/us/ac/pr/xx/ua and fsh. It adds igp, sourced from the connect response.
- `activateFeatures`'s drained lifecycle event flag is now conditional on rum_v2 (false under v2, since drain would not have happened yet when all features await connect response).

### Misc/cleanup

- Removed the deprecated `ck` query param from all harvests.
- _send.js_: omits the trailing ? when a harvest has no query string; submitMethod now defaults via `getSubmitMethod()`; request headers can now be extended per-call via `localOpts.headers` (used by Connector's retry headers).
- Session Replay feature: added an abort handler to stop any in-progress preload recording if its aggregate never successfully loads; Recorder now guards against triggering an early harvest before its aggregate exists.
- _consent.js_: `pveAgg.sendRum?.()` — guarded since only the v1 aggregate has `sendRum`.

https://newrelic.atlassian.net/wiki/spaces/TDP/pages/5853020595/Request+Response+Contract+CDD+Connect+RUM+Harvest+v2+endpoints

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-539835
https://new-relic.atlassian.net/browse/NR-539865
https://new-relic.atlassian.net/browse/NR-539872
https://new-relic.atlassian.net/browse/NR-585094

### Testing

Bunch modified & added for jests & e2e
