### PR TITLE
chore: Daily dispatch improvements

### DIFF
--- a/.github/actions/daily-dispatch/index.js
+++ b/.github/actions/daily-dispatch/index.js
@@ -50,6 +50,61 @@ const reviewerCommentEvents = (pr) => pr.timelineItems.nodes.flatMap((item) => {
   return []
 })
 
+// Renders one PR-list section (title, PR links, assignee/age/status context lines).
+// `statusSuffix(pr)` returns the bucket-specific trailing note for the context line, or ''.
+const renderPrSection = (blocks, textLines, { emoji, title, prList, emptyText, mttmHours, statusSuffix }) => {
+  if (prList.length === 0) {
+    blocks.push(sectionBlock(`*${emoji} ${title}*\n${emptyText}`))
+    textLines.push(`${title}: none`)
+    blocks.push(dividerBlock())
+    return
+  }
+
+  blocks.push(sectionBlock(`*${emoji} ${title}*\n${prList.length} PR${prList.length === 1 ? '' : 's'}, oldest first:`))
+  textLines.push(`${title}: ${prList.length}`)
+
+  // Capped low, and one Slack block per PR (not two), to keep the overall payload
+  // comfortably under Slack's 50-block-per-message limit now that PRs are split
+  // across four sections instead of one.
+  const maxDetailed = 6
+  for (const pr of prList.slice(0, maxDetailed)) {
+    const assignees = pr.assignees.nodes.map((assignee) => assignee.login)
+    const authorLogin = pr.author?.login
+
+    const prLink = `<${pr.url}|#${pr.number} ${escapeSlack(pr.title)}>`
+    const assigneeMentions = assignees.filter((login) => login !== authorLogin).map(mentionFor)
+
+    let prText
+    if (assignees.length > 0) {
+      prText = assigneeMentions.length > 0
+        ? `${prLink}\n*Assigned to:* ${assigneeMentions.join(' ')}`
+        : prLink
+    } else {
+      const availableReviewers = Object.keys(githubToSlack).filter((login) => login !== authorLogin).map(mentionFor).join(' ')
+      prText = `${prLink}\n${availableReviewers} please take a look.`
+    }
+
+    const createdDate = new Date(pr.createdAt)
+    const formattedDate = createdDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+    const prAgeHours = (Date.now() - createdDate) / (1000 * 60 * 60)
+    const ageIndicator = mttmHours === null ? '' : (prAgeHours <= mttmHours ? '🟢 ' : '🔴 ')
+
+    let statusText = `${ageIndicator}Open since ${formattedDate}`
+    statusText += statusSuffix(pr, assigneeMentions)
+    if (assignees.length === 0) {
+      statusText += ' • 🔴 No assignees yet'
+    }
+
+    blocks.push(sectionBlock(`${prText}\n_${statusText}_`))
+  }
+  blocks.push(dividerBlock())
+
+  if (prList.length > maxDetailed) {
+    blocks.push(contextBlock(`_...and ${prList.length - maxDetailed} more_`))
+    blocks.push(dividerBlock())
+  }
+}
+
 const headerBlock = (text) => ({ type: 'header', text: { type: 'plain_text', text, emoji: true } })
 const sectionBlock = (text) => ({ type: 'section', text: { type: 'mrkdwn', text } })
 const contextBlock = (text) => ({ type: 'context', elements: [{ type: 'mrkdwn', text }] })
