### PR TITLE
chore: Remove soft_nav feature flags references

### DIFF
--- a/.github/actions/build-agent2query/templates/latest-staging-config.js
+++ b/.github/actions/build-agent2query/templates/latest-staging-config.js
@@ -36,5 +36,4 @@ NREUM.init = {
     enabled: true
   }
 }
-NREUM.feature_flags = ['soft_nav']
 NREUM.info = { beacon: 'staging-bam-cell.nr-data.net', errorBeacon: 'staging-bam-cell.nr-data.net', licenseKey: '{{{latestStagingLicenseKey}}}', applicationID: '77606036', sa: 1 }

--- a/.github/actions/build-agent2query/templates/latest-us-prod-config.js
+++ b/.github/actions/build-agent2query/templates/latest-us-prod-config.js
@@ -36,5 +36,4 @@ NREUM.init = {
     enabled: true
   }
 }
-NREUM.feature_flags = ['soft_nav']
 NREUM.info = { beacon: 'bam.nr-data.net', errorBeacon: 'bam.nr-data.net', licenseKey: '{{{latestUsProdLicenseKey}}}', applicationID: '1431915022', sa: 1 }

--- a/.github/actions/build-agent2query/templates/released-staging-config.js
+++ b/.github/actions/build-agent2query/templates/released-staging-config.js
@@ -36,5 +36,4 @@ NREUM.init = {
     enabled: true
   }
 }
-NREUM.feature_flags = ['soft_nav']
 NREUM.info = { beacon: 'staging-bam-cell.nr-data.net', errorBeacon: 'staging-bam-cell.nr-data.net', licenseKey: '{{{releasedStagingLicenseKey}}}', applicationID: '78536307', sa: 1 }

--- a/.github/actions/build-agent2query/templates/released-us-prod-config.js
+++ b/.github/actions/build-agent2query/templates/released-us-prod-config.js
@@ -36,5 +36,4 @@ NREUM.init = {
     enabled: true
   }
 }
-NREUM.feature_flags = ['soft_nav']
 NREUM.info = { beacon: 'bam.nr-data.net', errorBeacon: 'bam.nr-data.net', licenseKey: '{{{releasedUsProdLicenseKey}}}', applicationID: '1431909786', sa: 1 }

--- a/tests/assets/mutation-observer-test.html
+++ b/tests/assets/mutation-observer-test.html
@@ -3,9 +3,6 @@
 <head>
   <title>MutationObserver Test</title>
   {init}
-  <script>
-    NREUM.init.feature_flags = ['soft_nav']
-  </script>
   {config} {loader}
   <script>
     // Dispatch click event synchronously before body element exists


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

For some reason, there were still some references to the `soft_nav` feature flag which has been removed as the feature is now the only de factor SPA. The flag is also deleted/cleaned up on the FF service for APM injection.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-615176

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
