### PR TITLE
chore: Bump safari test version to latest 26

### DIFF
--- a/tests/specs/session-trace/modes.e2e.js
+++ b/tests/specs/session-trace/modes.e2e.js
@@ -176,7 +176,9 @@ describe('respects feature flags', () => {
 
     ;[sessionTraceHarvests] = await Promise.all([
       sessionTraceCapture.waitForResult({ timeout: 10000 }),
-      $('#trigger').click()
+      browser.execute(function () { // this is less flaky than $('#trigger').click() on safari
+        document.getElementById('trigger').click()
+      })
     ])
 
     expect(sessionTraceHarvests.length).toBeGreaterThanOrEqual(1)

--- a/tools/browsers-lists/lt-desktop-supported.json
+++ b/tools/browsers-lists/lt-desktop-supported.json
@@ -40,15 +40,15 @@
   "safari": [
     {
       "browserName": "Safari",
-      "platformName": "macOS Sequoia",
+      "platformName": "macOS Tahoe",
       "browserVersion": "latest",
-			"comment": "mOS version 15 aka Sequoia will only have safari 18 on LT"
+			"comment": "mOS version 26 aka Tahoe maps to safari 26 on LT"
     },
     {
       "browserName": "Safari",
-      "platformName": "macOS Sonoma",
+      "platformName": "macOS Sequoia",
       "browserVersion": "latest",
-			"comment": "mOS version 14 aka Sonoma will only have safari 17 on LT"
+			"comment": "mOS version 15 aka Sequoia will only have safari 18 on LT"
     }
   ]
 }


### PR DESCRIPTION
Please add a one-paragraph summary here, suitable for a release notes description. This will help with documentation.
---
<!--
Thank you for submitting a pull request. This code is leveraged to monitor critical services. Before contributing, please read our [contributing guidelines](https://github.com/newrelic/newrelic-browser-agent/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/newrelic/.github/blob/main/CODE_OF_CONDUCT.md).
-->

### Overview

Safari 27 (Golden Gate) was attempted but led to testing timeouts on LT. It's supposed to be released later this month but unfortunately will have to be a separate effort when it gets fully released. LT have had problems with beta versions.

### Related Issue(s)

https://new-relic.atlassian.net/browse/NR-543668

### Testing

<!-- Please provide detailed steps for testing the changes in this pull request using a developers local environment. -->