@@ -76,6 +131,7 @@ do {
             reviewDecision
             createdAt
             headRefName
+            authorAssociation
             author {
               login
             }
@@ -145,10 +201,29 @@ const releasePR = prs.find((pr) =>
   pr.title.toLowerCase().includes('release-please')
 )
 
-// Filter and sort PRs needing review, oldest first
-const needsReview = prs
-  .filter((pr) => !pr.isDraft && !hasBlockedLabel(pr.labels) && pr.reviewDecision !== 'APPROVED')
-  .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+// External contributors (not org members/owners/collaborators) get their own
+// section - everyone else is bucketed by where they sit in the review cycle.
+const isExternal = (pr) => !['MEMBER', 'OWNER', 'COLLABORATOR'].includes(pr.authorAssociation)
+const byCreatedAtAsc = (a, b) => new Date(a.createdAt) - new Date(b.createdAt)
+
+const eligible = prs.filter((pr) => !pr.isDraft && !hasBlockedLabel(pr.labels) && pr.reviewDecision !== 'APPROVED')
+const externalPrs = eligible.filter(isExternal).sort(byCreatedAtAsc)
+const internalPrs = eligible.filter((pr) => !isExternal(pr))
+
+const reviewState = (pr) => {
+  const reviewerActivity = reviewerCommentEvents(pr).sort((a, b) => b - a)[0]
+  const lastCommitDate = pr.commits.nodes.length > 0
+    ? new Date(pr.commits.nodes[pr.commits.nodes.length - 1].commit.committedDate)
+    : null
+
+  if (!reviewerActivity) return 'neverReviewed'
+  if (!lastCommitDate || lastCommitDate <= reviewerActivity) return 'needsRevisions'
+  return 'needsReReview'
+}
+
+const neverReviewed = internalPrs.filter((pr) => reviewState(pr) === 'neverReviewed').sort(byCreatedAtAsc)
+const needsRevisions = internalPrs.filter((pr) => reviewState(pr) === 'needsRevisions').sort(byCreatedAtAsc)
+const needsReReview = internalPrs.filter((pr) => reviewState(pr) === 'needsReReview').sort(byCreatedAtAsc)
 
 // Fetch open issues
 const issues = []
@@ -228,6 +303,53 @@ const formatDuration = (hours) => {
   return `${days}d ${remainingHours}h`
 }
 
+// Fetch repo stats and per-environment deployment history in one shot
+const deploymentEnvironments = ['nr1-dev', 'nr1-staging', 'nr1-us-prod', 'nr1-eu-prod', 'nr1-jp-prod', 'public-release']
+
+const repoStatsAndDeploysQuery = `
+  query($owner: String!, $repo: String!, ${deploymentEnvironments.map((_, i) => `$env${i}: [String!]`).join(', ')}) {
+    repository(owner: $owner, name: $repo) {
+      stargazerCount
+      forkCount
+      watchers { totalCount }
+      ${deploymentEnvironments.map((_, i) => `
+      env${i}: deployments(environments: $env${i}, last: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes {
+          createdAt
+          commit { oid }
+          statuses(first: 10) {
+            nodes { state createdAt }
+          }
+        }
+      }`).join('\n')}
+    }
+  }
+`
+
+const repoStatsAndDeploysVars = { owner, repo }
+deploymentEnvironments.forEach((env, i) => { repoStatsAndDeploysVars[`env${i}`] = [env] })
+
+const repoStatsAndDeploysResponse = await octokit.graphql(repoStatsAndDeploysQuery, repoStatsAndDeploysVars)
+const repoStats = {
+  stars: repoStatsAndDeploysResponse.repository.stargazerCount,
+  forks: repoStatsAndDeploysResponse.repository.forkCount,
+  watchers: repoStatsAndDeploysResponse.repository.watchers.totalCount,
+}
+
+// A deployment's `latestStatus` goes INACTIVE once a newer deployment supersedes it in the
+// same environment - that's normal lifecycle, not a failure - so we scan each deployment's
+// full status history for a SUCCESS entry instead of trusting latestStatus alone.
+const lastSuccessfulDeploys = deploymentEnvironments.map((env, i) => {
+  const deployments = repoStatsAndDeploysResponse.repository[`env${i}`].nodes
+  for (const deployment of deployments) {
+    const successStatus = deployment.statuses.nodes.find((status) => status.state === 'SUCCESS')
+    if (successStatus) {
+      return { env, deployedAt: new Date(successStatus.createdAt), sha: deployment.commit.oid }
+    }
+  }
+  return { env, deployedAt: null, sha: null }
+})
+
 // Fetch workflow runs from the last 24 hours
 const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
 const workflowRuns = await octokit.rest.actions.listWorkflowRunsForRepo({
@@ -294,6 +416,10 @@ const metrics = {
   currentVersion,
   upcomingVersion,
   failedWorkflowCount: activeFailedRuns.length,
+  externalPrCount: externalPrs.length,
+  neverReviewedCount: neverReviewed.length,
+  needsRevisionsCount: needsRevisions.length,
+  needsReReviewCount: needsReReview.length,
 }
 
 for (const login of Object.keys(githubToSlack)) {
@@ -316,6 +442,44 @@ const textLines = ['Browser Agent Daily Dispatch']
 
 blocks.push(headerBlock('🌅 Browser Agent Daily Dispatch'))
 blocks.push(dividerBlock())
+
+// Build size status - the size-compare job in pull-request-checks.yml comments this
+// tag on every PR (including release-please's), so it's expected to exist once checks
+// finish running on the release PR.
+const ASSET_SIZE_COMMENT_TAG = '<!-- browser_agent asset size report -->'
+const sizeColorEmoji = { green: '🟢', yellow: '🟡', red: '🔴' }
+const sizeColorSeverity = { green: 0, yellow: 1, red: 2 }
+
+let buildSizeLines = null
+let buildSizePending = false
+
+if (releasePR) {
+  const { data: releaseComments } = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: releasePR.number,
+    per_page: 100,
+  })
+  const sizeComment = releaseComments.find((comment) => comment.body?.includes(ASSET_SIZE_COMMENT_TAG))
+
+  if (sizeComment) {
+    // Each data row: | agent | asset | ![size](...color=X) | ![deltaMain](...color=Y) | ![deltaRelease](...color=Z) |
+    // Matched per-line (not across the whole body) so the header/separator rows can't
+    // bleed into a following data row via a `\s*` that would otherwise cross the newline.
+    const rowPattern = /^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*!\[([^\]]*)]\([^)]*color=(\w+)\)\s*\|\s*!\[([^\]]*)]\([^)]*color=(\w+)\)\s*\|\s*!\[([^\]]*)]\([^)]*color=(\w+)\)\s*\|\s*$/
+    buildSizeLines = sizeComment.body.split('\n')
+      .map((line) => line.match(rowPattern))
+      .filter(Boolean)
+      .map((match) => {
+        const [, agent, asset, size, sizeColor, deltaMain, deltaMainColor, deltaRelease, deltaReleaseColor] = match
+        const worstColor = [sizeColor, deltaMainColor, deltaReleaseColor].sort((a, b) => (sizeColorSeverity[b] ?? 0) - (sizeColorSeverity[a] ?? 0))[0]
+        const emoji = sizeColorEmoji[worstColor] ?? '⚪'
+        return `${emoji} ${agent}/${asset}: ${size.trim()} (Δ main ${deltaMain.trim()}, Δ release ${deltaRelease.trim()})`
+      })
+  } else {
+    buildSizePending = true
+  }
+}
 
 // Version Status
 let versionText = `*📦 Version Status*\nThe Browser Agent is currently on version *${currentVersion}*`
