### PR TITLE
feat: Add internal adoption metrics for AJAX Payloads

### DIFF
--- a/.github/actions/comment-pull-request/action.yml
+++ b/.github/actions/comment-pull-request/action.yml
@@ -27,14 +27,11 @@ runs:
       shell: bash
     - name: Run action script
       id: action-script
+      env:
+        COMMENT: ${{ inputs.comment }}
+        COMMENT_TAG: ${{ inputs.comment_tag }}
       run: |
         node $GITHUB_ACTION_PATH/index.js \
           --github-token ${{ inputs.token }} \
-          --pr-number ${{ inputs.pr_number }} \
-          --comment '''
-            ${{ inputs.comment }}
-          ''' \
-          --comment-tag '''
-            ${{ inputs.comment_tag }}
-          '''
+          --pr-number ${{ inputs.pr_number }}
       shell: bash

--- a/.github/actions/comment-pull-request/args.js
+++ b/.github/actions/comment-pull-request/args.js
@@ -11,12 +11,6 @@ export const args = yargs(hideBin(process.argv))
   .string('githubToken')
   .describe('githubToken', 'Github authentication token')
 
-  .string('comment')
-  .describe('comment', 'The comment to place on the pull request')
-
-  .string('commentTag')
-  .describe('commentTag', 'The tag to use for updating an existing comment on the pull request')
-
   .demandOption(['prNumber', 'githubToken'])
 
   .argv

--- a/.github/actions/comment-pull-request/index.js
+++ b/.github/actions/comment-pull-request/index.js
@@ -3,8 +3,14 @@ import { args } from './args.js'
 
 const octokit = github.getOctokit(args.githubToken)
 
