### PR TITLE
feat: Include observer API for SPV events

### DIFF
--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -271,22 +271,11 @@ export class Aggregate extends AggregateBase {
         }, this.featureName, this.ee)
       }
       if (!agentRef.init.feature_flags.includes('no_spv')) {
-        registerHandler('spv', (report, timestamp) => {
-          const body = report.body || {}
+        registerHandler('spv', (violation, timestamp) => {
           this.addEvent({
             eventType: EVENT_TYPES.SPV,
             timestamp: this.#toEpoch(timestamp),
-            blockedUrl: body.blockedURL,
-            documentUrl: body.documentURL,
-            effectiveDirective: body.effectiveDirective,
-            originalPolicy: body.originalPolicy,
-            sourceFile: body.sourceFile,
-            statusCode: body.statusCode,
-            lineNumber: body.lineNumber,
-            columnNumber: body.columnNumber,
-            disposition: body.disposition,
-            sample: body.sample,
-            referrer: body.referrer
+            ...violation
           })
         }, this.featureName, this.ee)
       }

--- a/src/features/generic_events/aggregate/index.js
+++ b/src/features/generic_events/aggregate/index.js
@@ -271,21 +271,22 @@ export class Aggregate extends AggregateBase {
         }, this.featureName, this.ee)
       }
       if (!agentRef.init.feature_flags.includes('no_spv')) {
-        registerHandler('spv', (evt) => {
+        registerHandler('spv', (report, timestamp) => {
+          const body = report.body || {}
           this.addEvent({
             eventType: EVENT_TYPES.SPV,
-            timestamp: this.#toEpoch(evt.timeStamp),
-            blockedUri: evt.blockedURI,
-            documentUri: evt.documentURI,
-            effectiveDirective: evt.effectiveDirective,
-            originalPolicy: evt.originalPolicy,
-            sourceFile: evt.sourceFile,
-            statusCode: evt.statusCode,
-            lineNumber: evt.lineNumber,
-            columnNumber: evt.columnNumber,
-            disposition: evt.disposition,
-            sample: evt.sample,
-            referrer: evt.referrer
+            timestamp: this.#toEpoch(timestamp),
+            blockedUrl: body.blockedURL,
+            documentUrl: body.documentURL,
+            effectiveDirective: body.effectiveDirective,
+            originalPolicy: body.originalPolicy,
+            sourceFile: body.sourceFile,
+            statusCode: body.statusCode,
+            lineNumber: body.lineNumber,
+            columnNumber: body.columnNumber,
+            disposition: body.disposition,
+            sample: body.sample,
+            referrer: body.referrer
           })
         }, this.featureName, this.ee)
       }

--- a/src/features/generic_events/instrument/index.js
+++ b/src/features/generic_events/instrument/index.js
@@ -61,12 +61,26 @@ export class Instrument extends InstrumentBase {
         handle('ws-complete', [nrData, targets], undefined, this.featureName, this.ee)
       })
     }