@@ -341,6 +505,12 @@ if (releasePR) {
     versionText += '\n' + changeLines.join('\n')
   }
   textLines.push(`Next release: ${nextVersion} (#${releasePR.number})`)
+
+  if (buildSizeLines && buildSizeLines.length > 0) {
+    versionText += '\n\n*📏 Build Size vs Latest Release*\n' + buildSizeLines.join('\n')
+  } else if (buildSizePending) {
+    versionText += `\n\n📏 Build size report not yet available — see checks on <${releasePR.url}/checks|#${releasePR.number}>.`
+  }
 } else {
   versionText += '\nNo release is currently staged.'
 }
@@ -348,70 +518,45 @@ if (releasePR) {
 blocks.push(sectionBlock(versionText))
 blocks.push(dividerBlock())
 
-// PRs Needing Review
-if (needsReview.length === 0) {
-  blocks.push(sectionBlock('*👀 PRs Needing Review*\n✅ No open PRs currently need review.'))
-  textLines.push('PRs Needing Review: none')
-} else {
-  blocks.push(sectionBlock(`*👀 PRs Needing Review*\n${needsReview.length} PR${needsReview.length === 1 ? '' : 's'} awaiting review, oldest first:`))
-  textLines.push(`PRs Needing Review: ${needsReview.length}`)
+// External Contributor PRs
+renderPrSection(blocks, textLines, {
+  emoji: '🌍',
+  title: 'External Contributor PRs',
+  prList: externalPrs,
+  emptyText: '✅ No open PRs from external contributors.',
+  mttmHours,
+  statusSuffix: (pr) => ` • ${pr.authorAssociation}`,
+})
 
-  const maxDetailed = 12
-  for (const pr of needsReview.slice(0, maxDetailed)) {
-    const assignees = pr.assignees.nodes.map((assignee) => assignee.login)
-    const authorLogin = pr.author?.login
+// Never Reviewed
+renderPrSection(blocks, textLines, {
+  emoji: '🆕',
+  title: 'Never Reviewed',
+  prList: neverReviewed,
+  emptyText: '✅ No open PRs are awaiting a first review.',
+  mttmHours,
+  statusSuffix: () => ' • no review activity yet',
+})
 
-    const reviewerActivity = reviewerCommentEvents(pr).sort((a, b) => b - a)[0]
+// Needs Revisions (feedback given, author hasn't pushed since)
+renderPrSection(blocks, textLines, {
+  emoji: '🟠',
+  title: 'Needs Revisions',
+  prList: needsRevisions,
+  emptyText: '✅ No open PRs are waiting on author revisions.',
+  mttmHours,
+  statusSuffix: (pr) => ` • 🟠 This PR has been reviewed without new commits, ${pr.author?.login ? mentionFor(pr.author.login) : 'author'} please take a look.`,
+})
 
-    const lastCommitDate = pr.commits.nodes.length > 0
-      ? new Date(pr.commits.nodes[pr.commits.nodes.length - 1].commit.committedDate)
-      : null
-
-    const hasUnaddressedFeedback = reviewerActivity && (!lastCommitDate || lastCommitDate <= reviewerActivity)
-
-    const prLink = `<${pr.url}|#${pr.number} ${escapeSlack(pr.title)}>`
-    const assigneeMentions = assignees.filter((login) => login !== authorLogin).map(mentionFor)
-
-    let prText
-    if (assignees.length > 0) {
-      prText = assigneeMentions.length > 0
-        ? `${prLink}\n*Assigned to:*\n${assigneeMentions.join('\n')}`
-        : prLink
-    } else {
-      const availableReviewers = Object.keys(githubToSlack).filter((login) => login !== authorLogin).map(mentionFor).join(' ')
-      prText = `${prLink}\n${availableReviewers} please take a look.`
-    }
-    blocks.push(sectionBlock(prText))
-
-    const createdDate = new Date(pr.createdAt)
-    const formattedDate = createdDate.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
-    const prAgeHours = (Date.now() - createdDate) / (1000 * 60 * 60)
-    const ageIndicator = mttmHours === null ? '' : (prAgeHours <= mttmHours ? '🟢 ' : '🔴 ')
-
-    let statusText = `${ageIndicator}Open since ${formattedDate}`
-    if (hasUnaddressedFeedback) {
-      statusText += ` • 🟠 This PR has been reviewed without new commits, ${authorLogin ? mentionFor(authorLogin) : 'author'} please take a look.`
-    } else if (reviewerActivity) {
-      // Only reachable when reviewerActivity is truthy, i.e. there is at least one tracked reviewer comment.
-      if (assigneeMentions.length > 0) {
-        statusText += ` • 🟠 ${assigneeMentions.join(' ')} please take a look.`
-      }
-      // No assignees: skip this message entirely - the "No assignees yet" segment below covers it.
-    } else {
-      statusText += ' • no review activity yet'
-    }
-    if (assignees.length === 0) {
-      statusText += ' • 🔴 No assignees yet'
-    }
-    blocks.push(contextBlock(statusText))
-    blocks.push(dividerBlock())
-  }
-
-  if (needsReview.length > maxDetailed) {
-    blocks.push(contextBlock(`_...and ${needsReview.length - maxDetailed} more PR${needsReview.length - maxDetailed === 1 ? '' : 's'} awaiting review_`))
-    blocks.push(dividerBlock())
-  }
-}
+// Needs Re-Review (author pushed after feedback, reviewer hasn't looked again)
+renderPrSection(blocks, textLines, {
+  emoji: '🔁',
+  title: 'Needs Re-Review',
+  prList: needsReReview,
+  emptyText: '✅ No open PRs are waiting on a re-review.',
+  mttmHours,
+  statusSuffix: (pr, assigneeMentions) => (assigneeMentions.length > 0 ? ` • 🟠 ${assigneeMentions.join(' ')} please take a look.` : ''),
+})
 
 // Mean Time to Merge
 let mttmText = '*⏱️ Mean Time to Merge (Last 30 Days)*\n'
@@ -451,6 +596,21 @@ if (issues.length === 0) {
   }
   textLines.push(`Open Issues: ${issues.length}`)
 }
