### PR TITLE
feat: Add instrumentation to track races between tabs

### DIFF
--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -57,6 +57,8 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 <!--- A Session Trace was discard due to session expiration --->
 * Session/Expired/SessionTrace/Seen
 * Session/Disabled/MissingPerformanceNavigationTiming/Seen
+<!--- Another page was running at the same time and already updated the session state --->
+* Session/RaceCondition/Seen
 
 ### AJAX
 <!--- Ajax Events were Excluded because they matched the Agent beacon --->

--- a/src/common/harvest/connector.js
+++ b/src/common/harvest/connector.js
@@ -71,6 +71,8 @@ export class Connector {
       // Double check that there isn't a response saved (e.g. from another agent/browser tab) btwn the async time of the request and now in a race-condition.
       const cachedResp = session.state.cachedRumResponse
       if (cachedResp) {
+        // Report that we've seen a race condition on updating session state
+        handle(SUPPORTABILITY_METRIC_CHANNEL, ['Session/RaceCondition/Seen'], undefined, FEATURE_NAMES.metrics, this.#agentRef.ee)
         // `cachedRumResponse` is stored flat (`{ app, ...flags }`, matching the old v1 RUM response), so re-nest it before applying.
         const { app, ...config } = cachedResp
         this.#applyConnectResponse({ app, config })

--- a/tests/unit/common/harvest/connector.test.js
+++ b/tests/unit/common/harvest/connector.test.js
@@ -38,7 +38,7 @@ describe('Connector', () => {
       init: { feature_flags: [] },
       info: { licenseKey: 'license-key', applicationID: 'app-id' },
       runtime: { appMetadata: {}, session: undefined },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -56,7 +56,7 @@ describe('Connector', () => {
       init: { feature_flags: ['rum_v2'] },
       info: { licenseKey: 'license-key', applicationID: 'app-id' },
       runtime: { appMetadata: {}, session: undefined },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -91,7 +91,7 @@ describe('Connector', () => {
           write: jest.fn()
         }
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -116,7 +116,7 @@ describe('Connector', () => {
         appMetadata: {},
         session
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -148,7 +148,7 @@ describe('Connector', () => {
         appMetadata: {},
         session: undefined
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -185,7 +185,7 @@ describe('Connector', () => {
           write: jest.fn()
         }
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -231,7 +231,7 @@ describe('Connector', () => {
           write: jest.fn()
         }
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -272,7 +272,7 @@ describe('Connector', () => {
           write: jest.fn()
         }
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -296,7 +296,7 @@ describe('Connector', () => {
           write: jest.fn()
         }
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -333,7 +333,7 @@ describe('Connector', () => {
           write: jest.fn()
         }
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)
@@ -378,7 +378,7 @@ describe('Connector', () => {
         appMetadata: {},
         session
       },
-      ee: { abort: jest.fn() }
+      ee: { abort: jest.fn(), buffer: jest.fn(), emit: jest.fn() }
     }
 
     new Connector(agent)


### PR DESCRIPTION
Adds a supportability metric to track a race condition that occurs when another page runs at the same time with an updated session state.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

We're adding a supportability metric named `Session/RaceCondition/Seen`. This metric reports when you have the same agent (same app ID and license key) running in multiple tabs and they attempt to update the shared session state at the same time.

Angler: https://source.datanerd.us/agents/angler/pull/859

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-546642

### Testing

Make sure existing tests pass. This new supportability metric is troublesome to automatically test.