-    if (securityPolicyViolationEnabled && typeof globalScope.ReportingObserver === 'function') {
-      const cspObserver = new globalScope.ReportingObserver((reports) => { // csp-violation reports do not have timestamps of their own
-        reports.forEach(report => handle('spv', [report, now()], undefined, FEATURE_NAMES.genericEvents, this.ee))
-      }, { types: ['csp-violation'], buffered: true })
-      cspObserver.observe()
-      this.removeOnAbort.signal.addEventListener('abort', () => cspObserver.disconnect(), { once: true })
+    if (securityPolicyViolationEnabled) {
+      /** ReportingObserver's `csp-violation` type isn't reliably enabled everywhere out of the box:
+       *  - Safari only delivers it when the page sets a report-to CSP directive -- https://bugs.webkit.org/show_bug.cgi?id=320750;
+       *  - Firefox ships it behind the `dom.reporting.enabled` pref, which defaults to false;
+       * So it's only used for violations that occur before the agent loaded, targeting Chromium browsers. `buffered: true` replays
+       * that backlog in the observer's first callback invocation, after which it's disconnected and all future violations are
+       * covered by securitypolicyviolation, which is reliable across all browsers. */
+      if (typeof globalScope.ReportingObserver === 'function') {
+        const cspObserver = new globalScope.ReportingObserver((reports) => {
+          reports.forEach(report => {
+            handle('spv', [normalizeCspViolation(report), now()], undefined, FEATURE_NAMES.genericEvents, this.ee)
+          })
+          cspObserver.disconnect()
+        }, { types: ['csp-violation'], buffered: true })
+        cspObserver.observe()
+      }
+
+      globalScope.addEventListener('securitypolicyviolation', (evt) => {
+        handle('spv', [normalizeCspViolation(evt), evt.timeStamp], undefined, FEATURE_NAMES.genericEvents, this.ee)
+      }, eventListenerOpts(false, this.removeOnAbort.signal))
     }
     if (isBrowserScope) {
       wrapFetch(this.ee, agentRef)
@@ -133,6 +147,27 @@ export class Instrument extends InstrumentBase {
     /** If any of the sources are active, import the aggregator. otherwise deregister */
     if (genericEventSourceConfigs.some(x => x)) this.importAggregator(agentRef, () => import(/* webpackChunkName: "generic_events-aggregate" */ '../aggregate'))
     else this.deregisterDrain()
+  }
+}
+/** `Report.body` (ReportingObserver) and `SecurityPolicyViolationEvent` (securitypolicyviolation) describe the same
+ * violation with differently-named/shaped fields -- collapse both into one shape so downstream code doesn't care
+ * which mechanism produced it. `source` is either of those: a Report (fields under `.body`, URLs as blockedURL/
+ * documentURL) or the event (fields at the top level, URLs as blockedURI/documentURI). Also normalizes disposition's
+ * "reporting" (Report body) to "report" (event) so the value is consistent regardless of source. */
+function normalizeCspViolation (source) {
+  const body = source.body ?? source
+  return {
+    blockedUrl: body.blockedURL ?? source.blockedURI,
+    documentUrl: body.documentURL ?? source.documentURI,
+    effectiveDirective: body.effectiveDirective,
+    originalPolicy: body.originalPolicy,
+    sourceFile: body.sourceFile,
+    statusCode: body.statusCode,
+    lineNumber: body.lineNumber,
+    columnNumber: body.columnNumber,
+    disposition: body.disposition === 'reporting' ? 'report' : body.disposition,
+    sample: body.sample,
+    referrer: body.referrer
   }
 }
 

--- a/src/features/generic_events/instrument/index.js
+++ b/src/features/generic_events/instrument/index.js
@@ -6,6 +6,7 @@
 import { globalScope, isBrowserScope } from '../../../common/constants/runtime'
 import { handle } from '../../../common/event-emitter/handle'
 import { eventListenerOpts, windowAddEventListener } from '../../../common/event-listener/event-listener-opts'
+import { now } from '../../../common/timing/now'
 import { debounce } from '../../../common/util/invoke'
 import { setupAddPageActionAPI } from '../../../loaders/api/addPageAction'
 import { setupFinishedAPI } from '../../../loaders/api/finished'
@@ -60,10 +61,12 @@ export class Instrument extends InstrumentBase {
         handle('ws-complete', [nrData, targets], undefined, this.featureName, this.ee)
       })
     }