+blocks.push(dividerBlock())
+
+// Repository Stats
+blocks.push(sectionBlock(`*📊 Repository Stats*\n⭐ ${repoStats.stars} stars · 🍴 ${repoStats.forks} forks · 👀 ${repoStats.watchers} watchers`))
+textLines.push(`Repository Stats: ${repoStats.stars} stars, ${repoStats.forks} forks, ${repoStats.watchers} watchers`)
+blocks.push(dividerBlock())
+
+// Deployment Status
+const deployLines = lastSuccessfulDeploys.map(({ env, deployedAt, sha }) => {
+  if (!deployedAt) return `*${env}*: no successful deployment found in recent history`
+  const formattedDate = deployedAt.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  return `*${env}*: ${formattedDate} (\`${sha.slice(0, 7)}\`)`
+})
+blocks.push(sectionBlock(`*🚀 Deployment Status*\nLast successful deployment per environment:\n${deployLines.join('\n')}`))
+textLines.push(`Deployment Status: ${lastSuccessfulDeploys.filter((d) => d.deployedAt).length}/${lastSuccessfulDeploys.length} environments have a known successful deploy`)
 
 const payload = JSON.stringify({ text: textLines.join(' | '), blocks })
 const metricsJson = JSON.stringify(metrics)

--- a/.github/actions/daily-dispatch/index.js
+++ b/.github/actions/daily-dispatch/index.js
@@ -405,6 +405,51 @@ const linkForBranch = (branch) => {
 const upcomingVersionMatch = releasePR?.title.match(/(\d+\.\d+\.\d+)/)
 const upcomingVersion = upcomingVersionMatch ? upcomingVersionMatch[1] : ''
 
+// Fetch PRs actually created in the last 30 days (any state) for a real "PRs created per
+// person" rate. prsCreatedBy below is a snapshot of currently-open PRs, which double-counts
+// a long-lived PR on every daily sample instead of counting it once - averaging that snapshot
+// doesn't converge to "PRs created per week/month". This is a real, non-overlapping count
+// instead: each dispatch run reports "created in the trailing N days", so query these with
+// average(), not sum() - summing would multiply the count by however many samples fall in range.
+const createdLookbackDays = 30
+const createdLookbackCutoff = new Date(Date.now() - createdLookbackDays * 24 * 60 * 60 * 1000)
+const recentlyCreatedPRs = []
+let createdCursor = null
+
+do {
+  const response = await octokit.graphql(`
+    query($owner: String!, $repo: String!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(first: 50, states: [OPEN, MERGED, CLOSED], after: $cursor, orderBy: {field: CREATED_AT, direction: DESC}) {
+          nodes {
+            createdAt
+            author {
+              login
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  `, { owner, repo, cursor: createdCursor })
+
+  const connection = response.repository.pullRequests
+  recentlyCreatedPRs.push(...connection.nodes)
+  const oldestInPage = connection.nodes[connection.nodes.length - 1]
+  // PRs are ordered newest-created first, so once the oldest PR on this page is
+  // already past the lookback cutoff, every later page is too - stop paging.
+  createdCursor = connection.pageInfo.hasNextPage && oldestInPage && new Date(oldestInPage.createdAt) >= createdLookbackCutoff
+    ? connection.pageInfo.endCursor
+    : null
+} while (createdCursor)
+
+const createdCutoff7Days = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+const prsCreatedLast7Days = recentlyCreatedPRs.filter((pr) => new Date(pr.createdAt) >= createdCutoff7Days)
+const prsCreatedLast30Days = recentlyCreatedPRs.filter((pr) => new Date(pr.createdAt) >= createdLookbackCutoff)
+
 // Mean time to cycle: the gap between a reviewer comment and the next commit,
 // or between a commit and the next reviewer comment - i.e. every alternation
 // between "reviewer spoke" and "author pushed" across each open PR's timeline.
@@ -456,6 +501,8 @@ for (const login of Object.keys(githubToSlack)) {
   ).length
 
   metrics[`prsCreatedBy.${login}`] = prs.filter((pr) => pr.author?.login === login).length
+  metrics[`prsCreatedLast7Days.${login}`] = prsCreatedLast7Days.filter((pr) => pr.author?.login === login).length
+  metrics[`prsCreatedLast30Days.${login}`] = prsCreatedLast30Days.filter((pr) => pr.author?.login === login).length
 }
 
 // Build the daily dispatch Slack Block Kit payload