-let commentBody = args.comment.split('\n')
-commentBody = commentBody.concat(args.commentTag.split('\n'))
+const comment = process.env.COMMENT
+if (!comment) {
+  throw new Error('COMMENT environment variable is required')
+}
+const commentTag = process.env.COMMENT_TAG || ''
+
+let commentBody = comment.split('\n')
+commentBody = commentBody.concat(commentTag.split('\n'))
 
 while (commentBody.length > 0 && commentBody[0].trim() === '') {
   // Do not start the comment with an empty line
@@ -19,8 +25,8 @@ while (commentBody.length > 0 && commentBody[commentBody.length - 1].trim() === 
 // Trim surrounding whitespace
 commentBody = commentBody.map(c => c.trim())
 
-let comment
-if (args.commentTag && args.commentTag.toString().trim() !== '') {
+let existingComment
+if (commentTag.trim() !== '') {
   for await (const { data: comments} of octokit.paginate.iterator(
     octokit.rest.issues.listComments,
     {
@@ -29,19 +35,19 @@ if (args.commentTag && args.commentTag.toString().trim() !== '') {
       issue_number: args.prNumber
     }
   )) {
-    comment = comments.find(c => c?.body?.includes(args.commentTag.trim()))
-    if (comment) {
+    existingComment = comments.find(c => c?.body?.includes(commentTag.trim()))
+    if (existingComment) {
       break
     }
   }
 }
 
-if (comment) {
+if (existingComment) {
   await octokit.rest.issues.updateComment({
     owner: github.context.repo.owner,
     repo: github.context.repo.repo,
     issue_number: args.prNumber,
-    comment_id: comment.id,
+    comment_id: existingComment.id,
     body: commentBody.join('\n')
   })
 } else {

--- a/docs/supportability-metrics.md
+++ b/docs/supportability-metrics.md
@@ -71,6 +71,8 @@ A timeslice metric is harvested to the JSE/XHR consumer. An aggregation service 
 * Ajax/Metrics/Excluded/App
 <!--- Number of bytes added to reported Ajax event bodies by adding GQL metadata --->
 * Ajax/Events/GraphQL/Bytes-Added
+<!--- Number of bytes added to reported Ajax events by including request/response body, header, and query payload attributes --->
+* Ajax/Events/Payload/Bytes-Added
 <!--- Observed Ajax calls contained a CrossApplicationTracing header --->
 * Ajax/CrossApplicationTracing/Header/Seen
 

--- a/src/features/ajax/aggregate/index.js
+++ b/src/features/ajax/aggregate/index.js
@@ -212,6 +212,10 @@ export class Aggregate extends AggregateBase {
         ...(event.responseHeaders ? { responseHeaders: event.responseHeaders } : {})
       }, { addKey: addStringRaw, addVal: addStringWithTruncation })
 
+      // .length is UTF-16 code units, not true UTF-8 byte size, so this undercounts multi-byte characters -- but it reuses the
+      // already-serialized payloadAttrs strings instead of re-stringifying/byte-counting, which is worth the imprecision here.
+      if (payloadAttrs.length) this.reportSupportabilityMetric('Ajax/Events/Payload/Bytes-Added', payloadAttrs.join(';').length)
+
       const attrParts = [...regularAttrs, ...payloadAttrs]
       fields.unshift(numeric(attrParts.length))
 

--- a/src/features/soft_navigations/aggregate/ajax-node.js
+++ b/src/features/soft_navigations/aggregate/ajax-node.js
@@ -4,6 +4,9 @@
  */
 import { addCustomAttributes, getAddStringContext, nullable, numeric } from '../../../common/serialize/bel-serializer'
 import { createStringAdders } from '../../../common/payloads/payloads'
+import { handle } from '../../../common/event-emitter/handle'
+import { FEATURE_NAMES } from '../../../loaders/features/features'
+import { SUPPORTABILITY_METRIC_CHANNEL } from '../../metrics/constants'
 import { AJAX_ID } from '../../ajax/constants'
 import { NODE_TYPE } from '../constants'
 import { BelNode } from './bel-node'
@@ -82,6 +85,10 @@ export class AjaxNode extends BelNode {
       ...(this.responseBody ? { responseBody: this.responseBody } : {}),
       ...(this.responseHeaders ? { responseHeaders: this.responseHeaders } : {})
     }, { addKey: addStringRaw, addVal: addStringWithTruncation })
+
+    // .length is UTF-16 code units, not true UTF-8 byte size, so this undercounts multi-byte characters -- but it reuses the
+    // already-serialized payloadAttrs strings instead of re-stringifying/byte-counting, which is worth the imprecision here.
+    if (payloadAttrs.length) handle(SUPPORTABILITY_METRIC_CHANNEL, ['Ajax/Events/Payload/Bytes-Added', payloadAttrs.join(';').length], undefined, FEATURE_NAMES.metrics, agentRef.ee)
 
     let allAttachedNodes = [...regularAttrs, ...payloadAttrs]
     this.children.forEach(node => allAttachedNodes.push(node.serialize())) // no children is expected under ajax nodes at this time

--- a/tests/components/ajax/aggregate.test.js
+++ b/tests/components/ajax/aggregate.test.js
@@ -290,6 +290,37 @@ describe('prepareHarvest', () => {
     })
   })
 
+  test('reports Ajax/Events/Payload/Bytes-Added SM when payload attributes are present', () => {
+    const spy = jest.spyOn(ajaxAggregate, 'reportSupportabilityMetric')
+
+    context.requestHeaders = { 'content-type': 'application/json' }
+    context.requestBody = 'fooBody'
+    context.responseHeaders = { 'content-type': 'application/json' }
+    context.responseBody = 'barBody'
+    fakeAgent.init.ajax.capture_payloads = CAPTURE_PAYLOAD_SETTINGS.ALL
+    ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+    ajaxAggregate.makeHarvestPayload(false)
+
+    expect(spy).toHaveBeenCalledWith('Ajax/Events/Payload/Bytes-Added', expect.any(Number))
+    const [, bytesAdded] = spy.mock.calls.find(call => call[0] === 'Ajax/Events/Payload/Bytes-Added')
+    expect(bytesAdded).toBeGreaterThan(0)
+
+    spy.mockRestore()
+  })
+
+  test('does not report Ajax/Events/Payload/Bytes-Added SM when no payload attributes are present', () => {
+    const spy = jest.spyOn(ajaxAggregate, 'reportSupportabilityMetric')
+
+    ajaxAggregate.ee.emit('xhr', ajaxArguments, context)
+
+    ajaxAggregate.makeHarvestPayload(false)
+
+    expect(spy).not.toHaveBeenCalledWith('Ajax/Events/Payload/Bytes-Added', expect.any(Number))
+
+    spy.mockRestore()
+  })
+
   test('does not obfuscate reserved/system fields', async () => {
     const mockEvent = {
       startTime: 1000,

--- a/tests/specs/ajax/payload_capture.e2e.js
+++ b/tests/specs/ajax/payload_capture.e2e.js
@@ -1,4 +1,4 @@
-import { testAjaxEventsRequest, testInteractionEventsRequest } from '../../../tools/testing-server/utils/expect-tests'
+import { testAjaxEventsRequest, testInteractionEventsRequest, testMetricsRequest } from '../../../tools/testing-server/utils/expect-tests'
 
 describe('capture_payloads', () => {
   let ajaxEventsCapture, bIxnCapture
@@ -276,6 +276,61 @@ describe('capture_payloads - beacon exclusion', () => {
       const keys = event.children.map(x => x.key)
       expect(keys).toEqual(expect.arrayContaining(['ajaxRequest.id']))
       expect(keys).not.toEqual(expect.arrayContaining(['requestHeaders', 'requestBody', 'responseHeaders', 'responseBody']))
+    })
+  })
+})
+
+describe('capture_payloads - supportability metrics', () => {
+  let ajaxEventsCapture, bIxnCapture, metricsCapture
+
+  beforeEach(async () => {
+    [ajaxEventsCapture, bIxnCapture, metricsCapture] = await browser.testHandle.createNetworkCaptures('bamServer', [
+      { test: testAjaxEventsRequest },
+      { test: testInteractionEventsRequest },
+      { test: testMetricsRequest }
+    ])
+  })
+
+  ;['full', 'spa'].forEach((loader) => {
+    // under the 'full' loader, ajax events are harvested standalone (ajax feature's own serializer);
+    // under the 'spa' loader, they're instead routed into interaction (bIxn) events via soft navigations,
+    // and the SM is recorded from AjaxNode.serialize as part of that harvest -- both paths must report it
+    const eventsCapture = () => loader === 'spa' ? bIxnCapture : ajaxEventsCapture
+
+    it(`reports Ajax/Events/Payload/Bytes-Added when payload attributes are captured (${loader} loader)`, async () => {
+      await browser.url(await browser.testHandle.assetURL('ajax/xhr-payloads.html', {
+        init: { ajax: { capture_payloads: 'all' } }, loader
+      })).then(() => browser.waitForAgentLoad())
+
+      // the SM is only recorded once the relevant feature's own harvest runs its serializer; wait for
+      // that harvest to land before forcing a final metrics harvest, so the SM has actually been recorded by then
+      await eventsCapture().waitForResult({ totalCount: 1 })
+
+      const [[smHarvest]] = await Promise.all([
+        metricsCapture.waitForResult({ totalCount: 1 }),
+        browser.refresh()
+      ])
+      const bytesAddedSm = smHarvest.request.body.sm.find(sm => sm.params.name === 'Ajax/Events/Payload/Bytes-Added')
+
+      expect(bytesAddedSm).toBeDefined()
+      expect(bytesAddedSm.stats.c).toBeGreaterThan(0)
+      expect(bytesAddedSm.stats.t).toBeGreaterThan(0)
+    })
+
+    it(`does not report Ajax/Events/Payload/Bytes-Added when capture_payloads is none (${loader} loader)`, async () => {
+      await browser.url(await browser.testHandle.assetURL('ajax/xhr-payloads.html', {
+        init: { ajax: { capture_payloads: 'none' } }, loader
+      })).then(() => browser.waitForAgentLoad())
+
+      await eventsCapture().waitForResult({ totalCount: 1 })
+
+      const [[smHarvest]] = await Promise.all([
+        metricsCapture.waitForResult({ totalCount: 1 }),
+        browser.refresh()
+      ])
+      const bytesAddedSm = smHarvest.request.body.sm.find(sm => sm.params.name === 'Ajax/Events/Payload/Bytes-Added')
+
+      expect(bytesAddedSm).toBeUndefined()
     })
   })
 })

--- a/tests/unit/features/soft_navigations/aggregate/ajax-node.test.js
+++ b/tests/unit/features/soft_navigations/aggregate/ajax-node.test.js
@@ -8,10 +8,13 @@ jest.unmock('../../../../../src/common/serialize/bel-serializer')
 jest.unmock('../../../../../src/common/util/obfuscate')
 jest.unmock('../../../../../src/common/payloads/payloads')
 
+jest.mock('../../../../../src/common/event-emitter/handle', () => ({ handle: jest.fn() }))
+
 const someAgent = {
   agentIdentifier: 'abcd',
   info: {},
-  runtime: { obfuscator: new Obfuscator({ init: { obfuscate: [] } }) }
+  runtime: { obfuscator: new Obfuscator({ init: { obfuscate: [] } }) },
+  ee: {}
 }
 const someAjaxEvent = {
   method: 'POST',
@@ -85,6 +88,33 @@ test('Ajax serialize output is correct', () => {
   expect(ajn.serialize(0, someAgent)).toEqual("2,4,sg,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;5,'ajaxRequest.id,'1234")
   // The start (and end) timestamp should translate based on "parent" timestamp passed in:
   expect(ajn.serialize(512, someAgent)).toEqual("2,4,e8,sg,,,'POST,5p,'google.com,'/,3f,co,1,'1,'some_span_id,'some_trace_id,lx;5,'operationName,'Anonymous;5,'operationType,'QUERY;5,'operationFramework,'GraphQL;5,'ajaxRequest.id,'1234")
+})
+
+test('serialize does not report Ajax/Events/Payload/Bytes-Added SM when there are no payload attributes', () => {
+  const { handle } = require('../../../../../src/common/event-emitter/handle')
+  const ajn = new AjaxNode(someAjaxEvent)
+
+  ajn.serialize(0, someAgent)
+
+  expect(handle).not.toHaveBeenCalled()
+})
+
+test('serialize reports Ajax/Events/Payload/Bytes-Added SM when payload attributes are present', () => {
+  const { handle } = require('../../../../../src/common/event-emitter/handle')
+  const ajaxEventWithPayload = {
+    ...someAjaxEvent,
+    requestBody: 'fooBody',
+    requestHeaders: { 'content-type': 'application/json' },
+    responseBody: 'barBody',
+    responseHeaders: { 'content-type': 'application/json' }
+  }
+  const ajn = new AjaxNode(ajaxEventWithPayload)
+
+  ajn.serialize(0, someAgent)
+
+  expect(handle).toHaveBeenCalledWith('storeSupportabilityMetrics', ['Ajax/Events/Payload/Bytes-Added', expect.any(Number)], undefined, 'metrics', someAgent.ee)
+  const [, [, bytesAdded]] = handle.mock.calls[0]
+  expect(bytesAdded).toBeGreaterThan(0)
 })
 
 test('obfuscation happens before truncation and result stays under 4KB in browser interactions', () => {


### PR DESCRIPTION
Adds an internal metric measuring adoption of AJAX payload tracking for quality assurance and improvement purposes.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)
PLEASE REVIEW --> https://source.datanerd.us/agents/angler/pull/862

https://new-relic.atlassian.net/browse/NR-587322?atlOrigin=eyJpIjoiMjVmM2VjMzM4ZDE0NDk1NmIxOWIwMjQwMTEzMDQxOWUiLCJwIjoiaiJ9
<!-- Please provide a link to all Github and/or Jira issues related to the pull request. -->

Updated dashboard --> https://onenr.io/01wZXvegZj6

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
