### PR TITLE
fix: Upgrade web-vitals from 4.2.4 to 6.2.1 to plug a listener leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@newrelic/rrweb": "^1.1.2",
         "fflate": "0.8.2",
-        "web-vitals": "4.2.4"
+        "web-vitals": "6.2.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.4",
@@ -25736,9 +25736,9 @@
       }
     },
     "node_modules/web-vitals": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.2.1.tgz",
+      "integrity": "sha512-rLcLXA2sx6+9dE88NHFubwTtGxpK4yYBLj6qHPdFoCaLr0cXGb4efOqtKLlm4loGA4OEKHIQKMKzZkKyOh5ctw==",
       "license": "Apache-2.0"
     },
     "node_modules/webdriver": {

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
   "dependencies": {
     "@newrelic/rrweb": "^1.1.2",
     "fflate": "0.8.2",
-    "web-vitals": "4.2.4"
+    "web-vitals": "6.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.4",

--- a/src/common/vitals/cumulative-layout-shift.js
+++ b/src/common/vitals/cumulative-layout-shift.js
@@ -1,16 +1,17 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { onCLS } from 'web-vitals/attribution'
 import { VITAL_NAMES } from './constants'
 import { VitalMetric } from './vital-metric'
+import { registerVital } from './register-vital'
 import { isBrowserScope } from '../constants/runtime'
 
 export const cumulativeLayoutShift = new VitalMetric(VITAL_NAMES.CUMULATIVE_LAYOUT_SHIFT, (x) => x)
 
 if (isBrowserScope) {
-  onCLS(({ value, attribution, id }) => {
+  const handleCLS = ({ value, attribution, id }) => {
     const attrs = {
       metricId: id,
       largestShiftTarget: attribution.largestShiftTarget,
@@ -19,5 +20,6 @@ if (isBrowserScope) {
       loadState: attribution.loadState
     }
     cumulativeLayoutShift.update({ value, attrs })
-  }, { reportAllChanges: true })
+  }
+  registerVital(() => onCLS(handleCLS, { reportAllChanges: true }))
 }

--- a/src/common/vitals/first-contentful-paint.js
+++ b/src/common/vitals/first-contentful-paint.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { onFCP } from 'web-vitals/attribution'
@@ -7,6 +7,7 @@ import { onFCP } from 'web-vitals/attribution'
 import { iOSBelow16, initiallyHidden, isBrowserScope } from '../constants/runtime'
 import { VITAL_NAMES } from './constants'
 import { VitalMetric } from './vital-metric'
+import { registerVital } from './register-vital'
 
 export const firstContentfulPaint = new VitalMetric(VITAL_NAMES.FIRST_CONTENTFUL_PAINT)
 
@@ -27,7 +28,7 @@ if (isBrowserScope) {
     // ignore
     }
   } else {
-    onFCP(({ value, attribution }) => {
+    const handleFCP = ({ value, attribution }) => {
       if (initiallyHidden || firstContentfulPaint.isValid) return
       const attrs = {
         timeToFirstByte: attribution.timeToFirstByte,
@@ -35,6 +36,7 @@ if (isBrowserScope) {
         loadState: attribution.loadState
       }
       firstContentfulPaint.update({ value, attrs })
-    })
+    }
+    registerVital(() => onFCP(handleFCP))
   }
 }

--- a/src/common/vitals/interaction-to-next-paint.js
+++ b/src/common/vitals/interaction-to-next-paint.js
@@ -1,17 +1,21 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 import { onINP } from 'web-vitals/attribution'
 import { VitalMetric } from './vital-metric'
 import { VITAL_NAMES } from './constants'
+import { registerVital } from './register-vital'
 import { isBrowserScope } from '../constants/runtime'
 
 export const interactionToNextPaint = new VitalMetric(VITAL_NAMES.INTERACTION_TO_NEXT_PAINT)
 
 if (isBrowserScope) {
   /* Interaction-to-Next-Paint */
-  onINP(({ value, attribution, id }) => {
+  const handleINP = ({ value, attribution, id, entries }) => {
+    /* web-vitals v6 reports a synthetic INP (value 8, no entries, no interaction attribution) after bfcache restores when
+      every interaction stayed below the duration threshold; skip those so only measured interactions are reported, as in v4 */
+    if (!entries?.length) return
     const attrs = {
       metricId: id,
       eventTarget: attribution.interactionTarget, // event* attrs deprecated in v4, kept for NR backwards compatibility
@@ -26,5 +30,6 @@ if (isBrowserScope) {
       loadState: attribution.loadState
     }
     interactionToNextPaint.update({ value, attrs })
-  })
+  }
+  registerVital(() => onINP(handleINP))
 }

--- a/src/common/vitals/largest-contentful-paint.js
+++ b/src/common/vitals/largest-contentful-paint.js
@@ -5,13 +5,14 @@
 import { onLCP } from 'web-vitals/attribution'
 import { VitalMetric } from './vital-metric'
 import { VITAL_NAMES } from './constants'
+import { registerVital } from './register-vital'
 import { initiallyHidden, isBrowserScope } from '../constants/runtime'
 import { cleanURL } from '../url/clean-url'
 
 export const largestContentfulPaint = new VitalMetric(VITAL_NAMES.LARGEST_CONTENTFUL_PAINT)
 
 if (isBrowserScope) {
-  onLCP(({ value, attribution }) => {
+  const handleLCP = ({ value, attribution }) => {
   /* Largest Contentful Paint - As of WV v3, it still imperfectly tries to detect document vis state asap and isn't supposed to report if page starts hidden. */
     if (initiallyHidden || largestContentfulPaint.isValid) return
 
@@ -28,9 +29,10 @@ if (isBrowserScope) {
       attrs.eid = lcpEntry.id
       if (lcpEntry.element?.tagName) attrs.elTag = lcpEntry.element.tagName
     }
-    if (attribution.element) attrs.element = attribution.element
+    if (attribution.target) attrs.element = attribution.target // renamed from `element` in web-vitals v4->v5; NR attr name kept for backwards compatibility
     if (attribution.url) attrs.elUrl = cleanURL(attribution.url)
 
     largestContentfulPaint.update({ value, attrs })
-  })
+  }
+  registerVital(() => onLCP(handleLCP))
 }

--- a/src/common/vitals/register-vital.js
+++ b/src/common/vitals/register-vital.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Invokes a web-vitals registration (e.g. `onLCP(callback)`), tolerating environments where the registration itself
+ * throws. web-vitals >= 5 reads Performance Timeline APIs such as `performance.getEntriesByType` unguarded when a
+ * metric is registered; where those are missing the metric is simply never reported, instead of the throw failing
+ * the feature that imported it.
+ * @param {() => void} register
+ */
+export function registerVital (register) {
+  try {
+    register()
+  } catch (e) {
+    // metric unavailable in this environment
+  }
+}

--- a/src/common/vitals/time-to-first-byte.js
+++ b/src/common/vitals/time-to-first-byte.js
@@ -5,6 +5,7 @@
 import { globalScope, isBrowserScope, isiOS, originTime, getNavigationEntry } from '../constants/runtime'
 import { VITAL_NAMES } from './constants'
 import { VitalMetric } from './vital-metric'
+import { registerVital } from './register-vital'
 import { onTTFB } from 'web-vitals/attribution'
 
 export const timeToFirstByte = new VitalMetric(VITAL_NAMES.TIME_TO_FIRST_BYTE)
@@ -18,10 +19,11 @@ export const timeToFirstByte = new VitalMetric(VITAL_NAMES.TIME_TO_FIRST_BYTE)
  * - onTTFB relies on a truthy `responseStart` value, should ensure that exists before relying on it (seen to be falsy in certain Electron.js cases for instance)
  */
 if (isBrowserScope && getNavigationEntry() && !isiOS && window === window.parent) {
-  onTTFB(({ value, attribution }) => {
+  const handleTTFB = ({ value, attribution }) => {
     if (timeToFirstByte.isValid) return
     timeToFirstByte.update({ value, attrs: { navigationEntry: attribution.navigationEntry } })
-  })
+  }
+  registerVital(() => onTTFB(handleTTFB))
 } else {
   if (!timeToFirstByte.isValid) {
     const entry = {}

--- a/src/common/vitals/vital-metric.js
+++ b/src/common/vitals/vital-metric.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2025 New Relic, Inc. All rights reserved.
+ * Copyright 2020-2026 New Relic, Inc. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
 export class VitalMetric {
@@ -17,7 +17,8 @@ export class VitalMetric {
     const state = {
       value: this.roundingMethod(value),
       name: this.name,
-      attrs
+      // optional web-vitals attribution fields are omitted rather than being serialized as null attributes
+      attrs: Object.fromEntries(Object.entries(attrs).filter(([, attrValue]) => attrValue !== undefined))
     }
 
     this.history.push(state)

--- a/src/interfaces/registered-iframe-entity.js
+++ b/src/interfaces/registered-iframe-entity.js
@@ -7,6 +7,7 @@
 import { onCLS, onFCP, onINP, onLCP } from 'web-vitals'
 // internal
 import { globalScope, isBrowserScope } from '../common/constants/runtime'
+import { registerVital } from '../common/vitals/register-vital'
 import { isIFrameWindow } from '../common/dom/iframe'
 import { now } from '../common/timing/now'
 import { warn } from '../common/util/console'
@@ -179,12 +180,12 @@ export class RegisteredIframeEntity {
    */
   #setupVitalsListeners () {
     VITALS.forEach(([vitalFn, property]) => {
-      vitalFn(({ value }) => {
+      registerVital(() => vitalFn(({ value }) => {
         this.metadata.vitals[property].value = value
         this.#postMessageToParent(IFRAME_VITALS_UPDATE, {
           entries: [{ property, value }]
         })
-      }, { reportAllChanges: property === 'cls' || property === 'inp' })
+      }, { reportAllChanges: property === 'cls' || property === 'inp' }))
     })
   }
 

--- a/src/interfaces/registered-iframe-entity.js
+++ b/src/interfaces/registered-iframe-entity.js
@@ -180,7 +180,11 @@ export class RegisteredIframeEntity {
    */
   #setupVitalsListeners () {
     VITALS.forEach(([vitalFn, property]) => {
-      registerVital(() => vitalFn(({ value }) => {
+      registerVital(() => vitalFn(({ value, entries: vitalEntries }) => {
+        /* web-vitals v6 reports a synthetic INP (value 8, no entries) after bfcache restores when
+          every interaction stayed below the duration threshold; skip those so only measured
+          interactions are reported, matching the guard in src/common/vitals/interaction-to-next-paint.js */
+        if (property === 'inp' && !vitalEntries?.length) return
         this.metadata.vitals[property].value = value
         this.#postMessageToParent(IFRAME_VITALS_UPDATE, {
           entries: [{ property, value }]

--- a/tests/components/page_view_timing/aggregate.test.js
+++ b/tests/components/page_view_timing/aggregate.test.js
@@ -14,20 +14,35 @@ jest.mock('web-vitals/attribution', () => ({
   })),
   onFCP: jest.fn((cb) => cb({
     value: 1,
-    attribution: {}
+    attribution: {
+      timeToFirstByte: 12,
+      firstByteToFCP: 23,
+      loadState: 'dom-interactive'
+    }
   })),
   onINP: jest.fn((cb) => cb({
     value: 8,
+    id: 'v4-1234',
+    entries: [{ name: 'pointerdown', startTime: 8853.8, duration: 8 }],
     attribution: {
       interactionType: 'pointer',
       interactionTime: 8853.8,
       interactionTarget: 'button',
+      inputDelay: 1,
+      nextPaintTime: 8861.8,
+      processingDuration: 5,
+      presentationDelay: 2,
       loadState: 'complete'
     }
   })),
   onLCP: jest.fn((cb) => cb({
     value: 1,
-    attribution: {}
+    attribution: {
+      timeToFirstByte: 12,
+      resourceLoadDelay: 2,
+      resourceLoadDuration: 3,
+      elementRenderDelay: 4
+    }
   }))
 }))
 
@@ -165,17 +180,17 @@ test('does not obfuscate timing names or attribute keys', async () => {
 
   const lcp = findTimings(VITAL_NAMES.LARGEST_CONTENTFUL_PAINT)
   const checkLcpAttrs = (obj) => expect(lcp.attributes).toEqual(expect.arrayContaining([expect.objectContaining(obj)]))
-  checkLcpAttrs({ key: 'timeToFirstByte' })
-  checkLcpAttrs({ key: 'resourceLoadDelay' })
-  checkLcpAttrs({ key: 'resourceLoadDuration' })
-  checkLcpAttrs({ key: 'resourceLoadTime' })
-  checkLcpAttrs({ key: 'elementRenderDelay' })
+  checkLcpAttrs({ key: 'timeToFirstByte', value: 12 })
+  checkLcpAttrs({ key: 'resourceLoadDelay', value: 2 })
+  checkLcpAttrs({ key: 'resourceLoadDuration', value: 3 })
+  checkLcpAttrs({ key: 'resourceLoadTime', value: 3 })
+  checkLcpAttrs({ key: 'elementRenderDelay', value: 4 })
 
   const fcp = findTimings(VITAL_NAMES.FIRST_CONTENTFUL_PAINT)
   const checkFcpAttrs = (obj) => expect(fcp.attributes).toEqual(expect.arrayContaining([expect.objectContaining(obj)]))
-  checkFcpAttrs({ key: 'timeToFirstByte' })
-  checkFcpAttrs({ key: 'firstByteToFCP' })
-  checkFcpAttrs({ key: 'loadState' })
+  checkFcpAttrs({ key: 'timeToFirstByte', value: 12 })
+  checkFcpAttrs({ key: 'firstByteToFCP', value: 23 })
+  checkFcpAttrs({ key: 'loadState', value: 'dom-interactive' })
 
   const fi = findTimings(VITAL_NAMES.FIRST_INTERACTION)
   const checkFiAttrs = (obj) => expect(fi.attributes).toEqual(expect.arrayContaining([expect.objectContaining(obj)]))
@@ -185,16 +200,16 @@ test('does not obfuscate timing names or attribute keys', async () => {
 
   const inp = findTimings(VITAL_NAMES.INTERACTION_TO_NEXT_PAINT)
   const checkInpAttrs = (obj) => expect(inp.attributes).toEqual(expect.arrayContaining([expect.objectContaining(obj)]))
-  checkInpAttrs({ key: 'metricId' })
+  checkInpAttrs({ key: 'metricId', value: 'v4-1234' })
   checkInpAttrs({ key: 'eventTarget', value: 'button' })
-  checkInpAttrs({ key: 'eventTime' })
+  checkInpAttrs({ key: 'eventTime', value: 8853.8 })
   checkInpAttrs({ key: 'interactionTarget', value: 'button' })
-  checkInpAttrs({ key: 'interactionTime' })
+  checkInpAttrs({ key: 'interactionTime', value: 8853.8 })
   checkInpAttrs({ key: 'interactionType', value: 'pointer' })
-  checkInpAttrs({ key: 'inputDelay' })
-  checkInpAttrs({ key: 'nextPaintTime' })
-  checkInpAttrs({ key: 'processingDuration' })
-  checkInpAttrs({ key: 'presentationDelay' })
+  checkInpAttrs({ key: 'inputDelay', value: 1 })
+  checkInpAttrs({ key: 'nextPaintTime', value: 8861.8 })
+  checkInpAttrs({ key: 'processingDuration', value: 5 })
+  checkInpAttrs({ key: 'presentationDelay', value: 2 })
   checkInpAttrs({ key: 'loadState', value: 'complete' })
 
   const globalAttrs = []

--- a/tests/components/page_view_timing/index.test.js
+++ b/tests/components/page_view_timing/index.test.js
@@ -13,6 +13,8 @@ jest.mock('web-vitals/attribution', () => ({
   })),
   onINP: jest.fn((cb) => cb({
     value: 8,
+    id: 'v4-1234',
+    entries: [{ name: 'pointerdown', startTime: 8853.8, duration: 8 }],
     attribution: {
       interactionType: 'pointer',
       interactionTime: 8853.8,

--- a/tests/unit/common/vitals/cumulative-layout-shift.test.js
+++ b/tests/unit/common/vitals/cumulative-layout-shift.test.js
@@ -11,9 +11,9 @@ const clsAttribution = {
   loadState: 'dom-content-loaded'
 }
 let mockReturnVal = 0.123
-const getFreshCLSImport = async (codeToRun) => {
+const getFreshCLSImport = async (codeToRun, attribution = clsAttribution) => {
   jest.doMock('web-vitals/attribution', () => ({
-    onCLS: jest.fn(cb => cb({ value: mockReturnVal, attribution: clsAttribution, id: 'beepboop' }))
+    onCLS: jest.fn(cb => cb({ value: mockReturnVal, attribution, id: 'beepboop' }))
   }))
   const { cumulativeLayoutShift } = await import('../../../../src/common/vitals/cumulative-layout-shift')
   codeToRun(cumulativeLayoutShift)
@@ -28,6 +28,28 @@ describe('cls', () => {
         done()
       })
     })
+  })
+  test('omits largestShiftTarget when undefined (web-vitals v6 when the shift target node was removed)', (done) => {
+    mockReturnVal = 0.123
+    getFreshCLSImport(metric => {
+      metric.subscribe(({ value, attrs }) => {
+        expect(value).toEqual(0.123)
+        expect(attrs).toStrictEqual({
+          metricId: 'beepboop',
+          largestShiftTime: clsAttribution.largestShiftTime,
+          largestShiftValue: clsAttribution.largestShiftValue,
+          loadState: clsAttribution.loadState
+        })
+        done()
+      })
+    }, { ...clsAttribution, largestShiftTarget: undefined })
+  })
+  test('does NOT throw if web-vitals registration throws', async () => {
+    jest.doMock('web-vitals/attribution', () => ({
+      onCLS: jest.fn(() => { throw new TypeError('performance.getEntriesByType is not a function') })
+    }))
+    const { cumulativeLayoutShift } = await import('../../../../src/common/vitals/cumulative-layout-shift')
+    expect(cumulativeLayoutShift.isValid).toEqual(false)
   })
   test('does NOT report if not browser scoped', (done) => {
     jest.doMock('../../../../src/common/constants/runtime', () => ({

--- a/tests/unit/common/vitals/first-contentful-paint.test.js
+++ b/tests/unit/common/vitals/first-contentful-paint.test.js
@@ -29,6 +29,14 @@ describe('fcp', () => {
     })
   })
 
+  test('does NOT throw if web-vitals registration throws', async () => {
+    jest.doMock('web-vitals/attribution', () => ({
+      onFCP: jest.fn(() => { throw new TypeError('performance.getEntriesByType is not a function') })
+    }))
+    const { firstContentfulPaint } = await import('../../../../src/common/vitals/first-contentful-paint')
+    expect(firstContentfulPaint.isValid).toEqual(false)
+  })
+
   test('reports fcp from paintEntries if ios<16', (done) => {
     jest.doMock('../../../../src/common/constants/runtime', () => ({
       __esModule: true,

--- a/tests/unit/common/vitals/interaction-to-next-paint.test.js
+++ b/tests/unit/common/vitals/interaction-to-next-paint.test.js
@@ -14,9 +14,9 @@ const inpAttribution = {
   presentationDelay: 0,
   loadState: 'complete'
 }
-const getFreshINPImport = async (codeToRun) => {
+const getFreshINPImport = async (codeToRun, attribution = inpAttribution, entries = [{}]) => {
   jest.doMock('web-vitals/attribution', () => ({
-    onINP: jest.fn(cb => cb({ value: 8, attribution: inpAttribution, id: 'ruhroh' }))
+    onINP: jest.fn(cb => cb({ value: 8, attribution, id: 'ruhroh', entries }))
   }))
   const { interactionToNextPaint } = await import('../../../../src/common/vitals/interaction-to-next-paint')
   codeToRun(interactionToNextPaint)
@@ -41,6 +41,52 @@ describe('inp', () => {
       })
       done()
     }))
+  })
+
+  test('omits interactionTarget when web-vitals could not resolve the target (undefined as of v6)', (done) => {
+    getFreshINPImport(metric => metric.subscribe(({ value, attrs }) => {
+      expect(value).toEqual(8)
+      expect(attrs).toStrictEqual({
+        interactionTime: inpAttribution.interactionTime,
+        eventTime: inpAttribution.interactionTime,
+        interactionType: inpAttribution.interactionType,
+        inputDelay: inpAttribution.inputDelay,
+        nextPaintTime: inpAttribution.nextPaintTime,
+        processingDuration: inpAttribution.processingDuration,
+        presentationDelay: inpAttribution.presentationDelay,
+        loadState: inpAttribution.loadState,
+        metricId: 'ruhroh'
+      })
+      done()
+    }), { ...inpAttribution, interactionTarget: undefined })
+  })
+
+  test('does NOT report the synthetic no-entries INP web-vitals v6 emits after a bfcache restore', (done) => {
+    const dummyAttribution = {
+      // Mimic web-vitals v6 dummy INP attribution, reported when the interaction count went up with no event entry (bfcache restore / soft nav)
+      processedEventEntries: [],
+      longAnimationFrameEntries: [],
+      inputDelay: 0,
+      processingDuration: 0,
+      presentationDelay: 8,
+      loadState: 'complete'
+    }
+
+    getFreshINPImport(metric => {
+      metric.subscribe(() => {
+        console.log('should not have reported...')
+        expect(1).toEqual(2)
+      })
+      setTimeout(done, 1000)
+    }, dummyAttribution, [])
+  })
+
+  test('does NOT throw if web-vitals registration throws', async () => {
+    jest.doMock('web-vitals/attribution', () => ({
+      onINP: jest.fn(() => { throw new TypeError('performance.getEntriesByType is not a function') })
+    }))
+    const { interactionToNextPaint } = await import('../../../../src/common/vitals/interaction-to-next-paint')
+    expect(interactionToNextPaint.isValid).toEqual(false)
   })
 
   test('does NOT report if not browser scoped', (done) => {

--- a/tests/unit/common/vitals/largest-contentful-paint.test.js
+++ b/tests/unit/common/vitals/largest-contentful-paint.test.js
@@ -10,7 +10,7 @@ const lcpAttribution = {
     id: 'someid',
     element: { tagName: 'sometagName' }
   },
-  element: '#someid',
+  target: '#someid',
   timeToFirstByte: 1,
   resourceLoadDelay: 2,
   resourceLoadDuration: 3,
@@ -43,7 +43,7 @@ describe('lcp', () => {
         eid: lcpAttribution.lcpEntry.id,
         elUrl: 'http://domain.com/page', // url is cleaned so query & hash removed
         elTag: lcpAttribution.lcpEntry.element.tagName,
-        element: lcpAttribution.element,
+        element: lcpAttribution.target,
         timeToFirstByte: lcpAttribution.timeToFirstByte,
         resourceLoadDelay: lcpAttribution.resourceLoadDelay,
         resourceLoadDuration: lcpAttribution.resourceLoadDuration,
@@ -74,6 +74,14 @@ describe('lcp', () => {
       })
       done()
     }))
+  })
+
+  test('does NOT throw if web-vitals registration throws', async () => {
+    jest.doMock('web-vitals/attribution', () => ({
+      onLCP: jest.fn(() => { throw new TypeError('performance.getEntriesByType is not a function') })
+    }))
+    const { largestContentfulPaint } = await import('../../../../src/common/vitals/largest-contentful-paint')
+    expect(largestContentfulPaint.isValid).toEqual(false)
   })
 
   test('does NOT report if not browser scoped', (done) => {

--- a/tests/unit/common/vitals/register-vital.test.js
+++ b/tests/unit/common/vitals/register-vital.test.js
@@ -1,0 +1,15 @@
+import { registerVital } from '../../../../src/common/vitals/register-vital'
+
+describe('registerVital', () => {
+  test('invokes the registration', () => {
+    const register = jest.fn()
+    registerVital(register)
+    expect(register).toHaveBeenCalledTimes(1)
+  })
+
+  test('swallows a throwing registration', () => {
+    const register = jest.fn(() => { throw new TypeError('performance.getEntriesByType is not a function') })
+    expect(() => registerVital(register)).not.toThrow()
+    expect(register).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/common/vitals/time-to-first-byte.test.js
+++ b/tests/unit/common/vitals/time-to-first-byte.test.js
@@ -35,6 +35,28 @@ describe('ttfb', () => {
     }))
   })
 
+  test('does NOT throw if web-vitals registration throws', async () => {
+    const mockPerformance = {
+      getEntriesByType: jest.fn().mockReturnValue([{ responseStart: 100 }])
+    }
+    global.PerformanceNavigationTiming = jest.fn()
+    jest.doMock('../../../../src/common/constants/runtime', () => ({
+      __esModule: true,
+      isiOS: false,
+      isBrowserScope: true,
+      getNavigationEntry: () => mockPerformance?.getEntriesByType('navigation')?.[0],
+      globalScope: {
+        performance: mockPerformance
+      }
+    }))
+    jest.doMock('web-vitals/attribution', () => ({
+      onTTFB: jest.fn(() => { throw new TypeError('performance.getEntriesByType is not a function') })
+    }))
+
+    const { timeToFirstByte } = await import('../../../../src/common/vitals/time-to-first-byte')
+    expect(timeToFirstByte.isValid).toEqual(false)
+  })
+
   test('does NOT report if not browser scoped', (done) => {
     jest.doMock('../../../../src/common/constants/runtime', () => ({
       __esModule: true,

--- a/tests/unit/common/vitals/vital-metric.test.js
+++ b/tests/unit/common/vitals/vital-metric.test.js
@@ -39,6 +39,11 @@ describe('vital-metric', () => {
     })
   })
 
+  test('omits attrs whose value is undefined', () => {
+    vitalMetric.update({ value: 1, attrs: { kept: 'yes', alsoKept: 0, dropped: undefined, keptNull: null } })
+    expect(vitalMetric.current.attrs).toStrictEqual({ kept: 'yes', alsoKept: 0, keptNull: null })
+  })
+
   test('rounding', () => {
     // default rounding
     vitalMetric.update({ value: 1.234 })

--- a/tests/unit/interfaces/registered-iframe-entity.test.js
+++ b/tests/unit/interfaces/registered-iframe-entity.test.js
@@ -80,6 +80,25 @@ describe('RegisteredIframeEntity blocked state', () => {
     })
   }
 
+  it('still constructs and registers the remaining vitals when a web-vitals registration throws', async () => {
+    jest.resetModules()
+    const onCLS = jest.fn(() => { throw new TypeError('performance.getEntriesByType is not a function') })
+    const onLCP = jest.fn()
+    const onFCP = jest.fn()
+    const onINP = jest.fn()
+    jest.doMock('web-vitals', () => ({ onCLS, onFCP, onINP, onLCP }))
+    const { RegisteredIframeEntity: Entity } = await import('../../../src/interfaces/registered-iframe-entity')
+
+    const entity = new Entity({ id: 'my-id', name: 'my-name' })
+    await flushMicrotasks()
+
+    expect(entity).toBeInstanceOf(Entity)
+    expect(onCLS).toHaveBeenCalledTimes(1)
+    expect(onLCP).toHaveBeenCalledTimes(1)
+    expect(onFCP).toHaveBeenCalledTimes(1)
+    expect(onINP).toHaveBeenCalledTimes(1)
+  })
+
   it('becomes blocked when the registration response reports the container blocked the target', async () => {
     const entity = new RegisteredIframeEntity({ id: 'my-id', name: 'my-name' })
     await flushMicrotasks()

--- a/tests/unit/interfaces/registered-iframe-entity.test.js
+++ b/tests/unit/interfaces/registered-iframe-entity.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IFRAME_API_RESPONSE } from '../../../src/common/constants/iframe-constants'
+import { IFRAME_API_RESPONSE, IFRAME_VITALS_UPDATE } from '../../../src/common/constants/iframe-constants'
 
 describe('RegisteredIframeEntity blocked state', () => {
   let RegisteredIframeEntity
@@ -97,6 +97,46 @@ describe('RegisteredIframeEntity blocked state', () => {
     expect(onLCP).toHaveBeenCalledTimes(1)
     expect(onFCP).toHaveBeenCalledTimes(1)
     expect(onINP).toHaveBeenCalledTimes(1)
+  })
+
+  /** Re-imports the entity with web-vitals mocks that capture each registered callback, then completes registration */
+  const registerWithCapturedVitals = async () => {
+    jest.resetModules()
+    const callbacks = {}
+    const capture = (property) => jest.fn((cb) => { callbacks[property] = cb })
+    jest.doMock('web-vitals', () => ({ onCLS: capture('cls'), onFCP: capture('fcp'), onINP: capture('inp'), onLCP: capture('lcp') }))
+    const { RegisteredIframeEntity: Entity } = await import('../../../src/interfaces/registered-iframe-entity')
+
+    const entity = new Entity({ id: 'my-id', name: 'my-name' })
+    await flushMicrotasks()
+    respondToLastMessage({ target: { id: 'my-id', name: 'my-name', blocked: false } })
+    await flushMicrotasks()
+    postMessage.mockClear()
+    return { entity, callbacks }
+  }
+
+  it('does NOT forward the synthetic no-entries INP report web-vitals v6 emits after bfcache restores', async () => {
+    const { entity, callbacks } = await registerWithCapturedVitals()
+
+    callbacks.inp({ value: 8, entries: [] })
+    await flushMicrotasks()
+
+    expect(entity.metadata.vitals.inp.value).toBeNull()
+    expect(postMessage).not.toHaveBeenCalled()
+  })
+
+  it('still forwards measured INP, and a zero CLS with no layout-shift entries', async () => {
+    const { entity, callbacks } = await registerWithCapturedVitals()
+
+    callbacks.cls({ value: 0, entries: [] })
+    callbacks.inp({ value: 120, entries: [{ name: 'pointerdown', duration: 120 }] })
+    await flushMicrotasks()
+
+    expect(entity.metadata.vitals.cls.value).toBe(0)
+    expect(entity.metadata.vitals.inp.value).toBe(120)
+    expect(postMessage).toHaveBeenCalledTimes(2)
+    expect(postMessage.mock.calls[0][0]).toMatchObject({ type: IFRAME_VITALS_UPDATE, entries: [{ property: 'cls', value: 0 }] })
+    expect(postMessage.mock.calls[1][0]).toMatchObject({ type: IFRAME_VITALS_UPDATE, entries: [{ property: 'inp', value: 120 }] })
   })
 
   it('becomes blocked when the registration response reports the container blocked the target', async () => {

--- a/tools/jest/globals.mjs
+++ b/tools/jest/globals.mjs
@@ -6,6 +6,12 @@ if (typeof window !== 'undefined') {
   window.Response = jest.fn()
 }
 
+/** jsdom does not implement the Performance Timeline; web-vitals >= 5 calls this unguarded at metric registration */
+if (typeof performance !== 'undefined' && typeof performance.getEntriesByType !== 'function') {
+  // writable + configurable so individual tests can still redefine it
+  Object.defineProperty(performance, 'getEntriesByType', { value: () => [], writable: true, configurable: true })
+}
+
 /** silence unneeded console debug (warn(...)) noise during tests */
 if (typeof console !== 'undefined') {
   console.error = jest.fn()


### PR DESCRIPTION
Upgrades the bundled web-vitals library from 4.2.4 to 6.2.1, fixing an unbounded `document` `visibilitychange` listener leak: web-vitals 4.x registers a permanent listener on every INP report cycle, so long-lived pages accumulate hundreds of listeners. Also absorbs the v5/v6 attribution API changes the agent is exposed to (the `LCPAttribution.element` → `target` rename and newly-optional INP/CLS attribution fields) with no change to the attribute names the agent emits.
---

### Overview

web-vitals 4.2.4's `whenIdle()` calls `onHidden()` on every invocation, and `onHidden()` does a bare `document.addEventListener('visibilitychange', ...)` with no `once` and no removal. `onINP` invokes `whenIdle()` on every event-entry observer batch and every attribution cleanup cycle, so pages instrumented with page_view_timing leak roughly two permanent listeners per interaction batch for the life of the page (we measured 112 after ~45 minutes of ordinary use in a long-lived SPA). Upstream fixed this in web-vitals 5.0.0 (GoogleChrome/web-vitals#534 → #538) and there is no fixed 4.x release, so this bumps to the current 6.2.1.

Changes, mapped to the 4 → 6 breaking-change surface this agent actually touches:

* **`package.json` / `package-lock.json`**: `web-vitals` exact pin `4.2.4` → `6.2.1` (kept exact per #1133). Both entry points the agent imports (`web-vitals`, `web-vitals/attribution`) and all five consumed metric functions are unchanged in v6.
* **`src/common/vitals/largest-contentful-paint.js`**: `LCPAttribution.element` was renamed to `target` in v5 (GoogleChrome/web-vitals#585). The wrapper now reads `attribution.target` but keeps emitting the existing `element` attribute on `lcp` PageViewTiming events, so nothing changes for NRQL consumers. Without this, the attribute would silently disappear.
* **`src/common/vitals/interaction-to-next-paint.js`**: v6 emits a synthetic INP report (`value: 8`, `entries: []`, no interaction attribution) after a bfcache restore when every interaction stayed below the duration threshold (GoogleChrome/web-vitals#724). v4 reported nothing in that situation, so the wrapper skips reports without entries to keep only measured interactions — otherwise a constant 8 ms sample would be harvested as an `inp` PageViewTiming node indistinguishable from a real one.
* **`src/common/vitals/vital-metric.js`**: several attribution fields are optional as of v6 (`INPAttribution.interactionTarget` when the interacted element was removed before reporting, `CLSAttribution.largestShiftTarget` likewise, and every CLS field on a zero-shift report) where v4 coerced them to `''`. `VitalMetric.update()` now drops undefined-valued attrs once, centrally, so they are omitted from the payload instead of being serialized as null attributes — the same outcome the LCP wrapper already produced for its optional fields, without per-field guards in every wrapper.
* **`src/common/vitals/register-vital.js`** (new) and the five wrappers plus `src/interfaces/registered-iframe-entity.js`: web-vitals >= 5 calls `performance.getEntriesByType()` unguarded, synchronously, while a metric is registered (its "Baseline Widely available" policy dropped v4's feature check). The agent registers metrics at module top level, so wherever that API is missing — a consumer running an instrumented app under Jest/jsdom, a webview shimming `performance` — v6 would throw at import time, the aggregate chunk import would reject with warn code 34, and because page_view_event and soft_navigations import the FCP wrapper too, the PageView event itself would be lost. The `RegisteredIframeEntity` constructor would throw into customer code the same way. `registerVital()` wraps each registration in the try/catch idiom `first-paint.js` already uses for `PerformanceObserver`, so a missing API degrades to "that metric is not reported", exactly as with v4.
* **`tools/jest/globals.mjs`**: jest-environment-jsdom does not implement the Performance Timeline, so the same unguarded call meant 8 suites / 71 tests that transitively load the real library (page_view_timing aggregate unit tests, page_view_event and soft_navigations component tests) failed at module init with `TypeError: performance.getEntriesByType is not a function` — surfacing only as opaque 5 s hook timeouts because the import failure is caught and logged through the muted console. With `registerVital()` those suites no longer fail, but the polyfill (`() => []`, which the agent's own `getNavigationEntry()` already treats as "no entry") keeps the callback paths exercised under jsdom; it is defined writable/configurable because some tests redefine it.
* **`onFID`** (v5's headline removal) is not used by the agent — no change needed.

Behavioral notes for reviewers (library-side changes that can shift reported values; no agent code involved):

* The synthetic post-bfcache INP report described above is skipped for v4 parity. If you would rather adopt web-vitals' intent (so INP p75 isn't biased toward pages with only fast interactions), dropping the `entries` check in the INP wrapper passes them through; they arrive with only `metricId`/`inputDelay`/`processingDuration`/`presentationDelay`/`loadState`.
* Attribution selector strings sort their class lists as of v5 (#518) — `largestShiftTarget` / `interactionTarget` / LCP target strings can change form for multi-class elements.
* INP breakdowns are clamped to the INP duration and `nextPaintTime` to `processingStart` as of v5 (#528, #540, #546) — sub-metric values become more accurate.
* Prerendered pages now report FCP/LCP (#621); previously 4.2.4 could silently never report there.
* The idle callback is capped at 1 s (#755), so `reportAllChanges` subscribers (CLS here, plus cls/inp in `registered-iframe-entity`) hear more often on busy pages; both consumers are idempotent per-report handlers.
* The v6 attribution build registers a module-scope resource-timing PerformanceObserver retaining at most 50 entries (LCP subpart attribution) — new, bounded runtime footprint; it is feature-detected inside try/catch, so non-browser scopes are unaffected.
* web-vitals 5+ dist output is no longer ES5 (6.2.1 is ~ES2022, including `Array.prototype.at`). This is well within `.browserslistrc` (last 10 versions of the majors) and webpack/terser parse it fine, but since node_modules bundle untranspiled into the CDN loaders, browsers far outside the support matrix would now hit a parse error in the chunk carrying web-vitals rather than degrading. npm consumers whose bundlers don't transpile node_modules inherit the same floor — worth a release-note mention.
### Related Issue(s)

* Fixes #1845
* GoogleChrome/web-vitals#534 / GoogleChrome/web-vitals#538 (the upstream bug and fix)
* #1474 / #1477 (previously-deferred v5 bumps)
* #1832 (Soft Navigation API — web-vitals v6 mainlines `reportSoftNavs`, so this bump is a prerequisite)
* #1379 (precedent: leak-motivated web-vitals bump)

### Testing

* `tests/unit/common/vitals/largest-contentful-paint.test.js`: fixture updated to the v5+ `target` field; asserts the outgoing attribute is still named `element`.
* `tests/unit/common/vitals/interaction-to-next-paint.test.js`: new tests feeding a v6-shaped synthetic report (`entries: []`, `inputDelay: 0`, `processingDuration: 0`, `presentationDelay: value`, no interaction fields) and asserting it is not reported, and a report with an unresolved `interactionTarget` asserting the attr is omitted; existing full-shape test unchanged.
* `tests/unit/common/vitals/cumulative-layout-shift.test.js`: new test asserting `largestShiftTarget` is omitted when undefined.
* `tests/unit/common/vitals/vital-metric.test.js`: new test for the undefined-attr omission in `update()`.
* `tests/unit/common/vitals/register-vital.test.js` (new), plus a "does NOT throw if web-vitals registration throws" test in each of the five wrapper suites and in `registered-iframe-entity.test.js` (a throwing `onCLS` no longer aborts the constructor and the other vitals still register).
* `tests/components/page_view_timing/aggregate.test.js` and `index.test.js`: the web-vitals mock fixtures now carry the complete attribution shape (and `id`/`entries`) real web-vitals emits — they previously passed empty or partial attribution objects, which only satisfied the key-presence assertions because undefined attrs serialized as null attributes; the LCP/FCP/INP assertions now check values too.
* Full local jest runs against the installed 6.2.1 pass: 923 unit tests (93 suites), 568 component tests (33 suites). `tsc -b` + `tsd` clean; the CDN webpack build compiles and every loader carries the v6 `whenIdleOrHidden` registration (`{once: true, capture: true}`).
* Coverage limits: the jest suites mock web-vitals for the wrapper-level tests, so real-library behavior (including the leak fix itself) is exercised by the WDIO e2e specs (`tests/specs/pvt/timings.e2e.js` etc.), which need the LambdaTest matrix a maintainer must dispatch; none of those specs assert on the renamed/now-optional attribution fields. Locally, loading a built loader and counting `visibilitychange` registrations on `document` (patch `Document.prototype.addEventListener` before the agent) shows the count stays bounded with this change and grows monotonically with interaction without it.