--- a/.github/actions/daily-dispatch/index.js
+++ b/.github/actions/daily-dispatch/index.js
@@ -405,14 +405,22 @@ const linkForBranch = (branch) => {
 const upcomingVersionMatch = releasePR?.title.match(/(\d+\.\d+\.\d+)/)
 const upcomingVersion = upcomingVersionMatch ? upcomingVersionMatch[1] : ''
 
-// Fetch PRs actually created in the last 30 days (any state) for a real "PRs created per
-// person" rate. prsCreatedBy below is a snapshot of currently-open PRs, which double-counts
-// a long-lived PR on every daily sample instead of counting it once - averaging that snapshot
-// doesn't converge to "PRs created per week/month". This is a real, non-overlapping count
-// instead: each dispatch run reports "created in the trailing N days", so query these with
-// average(), not sum() - summing would multiply the count by however many samples fall in range.
-const createdLookbackDays = 30
-const createdLookbackCutoff = new Date(Date.now() - createdLookbackDays * 24 * 60 * 60 * 1000)
+// Find when this workflow last completed successfully, so we can report "PRs created since
+// then" as a clean, non-overlapping delta per run - summing these deltas in NRQL over any
+// window (a week, a month, a quarter) then gives an exact count for that window, with no
+// double-counting and no need to pick a fixed lookback window up front. Self-correcting if a
+// run is skipped or fails: the next run just covers the larger gap back to the last success.
+const previousRuns = await octokit.rest.actions.listWorkflowRuns({
+  owner,
+  repo,
+  workflow_id: 'daily-dispatch.yml',
+  status: 'success',
+  per_page: 5,
+})
+const previousRun = previousRuns.data.workflow_runs.find((run) => run.id !== github.context.runId)
+// Fall back to a 24h window if this is the very first run of the workflow.
+const sinceLastRunCutoff = previousRun ? new Date(previousRun.created_at) : new Date(Date.now() - 24 * 60 * 60 * 1000)
+
 const recentlyCreatedPRs = []
 let createdCursor = null
 
@@ -440,15 +448,13 @@ do {
   recentlyCreatedPRs.push(...connection.nodes)
   const oldestInPage = connection.nodes[connection.nodes.length - 1]
   // PRs are ordered newest-created first, so once the oldest PR on this page is
-  // already past the lookback cutoff, every later page is too - stop paging.
-  createdCursor = connection.pageInfo.hasNextPage && oldestInPage && new Date(oldestInPage.createdAt) >= createdLookbackCutoff
+  // already past the cutoff, every later page is too - stop paging.
+  createdCursor = connection.pageInfo.hasNextPage && oldestInPage && new Date(oldestInPage.createdAt) >= sinceLastRunCutoff
     ? connection.pageInfo.endCursor
     : null
 } while (createdCursor)
 
-const createdCutoff7Days = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-const prsCreatedLast7Days = recentlyCreatedPRs.filter((pr) => new Date(pr.createdAt) >= createdCutoff7Days)
-const prsCreatedLast30Days = recentlyCreatedPRs.filter((pr) => new Date(pr.createdAt) >= createdLookbackCutoff)
+const prsCreatedSinceLastRun = recentlyCreatedPRs.filter((pr) => new Date(pr.createdAt) >= sinceLastRunCutoff)
 
 // Mean time to cycle: the gap between a reviewer comment and the next commit,
 // or between a commit and the next reviewer comment - i.e. every alternation
@@ -501,8 +507,7 @@ for (const login of Object.keys(githubToSlack)) {
   ).length
 
   metrics[`prsCreatedBy.${login}`] = prs.filter((pr) => pr.author?.login === login).length
-  metrics[`prsCreatedLast7Days.${login}`] = prsCreatedLast7Days.filter((pr) => pr.author?.login === login).length
-  metrics[`prsCreatedLast30Days.${login}`] = prsCreatedLast30Days.filter((pr) => pr.author?.login === login).length
+  metrics[`prsCreatedSinceLastRun.${login}`] = prsCreatedSinceLastRun.filter((pr) => pr.author?.login === login).length
 }
 
 // Build the daily dispatch Slack Block Kit payload

