### PR TITLE
fix: Ensure Session Replay's custom masker applies to non-inputs

### DIFF
--- a/src/features/session_replay/shared/utils.js
+++ b/src/features/session_replay/shared/utils.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { gosNREUMOriginals } from '../../../common/window/nreum'
@@ -17,10 +17,8 @@ export function isPreloadAllowed (agentInit) {
 
 export function customMasker (text, element) {
   try {
-    if (typeof element?.type === 'string') {
-      if (element.type.toLowerCase() === 'password') return '*'.repeat(text?.length || 0)
-      if (element?.dataset?.nrUnmask !== undefined || element?.classList?.contains('nr-unmask')) return text
-    }
+    if (typeof element?.type === 'string' && element.type.toLowerCase() === 'password') return '*'.repeat(text?.length || 0)
+    if (element?.dataset?.nrUnmask !== undefined || element?.classList?.contains('nr-unmask')) return text
   } catch (err) {
     // likely an element was passed to this handler that was invalid and was missing attributes or methods
   }

--- a/tests/assets/rrweb-instrumented.html
+++ b/tests/assets/rrweb-instrumented.html
@@ -49,6 +49,9 @@
     <input type="password" id="pass-input" />
     <input type="text" id="text-input" />
     <hr />
+    <div id="text-plain">plain text node, no unmask decoration</div>
+    <div id="text-unmask-class" class="nr-unmask">text node unmasked via class</div>
+    <div id="text-unmask-data" data-nr-unmask>text node unmasked via data attribute</div>
     <div id="content-editable-div" contenteditable="true">text</div>
     <button onclick="moveImage()">Click</button>
     <button id="error-click" onclick="1=2">Click for Error</button>

--- a/tests/assets/rrweb-record.html
+++ b/tests/assets/rrweb-record.html
@@ -27,6 +27,7 @@
 </head>
 <body>
   this is a page intended to "manually" set up session replay and bypass the default "off" configs
+  <h1 data-nr-unmask>RUM Unit Test</h1>
   <hr />
   <hr />
   <div class="input-group">
@@ -51,6 +52,7 @@
       ss.href = 'https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.2/css/bootstrap.min.css'
       document.head.appendChild(ss)
       console.log("appended...")
+      document.querySelector('h1').innerHTML = 'RUM Unit Test - Updated'
     }, 3000)
   </script>
 </body>

--- a/tests/assets/rrweb-replayer-contents.html
+++ b/tests/assets/rrweb-replayer-contents.html
@@ -4,15 +4,21 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/rrweb@latest/dist/rrweb.min.css"
     />
-    <script src="https://cdn.jsdelivr.net/npm/rrweb@latest/dist/rrweb.min.js"></script>
+    <!-- <script type="module" src="https://cdn.jsdelivr.net/npm/rrweb@latest/dist/rrweb.min.js"></script> -->
   </head>
   <body>
-    <script>
+    <script type="module">
+      import * as rrweb from "https://cdn.jsdelivr.net/npm/rrweb@latest/dist/rrweb.min.js";
       (async () => {
         const urlParams = new URLSearchParams(window.location.search)
         const events = await fetch(`/session-replay?sessionId=${urlParams.get('sessionId')}`).then((r) => r.json());
         console.log("events", events);
-        const replayer = new rrweb.Replayer(events);
+        const replayer = new rrweb.Replayer(events, {
+          // Allows script/canvas execution in the replayed DOM iframe
+          UNSAFE_replayCanvas: true, 
+          // Disable inline script stripping if rrweb is filtering them out
+          blockClass: 'rr-block', 
+        });
         replayer.play();
       })();
     </script>

--- a/tests/specs/session-replay/rrweb-configuration.e2e.js
+++ b/tests/specs/session-replay/rrweb-configuration.e2e.js
@@ -95,7 +95,10 @@ describe('RRWeb Configuration', () => {
         expect(node.textContent).toMatch(/\s+/)
       })
 
-      const testNodes = JSONPath({ path: '$.[*].request.body.[?(!!@ && @.type===3 && !!@.textContent && @.textContent.match(/\\S+/) && ![\'script\',\'link\',\'style\'].includes(@parent.tagName))]', json: sessionReplaysHarvests })
+      // text-unmask-class/text-unmask-data are deliberately decorated to stay unmasked even under mask_text_selector:
+      // '*' -- excluded here since this test is about the blanket-masking behavior, not the unmask override (see the
+      // dedicated 'mask fn callbacks' tests below for that).
+      const testNodes = JSONPath({ path: '$.[*].request.body.[?(!!@ && @.type===3 && !!@.textContent && @.textContent.match(/\\S+/) && ![\'script\',\'link\',\'style\'].includes(@parent.tagName) && ![\'text-unmask-class\',\'text-unmask-data\'].includes(@parent.attributes.id))]', json: sessionReplaysHarvests })
       expect(testNodes.length).toBeGreaterThan(0)
 
       testNodes.forEach(node => {

--- a/tests/specs/session-replay/rrweb-configuration.e2e.js
+++ b/tests/specs/session-replay/rrweb-configuration.e2e.js
@@ -260,6 +260,24 @@ describe('RRWeb Configuration', () => {
       expect(textNode).toBeDefined()
       expect(textNode.textContent).not.toMatch(/\*+/)
     })
+
+    it('maskTextFn: should unmask a plain (non-input) text node by class when explicitly targeted by mask_text_selector', async () => {
+      await visit('rrweb-instrumented.html', { session_replay: { mask_text_selector: '#text-unmask-class' } })
+      const sessionReplaysHarvests = await getInitialHarvest()
+
+      const textNode = findTextNode(sessionReplaysHarvests, 'div', 'text-unmask-class')
+      expect(textNode).toBeDefined()
+      expect(textNode.textContent).not.toMatch(/\*+/)
+    })
+
+    it('maskTextFn: should unmask a plain (non-input) text node by data attr when explicitly targeted by mask_text_selector', async () => {
+      await visit('rrweb-instrumented.html', { session_replay: { mask_text_selector: '#text-unmask-data' } })
+      const sessionReplaysHarvests = await getInitialHarvest()
+
+      const textNode = findTextNode(sessionReplaysHarvests, 'div', 'text-unmask-data')
+      expect(textNode).toBeDefined()
+      expect(textNode.textContent).not.toMatch(/\*+/)
+    })
   })
 
   describe('block_selector', () => {

--- a/tests/specs/session-replay/rrweb-configuration.e2e.js
+++ b/tests/specs/session-replay/rrweb-configuration.e2e.js
@@ -231,6 +231,35 @@ describe('RRWeb Configuration', () => {
         { tagName: 'textarea', id: 'unmask-class', shouldMask: false }
       ])
     })