-    if (securityPolicyViolationEnabled) {
-      globalScope.addEventListener('securitypolicyviolation', (evt) => {
-        handle('spv', [evt], undefined, FEATURE_NAMES.genericEvents, this.ee)
-      }, eventListenerOpts(false, this.removeOnAbort.signal))
+    if (securityPolicyViolationEnabled && typeof globalScope.ReportingObserver === 'function') {
+      const cspObserver = new globalScope.ReportingObserver((reports) => { // csp-violation reports do not have timestamps of their own
+        reports.forEach(report => handle('spv', [report, now()], undefined, FEATURE_NAMES.genericEvents, this.ee))
+      }, { types: ['csp-violation'], buffered: true })
+      cspObserver.observe()
+      this.removeOnAbort.signal.addEventListener('abort', () => cspObserver.disconnect(), { once: true })
     }
     if (isBrowserScope) {
       wrapFetch(this.ee, agentRef)

--- a/tests/assets/csp-violation.html
+++ b/tests/assets/csp-violation.html
@@ -7,11 +7,20 @@
   <head>
     <title>RUM Unit Test</title>
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; connect-src *;">
+    <script>
+      // This runs before the agent loader below, so this violation should only be caught by the agent's
+      // ReportingObserver buffered replay (Chromium-reliable), not by the securitypolicyviolation listener,
+      // which can't attach in time to see it.
+      var preInjectionScript = document.createElement('script');
+      preInjectionScript.src = 'https://example.com/pre-injection';
+      document.head.appendChild(preInjectionScript);
+    </script>
     {init} {config} {loader}
   </head>
   <body>Instrumented
     <script>
-      // This script will trigger a CSP violation
+      // This runs after the agent has loaded, so this violation is caught by the securitypolicyviolation
+      // listener, which works reliably on every browser.
       var script = document.createElement('script');
       script.src = 'https://example.com';
       document.body.appendChild(script);

--- a/tests/components/generic_events/aggregate/index.test.js
+++ b/tests/components/generic_events/aggregate/index.test.js
@@ -328,25 +328,21 @@ describe('sub-features', () => {
   })
 
   test('should record security policy violations when enabled', () => {
-    const report = {
-      type: 'csp-violation',
-      url: 'https://test.com',
-      body: {
-        blockedURL: 'https://malicious.example',
-        documentURL: 'https://test.com',
-        effectiveDirective: 'script-src',
-        originalPolicy: "default-src 'self'",
-        sourceFile: 'https://test.com/index.js',
-        statusCode: 200,
-        lineNumber: 10,
-        columnNumber: 4,
-        disposition: 'enforce',
-        sample: 'inline-script',
-        referrer: 'https://referrer.test'
-      }
+    const violation = {
+      blockedUrl: 'https://malicious.example',
+      documentUrl: 'https://test.com',
+      effectiveDirective: 'script-src',
+      originalPolicy: "default-src 'self'",
+      sourceFile: 'https://test.com/index.js',
+      statusCode: 200,
+      lineNumber: 10,
+      columnNumber: 4,
+      disposition: 'enforce',
+      sample: 'inline-script',
+      referrer: 'https://referrer.test'
     }
 
-    genericEventsAggregate.ee.emit('spv', [report, performance.now()])
+    genericEventsAggregate.ee.emit('spv', [violation, performance.now()])
 
     const capturedEvent = genericEventsAggregate.events.get()[0]
 

--- a/tests/components/generic_events/aggregate/index.test.js
+++ b/tests/components/generic_events/aggregate/index.test.js
@@ -1,6 +1,5 @@
 import { Instrument as GenericEvents } from '../../../../src/features/generic_events/instrument'
 import { FEATURE_NAMES } from '../../../../src/loaders/features/features'
-import { globalScope } from '../../../../src/common/constants/runtime'
 import { expectHarvests } from '../../../util/basic-checks'
 import { resetAgent, setupAgent } from '../../setup-agent'
 
@@ -329,32 +328,33 @@ describe('sub-features', () => {
   })
 
   test('should record security policy violations when enabled', () => {
-    const event = new Event('securitypolicyviolation')
-    Object.defineProperties(event, {
-      blockedURI: { value: 'https://malicious.example' },
-      documentURI: { value: 'https://test.com' },
-      effectiveDirective: { value: 'script-src' },
-      violatedDirective: { value: 'script-src' },
-      originalPolicy: { value: "default-src 'self'" },
-      sourceFile: { value: 'https://test.com/index.js' },
-      statusCode: { value: 200 },
-      lineNumber: { value: 10 },
-      columnNumber: { value: 4 },
-      disposition: { value: 'enforce' },
-      sample: { value: 'inline-script' },
-      referrer: { value: 'https://referrer.test' }
-    })
+    const report = {
+      type: 'csp-violation',
+      url: 'https://test.com',
+      body: {
+        blockedURL: 'https://malicious.example',
+        documentURL: 'https://test.com',
+        effectiveDirective: 'script-src',
+        originalPolicy: "default-src 'self'",
+        sourceFile: 'https://test.com/index.js',
+        statusCode: 200,
+        lineNumber: 10,
+        columnNumber: 4,
+        disposition: 'enforce',
+        sample: 'inline-script',
+        referrer: 'https://referrer.test'
+      }
+    }
 
-    globalScope.dispatchEvent(event)
+    genericEventsAggregate.ee.emit('spv', [report, performance.now()])
 
-    const expectedTimestamp = Math.floor(mainAgent.runtime.timeKeeper.correctRelativeTimestamp(event.timeStamp))
     const capturedEvent = genericEventsAggregate.events.get()[0]
 
     expect(capturedEvent).toMatchObject({
       eventType: 'SecurityPolicyViolation',
-      timestamp: expectedTimestamp,
-      blockedUri: 'https://malicious.example',
-      documentUri: 'https://test.com',
+      timestamp: expect.any(Number),
+      blockedUrl: 'https://malicious.example',
+      documentUrl: 'https://test.com',
       effectiveDirective: 'script-src',
       originalPolicy: "default-src 'self'",
       sourceFile: 'https://test.com/index.js',
@@ -365,9 +365,8 @@ describe('sub-features', () => {
       sample: 'inline-script',
       referrer: 'https://referrer.test'
     })
-    expect(capturedEvent).not.toHaveProperty('violatedDirective')
-    expect(capturedEvent).not.toHaveProperty('blockedURI')
-    expect(capturedEvent).not.toHaveProperty('documentURI')
+    expect(capturedEvent).not.toHaveProperty('blockedURL')
+    expect(capturedEvent).not.toHaveProperty('documentURL')
   })
 })
 

--- a/tests/components/generic_events/instrument/index.test.js
+++ b/tests/components/generic_events/instrument/index.test.js
@@ -3,6 +3,7 @@ import * as handleModule from '../../../../src/common/event-emitter/handle'
 import { setupAgent } from '../../setup-agent'
 import { OBSERVED_EVENTS } from '../../../../src/features/generic_events/constants'
 import { FEATURE_NAMES } from '../../../../src/loaders/features/features'
+import { globalScope } from '../../../../src/common/constants/runtime'
 
 let mainAgent
 let genericEventsInstrument
@@ -198,6 +199,103 @@ describe('User frustrations - XMLHttpRequest', () => {
     xhr2.send()
     expect(handleSpy).toHaveBeenCalledWith('uaXhr', [], undefined, FEATURE_NAMES.genericEvents, expect.any(Object))
     expect(eeEmitSpy).toHaveBeenCalledWith('uaXhr', [], undefined)
+  })
+})
+
+describe('security policy violation reporting', () => {
+  let handleSpy, addEventListenerSpy, origReportingObserver
+
+  beforeEach(() => {
+    handleSpy = jest.spyOn(handleModule, 'handle')
+    addEventListenerSpy = jest.spyOn(globalScope, 'addEventListener')
+    origReportingObserver = global.ReportingObserver
+    mainAgent.init.feature_flags = []
+  })
+
+  afterEach(() => {
+    global.ReportingObserver = origReportingObserver
+    jest.restoreAllMocks()
+  })
+
+  function getSpvListener () {
+    return addEventListenerSpy.mock.calls.find(([type]) => type === 'securitypolicyviolation')[1]
+  }
+
+  function mockSpvEvent (fields) {
+    const evt = new Event('securitypolicyviolation')
+    Object.defineProperties(evt, Object.fromEntries(Object.entries(fields).map(([key, value]) => [key, { value }])))
+    return evt
+  }
+
+  test('processes the buffered pre-attach batch, disconnects, and still reports post-attach violations via securitypolicyviolation', () => {
+    let observerCallback
+    const disconnectMock = jest.fn()
+    const observeMock = jest.fn()
+    global.ReportingObserver = jest.fn((cb) => {
+      observerCallback = cb
+      return { observe: observeMock, disconnect: disconnectMock }
+    })
+
+    const instrument = new GenericEvents(mainAgent)
+
+    const bufferedReport = {
+      type: 'csp-violation',
+      body: {
+        blockedURL: 'https://malicious.example/buffered',
+        documentURL: 'https://test.com',
+        effectiveDirective: 'script-src',
+        originalPolicy: "default-src 'self'",
+        sourceFile: 'https://test.com/index.js',
+        statusCode: 200,
+        lineNumber: 10,
+        columnNumber: 4,
+        disposition: 'enforce',
+        sample: 'inline',
+        referrer: 'https://referrer.test'
+      }
+    }
+
+    observerCallback([bufferedReport])
+
+    expect(observeMock).toHaveBeenCalledTimes(1)
+    expect(disconnectMock).toHaveBeenCalledTimes(1)
+    expect(handleSpy).toHaveBeenCalledWith('spv', [expect.objectContaining({
+      blockedUrl: 'https://malicious.example/buffered',
+      documentUrl: 'https://test.com'
+    }), expect.any(Number)], undefined, FEATURE_NAMES.genericEvents, instrument.ee)
+
+    handleSpy.mockClear()
+
+    getSpvListener()(mockSpvEvent({
+      blockedURI: 'https://malicious.example/post-attach',
+      documentURI: 'https://test.com',
+      effectiveDirective: 'script-src',
+      sourceFile: 'https://test.com/index.js',
+      lineNumber: 20,
+      columnNumber: 4
+    }))
+    expect(handleSpy).toHaveBeenCalledWith('spv', [expect.objectContaining({
+      blockedUrl: 'https://malicious.example/post-attach'
+    }), expect.any(Number)], undefined, FEATURE_NAMES.genericEvents, instrument.ee)
+  })
+
+  test('still reports via securitypolicyviolation when ReportingObserver is unsupported', () => {
+    global.ReportingObserver = undefined
+
+    const instrument = new GenericEvents(mainAgent)
+
+    getSpvListener()(mockSpvEvent({
+      blockedURI: 'https://malicious.example',
+      documentURI: 'https://test.com',
+      effectiveDirective: 'script-src',
+      sourceFile: 'https://test.com/index.js',
+      lineNumber: 10,
+      columnNumber: 4
+    }))
+
+    expect(handleSpy).toHaveBeenCalledWith('spv', [expect.objectContaining({
+      blockedUrl: 'https://malicious.example'
+    }), expect.any(Number)], undefined, FEATURE_NAMES.genericEvents, instrument.ee)
   })
 })
 

--- a/tests/specs/csp.e2e.js
+++ b/tests/specs/csp.e2e.js
@@ -84,11 +84,11 @@ describe('Content Security Policy', () => {
     const CSP_HTML_PATH = '/tests/assets/csp-violation.html'
     const expectedSpv = {
       eventType: 'SecurityPolicyViolation',
-      blockedUri: 'https://example.com/',
+      blockedUrl: 'https://example.com/',
       columnNumber: expect.any(Number),
       currentUrl: expect.stringContaining(CSP_HTML_PATH),
       disposition: 'enforce',
-      documentUri: expect.stringContaining(CSP_HTML_PATH),
+      documentUrl: expect.stringContaining(CSP_HTML_PATH),
       effectiveDirective: 'script-src-elem',
       lineNumber: 18,
       originalPolicy: expect.stringMatching(/^default-src 'self' 'unsafe-inline'; connect-src \*;?$/),

--- a/tests/specs/csp.e2e.js
+++ b/tests/specs/csp.e2e.js
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { testInsRequest, testSupportMetricsRequest } from '../../tools/testing-server/utils/expect-tests'
+import { onlyChromium } from '../../tools/browser-matcher/common-matchers.mjs'
 
 describe('Content Security Policy', () => {
   afterEach(async () => {
@@ -70,7 +71,26 @@ describe('Content Security Policy', () => {
     )
   })
 
-  it('should send SecurityPolicyViolation event from csp-violation page', async () => {
+  /**
+   * SecurityPolicyViolation is reported via two mechanisms (see NR-610205):
+   *  - the securitypolicyviolation listener, which works reliably on every browser but can only catch violations
+   *    that occur after the (asynchronously loaded) agent has attached it
+   *  - a ReportingObserver on the `csp-violation` type with `buffered: true`, used only to replay the pre-attach
+   *    backlog once, then disconnected
+   * csp-violation.html triggers one violation before the agent loader runs (pre-injection) and one after
+   * (post-injection) to exercise both paths. The pre-injection one is only asserted on Chromium because
+   * ReportingObserver's csp-violation delivery isn't reliable elsewhere out of the box:
+   *  - https://bugs.webkit.org/show_bug.cgi?id=320750 -- Safari/WebKit never delivers csp-violation reports unless
+   *    the page's CSP sets a `report-to` directive (which CSP via a `<meta>` tag can't even do, and which almost no
+   *    real-world site configures), so Safari gets nothing for the common case.
+   *  - https://bugs.webkit.org/show_bug.cgi?id=315730 -- when WebKit does deliver, it fires duplicate csp-violation
+   *    reports for the same violation, ~50-60ms apart.
+   *  - Firefox ships ReportingObserver/csp-violation behind the `dom.reporting.enabled` pref, which defaults to
+   *    false (confirmed in mozilla-central's StaticPrefList.yaml), so it's off out of the box.
+   * All three were still true as of 2026-09-04. The post-injection violation is asserted on every browser, since it
+   * only depends on the universally-reliable securitypolicyviolation listener.
+   */
+  it('should send SecurityPolicyViolation events from csp-violation page', async () => {
     const insightsCapture = await browser.testHandle.createNetworkCaptures('bamServer', {
       test: testInsRequest
     })
@@ -79,18 +99,17 @@ describe('Content Security Policy', () => {
     await browser.url(testUrl).then(() => browser.waitForAgentLoad())
 
     const [insHarvests] = await insightsCapture.waitForResult({ totalCount: 1 })
-    const spvEvent = insHarvests.request.body.ins.find(evt => evt.eventType === 'SecurityPolicyViolation')
+    const spvEvents = insHarvests.request.body.ins.filter(evt => evt.eventType === 'SecurityPolicyViolation')
 
     const CSP_HTML_PATH = '/tests/assets/csp-violation.html'
-    const expectedSpv = {
+    const commonExpectedFields = {
       eventType: 'SecurityPolicyViolation',
-      blockedUrl: 'https://example.com/',
       columnNumber: expect.any(Number),
       currentUrl: expect.stringContaining(CSP_HTML_PATH),
       disposition: 'enforce',
       documentUrl: expect.stringContaining(CSP_HTML_PATH),
       effectiveDirective: 'script-src-elem',
-      lineNumber: 18,
+      lineNumber: expect.any(Number),
       originalPolicy: expect.stringMatching(/^default-src 'self' 'unsafe-inline'; connect-src \*;?$/),
       pageUrl: expect.stringContaining(CSP_HTML_PATH),
       referrer: expect.any(String),
@@ -99,6 +118,19 @@ describe('Content Security Policy', () => {
       statusCode: 200,
       timestamp: expect.any(Number)
     }
-    expect(spvEvent).toEqual(expect.objectContaining(expectedSpv))
+
+    const postInjectionSpv = spvEvents.find(evt => evt.blockedUrl === 'https://example.com/')
+    expect(postInjectionSpv).toEqual(expect.objectContaining({
+      ...commonExpectedFields,
+      blockedUrl: 'https://example.com/'
+    }))
+
+    if (browserMatch(onlyChromium)) {
+      const preInjectionSpv = spvEvents.find(evt => evt.blockedUrl === 'https://example.com/pre-injection')
+      expect(preInjectionSpv).toEqual(expect.objectContaining({
+        ...commonExpectedFields,
+        blockedUrl: 'https://example.com/pre-injection'
+      }))
+    }
   })
 })


### PR DESCRIPTION
Use the `ReportingObserver` API to catch `securitypolicyviolation` events that occurred prior to the agent loader execution. In practice, this mainly affects chromium browsers, as existing configs and bugs affect Firefox and Safari collection.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

<!-- Please describe the changes present in the pull request and, if applicable, describe why the changes are needed. -->

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-610205

### Testing

Updated