--- a/.github/actions/daily-dispatch/index.js
+++ b/.github/actions/daily-dispatch/index.js
@@ -52,7 +52,7 @@ const reviewerCommentEvents = (pr) => pr.timelineItems.nodes.flatMap((item) => {
 
 // Renders one PR-list section (title, PR links, assignee/age/status context lines).
 // `statusSuffix(pr)` returns the bucket-specific trailing note for the context line, or ''.
-const renderPrSection = (blocks, textLines, { emoji, title, prList, emptyText, mttmHours, statusSuffix }) => {
+const renderPrSection = (blocks, textLines, { emoji, title, prList, emptyText, mttmHours, statusSuffix, showCount = true }) => {
   if (prList.length === 0) {
     blocks.push(sectionBlock(`*${emoji} ${title}*\n${emptyText}`))
     textLines.push(`${title}: none`)
@@ -60,7 +60,8 @@ const renderPrSection = (blocks, textLines, { emoji, title, prList, emptyText, m
     return
   }
 
-  blocks.push(sectionBlock(`*${emoji} ${title}*\n${prList.length} PR${prList.length === 1 ? '' : 's'}, oldest first:`))
+  const header = showCount ? `*${emoji} ${title}*\n${prList.length} PR${prList.length === 1 ? '' : 's'}, oldest first:` : `*${emoji} ${title}*`
+  blocks.push(sectionBlock(header))
   textLines.push(`${title}: ${prList.length}`)
 
   // Capped low, and one Slack block per PR (not two), to keep the overall payload
@@ -203,10 +204,19 @@ const releasePR = prs.find((pr) =>
 
 // External contributors (not org members/owners/collaborators) get their own
 // section - everyone else is bucketed by where they sit in the review cycle.
-const isExternal = (pr) => !['MEMBER', 'OWNER', 'COLLABORATOR'].includes(pr.authorAssociation)
+//
+// authorAssociation is under-reported (falls back to CONTRIBUTOR/NONE instead of
+// MEMBER) when the querying token can't see the author's org membership - which is
+// the case for the default GITHUB_TOKEN and any maintainer whose org membership is
+// private. Treat anyone we already track as a reviewer as internal regardless of
+// what authorAssociation reports, since that quirk only ever under-reports membership.
+const knownInternalLogins = new Set(Object.keys(githubToSlack))
+const isExternal = (pr) => !knownInternalLogins.has(pr.author?.login) && !['MEMBER', 'OWNER', 'COLLABORATOR'].includes(pr.authorAssociation)
 const byCreatedAtAsc = (a, b) => new Date(a.createdAt) - new Date(b.createdAt)
 
-const eligible = prs.filter((pr) => !pr.isDraft && !hasBlockedLabel(pr.labels) && pr.reviewDecision !== 'APPROVED')
+// The release-please PR is release automation, not a contributor PR to review -
+// it's already covered by the Version Status section, so keep it out of all four buckets.
+const eligible = prs.filter((pr) => pr !== releasePR && !pr.isDraft && !hasBlockedLabel(pr.labels) && pr.reviewDecision !== 'APPROVED')
 const externalPrs = eligible.filter(isExternal).sort(byCreatedAtAsc)
 const internalPrs = eligible.filter((pr) => !isExternal(pr))
 
@@ -313,7 +323,7 @@ const repoStatsAndDeploysQuery = `
       forkCount
       watchers { totalCount }
       ${deploymentEnvironments.map((_, i) => `
-      env${i}: deployments(environments: $env${i}, last: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+      env${i}: deployments(environments: $env${i}, first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
         nodes {
           createdAt
           commit { oid }
@@ -330,10 +340,22 @@ const repoStatsAndDeploysVars = { owner, repo }
 deploymentEnvironments.forEach((env, i) => { repoStatsAndDeploysVars[`env${i}`] = [env] })
 
 const repoStatsAndDeploysResponse = await octokit.graphql(repoStatsAndDeploysQuery, repoStatsAndDeploysVars)
+
+let npmWeeklyDownloads = null
+try {
+  const npmWeeklyDownloadsResponse = await fetch(`https://api.npmjs.org/downloads/point/last-week/${packageJson.name}`)
+  if (npmWeeklyDownloadsResponse.ok) {
+    npmWeeklyDownloads = (await npmWeeklyDownloadsResponse.json()).downloads
+  }
+} catch (error) {
+  console.warn(`Failed to fetch npm weekly downloads: ${error.message}`)
+}
+
 const repoStats = {
   stars: repoStatsAndDeploysResponse.repository.stargazerCount,
   forks: repoStatsAndDeploysResponse.repository.forkCount,
   watchers: repoStatsAndDeploysResponse.repository.watchers.totalCount,
+  npmWeeklyDownloads,
 }
 
 // A deployment's `latestStatus` goes INACTIVE once a newer deployment supersedes it in the
@@ -443,6 +465,12 @@ const textLines = ['Browser Agent Daily Dispatch']
 blocks.push(headerBlock('🌅 Browser Agent Daily Dispatch'))
 blocks.push(dividerBlock())
 
+// Repository Stats
+const npmDownloadsText = repoStats.npmWeeklyDownloads === null ? 'unavailable' : `${repoStats.npmWeeklyDownloads.toLocaleString('en-US')} weekly NPM downloads`
+blocks.push(sectionBlock(`*📊 Repository Stats*\n⭐ ${repoStats.stars} stars · 🍴 ${repoStats.forks} forks · 👀 ${repoStats.watchers} watchers · 📥 ${npmDownloadsText}`))
+textLines.push(`Repository Stats: ${repoStats.stars} stars, ${repoStats.forks} forks, ${repoStats.watchers} watchers, ${npmDownloadsText}`)
+blocks.push(dividerBlock())
+
 // Build size status - the size-compare job in pull-request-checks.yml comments this
 // tag on every PR (including release-please's), so it's expected to exist once checks
 // finish running on the release PR.
@@ -471,10 +499,12 @@ if (releasePR) {
       .map((line) => line.match(rowPattern))
       .filter(Boolean)
       .map((match) => {
-        const [, agent, asset, size, sizeColor, deltaMain, deltaMainColor, deltaRelease, deltaReleaseColor] = match
-        const worstColor = [sizeColor, deltaMainColor, deltaReleaseColor].sort((a, b) => (sizeColorSeverity[b] ?? 0) - (sizeColorSeverity[a] ?? 0))[0]
+        // deltaMain is dropped - the release PR is synced with main, so it's ~always 0%.
+        const [, agent, asset, size, sizeColor, , , deltaRelease, deltaReleaseColor] = match
+        const worstColor = [sizeColor, deltaReleaseColor].sort((a, b) => (sizeColorSeverity[b] ?? 0) - (sizeColorSeverity[a] ?? 0))[0]
         const emoji = sizeColorEmoji[worstColor] ?? '⚪'
-        return `${emoji} ${agent}/${asset}: ${size.trim()} (Δ main ${deltaMain.trim()}, Δ release ${deltaRelease.trim()})`
+        const cleanDelta = deltaRelease.trim().replace(/\s+/g, '')
+        return `${emoji} ${agent}/${asset}: ${size.trim()} (${cleanDelta})`
       })
   } else {
     buildSizePending = true
@@ -517,6 +547,18 @@ if (releasePR) {
 
 blocks.push(sectionBlock(versionText))
 blocks.push(dividerBlock())
+
+// Release PR - kept separate from the review-state buckets below since it's release
+// automation (release-please), not a contributor PR that needs the same triage.
+renderPrSection(blocks, textLines, {
+  emoji: '🔖',
+  title: 'Release PR',
+  prList: releasePR ? [releasePR] : [],
+  emptyText: 'No release is currently staged.',
+  mttmHours,
+  statusSuffix: (pr) => ` • Review: ${pr.reviewDecision ?? 'PENDING'}`,
+  showCount: false,
+})
 
 // External Contributor PRs
 renderPrSection(blocks, textLines, {
@@ -596,11 +638,6 @@ if (issues.length === 0) {
   }
   textLines.push(`Open Issues: ${issues.length}`)
 }
-blocks.push(dividerBlock())
-
-// Repository Stats
-blocks.push(sectionBlock(`*📊 Repository Stats*\n⭐ ${repoStats.stars} stars · 🍴 ${repoStats.forks} forks · 👀 ${repoStats.watchers} watchers`))
-textLines.push(`Repository Stats: ${repoStats.stars} stars, ${repoStats.forks} forks, ${repoStats.watchers} watchers`)
 blocks.push(dividerBlock())
 
 // Deployment Status

--- a/.github/actions/daily-dispatch/index.js
+++ b/.github/actions/daily-dispatch/index.js
@@ -456,6 +456,77 @@ do {
 
 const prsCreatedSinceLastRun = recentlyCreatedPRs.filter((pr) => new Date(pr.createdAt) >= sinceLastRunCutoff)
 
+// Fetch PRs with any activity since the last run (any state, ordered by UPDATED_AT since a
+// review comment on a PR created months ago still counts) so we can find new review comments
+// left by each tracked reviewer since then - same non-overlapping-delta approach as created PRs.
+const recentlyUpdatedPRs = []
+let updatedCursor = null
+
+do {
+  const response = await octokit.graphql(`
+    query($owner: String!, $repo: String!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(first: 50, states: [OPEN, MERGED, CLOSED], after: $cursor, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            updatedAt
+            author {
+              login
+            }
+            timelineItems(last: 50, itemTypes: [PULL_REQUEST_REVIEW, ISSUE_COMMENT, PULL_REQUEST_REVIEW_THREAD]) {
+              nodes {
+                __typename
+                ... on PullRequestReview {
+                  author {
+                    login
+                  }
+                  createdAt
+                }
+                ... on IssueComment {
+                  author {
+                    login
+                  }
+                  createdAt
+                }
+                ... on PullRequestReviewThread {
+                  comments(first: 1) {
+                    nodes {
+                      author {
+                        login
+                      }
+                      createdAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  `, { owner, repo, cursor: updatedCursor })
+
+  const connection = response.repository.pullRequests
+  recentlyUpdatedPRs.push(...connection.nodes)
+  const oldestInPage = connection.nodes[connection.nodes.length - 1]
+  // PRs are ordered newest-updated first, so once the oldest PR on this page hasn't
+  // been touched since the cutoff, every later page is too - stop paging.
+  updatedCursor = connection.pageInfo.hasNextPage && oldestInPage && new Date(oldestInPage.updatedAt) >= sinceLastRunCutoff
+    ? connection.pageInfo.endCursor
+    : null
+} while (updatedCursor)
+
+const hasReviewActivitySince = (pr, login, cutoff) => pr.timelineItems.nodes.some((item) => {
+  if (item.author?.login === login && item.createdAt && new Date(item.createdAt) >= cutoff) return true
+  if (item.__typename === 'PullRequestReviewThread' && item.comments?.nodes) {
+    return item.comments.nodes.some((comment) => comment.author?.login === login && new Date(comment.createdAt) >= cutoff)
+  }
+  return false
+})
+
 // Mean time to cycle: the gap between a reviewer comment and the next commit,
 // or between a commit and the next reviewer comment - i.e. every alternation
 // between "reviewer spoke" and "author pushed" across each open PR's timeline.
@@ -508,6 +579,7 @@ for (const login of Object.keys(githubToSlack)) {
 
   metrics[`prsCreatedBy.${login}`] = prs.filter((pr) => pr.author?.login === login).length
   metrics[`prsCreatedSinceLastRun.${login}`] = prsCreatedSinceLastRun.filter((pr) => pr.author?.login === login).length
+  metrics[`prsReviewedSinceLastRun.${login}`] = recentlyUpdatedPRs.filter((pr) => hasReviewActivitySince(pr, login, sinceLastRunCutoff)).length
 }
 
 // Build the daily dispatch Slack Block Kit payload


### PR DESCRIPTION
Extends the Daily Dispatch Slack report with clearer PR triage, build-size visibility for the upcoming release, and basic repo/npm health stats.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview
See the new format [here](https://newrelic.slack.com/archives/C04E6RHTBCK/p1788886487261439).

Reworks `.github/actions/daily-dispatch/index.js` to give the daily dispatch more useful, better-organized triage information:

- **PR triage is now split into five sections** instead of one flat "PRs Needing Review" list:
  - `🔖 Release PR` — the release-please PR, called out on its own since it's release automation, not a PR that needs the normal review triage.
  - `🌍 External Contributor PRs` — PRs from non-org-member authors.
  - `🆕 Never Reviewed` — no reviewer activity yet.
  - `🟠 Needs Revisions` — reviewer feedback given, author hasn't pushed since.
  - `🔁 Needs Re-Review` — author pushed since the last feedback, reviewer hasn't looked again.
  - External-contributor classification uses GitHub's `authorAssociation`, but also treats anyone already tracked in the dispatch's reviewer map as internal regardless of what `authorAssociation` reports — that field silently under-reports org membership (falls back to `CONTRIBUTOR`/`NONE`) when the querying token can't see the author's org membership, which is the case for the default `GITHUB_TOKEN` and any maintainer whose org membership is private.
- **Version Status now includes build size vs. the latest release.** The `size-compare` job in `pull-request-checks.yml` already comments an asset size report (tagged `<!-- browser_agent asset size report -->`) on every PR, including the release-please PR since it's a normal PR against `main`. The dispatch parses that comment and shows each asset's current size and percent change vs. the latest release tag, colored green/yellow/red to match the report's own thresholds. The comparison against `main` is dropped since the release PR is synced with `main` and that diff is always ~0%. If the comment isn't there yet (checks still running), the dispatch links out to the PR's checks instead of silently omitting the section.
- **New "📊 Repository Stats" section** (moved to the top of the message): stars, forks, watchers, and weekly npm downloads (from the public `api.npmjs.org` downloads endpoint, degrading to "unavailable" instead of failing the whole dispatch if that call errors).
- **New "🚀 Deployment Status" section**: the last successful deployment per environment (`nr1-dev`, `nr1-staging`, `nr1-us-prod`, `nr1-eu-prod`, `nr1-jp-prod`, `public-release`). This required scanning each deployment's full status history for a `SUCCESS` entry rather than trusting `latestStatus`, since GitHub flips a deployment's `latestStatus` to `INACTIVE` once a newer deployment supersedes it in the same environment — that's normal lifecycle, not a failure indicator. Also caught and fixed a `last`/`first` connection-pagination bug during development: `deployments(last: 10, orderBy: CREATED_AT DESC)` returns the *tail* of that already-sorted list (the oldest deployments in the sampled range), not the most recent ones — it needs `first: 10`.
- The per-PR sections now render one Slack block per PR instead of two, and cap at 6 PRs each, to keep the overall message comfortably under Slack's 50-block-per-message limit now that PRs are split across five sections instead of one.
- Added matching metrics fields (`externalPrCount`, `neverReviewedCount`, `needsRevisionsCount`, `needsReReviewCount`) to the existing `Br0ws3rMetrics` custom event payload.

No workflow or permissions changes were needed — everything is derivable from data the existing `GITHUB_TOKEN` scopes and public APIs already allow.

### Related Issue(s)

N/A

### Testing

Ran the action script directly against the live repository (`GITHUB_TOKEN=$(gh auth token) GITHUB_REPOSITORY=newrelic/newrelic-browser-agent node .github/actions/daily-dispatch/index.js`) and inspected the generated Slack Block Kit payload and metrics JSON after each change to confirm:
- PR bucketing matches the actual review state of real open PRs (spot-checked against `gh pr list` and individual PR timelines).
- The release-please PR appears only in its own section, never in the four review-state/external buckets.
- The asset size report parses correctly against the real comment on the open release-please PR, including the header/separator-row bleed-through bug found and fixed along the way.
- Deployment dates match what's shown on GitHub's own `/deployments/<environment>` pages for each tracked environment.
- npm weekly downloads match `https://api.npmjs.org/downloads/point/last-week/@newrelic/browser-agent` and degrade to "unavailable" without crashing when that call fails.
- Total Slack block count for the current repo state (34 blocks) stays well under Slack's 50-block limit.