+
+    // NR-fix: a plain (non-input) element -- e.g. the container of a text node -- has no `.type` property.
+    // maskTextFn must still honor the unmask class/data attribute on elements like this, not just on inputs.
+    it('maskTextFn: should mask a plain (non-input) text node with no unmask decoration (control test)', async () => {
+      await visit('rrweb-instrumented.html', { session_replay: { mask_text_selector: '*' } })
+      const sessionReplaysHarvests = await getInitialHarvest()
+
+      const textNode = findTextNode(sessionReplaysHarvests, 'div', 'text-plain')
+      expect(textNode).toBeDefined()
+      expect(textNode.textContent).toMatch(/\*+/)
+    })
+
+    it('maskTextFn: should unmask a plain (non-input) text node by class', async () => {
+      await visit('rrweb-instrumented.html', { session_replay: { mask_text_selector: '*' } })
+      const sessionReplaysHarvests = await getInitialHarvest()
+
+      const textNode = findTextNode(sessionReplaysHarvests, 'div', 'text-unmask-class')
+      expect(textNode).toBeDefined()
+      expect(textNode.textContent).not.toMatch(/\*+/)
+    })
+
+    it('maskTextFn: should unmask a plain (non-input) text node by data attr', async () => {
+      await visit('rrweb-instrumented.html', { session_replay: { mask_text_selector: '*' } })
+      const sessionReplaysHarvests = await getInitialHarvest()
+
+      const textNode = findTextNode(sessionReplaysHarvests, 'div', 'text-unmask-data')
+      expect(textNode).toBeDefined()
+      expect(textNode.textContent).not.toMatch(/\*+/)
+    })
   })
 
   describe('block_selector', () => {
@@ -328,6 +357,24 @@ describe('RRWeb Configuration', () => {
 
   function getInitialHarvest () {
     return sessionReplaysCapture.waitForResult({ totalCount: 1, timeout: 10000 })
+  }
+
+  /**
+   * Finds the single text-node child of the given element (by tagName + id) in the initial snapshot harvest.
+   * @param {Array} sessionReplaysHarvests
+   * @param {string} tagName
+   * @param {string} id
+   * @returns {{textContent: string}|undefined}
+   */
+  function findTextNode (sessionReplaysHarvests, tagName, id) {
+    const snapshotHarvest = sessionReplaysHarvests.find(x => decodeAttributes(x.request.query.attributes).hasSnapshot === true)
+    expect(snapshotHarvest).toBeDefined()
+
+    const elementNode = JSONPath({ path: `$.request.body.[?(!!@ && @.tagName==='${tagName}' && @.attributes.id==='${id}')]`, json: snapshotHarvest })
+    expect(elementNode.length).toBe(1)
+
+    const textNodes = JSONPath({ path: '$.childNodes.[?(@.type===3)]', json: elementNode[0] })
+    return textNodes[0]
   }
 
   /**

--- a/tests/unit/features/session_replay/shared/utils.test.js
+++ b/tests/unit/features/session_replay/shared/utils.test.js
@@ -88,4 +88,27 @@ describe('customMasker', () => {
     const element2 = { type: 'string', classList: { contains: () => true } }
     expect(sessionReplaySharedUtils.customMasker(text, element2)).toEqual('   \n   ')
   })
+
+  // A text node's container element (e.g. a plain <div>/<span>) has no `.type` property at all -- unlike the
+  // `{ type: 'string' }` cases above. The unmask check must not be gated behind having a `.type`.
+  test('should return input text as masked when the element has no "type" property and is not decorated with unmask option', async () => {
+    const text = 'foobar'
+    const element = {}
+
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('******')
+  })
+
+  test('should return input text as-is when the element has no "type" property but is decorated with unmask option via data attribute', async () => {
+    const text = 'foobar'
+    const element = { dataset: { nrUnmask: true } }
+
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('foobar')
+  })
+
+  test('should return input text as-is when the element has no "type" property but is decorated with unmask option via class', async () => {
+    const text = 'foobar'
+    const element = { classList: { contains: () => true } }
+
+    expect(sessionReplaySharedUtils.customMasker(text, element)).toEqual('foobar')
+  })
 })


### PR DESCRIPTION
Fixed an issue where the custom masker function was not applying to certain element types. The custom masker is applied to elements that are decorated with one of `nr-umask` CSS class or `data-nr-unmask` data attribute, allowing a node that would otherwise be masked to be overridden and its text contents exposed.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
https://new-relic.atlassian.net/browse/NR-575039?atlOrigin=eyJpIjoiZDRjZjg3MDJlYTRmNDU0NmE4OGFjYzZkNGY0ZmJjYTUiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

### Testing
Tests have been added to validate that unmasking can be applied to standard text elements that are otherwise flagged as maskable.
<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
