### PR TITLE
fix: Apply hard cap to MFE FCP

### DIFF
--- a/src/common/v2/mfe-vitals.js
+++ b/src/common/v2/mfe-vitals.js
@@ -124,6 +124,9 @@ const observePerformance = (observers, config, onEntry) => {
 export function trackMFEVitals (target, timings) {
   let fcpObservedAt
   let lcpObservedAt
+  // Once disconnect() runs, no further vitals data should be written - even from an observer callback that was
+  // already in flight when disconnect() was called.
+  let disconnected = false
 
   const getTimeRelativeToScriptStart = (capturedAt) => {
     if (capturedAt == null) return capturedAt
@@ -132,12 +135,21 @@ export function trackMFEVitals (target, timings) {
 
   const vitals = {
     fcp: {
-      get value () { return getTimeRelativeToScriptStart(fcpObservedAt) },
-      set value (v) { fcpObservedAt = v }
+      // A clock freeze/tab suspend between script registration and first paint can make this value huge once the
+      // tab resumes. Rather than report a multi-hour "FCP", drop it so bad data doesn't reach the backend.
+      get value () {
+        const relative = getTimeRelativeToScriptStart(fcpObservedAt)
+        return relative > CORRELATION_STALE_THRESHOLD_MS ? undefined : relative
+      },
+      set value (v) { if (!disconnected) fcpObservedAt = v }
     },
     lcp: {
-      get value () { return getTimeRelativeToScriptStart(lcpObservedAt) },
-      set value (v) { lcpObservedAt = v }
+      // LCP can never occur before FCP, so if FCP was dropped as invalid, LCP is derived from the same untrustworthy clock and must be dropped too.
+      get value () {
+        if (vitals.fcp.value === undefined) return undefined
+        return getTimeRelativeToScriptStart(lcpObservedAt)
+      },
+      set value (v) { if (!disconnected) lcpObservedAt = v }
     },
     cls: {
       value: undefined
@@ -159,14 +171,21 @@ export function trackMFEVitals (target, timings) {
   }, CORRELATION_STALE_THRESHOLD_MS)
 
   const populateVitalMinimums = () => {
-    fcpObservedAt ??= now()
+    if (disconnected) return
+    if (fcpObservedAt == null) {
+      const capturedAt = now()
+      // If the very first observed render already exceeds the window, the clock is untrustworthy for this
+      // MFE (e.g. tab was frozen/suspended between registration and paint) - shut everything down instead
+      // of seeding vitals with data derived from it.
+      if (getTimeRelativeToScriptStart(capturedAt) > CORRELATION_STALE_THRESHOLD_MS) {
+        vitals.disconnect()
+        return
+      }
+      fcpObservedAt = capturedAt
+    }
     lcpObservedAt ??= now()
     vitals.cls.value ??= 0
   }
-
-  // if the MFE has already rendered something on the page before we could set up listeners, just populate vital minimums immediately
-  const existingRoots = globalScope.document?.querySelectorAll(`[data-nr-mfe-id="${escapeSelectorValue(target.id)}"]`)
-  if (Array.from(existingRoots || []).some(x => isMatch(x.dataset, target))) populateVitalMinimums()
 
   // Track FCP - first contentful paint
   const fcpObs = observeMutations(target, (_, obs) => {
@@ -183,12 +202,13 @@ export function trackMFEVitals (target, timings) {
 
   try {
     resizeObs = new globalScope.ResizeObserver((entries) => {
+      if (disconnected) return
       entries.forEach((entry) => {
         try {
           const size = entry.contentRect.width * entry.contentRect.height
           if (size > largestSize) {
             largestSize = size
-            lcpObservedAt = now()
+            vitals.lcp.value = now()
           }
           resizeObs.unobserve(entry.target)
         } catch (e) {
@@ -245,7 +265,7 @@ export function trackMFEVitals (target, timings) {
   // Track CLS - cumulative layout shift
   // Initialize CLS to 0 if browser supports it
   observePerformance(observers, { type: 'layout-shift', buffered: true }, (entry) => {
-    if (entry.hadRecentInput) return
+    if (disconnected || entry.hadRecentInput) return
     ;(entry.sources || []).some(source => {
       if (isInMFE(source.node, target)) {
         // an observed "CLS" means _something_ rendered for the MFE, so at minimum we can make sure all the baseline values are populated for the vitals
@@ -259,7 +279,7 @@ export function trackMFEVitals (target, timings) {
 
   // Track INP - interaction to next paint
   observePerformance(observers, { type: 'event', buffered: true, durationThreshold: 40 }, (entry) => {
-    if (!entry.interactionId || !isInMFE(entry.target, target)) return
+    if (disconnected || !entry.interactionId || !isInMFE(entry.target, target)) return
     if (vitals.inp.value === undefined || entry.duration > vitals.inp.value) {
       // an observed "INP" means _something_ rendered for the MFE, so at minimum we can make sure all the baseline values are populated for the vitals
       populateVitalMinimums()
@@ -276,6 +296,7 @@ export function trackMFEVitals (target, timings) {
 
   // Disconnect all observers
   vitals.disconnect = () => {
+    disconnected = true
     // Disconnect all observers
     observers.forEach(obs => {
       try {
@@ -316,6 +337,12 @@ export function trackMFEVitals (target, timings) {
   ;['visibilitychange', 'pagehide'].forEach(type => {
     globalScope.addEventListener(type, vitals.disconnect, { once: true, passive: true })
   })
+
+  // If the MFE has already rendered something on the page before we could set up listeners, just populate vital
+  // minimums immediately. Done last, once `observers` is fully populated and `vitals.disconnect` has its real
+  // implementation, so a stale-clock detection here can actually tear everything down instead of no-op'ing.
+  const existingRoots = globalScope.document?.querySelectorAll(`[data-nr-mfe-id="${escapeSelectorValue(target.id)}"]`)
+  if (Array.from(existingRoots || []).some(x => isMatch(x.dataset, target))) populateVitalMinimums()
 
   return vitals
 }

--- a/tests/specs/api/register/mfe-vitals.e2e.js
+++ b/tests/specs/api/register/mfe-vitals.e2e.js
@@ -40,17 +40,18 @@ function validateVitals (timingEvent, options = {}) {
     expect(fcp).toBeDefined()
     expect(fcp).not.toBeUndefined()
     expect(fcp).toBeGreaterThan(0)
-    expect(fcp).toBeLessThan(10000) // Less than 10 seconds
   } else if (fcp !== undefined) {
     // If FCP is present (but not required), validate it's reasonable
     expect(fcp).toBeGreaterThanOrEqual(0)
   }
+  // Whenever FCP is present at all, it must never exceed the stale-clock cap - a defensive guard against a
+  // tab-freeze/clock-drift scenario reporting a multi-hour "FCP" (see mfe-vitals.js's fcp.value getter)
+  if (fcp !== undefined) expect(fcp).toBeLessThan(10000)
 
   if (expectLCP) {
     expect(lcp).toBeDefined()
     expect(lcp).not.toBeUndefined()
     expect(lcp).toBeGreaterThan(0)
-    expect(lcp).toBeLessThan(10000)
     // LCP should be >= FCP if both are present
     if (fcp !== undefined) {
       expect(lcp).toBeGreaterThanOrEqual(fcp)
@@ -58,6 +59,8 @@ function validateVitals (timingEvent, options = {}) {
   } else if (lcp !== undefined) {
     expect(lcp).toBeGreaterThanOrEqual(0)
   }
+  // LCP can never be observed before FCP, so if FCP was ever dropped as stale, LCP must never leak through either
+  if (fcp === undefined) expect(lcp).toBeUndefined()
 
   if (expectCLS) {
     expect(cls).toBeDefined()
@@ -331,7 +334,9 @@ describe('Register API - MFE Vitals Tracking', () => {
     await browser.pause(11000)
 
     // Render content AFTER the timeout should have fired - since observers should already be
-    // disconnected at this point, this should NOT be picked up as FCP/LCP/CLS/INP
+    // disconnected at this point, this should NOT be picked up as FCP/LCP/CLS/INP. The element is
+    // sized to also qualify as the largest contentful paint candidate, so this also exercises the
+    // FCP -> LCP cascade: LCP must never be reported once FCP has been dropped as stale/never-observed.
     await browser.execute(function () {
       const div = document.createElement('div')
       div.textContent = 'Late content after FCP timeout'

--- a/tests/unit/common/v2/mfe-vitals.test.js
+++ b/tests/unit/common/v2/mfe-vitals.test.js
@@ -1093,6 +1093,69 @@ describe('trackMFEVitals', () => {
     })
   })
 
+  describe('FCP/LCP staleness cap', () => {
+    it('should drop FCP and disconnect all observers when the first observed render already exceeds the stale threshold', () => {
+      // Force any `now()` reading to land far past the 10s cap relative to scriptStart, simulating a
+      // clock freeze/tab suspend between script registration and first paint.
+      timings.scriptStart = -1000000
+
+      const vitals = trackMFEVitals(mfeTarget, timings)
+
+      expect(vitals.fcp.value).toBeUndefined()
+      expect(vitals.lcp.value).toBeUndefined()
+
+      const lcpObserver = mockMutationObserver.mock.instances[1]
+      expect(lcpObserver.disconnect).toHaveBeenCalled()
+      mockPerformanceObserver.mock.instances.forEach(instance => {
+        expect(instance.disconnect).toHaveBeenCalled()
+      })
+    })
+
+    it('should drop a stale FCP value read directly rather than reporting a multi-hour duration', () => {
+      const vitals = trackMFEVitals(mfeTarget, timings)
+
+      vitals.fcp.value = 999999
+
+      expect(vitals.fcp.value).toBeUndefined()
+    })
+
+    it('should drop LCP whenever FCP is invalid, even if LCP itself would be under the threshold', () => {
+      const vitals = trackMFEVitals(mfeTarget, timings)
+
+      vitals.fcp.value = 999999
+      vitals.lcp.value = 50 // a small, otherwise-valid relative LCP
+
+      expect(vitals.lcp.value).toBeUndefined()
+    })
+
+    it('should not drop FCP/LCP when both are within the stale threshold', () => {
+      const vitals = trackMFEVitals(mfeTarget, timings)
+
+      vitals.fcp.value = 105
+      vitals.lcp.value = 120
+
+      expect(vitals.fcp.value).toBe(15) // 105 - scriptStart(90)
+      expect(vitals.lcp.value).toBe(30) // 120 - scriptStart(90)
+    })
+
+    it('should reject writes to fcp/lcp value setters once disconnected, even from an in-flight callback', () => {
+      // Avoid the automatic existingRoots-triggered populate so only the explicit setter calls below affect state
+      mockDocument.querySelectorAll = jest.fn(() => [])
+
+      const vitals = trackMFEVitals(mfeTarget, timings)
+
+      vitals.fcp.value = 105 // valid, pre-disconnect
+      vitals.disconnect()
+
+      // Simulate an observer callback that was already in flight when disconnect() ran
+      vitals.fcp.value = 200
+      vitals.lcp.value = 200
+
+      expect(vitals.fcp.value).toBe(15) // unchanged - the post-disconnect write was rejected
+      expect(vitals.lcp.value).toBeUndefined() // never set, and would cascade-drop from fcp anyway if it were
+    })
+  })
+
   describe('disconnect functionality', () => {
     it('should disconnect all observers', () => {
       const vitals = trackMFEVitals(mfeTarget, timings)


### PR DESCRIPTION
Fixes an issue where MFE vitals could occasionally report out of bounds FCP/LCP values (e.g. after a browser tab freeze or suspend) instead of being dropped like other stale data.
---

### Overview
Some MFEs were still occasionally reporting FCP values with large durations (2+ hours) despite the existing 10-second give-up timeout added in #1823. Assumed root cause: setTimeout timers can pause while a tab is frozen/suspended (bfcache, mobile background) even though performance.now() keeps advancing through real wall-clock time — so on resume, a mutation callback observing the first paint can win the race against the disconnect callback and set an our of bounds FCP before the disconnect cycle can veto it.

This PR adds a stale-clock cap directly to trackMFEVitals in mfe-vitals.js:

- The FCP value getter now drops (undefined) any relative timestamp exceeding the existing 10s threshold, instead of reporting it.
- The LCP value getter cascades: if FCP is invalid, LCP is dropped too, since LCP can never occur before FCP and would be derived from the same untrustworthy clock.
- populateVitalMinimums now checks staleness before seeding fcpObservedAt, and disconnects immediately if the very first observed render is already stale, rather than seeding bad data and waiting for the timeout.
- A disconnected flag now guards every vitals-writing path (setters, resize/CLS/INP observer callbacks) so a callback already in flight when disconnect() runs can't sneak a late write in afterward.
- Fixed an ordering bug uncovered while making this change: the "MFE already rendered before we started observing" fast path called populateVitalMinimums() before observers was populated and before disconnect had its real implementation assigned, so an early stale-detection there would have silently no-op'd. Moved it to run after full setup.

### Related Issue(s)
Follow up to https://new-relic.atlassian.net/browse/NR-597354 as that work was not completely successful.

### Testing
Unit: extended tests/unit/common/v2/mfe-vitals.test.js with cases for the FCP cap, the FCP→LCP cascade, and rejecting writes after disconnect() (41/41 passing).
E2E (wdio, run manually): extended tests/specs/api/register/mfe-vitals.e2e.js — the shared validateVitals helper now universally enforces the 10s FCP cap and the FCP→LCP cascade invariant across all existing scenarios, and the existing "give up after 10s" test now explicitly documents that it also exercises the cascade with a qualifying LCP-sized element added after the timeout.
To test manually: register an MFE, then simulate a stalled clock/backgrounded tab before first paint and confirm no FCP/LCP is reported instead of an inflated value; run npx jest tests/unit/common/v2/mfe-vitals.test.js and the mfe-vitals.e2e.js wdio spec.